### PR TITLE
feat: handle pipeline in expr context

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -16,7 +16,6 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.api.lsp.provider.completion.ExprContext.UnderPipeline
 import ca.uwaterloo.flix.api.lsp.{Command, CompletionItem, CompletionItemKind, CompletionItemLabelDetails, InsertTextFormat, Position, Range, TextEdit}
 import ca.uwaterloo.flix.language.ast.shared.AnchorPosition
 import ca.uwaterloo.flix.language.ast.{Name, ResolvedAst, SourceLocation, Symbol, Type, TypedAst}
@@ -163,8 +162,8 @@ sealed trait Completion {
       val qualifiedName = decl.sym.toString
       val label = if (qualified) qualifiedName else decl.sym.name
       val snippet = ectx match {
-        case ExprContext.UnderApply => CompletionUtils.getApplySnippet(label, Nil)
-        case UnderPipeline => CompletionUtils.getApplySnippet(label, decl.spec.fparams.dropRight(1))
+        case ExprContext.InsideApply => CompletionUtils.getApplySnippet(label, Nil)
+        case ExprContext.InsidePipeline => CompletionUtils.getApplySnippet(label, decl.spec.fparams.dropRight(1))
         case ExprContext.Unknown => CompletionUtils.getApplySnippet(label, decl.spec.fparams)
       }
       val description = if(!qualified) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -16,6 +16,7 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.api.lsp.provider.completion.ExprContext.UnderPipeline
 import ca.uwaterloo.flix.api.lsp.{Command, CompletionItem, CompletionItemKind, CompletionItemLabelDetails, InsertTextFormat, Position, Range, TextEdit}
 import ca.uwaterloo.flix.language.ast.shared.AnchorPosition
 import ca.uwaterloo.flix.language.ast.{Name, ResolvedAst, SourceLocation, Symbol, Type, TypedAst}
@@ -163,6 +164,7 @@ sealed trait Completion {
       val label = if (qualified) qualifiedName else decl.sym.name
       val snippet = ectx match {
         case ExprContext.UnderApply => CompletionUtils.getApplySnippet(label, Nil)
+        case UnderPipeline => CompletionUtils.getApplySnippet(label, decl.spec.fparams.dropRight(1))
         case ExprContext.Unknown => CompletionUtils.getApplySnippet(label, decl.spec.fparams)
       }
       val description = if(!qualified) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -70,10 +70,10 @@ object DefCompleter {
     stack match {
       case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyClo(_, _, _, _, _) :: _ =>
         // The leaf is an error followed by an ApplyClo expression.
-        ExprContext.UnderApply
+        ExprContext.InsideApply
       case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyDef(DefSymUse(sym, _), _, _, _, _, _) :: _ if sym.text == "|>" =>
         // The leaf is an error followed by an ApplyDef expression with the symbol "|>".
-        ExprContext.UnderPipeline
+        ExprContext.InsidePipeline
       case _ => ExprContext.Unknown
     }
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -16,17 +16,19 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.api.lsp.{LspUtil, Position, Range}
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.DefCompletion
+import ca.uwaterloo.flix.api.lsp.{LspUtil, Position, Range}
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
 import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, Root}
+import ca.uwaterloo.flix.language.ast.shared.SymUse.DefSymUse
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
 import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
+import ca.uwaterloo.flix.language.errors.ResolutionError.UndefinedName
 
 object DefCompleter {
   /**
     * Returns a List of Completion for definitions.
-    * Whether the returned completions are qualified is based on whether the UndefinaedName is qualified.
+    * Whether the returned completions are qualified is based on whether the UndefinedName is qualified.
     * When providing completions for unqualified defs that is not in scope, we will also automatically use the def.
     */
   def getCompletions(uri: String, pos: Position, qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope)(implicit root: Root, flix: Flix): Iterable[Completion] = {
@@ -66,9 +68,12 @@ object DefCompleter {
     val stack = LspUtil.getStack(uri, pos)
     // The stack contains the path of expressions from the leaf to the root.
     stack match {
-      case Expr.Error(_, _, _) :: Expr.ApplyClo(_, _, _, _, _) :: _ =>
-        // The leaf is an error followed by an apply expression.
+      case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyClo(_, _, _, _, _) :: _ =>
+        // The leaf is an error followed by an ApplyClo expression.
         ExprContext.UnderApply
+      case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyDef(DefSymUse(sym, _), _, _, _, _, _) :: _ if sym.text == "|>" =>
+        // The leaf is an error followed by an ApplyDef expression with the symbol "|>".
+        ExprContext.UnderPipeline
       case _ => ExprContext.Unknown
     }
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprContext.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprContext.scala
@@ -27,6 +27,15 @@ object ExprContext {
   case object UnderApply extends ExprContext
 
   /**
+    * Represents an expression in a match context.
+    *
+    * For example, in `1 |> println` we have that `println` is `UnderPipeline`.
+    *
+    * Currently, the only pipeline considered is `|>`, so the number of arguments from the pipeline is always 1.
+    */
+  case object UnderPipeline extends ExprContext
+
+  /**
     * Represents an expression in an unknown context.
     */
   case object Unknown extends ExprContext

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprContext.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprContext.scala
@@ -24,7 +24,7 @@ object ExprContext {
     *
     * For example, in `e1(e2, e3)` we have that `e1` is `UnderApply` but `e2` and `e3` are not.
     */
-  case object UnderApply extends ExprContext
+  case object InsideApply extends ExprContext
 
   /**
     * Represents an expression in a match context.
@@ -33,7 +33,7 @@ object ExprContext {
     *
     * Currently, the only pipeline considered is `|>`, so the number of arguments from the pipeline is always 1.
     */
-  case object UnderPipeline extends ExprContext
+  case object InsidePipeline extends ExprContext
 
   /**
     * Represents an expression in an unknown context.


### PR DESCRIPTION
Now we can handle pipeline and () as the def context:
<img width="685" alt="image" src="https://github.com/user-attachments/assets/77ec774a-8437-4b51-b54b-5cbaabf0cfbe" />
<img width="516" alt="image" src="https://github.com/user-attachments/assets/657872a7-73d6-45e1-a51f-7807bfc4aa83" />
<img width="886" alt="image" src="https://github.com/user-attachments/assets/8bdd17f3-97a0-4022-8110-fc13e7af8888" />
<img width="480" alt="image" src="https://github.com/user-attachments/assets/4ea4b579-3802-47ae-a345-f9060d074468" />
<img width="910" alt="image" src="https://github.com/user-attachments/assets/f2e207c5-576b-40d2-b7ba-f71262634f06" />
<img width="728" alt="image" src="https://github.com/user-attachments/assets/31ccf516-64de-41eb-9cf5-3f5d4e29dce4" />

Note that if there is both pipeline and (), () will dominate since it's closer to the error.

As a result, the completion in this mixed context is just what we want:
<img width="864" alt="image" src="https://github.com/user-attachments/assets/4d6e5da7-1eaf-4eaa-8659-a0af15139901" />
<img width="620" alt="image" src="https://github.com/user-attachments/assets/79d8380e-8373-48ae-ac83-9869c4164b75" />

So there is no need to consider the state machine(it's only needed if we want the exact arg count in mixed context)