### PR TITLE
feat: handle runWith in expr context

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -163,6 +163,7 @@ sealed trait Completion {
       val label = if (qualified) qualifiedName else decl.sym.name
       val snippet = ectx match {
         case ExprContext.InsideApply => CompletionUtils.getApplySnippet(label, Nil)
+        case ExprContext.InsideRunWith => CompletionUtils.getApplySnippet(label, Nil)
         case ExprContext.InsidePipeline => CompletionUtils.getApplySnippet(label, decl.spec.fparams.dropRight(1))
         case ExprContext.Unknown => CompletionUtils.getApplySnippet(label, decl.spec.fparams)
       }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -74,6 +74,9 @@ object DefCompleter {
       case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyDef(DefSymUse(sym, _), _, _, _, _, _) :: _ if sym.text == "|>" =>
         // The leaf is an error followed by an ApplyDef expression with the symbol "|>".
         ExprContext.InsidePipeline
+      case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.RunWith(_, _, _, _, _) :: _ =>
+        // The leaf is an error followed by an ApplyDef expression.
+        ExprContext.InsideRunWith
       case _ => ExprContext.Unknown
     }
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprContext.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprContext.scala
@@ -36,6 +36,13 @@ object ExprContext {
   case object InsidePipeline extends ExprContext
 
   /**
+    * Represents an expression in a run with context.
+    *
+    * For example, in `run { e1 } with e2` we have that `e2` is `InsideRunWith` while `e1` is not.
+    */
+  case object InsideRunWith extends ExprContext
+
+  /**
     * Represents an expression in an unknown context.
     */
   case object Unknown extends ExprContext


### PR DESCRIPTION
preview:
![image](https://github.com/user-attachments/assets/a49cb687-cd30-4951-bb28-5a0c3a186af7)
![image](https://github.com/user-attachments/assets/e7a31f17-3850-4590-96f1-47855c201cc3)

I just choose to complete only the name, no ().

Is it possible that we need to provide a ()? I think their signature should always be `Unit -> a` (this holds for all existing runWith)
