### PR TITLE
chore: share stack in CompletionProvider

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LspUtil.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspUtil.scala
@@ -35,7 +35,7 @@ object LspUtil {
     *
     * So the stack actually contains a path from the leaf node that contains the given position to the root node, with the leaf node at the top of the stack.
     */
-  def getStack(uri: String, pos: Position)(implicit root: Root, flix: Flix): List[AnyRef] = {
+  def getStack(uri: String, pos: Position)(implicit root: Root): List[AnyRef] = {
     val stack = StackConsumer()
 
     if (pos.character >= 2) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -47,8 +47,9 @@ object CompletionProvider {
     * Returns all completions in the given `uri` at the given position `pos`.
     */
   private def getCompletions(uri: String, pos: Position, currentErrors: List[CompilationMessage])(implicit root: Root, flix: Flix): List[Completion] = {
+    val stack = LspUtil.getStack(uri, pos)
     if (currentErrors.isEmpty)
-      HoleCompleter.getHoleCompletion(uri, pos).toList
+      HoleCompleter.getHoleCompletion(stack).toList
     else
       errorsAt(uri, pos, currentErrors).flatMap {
         case err: WeederError.UndefinedAnnotation => KeywordCompleter.getModKeywords(Range.from(err.loc))
@@ -73,7 +74,7 @@ object CompletionProvider {
           AutoImportCompleter.getCompletions(ident, range, ap, scp) ++
             LocalScopeCompleter.getCompletionsExpr(range, scp) ++
             KeywordCompleter.getExprKeywords(range) ++
-            DefCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
+            DefCompleter.getCompletions(stack, qn, range, ap, scp) ++
             EnumCompleter.getCompletions(qn, range, ap, scp, withTypeParameters = false) ++
             EffectCompleter.getCompletions(qn, range, ap, scp, inHandler = false) ++
             OpCompleter.getCompletions(qn, range, ap, scp) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -74,7 +74,7 @@ object CompletionProvider {
           AutoImportCompleter.getCompletions(ident, range, ap, scp) ++
             LocalScopeCompleter.getCompletionsExpr(range, scp) ++
             KeywordCompleter.getExprKeywords(range) ++
-            DefCompleter.getCompletions(stack, qn, range, ap, scp) ++
+            DefCompleter.getCompletions(qn, stack, range, ap, scp) ++
             EnumCompleter.getCompletions(qn, range, ap, scp, withTypeParameters = false) ++
             EffectCompleter.getCompletions(qn, range, ap, scp, inHandler = false) ++
             OpCompleter.getCompletions(qn, range, ap, scp) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -30,7 +30,7 @@ object DefCompleter {
     * Whether the returned completions are qualified is based on whether the UndefinedName is qualified.
     * When providing completions for unqualified defs that is not in scope, we will also automatically use the def.
     */
-  def getCompletions(stack: List[AnyRef], qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope)(implicit root: Root): Iterable[Completion] = {
+  def getCompletions(qn: Name.QName, stack: List[AnyRef], range: Range, ap: AnchorPosition, scp: LocalScope)(implicit root: Root): Iterable[Completion] = {
     val ectx = getExprContext(stack)
 
     if (qn.namespace.nonEmpty) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -15,9 +15,8 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.DefCompletion
-import ca.uwaterloo.flix.api.lsp.{LspUtil, Position, Range}
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
 import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, Root}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.DefSymUse
@@ -31,8 +30,8 @@ object DefCompleter {
     * Whether the returned completions are qualified is based on whether the UndefinedName is qualified.
     * When providing completions for unqualified defs that is not in scope, we will also automatically use the def.
     */
-  def getCompletions(uri: String, pos: Position, qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope)(implicit root: Root, flix: Flix): Iterable[Completion] = {
-    val ectx = getExprContext(uri, pos)
+  def getCompletions(stack: List[AnyRef], qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope)(implicit root: Root): Iterable[Completion] = {
+    val ectx = getExprContext(stack)
 
     if (qn.namespace.nonEmpty) {
       root.defs.values.collect {
@@ -64,8 +63,7 @@ object DefCompleter {
   /**
     * Returns the expression context at the given `uri` and position `pos`.
     */
-  private def getExprContext(uri: String, pos: Position)(implicit root: Root, flix: Flix): ExprContext = {
-    val stack = LspUtil.getStack(uri, pos)
+  private def getExprContext(stack: List[AnyRef]): ExprContext = {
     // The stack contains the path of expressions from the leaf to the root.
     stack match {
       case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyClo(_, _, _, _, _) :: _ =>

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/HoleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/HoleCompleter.scala
@@ -16,9 +16,6 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.api.lsp.acceptors.InsideAcceptor
-import ca.uwaterloo.flix.api.lsp.consumers.StackConsumer
-import ca.uwaterloo.flix.api.lsp.{Position, Visitor}
 import ca.uwaterloo.flix.language.ast.shared.Scope
 import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypedAst}
 import ca.uwaterloo.flix.language.phase.typer.ConstraintSolver2
@@ -28,15 +25,8 @@ object HoleCompleter {
   /**
     * Gets completions for when the cursor position is on a hole expression with an expression
     */
-  def getHoleCompletion(uri: String, pos: Position)(implicit root: TypedAst.Root, flix: Flix): Iterable[Completion] = {
-    val stack = StackConsumer()
-
-    if (pos.character >= 2) {
-      val leftPos = Position(pos.line, pos.character - 1)
-      Visitor.visitRoot(root, stack, InsideAcceptor(uri, leftPos))
-    }
-
-    stack.getStack.headOption match {
+  def getHoleCompletion(stack: List[AnyRef])(implicit root: TypedAst.Root, flix: Flix): Iterable[Completion] = {
+    stack.headOption match {
       case Some(TypedAst.Expr.HoleWithExp(TypedAst.Expr.Var(sym, sourceType, _), _, targetType, _, loc)) =>
         HoleCompleter.candidates(sourceType, targetType, root)
           .map(root.defs(_))

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
@@ -16,6 +16,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.SigCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Namespace, Sig, Trait}
@@ -26,7 +27,7 @@ object SignatureCompleter {
   /**
     * Returns a List of Completion for Sig for UndefinedName.
     */
-  def getCompletions(qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope)(implicit root: TypedAst.Root): Iterable[Completion] = {
+  def getCompletions(qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope)(implicit root: TypedAst.Root, flix: Flix): Iterable[Completion] = {
     if (qn.namespace.nonEmpty) {
       fullyQualifiedCompletion(qn, range, ap) ++ partiallyQualifiedCompletions(qn, range, ap, scp)
     } else


### PR DESCRIPTION
More and more completers in CompletionProvider will need use the stack, while the stack is read-only and the same across all completers.

We can build the stack in CompletionProvider and pass it to any completer that needs it.

Similar things can be done for ExprContext, which will be shared across several completers. Shall we also share that?