### PR TITLE
feat: support Signature Help for signature

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/SignatureInformation.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SignatureInformation.scala
@@ -24,11 +24,11 @@ import org.json4s.JsonDSL.*
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
 object SignatureInformation {
-  def from(symbol: Symbol, spec: TypedAst.Spec, idxActiveParameter: Int)(implicit flix: Flix): SignatureInformation = {
-    val label = symbol.toString + LspUtil.getLabelForSpec(spec)
+  def from(sym: Symbol, spec: TypedAst.Spec, activeParameter: Int)(implicit flix: Flix): SignatureInformation = {
+    val label = sym.toString + LspUtil.getLabelForSpec(spec)
     val documentation = spec.doc.text
     val parameters = spec.fparams.map(ParameterInformation.from)
-    SignatureInformation(label, Some(documentation), parameters, idxActiveParameter)
+    SignatureInformation(label, Some(documentation), parameters, activeParameter)
   }
 }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/SignatureInformation.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SignatureInformation.scala
@@ -24,13 +24,12 @@ import org.json4s.JsonDSL.*
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
 object SignatureInformation {
-  def from(defn: TypedAst.Def, activeParameter: Int)(implicit flix: Flix): SignatureInformation = {
-    val label = defn.sym.toString + LspUtil.getLabelForSpec(defn.spec)
-    val documentation = defn.spec.doc.text
-    val parameters = defn.spec.fparams.map(ParameterInformation.from)
-    SignatureInformation(label, Some(documentation), parameters, activeParameter)
+  def from(symbol: String, spec: TypedAst.Spec, idxActiveParameter: Int)(implicit flix: Flix): SignatureInformation = {
+    val label = symbol + LspUtil.getLabelForSpec(spec)
+    val documentation = spec.doc.text
+    val parameters = spec.fparams.map(ParameterInformation.from)
+    SignatureInformation(label, Some(documentation), parameters, idxActiveParameter)
   }
-
 }
 
 case class SignatureInformation(label: String, documentation: Option[String], parameters: List[ParameterInformation], activeParameter: Int) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/SignatureInformation.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SignatureInformation.scala
@@ -17,15 +17,15 @@
 package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
 import org.json4s.JValue
 import org.json4s.JsonDSL.*
 
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
 object SignatureInformation {
-  def from(symbol: String, spec: TypedAst.Spec, idxActiveParameter: Int)(implicit flix: Flix): SignatureInformation = {
-    val label = symbol + LspUtil.getLabelForSpec(spec)
+  def from(symbol: Symbol, spec: TypedAst.Spec, idxActiveParameter: Int)(implicit flix: Flix): SignatureInformation = {
+    val label = symbol.toString + LspUtil.getLabelForSpec(spec)
     val documentation = spec.doc.text
     val parameters = spec.fparams.map(ParameterInformation.from)
     SignatureInformation(label, Some(documentation), parameters, idxActiveParameter)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SignatureHelpProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SignatureHelpProvider.scala
@@ -18,8 +18,8 @@ package ca.uwaterloo.flix.api.lsp.provider
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.{LspUtil, Position, SignatureHelp, SignatureInformation}
-import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
+import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
 
 object SignatureHelpProvider {
   /**
@@ -35,6 +35,15 @@ object SignatureHelpProvider {
     }
   }
 
+  /**
+    * Builds the signature help for the given symbol and its specification.
+    *
+    * @param symbol the symbol of the function/signature.
+    * @param spec   the specification of the function/signature.
+    * @param exps   the expressions passed as arguments to the function/signature.
+    * @param pos    the position of the cursor.
+    * @return a SignatureHelp object containing the signature information.
+    */
   private def buildSignatureHelp(symbol: Symbol, spec: TypedAst.Spec, exps: List[TypedAst.Expr], pos: Position)(implicit flix: Flix): SignatureHelp = {
     // Count the index of the active parameter, which is the first expression that contains the position of the cursor.
     val idxActiveParameter = exps.indexWhere(exp => pos.containedBy(exp.loc))

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SignatureHelpProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SignatureHelpProvider.scala
@@ -29,25 +29,25 @@ object SignatureHelpProvider {
   def provideSignatureHelp(uri: String, pos: Position)(implicit root: Root, flix: Flix): Option[SignatureHelp] = {
     LspUtil.getStack(uri, pos).collectFirst {
       case TypedAst.Expr.ApplyDef(defnSymUse, exps, _, _, _, _) =>
-        buildSignatureHelp(defnSymUse.sym, root.defs(defnSymUse.sym).spec, exps, pos)
+        mkSignatureHelp(defnSymUse.sym, root.defs(defnSymUse.sym).spec, exps, pos)
       case TypedAst.Expr.ApplySig(sigSymUse, exps, _, _, _, _) =>
-        buildSignatureHelp(sigSymUse.sym, root.sigs(sigSymUse.sym).spec, exps, pos)
+        mkSignatureHelp(sigSymUse.sym, root.sigs(sigSymUse.sym).spec, exps, pos)
     }
   }
 
   /**
     * Builds the signature help for the given symbol and its specification.
     *
-    * @param symbol the symbol of the function/signature.
+    * @param sym the symbol of the function/signature.
     * @param spec   the specification of the function/signature.
     * @param exps   the expressions passed as arguments to the function/signature.
     * @param pos    the position of the cursor.
     * @return a SignatureHelp object containing the signature information.
     */
-  private def buildSignatureHelp(symbol: Symbol, spec: TypedAst.Spec, exps: List[TypedAst.Expr], pos: Position)(implicit flix: Flix): SignatureHelp = {
+  private def mkSignatureHelp(sym: Symbol, spec: TypedAst.Spec, exps: List[TypedAst.Expr], pos: Position)(implicit flix: Flix): SignatureHelp = {
     // Count the index of the active parameter, which is the first expression that contains the position of the cursor.
-    val idxActiveParameter = exps.indexWhere(exp => pos.containedBy(exp.loc))
-    val signatureInfo = SignatureInformation.from(symbol, spec, idxActiveParameter)
+    val activeParameter = exps.indexWhere(exp => pos.containedBy(exp.loc))
+    val signatureInfo = SignatureInformation.from(sym, spec, activeParameter)
     SignatureHelp(List(signatureInfo), 0, 0)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SignatureHelpProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SignatureHelpProvider.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.{LspUtil, Position, SignatureHelp, SignatureInformation}
-import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
 
 object SignatureHelpProvider {
@@ -29,13 +29,13 @@ object SignatureHelpProvider {
   def provideSignatureHelp(uri: String, pos: Position)(implicit root: Root, flix: Flix): Option[SignatureHelp] = {
     LspUtil.getStack(uri, pos).collectFirst {
       case TypedAst.Expr.ApplyDef(defnSymUse, exps, _, _, _, _) =>
-        buildSignatureHelp(defnSymUse.sym.toString, root.defs(defnSymUse.sym).spec, exps, pos)
+        buildSignatureHelp(defnSymUse.sym, root.defs(defnSymUse.sym).spec, exps, pos)
       case TypedAst.Expr.ApplySig(sigSymUse, exps, _, _, _, _) =>
-        buildSignatureHelp(sigSymUse.sym.toString, root.sigs(sigSymUse.sym).spec, exps, pos)
+        buildSignatureHelp(sigSymUse.sym, root.sigs(sigSymUse.sym).spec, exps, pos)
     }
   }
 
-  private def buildSignatureHelp(symbol: String, spec: TypedAst.Spec, exps: List[TypedAst.Expr], pos: Position)(implicit flix: Flix): SignatureHelp = {
+  private def buildSignatureHelp(symbol: Symbol, spec: TypedAst.Spec, exps: List[TypedAst.Expr], pos: Position)(implicit flix: Flix): SignatureHelp = {
     // Count the index of the active parameter, which is the first expression that contains the position of the cursor.
     val idxActiveParameter = exps.indexWhere(exp => pos.containedBy(exp.loc))
     val signatureInfo = SignatureInformation.from(symbol, spec, idxActiveParameter)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -184,7 +184,7 @@ sealed trait Completion {
         insertTextFormat    = InsertTextFormat.Snippet,
         kind                = CompletionItemKind.Function,
         additionalTextEdits = additionalTextEdit,
-        command = Some(Command("editor.action.triggerParameterHints", "editor.action.triggerParameterHints", Nil))
+        command             = Some(Command("editor.action.triggerParameterHints", "editor.action.triggerParameterHints", Nil))
       )
 
     case Completion.EnumCompletion(enm, range, ap, qualified, inScope, withTypeParameters) =>
@@ -407,7 +407,8 @@ sealed trait Completion {
         documentation       = Some(sig.spec.doc.text),
         insertTextFormat    = InsertTextFormat.Snippet,
         kind                = CompletionItemKind.Function,
-        additionalTextEdits = additionalTextEdit
+        additionalTextEdits = additionalTextEdit,
+        command             = Some(Command("editor.action.triggerParameterHints", "editor.action.triggerParameterHints", Nil))
       )
 
     case Completion.EnumTagCompletion(tag, namespace, range, ap, qualified, inScope) =>


### PR DESCRIPTION
Preview:
<img width="631" alt="image" src="https://github.com/user-attachments/assets/d22d1101-f1e2-4077-b7c7-6d586dd0a33f" />
<img width="635" alt="image" src="https://github.com/user-attachments/assets/6d4f7d2a-714e-4386-a2a3-c187e16fe25c" />
<img width="657" alt="image" src="https://github.com/user-attachments/assets/5ffa6420-d692-4199-b50a-3dd6a7b951e1" />

Also, when moving back, the active parameter will follow correctly.

<img width="647" alt="image" src="https://github.com/user-attachments/assets/13a904ac-cb8a-4c4f-99c0-f427cee43aa2" />

Also works for snippet!
<img width="601" alt="image" src="https://github.com/user-attachments/assets/2b9427cb-8b22-48ab-b73d-6023e1ff630f" />
<img width="641" alt="image" src="https://github.com/user-attachments/assets/92df1960-9c49-4ae9-a4ee-c4d7a9aae3ad" />

