### PR TITLE
fix: pass RunWith down the compiler when there is only run

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1723,7 +1723,7 @@ object Weeder2 {
         traverse(maybeWith)(visitRunWithBody),
       ) {
         // Bad case: run expr
-        case (_, Nil) =>
+        case (expr, Nil) =>
           // Fall back on Expr.Error
           val error = UnexpectedToken(
             expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordCatch, TokenKind.KeywordWith)),
@@ -1731,7 +1731,7 @@ object Weeder2 {
             SyntacticContext.Expr.OtherExpr,
             loc = tree.loc)
           sctx.errors.add(error)
-          Validation.Success(Expr.Error(error))
+          Validation.Success(Expr.RunWith(expr, Nil, tree.loc))
         // Case: run expr [with expr]...
         case (expr, exprs) => Validation.Success(Expr.RunWith(expr, exprs, tree.loc))
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1731,7 +1731,7 @@ object Weeder2 {
             SyntacticContext.Expr.OtherExpr,
             loc = tree.loc)
           sctx.errors.add(error)
-          Validation.Success(Expr.RunWith(expr, Nil, tree.loc))
+          Validation.Success(Expr.RunWith(expr, List(Expr.Error(error)), tree.loc))
         // Case: run expr [with expr]...
         case (expr, exprs) => Validation.Success(Expr.RunWith(expr, exprs, tree.loc))
       }


### PR DESCRIPTION
fixes #10341

preview:
![image](https://github.com/user-attachments/assets/87b1aeb7-437d-43a6-a145-3dd0d0e22ac7)
