### PR TITLE
fix: pass TryCatch down the compiler when there is only try

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1753,7 +1753,7 @@ object Weeder2 {
         traverse(maybeCatch)(visitTryCatchBody),
       ) {
         // Bad case: try expr
-        case (_, Nil) =>
+        case (expr, Nil) =>
           // Fall back on Expr.Error
           val error = UnexpectedToken(
             expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordCatch, TokenKind.KeywordWith)),
@@ -1761,7 +1761,7 @@ object Weeder2 {
             SyntacticContext.Expr.OtherExpr,
             loc = tree.loc)
           sctx.errors.add(error)
-          Validation.Success(Expr.Error(error))
+          Validation.Success(Expr.TryCatch(expr, List(Expr.Error(error)), tree.loc))
         // Case: try expr catch { rules... }
         case (expr, catches) => Validation.Success(Expr.TryCatch(expr, catches.flatten, tree.loc))
       }


### PR DESCRIPTION
Here we want to fix the problem the way we fix RunWith.

But Expr.TryCatch are expecting `List[CatchRule]`, we don't have something like `CatchRuleError` can use here :(

I think this also applies to all other non-expr constructs.