### PR TITLE
feat: use ExprContext in SigCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -77,7 +77,7 @@ object CompletionProvider {
             EnumCompleter.getCompletions(qn, range, ap, scp, withTypeParameters = false) ++
             EffectCompleter.getCompletions(qn, range, ap, scp, inHandler = false) ++
             OpCompleter.getCompletions(qn, range, ap, scp) ++
-            SignatureCompleter.getCompletions(qn, range, ap, scp) ++
+            SignatureCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             EnumTagCompleter.getCompletions(qn, range, ap, scp) ++
             TraitCompleter.getCompletions(qn, TraitUsageKind.Expr, range, ap, scp) ++
             ModuleCompleter.getCompletions(qn, range, ap, scp)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.api.lsp.{Command, CompletionItem, CompletionItemKind, CompletionItemLabelDetails, InsertTextFormat, Position, Range, TextEdit}
+import ca.uwaterloo.flix.api.lsp.{Command, CompletionItem, CompletionItemKind, CompletionItemLabelDetails, InsertTextFormat, LspUtil, Position, Range, TextEdit}
 import ca.uwaterloo.flix.language.ast.shared.AnchorPosition
 import ca.uwaterloo.flix.language.ast.{Name, ResolvedAst, SourceLocation, Symbol, Type, TypedAst}
 import ca.uwaterloo.flix.language.fmt.{FormatScheme, FormatType}
@@ -161,12 +161,7 @@ sealed trait Completion {
     case Completion.DefCompletion(decl, range, ap, qualified, inScope, ectx) =>
       val qualifiedName = decl.sym.toString
       val label = if (qualified) qualifiedName else decl.sym.name
-      val snippet = ectx match {
-        case ExprContext.InsideApply => CompletionUtils.getApplySnippet(label, Nil)
-        case ExprContext.InsidePipeline => CompletionUtils.getApplySnippet(label, decl.spec.fparams.dropRight(1))
-        case ExprContext.InsideRunWith => CompletionUtils.getApplySnippet(label, decl.spec.fparams.dropRight(1))
-        case ExprContext.Unknown => CompletionUtils.getApplySnippet(label, decl.spec.fparams)
-      }
+      val snippet = LspUtil.mkSpecSnippet(label, decl.spec, ectx)
       val description = if(!qualified) {
         Some(if (inScope) qualifiedName else s"use $qualifiedName")
       } else None
@@ -386,13 +381,13 @@ sealed trait Completion {
         kind                = CompletionItemKind.Function,
       )
 
-    case Completion.SigCompletion(sig, namespace, range, ap, qualified, inScope) =>
+    case Completion.SigCompletion(sig, namespace, range, ap, qualified, inScope, ectx) =>
       val qualifiedName =  if (namespace.nonEmpty)
         s"$namespace.${sig.sym.name}"
       else
         sig.sym.toString
       val name = if (qualified) qualifiedName else sig.sym.name
-      val snippet = CompletionUtils.getApplySnippet(name, sig.spec.fparams)
+      val snippet = LspUtil.mkSpecSnippet(name, sig.spec, ectx)
       val description = if(!qualified) {
         Some(if (inScope) qualifiedName else s"use $qualifiedName")
       } else None
@@ -790,8 +785,9 @@ object Completion {
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
+    * @param ectx       the expression context.
     */
-  case class SigCompletion(sig: TypedAst.Sig, namespace: String, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class SigCompletion(sig: TypedAst.Sig, namespace: String, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, ectx: ExprContext) extends Completion
 
   /**
     * Represents an Enum Tag completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -17,13 +17,11 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.DefCompletion
-import ca.uwaterloo.flix.api.lsp.{LspUtil, Position, Range}
+import ca.uwaterloo.flix.api.lsp.{Position, Range}
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
-import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, Root}
-import ca.uwaterloo.flix.language.ast.shared.SymUse.DefSymUse
+import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
 import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
-import ca.uwaterloo.flix.language.errors.ResolutionError.UndefinedName
 
 object DefCompleter {
   /**
@@ -32,7 +30,7 @@ object DefCompleter {
     * When providing completions for unqualified defs that is not in scope, we will also automatically use the def.
     */
   def getCompletions(uri: String, pos: Position, qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope)(implicit root: Root, flix: Flix): Iterable[Completion] = {
-    val ectx = getExprContext(uri, pos)
+    val ectx = ExprContext.getExprContext(uri, pos)
 
     if (qn.namespace.nonEmpty) {
       root.defs.values.collect {
@@ -59,25 +57,5 @@ object DefCompleter {
     })
     val isRoot = decl.sym.namespace.isEmpty
     isRoot || isResolved
-  }
-
-  /**
-    * Returns the expression context at the given `uri` and position `pos`.
-    */
-  private def getExprContext(uri: String, pos: Position)(implicit root: Root, flix: Flix): ExprContext = {
-    val stack = LspUtil.getStack(uri, pos)
-    // The stack contains the path of expressions from the leaf to the root.
-    stack match {
-      case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyClo(_, _, _, _, _) :: _ =>
-        // The leaf is an error followed by an ApplyClo expression.
-        ExprContext.InsideApply
-      case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyDef(DefSymUse(sym, _), _, _, _, _, _) :: _ if sym.text == "|>" =>
-        // The leaf is an error followed by an ApplyDef expression with the symbol "|>".
-        ExprContext.InsidePipeline
-      case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.RunWith(_, _, _, _, _) :: _ =>
-        // The leaf is an error followed by a RunWith expression.
-        ExprContext.InsideRunWith
-      case _ => ExprContext.Unknown
-    }
   }
 }


### PR DESCRIPTION
Preview:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/d5f4d96f-dff6-43cf-8151-75e4bda815e8" />
<img width="632" alt="image" src="https://github.com/user-attachments/assets/ee4cae94-c7bc-465a-9331-cab9794ae959" />
<img width="700" alt="image" src="https://github.com/user-attachments/assets/f628a80d-3978-4fc8-9980-7ebd56c9184d" />
<img width="569" alt="image" src="https://github.com/user-attachments/assets/95258c26-402c-4800-8f43-744143e9916f" />

Each call to `getExprContext` will rebuild its own stack, related to #10344

`getExprContext` is placed in ExprContext.scala for reuse.

`mkSpecSnippet` is placed in LspUtil.scala for reuse.