### PR TITLE
feat: use ExprContext in OpCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -76,7 +76,7 @@ object CompletionProvider {
             DefCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             EnumCompleter.getCompletions(qn, range, ap, scp, withTypeParameters = false) ++
             EffectCompleter.getCompletions(qn, range, ap, scp, inHandler = false) ++
-            OpCompleter.getCompletions(qn, range, ap, scp) ++
+            OpCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             SignatureCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             EnumTagCompleter.getCompletions(qn, range, ap, scp) ++
             TraitCompleter.getCompletions(qn, TraitUsageKind.Expr, range, ap, scp) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -339,13 +339,13 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.OpCompletion(op, namespace, range, ap, qualified, inScope) =>
+    case Completion.OpCompletion(op, namespace, range, ap, qualified, inScope, ectx) =>
       val qualifiedName =  if (namespace.nonEmpty)
         s"$namespace.${op.sym.name}"
       else
         op.sym.toString
       val name = if (qualified) qualifiedName else op.sym.name
-      val snippet = CompletionUtils.getApplySnippet(name, op.spec.fparams)
+      val snippet = LspUtil.mkSpecSnippet(name, op.spec, ectx)
       val description = if(!qualified) {
         Some(if (inScope) qualifiedName else s"use $qualifiedName")
       } else None
@@ -765,8 +765,9 @@ object Completion {
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the op is inScope.
+    * @param ectx       the expression context.
     */
-  case class OpCompletion(op: TypedAst.Op, namespace: String, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class OpCompletion(op: TypedAst.Op, namespace: String, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, ectx: ExprContext) extends Completion
 
   /**
     * Represents an Op Handler completion


### PR DESCRIPTION
Prewview:
![image](https://github.com/user-attachments/assets/de0e386d-c55e-4890-886c-1d7fcb5ce1f8)
![image](https://github.com/user-attachments/assets/aad8575c-64c0-4658-9c9c-4d9a74a972ce)
![image](https://github.com/user-attachments/assets/4aba9ddc-8725-4173-a701-699cddc3ddb7)
![image](https://github.com/user-attachments/assets/111f0903-e0a4-4f1e-bef6-6bffaa5247da)

Now we use the exprContext for def sig and op.

they are actually using the same ectx, since the uri and pos are always the same.

Another method, is to build the context in `autoComplete`, and pass it to toCompletionItem as a context, so when building completion item for def/sig/op, we can use this context to generate the correct snippet.