### PR TITLE
feat: use ExprContext for EnumTagCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -47,8 +47,6 @@ object CompletionProvider {
     * Returns all completions in the given `uri` at the given position `pos`.
     */
   private def getCompletions(uri: String, pos: Position, currentErrors: List[CompilationMessage])(implicit root: Root, flix: Flix): List[Completion] = {
-    val stack = LspUtil.getStack(uri, pos)
-    stack.foreach(item => println(s"$item\n"))
     if (currentErrors.isEmpty)
       HoleCompleter.getHoleCompletion(uri, pos).toList
     else

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -47,6 +47,8 @@ object CompletionProvider {
     * Returns all completions in the given `uri` at the given position `pos`.
     */
   private def getCompletions(uri: String, pos: Position, currentErrors: List[CompilationMessage])(implicit root: Root, flix: Flix): List[Completion] = {
+    val stack = LspUtil.getStack(uri, pos)
+    stack.foreach(item => println(s"$item\n"))
     if (currentErrors.isEmpty)
       HoleCompleter.getHoleCompletion(uri, pos).toList
     else
@@ -61,7 +63,7 @@ object CompletionProvider {
           val qn = err.qn
           val range = Range.from(err.loc)
           EnumCompleter.getCompletions(qn, range, ap, scp, withTypeParameters = false) ++
-            EnumTagCompleter.getCompletions(qn, range, ap, scp) ++
+            EnumTagCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             ModuleCompleter.getCompletions(qn, range, ap, scp)
 
         case err: ResolutionError.UndefinedName =>
@@ -78,7 +80,7 @@ object CompletionProvider {
             EffectCompleter.getCompletions(qn, range, ap, scp, inHandler = false) ++
             OpCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             SignatureCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
-            EnumTagCompleter.getCompletions(qn, range, ap, scp) ++
+            EnumTagCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             TraitCompleter.getCompletions(qn, TraitUsageKind.Expr, range, ap, scp) ++
             ModuleCompleter.getCompletions(qn, range, ap, scp)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -407,13 +407,18 @@ sealed trait Completion {
         command             = Some(Command("editor.action.triggerParameterHints", "editor.action.triggerParameterHints", Nil))
       )
 
-    case Completion.EnumTagCompletion(tag, namespace, range, ap, qualified, inScope) =>
+    case Completion.EnumTagCompletion(tag, namespace, range, ap, qualified, inScope, ectx) =>
       val qualifiedName = if (namespace.nonEmpty)
         s"$namespace.${tag.sym.name}"
       else
         tag.sym.toString
       val name = if (qualified) qualifiedName else tag.sym.name
-      val snippet = name + CompletionUtils.formatTypesSnippet(tag.tpes)
+      val snippet = ectx match {
+        case ExprContext.InsideApply => name
+        case ExprContext.InsidePipeline => name + CompletionUtils.formatTypesSnippet(tag.tpes.dropRight(1))
+        case ExprContext.InsideRunWith => name + CompletionUtils.formatTypesSnippet(tag.tpes)
+        case ExprContext.Unknown => name + CompletionUtils.formatTypesSnippet(tag.tpes)
+      }
       val label = name + CompletionUtils.formatTypes(tag.tpes)
       val description = if(!qualified) {
         Some(if (inScope) qualifiedName else s"use $qualifiedName")
@@ -799,8 +804,9 @@ object Completion {
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
+    * @param ectx       the expression context.
     */
-  case class EnumTagCompletion(tag: TypedAst.Case, namespace: String, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class EnumTagCompletion(tag: TypedAst.Case, namespace: String, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, ectx: ExprContext) extends Completion
 
   /**
     * Represents a Module completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -416,7 +416,9 @@ sealed trait Completion {
       val snippet = ectx match {
         case ExprContext.InsideApply => name
         case ExprContext.InsidePipeline => name + CompletionUtils.formatTypesSnippet(tag.tpes.dropRight(1))
-        case ExprContext.InsideRunWith => name + CompletionUtils.formatTypesSnippet(tag.tpes)
+        case ExprContext.InsideRunWith =>
+          // Technically not possible, but we just revert to default behavior.
+          name + CompletionUtils.formatTypesSnippet(tag.tpes)
         case ExprContext.Unknown => name + CompletionUtils.formatTypesSnippet(tag.tpes)
       }
       val label = name + CompletionUtils.formatTypes(tag.tpes)


### PR DESCRIPTION
We've already applied ExprContext to EnumTagCompleter. Similarly, we can use that for EnumTag.

Preview:
![image](https://github.com/user-attachments/assets/5d6e1ff9-6092-41c8-aace-9150f7d468e0)
![image](https://github.com/user-attachments/assets/a97cd83a-7170-46fc-9006-ba4863f2695e)
![image](https://github.com/user-attachments/assets/3699c32e-b57a-4e10-a6b8-21d204cfe5fb)
![image](https://github.com/user-attachments/assets/05b50bd3-ead9-474d-b8de-e74b89da3026)

Now several problems arise during the impl:
- It is possible that the ectx for EnumTagCompleter is `InsideRunWith`, which is actually an invalid context to complete to a EnumTag. What we should do in this case is to stop returning completion for enum tag. But in `toCompletionItem`, we have no choice but have to return one CompletionItem. This problem implies that:
  - Not only can we use this context to determine the content of a completion, but also whether we should offer a completion.
  - We may need a method to suppress the completion in `toCompletionItem`
- EnumTagCompleter is also used for `UndefinedTag`, which mean the current ExprContext, which is detecting `UndefinedName` in the leaf, will only find `ExprContext.Unknown`. The real context for a UndefinedTag is:
![image](https://github.com/user-attachments/assets/bb3259aa-577c-4713-81ca-dc332f129e1d)
Pattern.Error -> MatchRule -> Match