### PR TITLE
feat: provide completions over resolved enum tag

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -47,8 +47,11 @@ object CompletionProvider {
     * Returns all completions in the given `uri` at the given position `pos`.
     */
   private def getCompletions(uri: String, pos: Position, currentErrors: List[CompilationMessage])(implicit root: Root, flix: Flix): List[Completion] = {
+    val stack = LspUtil.getStack(uri, pos)
+    stack.foreach(item => println(s"$item\n"))
     if (currentErrors.isEmpty)
-      HoleCompleter.getHoleCompletion(uri, pos).toList
+      HoleCompleter.getHoleCompletion(uri, pos).toList ++
+        EnumTagCompleter.getFurtherCompletions(uri, pos)
     else
       errorsAt(uri, pos, currentErrors).flatMap {
         case err: WeederError.UndefinedAnnotation => KeywordCompleter.getModKeywords(Range.from(err.loc))

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -47,8 +47,6 @@ object CompletionProvider {
     * Returns all completions in the given `uri` at the given position `pos`.
     */
   private def getCompletions(uri: String, pos: Position, currentErrors: List[CompilationMessage])(implicit root: Root, flix: Flix): List[Completion] = {
-    val stack = LspUtil.getStack(uri, pos)
-    stack.foreach(item => println(s"$item\n"))
     if (currentErrors.isEmpty)
       HoleCompleter.getHoleCompletion(uri, pos).toList ++
         EnumTagCompleter.getFurtherCompletions(uri, pos)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
@@ -16,8 +16,9 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.lsp.Range
+import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.EnumTagCompletion
+import ca.uwaterloo.flix.api.lsp.{Position, Range}
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Case, Enum, Namespace}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
 import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypedAst}
@@ -36,6 +37,19 @@ object EnumTagCompleter {
             EnumTagCompletion(tag, "", range, ap, qualified = false, inScope = inScope(tag, scp))
         }
       )
+  }
+
+  /**
+    * Returns a List of Completion for Tag that has been successfully resolved.
+    */
+  def getFurtherCompletions(uri: String, pos: Position)(implicit root: TypedAst.Root, flix: Flix): Iterable[Completion] = {
+    EnumTagContext.getEnumTagContext(uri, pos) match {
+      case EnumTagContext.AfterCompleteEnumTag(symUse) =>
+        root.enums(symUse.sym.enumSym).cases.map{ case (_, tag) =>
+          EnumTagCompletion(tag, "", Range.from(symUse.loc), AnchorPosition(1,1,0), qualified = true, inScope = true)
+        }
+      case EnumTagContext.Unknown => Iterable.empty
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagContext.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagContext.scala
@@ -50,10 +50,10 @@ object EnumTagContext {
     */
   def getEnumTagContext(uri: String, pos: Position)(implicit root: TypedAst.Root, flix: Flix): EnumTagContext = {
     LspUtil.getStack(uri, pos) match {
-      case (symUse@SymUse.CaseSymUse(_, _)) :: Expr.Tag(_, _ :: _, _, _, _) :: _ =>
+      case (symUse@SymUse.CaseSymUse(_, loc)) :: Expr.Tag(_, _ :: _, _, _, _) :: _ if !loc.isSynthetic =>
         // The leaf is a case symbol followed by a Tag expression with arguments.
         EnumTagContext.InsideAppliedEnumTag(symUse)
-      case (symUse@SymUse.CaseSymUse(_, _)) :: Expr.Tag(_, Nil, _, _, _) :: _ =>
+      case (symUse@SymUse.CaseSymUse(_, loc)) :: Expr.Tag(_, Nil, _, _, _) :: _ if !loc.isSynthetic =>
         // The leaf is a case symbol followed by a Tag expression.
         EnumTagContext.InsideValidEnumTag(symUse)
       case _ => EnumTagContext.Unknown

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagContext.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagContext.scala
@@ -28,15 +28,21 @@ object EnumTagContext {
   /**
     * Represents an expression in a complete enum context.
     *
-    * For example, in `Clr.Red|` we have that cursor is `InsideCompleteEnumTag`.
+    * For example, in `Clr.Red|` where Red is a valid case, we say that cursor position is `AfterCompleteEnumTag`.
     */
   case class AfterCompleteEnumTag(sym: SymUse.CaseSymUse) extends EnumTagContext
 
+  /**
+    * Represents an expression in all other contexts.
+    */
   case object Unknown extends EnumTagContext
 
+  /**
+    * Returns the context of the enum tag at the given position.
+    * Only a CaseSymUse followed by a Tag expression is considered AfterCompleteEnumTag context.
+    */
   def getEnumTagContext(uri: String, pos: Position)(implicit root: TypedAst.Root, flix: Flix): EnumTagContext = {
-    val stack = LspUtil.getStack(uri, pos)
-    stack match {
+    LspUtil.getStack(uri, pos) match {
       case (symUse@SymUse.CaseSymUse(_, _)) :: Expr.Tag(_, _, _, _, _) :: _ =>
         // The leaf is a case symbol followed by a Tag expression.
         EnumTagContext.AfterCompleteEnumTag(symUse)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagContext.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagContext.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Chenhao Gao
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.api.lsp.provider.completion
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.api.lsp.{LspUtil, Position}
+import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.TypedAst.Expr
+import ca.uwaterloo.flix.language.ast.shared.SymUse
+
+sealed trait EnumTagContext
+
+object EnumTagContext {
+  /**
+    * Represents an expression in a complete enum context.
+    *
+    * For example, in `Clr.Red|` we have that cursor is `InsideCompleteEnumTag`.
+    */
+  case class AfterCompleteEnumTag(sym: SymUse.CaseSymUse) extends EnumTagContext
+
+  case object Unknown extends EnumTagContext
+
+  def getEnumTagContext(uri: String, pos: Position)(implicit root: TypedAst.Root, flix: Flix): EnumTagContext = {
+    val stack = LspUtil.getStack(uri, pos)
+    stack match {
+      case (symUse@SymUse.CaseSymUse(_, _)) :: Expr.Tag(_, _, _, _, _) :: _ =>
+        // The leaf is a case symbol followed by a Tag expression.
+        EnumTagContext.AfterCompleteEnumTag(symUse)
+      case _ => EnumTagContext.Unknown
+    }
+  }
+}
+
+


### PR DESCRIPTION
fixes #10133

Now we can get completions after a resolved enum tag.

Preview:
![image](https://github.com/user-attachments/assets/0c7e1c3f-73be-49ff-90f8-a1e59fbcc035)
![image](https://github.com/user-attachments/assets/aca62559-04d2-4e42-8e38-242acc776178)
![image](https://github.com/user-attachments/assets/fa0fc10b-8288-4f20-a566-dea3309666a8)

First step to providing more completions over error-free programs.

The current impl is:
- Visit the AST to build the EnumTagContext
- If the leaf is `SymUse.CaseSymUse`, we are inside a successfully resolved EnumTag node.
- use the SymUse to find the enum and provide further completions.

It also works if we are not at the end of the symuse:
![image](https://github.com/user-attachments/assets/5a75a0d0-6ca5-41c1-b39c-63f0a38ac0b8)
![image](https://github.com/user-attachments/assets/4fa8ceb9-842f-4fdd-948e-55278555d2df)

Or even the namespace:
![image](https://github.com/user-attachments/assets/752239ff-57e0-45a0-aa14-93ed8e3651f3)
![image](https://github.com/user-attachments/assets/6a458688-e45a-48fe-a292-fb2c7d856cfb)

But the information we can currently get from the SymUse is still very limited
- We can not access anchor position. Thus we don't know where to insert the extra use.
- We can not access the local scope, so we don't even know if we should insert the extra use.
- We don't know currently the context like if EnumTag is applied, but we can know that from the stack.

I am not sure, but I think we can just suppress the completion which is identical to the current content.