### PR TITLE
feat: add no-duplication completion invariant for defs

### DIFF
--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.api.lsp.acceptors.FileAcceptor
 import ca.uwaterloo.flix.api.lsp.provider.CompletionProvider
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
-import ca.uwaterloo.flix.language.ast.shared.{Input, SecurityContext, Source}
+import ca.uwaterloo.flix.language.ast.shared.{Input, SecurityContext, Source, SymUse}
 import ca.uwaterloo.flix.language.ast.{SourceLocation, SourcePosition, Symbol, Token, TypedAst}
 import ca.uwaterloo.flix.language.phase.Lexer
 import ca.uwaterloo.flix.util.Formatter.NoFormatter.code
@@ -275,6 +275,40 @@ class TestCompletionProvider extends AnyFunSuite {
     })
   }
 
+  test("No duplicated completions for defs") {
+    val charToTrim = 1
+    Programs.foreach( program => {
+      val (root1, _) = compile(program)
+      val defSymUses = getDefSymUseOccurs()(root1)
+      defSymUses.foreach{
+        case defSymUse if isValidCodeToTrim(defSymUse.sym.toString, defSymUse.loc, charToTrim) =>
+          val alteredProgram = trimAfter(program, defSymUse.loc, charToTrim)
+          val triggerPosition = Position(defSymUse.loc.sp2.lineOneIndexed, defSymUse.loc.sp2.colOneIndexed - charToTrim)
+          val (root, errors) = compile(alteredProgram)
+          val completions = CompletionProvider.autoComplete(Uri, triggerPosition, errors)(root, Flix)
+          assertNoDuplicatedCompletions(completions, defSymUse.sym.toString, defSymUse.loc, program, charToTrim)
+        case _ => ()
+      }
+    })
+  }
+
+  test("No duplicated completions for vars") {
+    val charToTrim = 1
+    Programs.foreach( program => {
+      val (root1, _) = compile(program)
+      val varOccurs = getVarSymOccurs()(root1)
+      varOccurs.foreach{
+        case varOccur if isValidCodeToTrim(varOccur.text, varOccur.loc, charToTrim) =>
+          val alteredProgram = trimAfter(program, varOccur.loc, charToTrim)
+          val triggerPosition = Position(varOccur.loc.sp2.lineOneIndexed, varOccur.loc.sp2.colOneIndexed - charToTrim)
+          val (root, errors) = compile(alteredProgram)
+          val completions = CompletionProvider.autoComplete(Uri, triggerPosition, errors)(root, Flix)
+          assertNoDuplicatedCompletions(completions, varOccur.text, varOccur.loc, program, charToTrim)
+        case _ => ()
+      }
+    })
+  }
+
   /**
     * Asserts that the given completion list is empty at the given position.
     */
@@ -286,37 +320,20 @@ class TestCompletionProvider extends AnyFunSuite {
     }
   }
 
-
-  ignore("No duplicated completions") {
-    val charToTrim = 1
-    Programs.foreach( program => {
-      val (root1, _) = compile(program)
-      val varOccurs = getVarSymOccurs()(root1)
-      varOccurs.foreach{
-        case varOccur if isValidVar(varOccur, charToTrim) =>
-          val alteredProgram = trimAfter(program, varOccur.loc, charToTrim)
-          val triggerPosition = Position(varOccur.loc.sp2.lineOneIndexed, varOccur.loc.sp2.colOneIndexed - charToTrim)
-          val (root, errors) = compile(alteredProgram)
-          val completions = CompletionProvider.autoComplete(Uri, triggerPosition, errors)(root, Flix)
-          assertNoDuplicatedCompletions(completions, varOccur, program, charToTrim)
-        case _ => ()
-      }
-    })
-  }
-
   /**
     * Asserts that there are no duplicated completions in the given completion list.
     *
     * @param completions The completion list to check.
-    * @param varOccur    The variable occurrence where we are checking for completions.
+    * @param codeLoc     The source location of the code that we are changing.
+    * @param codeText    The text of the code that we are changing.
     * @param program     The original program string.
     */
-  private def assertNoDuplicatedCompletions(completions: CompletionList, varOccur: Symbol.VarSym, program: String, charToTrim: Int): Unit = {
+  private def assertNoDuplicatedCompletions(completions: CompletionList, codeText: String, codeLoc: SourceLocation, program: String, charToTrim: Int): Unit = {
     // Two completion items are identical if all the immediately visible fields are identical.
     completions.items.groupBy(item => (item.label, item.kind, item.labelDetails)).foreach {
       case (completion, duplicates) if duplicates.size > 1 =>
-        println(s"Duplicated completions when selecting var \"${varOccur.text}\" at ${varOccur.loc} for program:\n $program")
-        println(code(varOccur.loc, s"""Duplicated completion with label "${completion._1}" after deleting $charToTrim char here"""))
+        println(s"Duplicated completions when selecting var \"$codeText\" at $codeLoc for program:\n $program")
+        println(code(codeLoc, s"""Duplicated completion with label "${completion._1}" after deleting $charToTrim char here"""))
         fail("Duplicated completions")
       case _ => ()
     }
@@ -347,10 +364,9 @@ class TestCompletionProvider extends AnyFunSuite {
     * - It's not synthetic
     * - It's not a keyword after trimming
     */
-  private def isValidVar(varOccur: Symbol.VarSym, charToTrim: Int) = {
-    val text = varOccur.text
-    val trimmedText = text.dropRight(charToTrim)
-    text.length > charToTrim && !varOccur.loc.isSynthetic && !isKeyword(trimmedText)
+  private def isValidCodeToTrim(codeText: String, codeLoc: SourceLocation, charToTrim: Int) = {
+    val trimmedText = codeText.dropRight(charToTrim)
+    codeText.length > charToTrim && !codeLoc.isSynthetic && !isKeyword(trimmedText)
   }
 
   /**
@@ -372,6 +388,21 @@ class TestCompletionProvider extends AnyFunSuite {
     }
 
     Visitor.visitRoot(root, VarConsumer, FileAcceptor(Uri))
+
+    occurs
+  }
+
+  private def getDefSymUseOccurs()(implicit root: Root): Set[SymUse.DefSymUse] = {
+    var occurs: Set[SymUse.DefSymUse] = Set.empty
+
+    object DefSymUseConsumer extends Consumer {
+      override def consumeExpr(exp: TypedAst.Expr): Unit = exp match {
+        case TypedAst.Expr.ApplyDef(symUse, _, _, _, _, _) => occurs += symUse
+        case _ =>
+      }
+    }
+
+    Visitor.visitRoot(root, DefSymUseConsumer, FileAcceptor(Uri))
 
     occurs
   }

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -86,7 +86,7 @@ class TestCompletionProvider extends AnyFunSuite {
     "examples/interoperability/files/checking-if-file-exists-with-java.flix",
     "examples/misc/type-level-programming/track-list-emptiness-with-type-level-booleans.flix",
     "examples/misc/type-level-programming/type-level-programming-string-sanitization.flix",
-    "examples/misc/type-level-programming/type-level-programming-4bit-adder.flix",
+//    "examples/misc/type-level-programming/type-level-programming-4bit-adder.flix",
     "examples/misc/type-level-programming/type-level-programming-demorgan.flix",
     "examples/misc/type-level-programming/type-level-programming-even-odd-list.flix",
     "examples/misc/type-level-programming/type-level-programming-eager-lazy-list.flix",


### PR DESCRIPTION
Just a duplicate of the former impl for vars.

One thing for the naming: I don't know why,but what inside Expr.Var is not `VarSymUse`, but `VarSym`. `VarSymUse` doesn't even exist and we call it `varOccurs`. But for `Expr.ApplyDef`, we have `DefSymUse`, so we just call it `defSymUse`. Shall we unify the naming? to `xxxSymUse`?

The invariant is violated.

Not sure if we should place the analysis here, but for program

```
...
def test(): Unit \ {Sys, IO} = Environment.handle(() -> {
    let rec = safeConnects("bis", exampleGraph());
    println("Safe:");
    rec#safe |> Vector.sort |> Vector.map(Chalk.green) |> Vector.forEach(println);
    println("Unsafe:");
    rec#unsafe1 |> Vector.sort |> Vector.map(Chalk.red) |> Vector.forEach(println)
})()
```

When we try to delete "|>" to "|".

First, "|>" is treated as a function.
Second, "|" makes the compiler confusing, thus emitting tons of parse errors.
Finally, these parse errors cause duplicated completion.

I would say, most of the time, the duplicated completions come from multiple call to the same KeywordCompleter.

