### PR TITLE
refactor: remove null casting logic from `TypeReconstruction`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -450,6 +450,9 @@ object Safety {
       )
 
       (Type.eraseAliases(from).baseType, to.map(Type.eraseAliases).map(_.baseType)) match {
+        // Allow all null casts
+        case (Type.Null, _) => ()
+
         // Allow casts where one side is a type variable.
         case (Type.Var(_, _), _) => ()
         case (_, Some(Type.Var(_, _))) => ()

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -450,7 +450,7 @@ object Safety {
       )
 
       (Type.eraseAliases(from).baseType, to.map(Type.eraseAliases).map(_.baseType)) match {
-        // Allow all null casts
+        // Allow all null casts.
         case (Type.Null, _) => ()
 
         // Allow casts where one side is a type variable.

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -368,10 +368,6 @@ object TypeReconstruction {
           TypedAst.Expr.CheckedCast(cast, e, e.tpe, eff, loc)
       }
 
-    case KindedAst.Expr.UncheckedCast(KindedAst.Expr.Cst(Constant.Null, _), _, _, tvar, loc) =>
-      val t = subst(tvar)
-      TypedAst.Expr.Cst(Constant.Null, t, loc)
-
     case KindedAst.Expr.UncheckedCast(exp, declaredType0, declaredEff0, tvar, loc) =>
       val e = visitExp(exp)
       val declaredType = declaredType0.map(tpe => subst(tpe))


### PR DESCRIPTION
This doesn't belong here and makes internal Asts nonwelltyped