### PR TITLE
refactor: remove unused AST cast info

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -102,7 +102,7 @@ object MonoAst {
 
     case class Ascribe(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class Cast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Cast(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/OccurrenceAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/OccurrenceAst.scala
@@ -90,7 +90,7 @@ object OccurrenceAst {
 
     case class Ascribe(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class Cast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Cast(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -44,8 +44,7 @@ object MonoAstPrinter {
     case Expr.VectorLoad(exp1, exp2, _, _, _) => DocAst.Expr.VectorLoad(print(exp1), print(exp2))
     case Expr.VectorLength(exp, _) => DocAst.Expr.VectorLength(print(exp))
     case Expr.Ascribe(exp, tpe, _, _) => DocAst.Expr.AscriptionTpe(print(exp), TypePrinter.print(tpe))
-    case Expr.Cast(exp, Some(declaredType), _, _, _, _) => DocAst.Expr.Cast(print(exp), TypePrinter.print(declaredType))
-    case Expr.Cast(_, _, _, _, _, _) => DocAst.Expr.Unknown
+    case Expr.Cast(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule))
     case Expr.RunWith(exp, effUse, rules, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map(printHandlerRule))
     case Expr.Do(op, exps, _, _, _) => DocAst.Expr.Do(op.sym, exps.map(print))

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
@@ -580,7 +580,7 @@ object Monomorpher {
     case LoweredAst.Expr.Cast(exp, _, _, tpe, eff, loc) =>
       // Drop the declaredType and declaredEff.
       val e = specializeExp(exp, env0, subst)
-      mkCast(e, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.Cast(e, subst(tpe), subst(eff), loc)
 
     case LoweredAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = specializeExp(exp, env0, subst)

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.LoweredAst.Instance
 import ca.uwaterloo.flix.language.ast.shared.Scope
-import ca.uwaterloo.flix.language.ast.{Kind, LoweredAst, MonoAst, Name, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{AtomicOp, Kind, LoweredAst, MonoAst, Name, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.phase.typer.{ConstraintSolver2, Progress, TypeReduction2}
 import ca.uwaterloo.flix.language.phase.unification.Substitution
@@ -580,7 +580,7 @@ object Monomorpher {
     case LoweredAst.Expr.Cast(exp, _, _, tpe, eff, loc) =>
       // Drop the declaredType and declaredEff.
       val e = specializeExp(exp, env0, subst)
-      MonoAst.Expr.Cast(e, None, None, subst(tpe), subst(eff), loc)
+      mkCast(e, subst(tpe), subst(eff), loc)
 
     case LoweredAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = specializeExp(exp, env0, subst)
@@ -612,6 +612,43 @@ object Monomorpher {
       val methods = methods0.map(specializeJvmMethod(_, env0, subst))
       MonoAst.Expr.NewObject(name, clazz, subst(tpe), subst(eff), methods, loc)
 
+  }
+
+  private def mkCast(e: MonoAst.Expr, tpe: Type, eff: Type, loc: SourceLocation)(implicit flix: Flix): MonoAst.Expr = {
+    (e.tpe, tpe) match {
+      case (Type.Char, Type.Char) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (Type.Char, Type.Int32) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (Type.Bool, Type.Bool) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (Type.Int8, Type.Int8) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (Type.Int16, Type.Int16) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (Type.Int32, Type.Int32) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (Type.Int64, Type.Int64) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (Type.Float32, Type.Float32) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (Type.Float64, Type.Float64) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (x, y) if !isPrimType(x) && !isPrimType(y) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
+      case (_, _) =>
+        val crash = MonoAst.Expr.ApplyAtomic(AtomicOp.MatchError, Nil, tpe, eff, loc)
+        MonoAst.Expr.Stm(e, crash, tpe, eff, loc)
+    }
+  }
+
+  private def isPrimType(tpe: Type): Boolean = tpe match {
+    case Type.Char => true
+    case Type.Bool => true
+    case Type.Int8 => true
+    case Type.Int16 => true
+    case Type.Int32 => true
+    case Type.Int64 => true
+    case Type.Float32 => true
+    case Type.Float64 => true
+    case Type.Cst(_, _) => false
+    case Type.Apply(_, _, _) => false
+    case Type.Var(_, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
+    case Type.Alias(_, _, _, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
+    case Type.AssocType(_, _, _, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
+    case Type.JvmToType(_, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
+    case Type.JvmToEff(_, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
+    case Type.UnresolvedJvmType(_, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.LoweredAst.Instance
 import ca.uwaterloo.flix.language.ast.shared.Scope
-import ca.uwaterloo.flix.language.ast.{AtomicOp, Kind, LoweredAst, MonoAst, Name, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Kind, LoweredAst, MonoAst, Name, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.phase.typer.{ConstraintSolver2, Progress, TypeReduction2}
 import ca.uwaterloo.flix.language.phase.unification.Substitution
@@ -612,43 +612,6 @@ object Monomorpher {
       val methods = methods0.map(specializeJvmMethod(_, env0, subst))
       MonoAst.Expr.NewObject(name, clazz, subst(tpe), subst(eff), methods, loc)
 
-  }
-
-  private def mkCast(e: MonoAst.Expr, tpe: Type, eff: Type, loc: SourceLocation)(implicit flix: Flix): MonoAst.Expr = {
-    (e.tpe, tpe) match {
-      case (Type.Char, Type.Char) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (Type.Char, Type.Int32) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (Type.Bool, Type.Bool) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (Type.Int8, Type.Int8) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (Type.Int16, Type.Int16) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (Type.Int32, Type.Int32) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (Type.Int64, Type.Int64) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (Type.Float32, Type.Float32) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (Type.Float64, Type.Float64) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (x, y) if !isPrimType(x) && !isPrimType(y) => MonoAst.Expr.Cast(e, None, None, tpe, eff, loc)
-      case (_, _) =>
-        val crash = MonoAst.Expr.ApplyAtomic(AtomicOp.MatchError, Nil, tpe, eff, loc)
-        MonoAst.Expr.Stm(e, crash, tpe, eff, loc)
-    }
-  }
-
-  private def isPrimType(tpe: Type): Boolean = tpe match {
-    case Type.Char => true
-    case Type.Bool => true
-    case Type.Int8 => true
-    case Type.Int16 => true
-    case Type.Int32 => true
-    case Type.Int64 => true
-    case Type.Float32 => true
-    case Type.Float64 => true
-    case Type.Cst(_, _) => false
-    case Type.Apply(_, _, _) => false
-    case Type.Var(_, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
-    case Type.Alias(_, _, _, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
-    case Type.AssocType(_, _, _, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
-    case Type.JvmToType(_, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
-    case Type.JvmToEff(_, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
-    case Type.UnresolvedJvmType(_, _) => throw InternalCompilerException(s"Unexpected monomorphed type '$tpe'", tpe.loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -216,7 +216,7 @@ object Simplifier {
 
     case MonoAst.Expr.Ascribe(exp, _, _, _) => visitExp(exp)
 
-    case MonoAst.Expr.Cast(exp, _, _, tpe, eff, loc) =>
+    case MonoAst.Expr.Cast(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
       SimplifiedAst.Expr.ApplyAtomic(AtomicOp.Cast, List(e), t, simplifyEffect(eff), loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -328,9 +328,9 @@ object Inliner {
       val e = visitExp(exp, ctx0)
       Expr.Ascribe(e, tpe, eff, loc)
 
-    case Expr.Cast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+    case Expr.Cast(exp, tpe, eff, loc) =>
       val e = visitExp(exp, ctx0)
-      Expr.Cast(e, declaredType, declaredEff, tpe, eff, loc)
+      Expr.Cast(e, tpe, eff, loc)
 
     case Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp, ctx0)

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
@@ -190,7 +190,7 @@ object LambdaDrop {
     case Expr.Ascribe(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Cast(exp, _, _, _, _, _) =>
+    case Expr.Cast(exp, _, _, _) =>
       visitExp(exp)
 
     case Expr.TryCatch(exp1, rules, _, _, _) =>
@@ -319,9 +319,9 @@ object LambdaDrop {
       val e = rewriteExp(exp)
       Expr.Ascribe(e, tpe, eff, loc)
 
-    case Expr.Cast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+    case Expr.Cast(exp, tpe, eff, loc) =>
       val e = rewriteExp(exp)
-      Expr.Cast(e, declaredType, declaredEff, tpe, eff, loc)
+      Expr.Cast(e, tpe, eff, loc)
 
     case Expr.TryCatch(exp1, rules, tpe, eff, loc) =>
       val e1 = rewriteExp(exp1)

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -230,12 +230,12 @@ object OccurrenceAnalyzer {
           (OccurrenceAst.Expr.Ascribe(e, tpe, eff, loc), ctx)
         }
 
-      case OccurrenceAst.Expr.Cast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+      case OccurrenceAst.Expr.Cast(exp, tpe, eff, loc) =>
         val (e, ctx) = visitExp(exp)
         if (e eq exp) {
           (exp0, ctx) // Reuse exp0.
         } else {
-          (OccurrenceAst.Expr.Cast(e, declaredType, declaredEff, tpe, eff, loc), ctx)
+          (OccurrenceAst.Expr.Cast(e, tpe, eff, loc), ctx)
         }
 
       case OccurrenceAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Optimizer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Optimizer.scala
@@ -125,9 +125,9 @@ object Optimizer {
         val e = visitExp(exp)
         OccurrenceAst.Expr.Ascribe(e, tpe, eff, loc)
 
-      case MonoAst.Expr.Cast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+      case MonoAst.Expr.Cast(exp, tpe, eff, loc) =>
         val e = visitExp(exp)
-        OccurrenceAst.Expr.Cast(e, declaredType, declaredEff, tpe, eff, loc)
+        OccurrenceAst.Expr.Cast(e, tpe, eff, loc)
 
       case MonoAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>
         val e = visitExp(exp)
@@ -294,9 +294,9 @@ object Optimizer {
         val e = visitExp(exp)
         MonoAst.Expr.Ascribe(e, tpe, eff, loc)
 
-      case OccurrenceAst.Expr.Cast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+      case OccurrenceAst.Expr.Cast(exp, tpe, eff, loc) =>
         val e = visitExp(exp)
-        MonoAst.Expr.Cast(e, declaredType, declaredEff, tpe, eff, loc)
+        MonoAst.Expr.Cast(e, tpe, eff, loc)
 
       case OccurrenceAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>
         val e = visitExp(exp)


### PR DESCRIPTION
These two values are alwasy `None` and also unused.