### PR TITLE
fix: do not visit let-bindings in `bindArgs` in `Inliner`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -529,7 +529,7 @@ object Inliner {
   /**
     * Returns `true` if
     *   - the local context shows that we are not currently inlining and
-    *   - `defn` does not refer to itself.
+    *   - `defn` does not refer to itself and
     *   - is a direct call to another function.
     */
   private def shouldInlineDef(defn: OccurrenceAst.Def, ctx0: LocalContext): Boolean = {


### PR DESCRIPTION
Seems to a small speedup