### PR TITLE
fix: use the correct loc when finding Vars in TestCompletionProvider

### DIFF
--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -298,12 +298,12 @@ class TestCompletionProvider extends AnyFunSuite {
       val (root1, _) = compile(program)
       val varOccurs = getVarSymOccurs()(root1)
       varOccurs.foreach{
-        case varOccur if isValidCodeToTrim(varOccur.text, varOccur.loc, numToTrim) =>
-          val alteredProgram = trimAfter(program, varOccur.loc, numToTrim)
-          val triggerPosition = Position(varOccur.loc.sp2.lineOneIndexed, varOccur.loc.sp2.colOneIndexed - numToTrim)
+        case (varSym, loc) if isValidCodeToTrim(varSym.text, loc, numToTrim) =>
+          val alteredProgram = trimAfter(program, loc, numToTrim)
+          val triggerPosition = Position(loc.sp2.lineOneIndexed, loc.sp2.colOneIndexed - numToTrim)
           val (root, errors) = compile(alteredProgram)
           val completions = CompletionProvider.autoComplete(Uri, triggerPosition, errors)(root, Flix)
-          assertNoDuplicatedCompletions(completions, varOccur.text, varOccur.loc, program, numToTrim)
+          assertNoDuplicatedCompletions(completions, varSym.text, loc, program, numToTrim)
         case _ => ()
       }
     })
@@ -385,12 +385,12 @@ class TestCompletionProvider extends AnyFunSuite {
   /**
     * Returns the set of variable symbols that occur in the given root.
     */
-  private def getVarSymOccurs()(implicit root: Root): Set[Symbol.VarSym] = {
-    var occurs: Set[Symbol.VarSym] = Set.empty
+  private def getVarSymOccurs()(implicit root: Root): Set[(Symbol.VarSym, SourceLocation)] = {
+    var occurs: Set[(Symbol.VarSym, SourceLocation)] = Set.empty
 
     object VarConsumer extends Consumer {
       override def consumeExpr(exp: TypedAst.Expr): Unit = exp match {
-          case TypedAst.Expr.Var(sym, _, _) => occurs += sym
+          case TypedAst.Expr.Var(sym, _, loc) => occurs += ((sym, loc))
           case _ =>
         }
     }


### PR DESCRIPTION
fixes #10465
