### PR TITLE
feat: pass prefix to KeywordCompleter for filtering

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -51,7 +51,7 @@ object CompletionProvider {
       HoleCompleter.getHoleCompletion(uri, pos).toList
     else
       errorsAt(uri, pos, currentErrors).flatMap {
-        case err: WeederError.UndefinedAnnotation => KeywordCompleter.getModKeywords(Range.from(err.loc))
+        case WeederError.UndefinedAnnotation(name, loc) => KeywordCompleter.getModKeywords(Some(name), Range.from(loc))
 
         case err: WeederError.UnqualifiedUse => UseCompleter.getCompletions(err.qn, Range.from(err.loc))
 
@@ -72,7 +72,7 @@ object CompletionProvider {
           val range = Range.from(err.loc)
           AutoImportCompleter.getCompletions(ident, range, ap, scp) ++
             LocalScopeCompleter.getCompletionsExpr(range, scp) ++
-            KeywordCompleter.getExprKeywords(range) ++
+            KeywordCompleter.getExprKeywords(Some(qn.toString), range) ++
             DefCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             EnumCompleter.getCompletions(qn, range, ap, scp, withTypeParameters = false) ++
             EffectCompleter.getCompletions(qn, range, ap, scp, inHandler = false) ++
@@ -125,13 +125,13 @@ object CompletionProvider {
     else e.sctx match {
       // Expressions.
       case SyntacticContext.Expr.Constraint => (PredicateCompleter.getCompletions(uri, range) ++ KeywordCompleter.getConstraintKeywords(range)).toList
-      case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords(range)
+      case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords(None, range)
 
       // Declarations.
       case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords(range)
       case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords(range)
       case SyntacticContext.Decl.Instance => KeywordCompleter.getInstanceKeywords(range)
-      case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords(range) ++ ExprSnippetCompleter.getCompletions(range)
+      case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords(None, range) ++ ExprSnippetCompleter.getCompletions(range)
       case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords(range)
       case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords(range)
       case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords(range)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -70,7 +70,7 @@ object CompletionProvider {
           val ident = err.qn.ident.name
           val qn = err.qn
           val range = Range.from(err.loc)
-          val keywordCompletions = if (qn.namespace.nonEmpty)
+          val keywordCompletions = if (qn.namespace.isEmpty)
             KeywordCompleter.getExprKeywords(Some(qn.toString), range)
           else Nil
           AutoImportCompleter.getCompletions(ident, range, ap, scp) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -39,8 +39,8 @@ import ca.uwaterloo.flix.language.errors.{ParseError, ResolutionError, TypeError
 object CompletionProvider {
 
   def autoComplete(uri: String, pos: Position, currentErrors: List[CompilationMessage])(implicit root: Root, flix: Flix): CompletionList = {
-      val items = getCompletions(uri, pos, currentErrors)(root, flix).map(_.toCompletionItem)
-      CompletionList(isIncomplete = true, items)
+    val items = getCompletions(uri, pos, currentErrors)(root, flix).map(_.toCompletionItem)
+    CompletionList(isIncomplete = true, items)
   }
 
   /**
@@ -70,9 +70,11 @@ object CompletionProvider {
           val ident = err.qn.ident.name
           val qn = err.qn
           val range = Range.from(err.loc)
+          val keywordCompletions = if (qn.namespace.nonEmpty)
+            KeywordCompleter.getExprKeywords(Some(qn.toString), range)
+          else Nil
           AutoImportCompleter.getCompletions(ident, range, ap, scp) ++
             LocalScopeCompleter.getCompletionsExpr(range, scp) ++
-            KeywordCompleter.getExprKeywords(Some(qn.toString), range) ++
             DefCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             EnumCompleter.getCompletions(qn, range, ap, scp, withTypeParameters = false) ++
             EffectCompleter.getCompletions(qn, range, ap, scp, inHandler = false) ++
@@ -80,7 +82,8 @@ object CompletionProvider {
             SignatureCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             EnumTagCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             TraitCompleter.getCompletions(qn, TraitUsageKind.Expr, range, ap, scp) ++
-            ModuleCompleter.getCompletions(qn, range, ap, scp)
+            ModuleCompleter.getCompletions(qn, range, ap, scp) ++
+            keywordCompletions
 
         case err: ResolutionError.UndefinedType =>
           val ap = err.ap

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -534,6 +534,10 @@ sealed trait Completion {
   }
 }
 
+sealed trait NamedCompletion extends Completion{
+  def name: String
+}
+
 object Completion {
 
   /**
@@ -543,7 +547,7 @@ object Completion {
     * @param range     the range of the completion.
     * @param priority  the completion priority of the keyword.
     */
-  case class KeywordCompletion(name: String, range: Range, priority: Priority) extends Completion
+  case class KeywordCompletion(name: String, range: Range, priority: Priority) extends NamedCompletion
 
   /**
     * Represents a keyword literal completion (i.e. `true`).
@@ -562,11 +566,11 @@ object Completion {
     *
     * `f(fal)`  --->    `f(false˽)`
     *
-    * @param literal   the literal keyword text.
+    * @param name   the literal keyword text.
     * @param range     the range of the completion.
     * @param priority  the priority of the keyword.
     */
-  case class KeywordLiteralCompletion(literal: String, range: Range, priority: Priority) extends Completion
+  case class KeywordLiteralCompletion(name: String, range: Range, priority: Priority) extends NamedCompletion
 
   /**
     * Represents a completion for a kind.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -35,7 +35,7 @@ object KeywordCompleter {
   /**
     * Module keywords. These are keywords that can occur in a module.
     */
-  def getModKeywords(range: Range): List[Completion] =
+  def getModKeywords(name: Option[String], range: Range): List[Completion.KeywordCompletion] =
     List(
       // D
       Completion.KeywordCompletion("@Deprecated"      , range, Priority.Low),
@@ -66,7 +66,7 @@ object KeywordCompleter {
       Completion.KeywordCompletion("use"              , range, Priority.Default),
       // W
       Completion.KeywordCompletion("with"             , range, Priority.Default),
-    )
+    ).filter(c => CompletionUtils.fuzzyMatch(name.getOrElse(""), c.name))
 
   /**
     * Enum keywords. These are keywords that can appear within the declaration of an enum.
@@ -87,7 +87,7 @@ object KeywordCompleter {
   /**
     * Expression keywords. These are keywords that can appear within expressions (fx within the body of a function).
     */
-  def getExprKeywords(range: Range): List[Completion] =
+  def getExprKeywords(name: Option[String], range: Range): List[Completion] = {
     List(
       // A
       Completion.KeywordCompletion("and"         , range, Priority.Default),
@@ -100,7 +100,6 @@ object KeywordCompleter {
       // E
       Completion.KeywordCompletion("else"        , range, Priority.Default),
       // F
-      Completion.KeywordLiteralCompletion("false", range, Priority.Higher),
       Completion.KeywordCompletion("forA"        , range, Priority.Lowest),
       Completion.KeywordCompletion("forM"        , range, Priority.Low),
       Completion.KeywordCompletion("force"       , range, Priority.High),
@@ -121,7 +120,6 @@ object KeywordCompleter {
       // N
       Completion.KeywordCompletion("new"         , range, Priority.Low),
       Completion.KeywordCompletion("not"         , range, Priority.High),
-      Completion.KeywordLiteralCompletion("null" , range, Priority.Lower),
       // O
       Completion.KeywordCompletion("or"          , range, Priority.Default),
       // P
@@ -138,7 +136,6 @@ object KeywordCompleter {
       Completion.KeywordCompletion("spawn"       , range, Priority.Low),
       // T
       Completion.KeywordCompletion("throw"       , range, Priority.Lowest),
-      Completion.KeywordLiteralCompletion("true" , range, Priority.Higher),
       Completion.KeywordCompletion("try"         , range, Priority.High),
       Completion.KeywordCompletion("typematch"   , range, Priority.Low),
       // U
@@ -149,7 +146,12 @@ object KeywordCompleter {
       Completion.KeywordCompletion("without"     , range, Priority.Default),
       // Y
       Completion.KeywordCompletion("yield"       , range, Priority.Default)
-    )
+    ).filter(c => CompletionUtils.fuzzyMatch(name.getOrElse(""), c.name)) ++ List (
+      Completion.KeywordLiteralCompletion("false", range, Priority.Higher),
+      Completion.KeywordLiteralCompletion("null" , range, Priority.Lower),
+      Completion.KeywordLiteralCompletion("true" , range, Priority.Higher),
+    ).filter(c => CompletionUtils.fuzzyMatch(name.getOrElse(""), c.literal))
+  }
 
   /**
     * Instance declaration keywords.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -66,7 +66,7 @@ object KeywordCompleter {
       Completion.KeywordCompletion("use"              , range, Priority.Default),
       // W
       Completion.KeywordCompletion("with"             , range, Priority.Default),
-    ).filter(c => CompletionUtils.fuzzyMatch(name.getOrElse(""), c.name))
+    ).filter(c => c.name.startsWith(name.getOrElse("")))
 
   /**
     * Enum keywords. These are keywords that can appear within the declaration of an enum.
@@ -146,11 +146,11 @@ object KeywordCompleter {
       Completion.KeywordCompletion("without"     , range, Priority.Default),
       // Y
       Completion.KeywordCompletion("yield"       , range, Priority.Default)
-    ).filter(c => CompletionUtils.fuzzyMatch(name.getOrElse(""), c.name)) ++ List (
+    ).filter(c => c.name.startsWith(name.getOrElse(""))) ++ List (
       Completion.KeywordLiteralCompletion("false", range, Priority.Higher),
       Completion.KeywordLiteralCompletion("null" , range, Priority.Lower),
       Completion.KeywordLiteralCompletion("true" , range, Priority.Higher),
-    ).filter(c => CompletionUtils.fuzzyMatch(name.getOrElse(""), c.literal))
+    ).filter(c => c.literal.startsWith(name.getOrElse("")))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -35,7 +35,7 @@ object KeywordCompleter {
   /**
     * Module keywords. These are keywords that can occur in a module.
     */
-  def getModKeywords(name: Option[String], range: Range): List[Completion.KeywordCompletion] =
+  def getModKeywords(name: Option[String], range: Range): List[Completion] =
     List(
       // D
       Completion.KeywordCompletion("@Deprecated"      , range, Priority.Low),
@@ -100,6 +100,7 @@ object KeywordCompleter {
       // E
       Completion.KeywordCompletion("else"        , range, Priority.Default),
       // F
+      Completion.KeywordLiteralCompletion("false", range, Priority.Higher),
       Completion.KeywordCompletion("forA"        , range, Priority.Lowest),
       Completion.KeywordCompletion("forM"        , range, Priority.Low),
       Completion.KeywordCompletion("force"       , range, Priority.High),
@@ -120,6 +121,7 @@ object KeywordCompleter {
       // N
       Completion.KeywordCompletion("new"         , range, Priority.Low),
       Completion.KeywordCompletion("not"         , range, Priority.High),
+      Completion.KeywordLiteralCompletion("null" , range, Priority.Lower),
       // O
       Completion.KeywordCompletion("or"          , range, Priority.Default),
       // P
@@ -136,6 +138,7 @@ object KeywordCompleter {
       Completion.KeywordCompletion("spawn"       , range, Priority.Low),
       // T
       Completion.KeywordCompletion("throw"       , range, Priority.Lowest),
+      Completion.KeywordLiteralCompletion("true" , range, Priority.Higher),
       Completion.KeywordCompletion("try"         , range, Priority.High),
       Completion.KeywordCompletion("typematch"   , range, Priority.Low),
       // U
@@ -146,11 +149,7 @@ object KeywordCompleter {
       Completion.KeywordCompletion("without"     , range, Priority.Default),
       // Y
       Completion.KeywordCompletion("yield"       , range, Priority.Default)
-    ).filter(c => c.name.startsWith(name.getOrElse(""))) ++ List (
-      Completion.KeywordLiteralCompletion("false", range, Priority.Higher),
-      Completion.KeywordLiteralCompletion("null" , range, Priority.Lower),
-      Completion.KeywordLiteralCompletion("true" , range, Priority.Higher),
-    ).filter(c => c.literal.startsWith(name.getOrElse("")))
+    ).filter(c => c.name.startsWith(name.getOrElse("")))
   }
 
   /**


### PR DESCRIPTION
fixes #10466

Note that in ExprKeyword I split the list into two parts to make sure each list is of the same type.

Or we can change the Completion types to keep things in one list.