### PR TITLE
feat: completion invariant that auto use/import should be lower

### DIFF
--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -342,19 +342,33 @@ class TestCompletionProvider extends AnyFunSuite {
     *
     * Auto use/import completions should be lower than all other completions.
     *
-    * Note that a lower ranking means a larger sortText.
-    *
     * @param completions The completion list to check.
     * @param program     The original program string.
     * @param loc         The source location of the code that we are changing.
     */
   private def assertLowerOrderForUseImport(completions: CompletionList, program: String, loc: SourceLocation): Unit = {
     val (otherCompletions, useImportCompletions) = completions.items.partition(_.additionalTextEdits.isEmpty)
-    val lowestOtherCompletionSortText = otherCompletions.map(_.sortText).max
-    val highestUseImportCompletionSortText = useImportCompletions.map(_.sortText).min
-    if (lowestOtherCompletionSortText > highestUseImportCompletionSortText) {
+    assertPriorityHigher(otherCompletions, useImportCompletions, program, loc)
+  }
+
+  /**
+    * Asserts that the given completion list is ordered correctly.
+    *
+    * All completions in `higherCompletions` should be ranked higher than all completions in `lowerCompletions`.
+    *
+    * Note that higher-ranked completions should have a lower sortText value.
+    *
+    * @param higherCompletions The completion list to check.
+    * @param lowerCompletions  The completion list to check.
+    * @param program           The original program string.
+    * @param loc               The source location of the code that we are changing.
+    */
+  private def assertPriorityHigher(higherCompletions: Iterable[CompletionItem], lowerCompletions: Iterable[CompletionItem], program: String, loc: SourceLocation): Unit = {
+    val lowerSortText = lowerCompletions.map(_.sortText).max
+    val higherSortText = higherCompletions.map(_.sortText).min
+    if (lowerSortText > higherSortText) {
       println(s"Invalid Order: auto use/import completions are not lower than others for program:\n$program")
-      println(code(loc, s"Here we have sortText($lowestOtherCompletionSortText) < sortText($highestUseImportCompletionSortText), which violates the invariant."))
+      println(code(loc, s"Here we have sortText($lowerSortText) < sortText($higherSortText), which violates the invariant."))
       fail("Invalid Order for use/import completions")
     }
   }

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -320,7 +320,8 @@ class TestCompletionProvider extends AnyFunSuite {
           val triggerPosition = Position(defSymUse.loc.sp2.lineOneIndexed, defSymUse.loc.sp2.colOneIndexed - charToTrim)
           val (root, errors) = compile(alteredProgram)
           val completions = CompletionProvider.autoComplete(Uri, triggerPosition, errors)(root, Flix)
-          assertLowerOrderForUseImport(completions, program, defSymUse.loc)
+          val (otherCompletions, useImportCompletions) = completions.items.partition(_.additionalTextEdits.isEmpty)
+          assertPriorityHigher(otherCompletions, useImportCompletions, program, defSymUse.loc)
         case _ => ()
       }
     })
@@ -335,20 +336,6 @@ class TestCompletionProvider extends AnyFunSuite {
       println(s"Found completions: ${completions.map(_.label)}")
       fail(s"Expected no completions at position $pos, but found ${completions.length} completions.")
     }
-  }
-
-  /**
-    * Asserts that the given completion list is ordered correctly for use/import completions.
-    *
-    * Auto use/import completions should be lower than all other completions.
-    *
-    * @param completions The completion list to check.
-    * @param program     The original program string.
-    * @param loc         The source location of the code that we are changing.
-    */
-  private def assertLowerOrderForUseImport(completions: CompletionList, program: String, loc: SourceLocation): Unit = {
-    val (otherCompletions, useImportCompletions) = completions.items.partition(_.additionalTextEdits.isEmpty)
-    assertPriorityHigher(otherCompletions, useImportCompletions, program, loc)
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -342,15 +342,17 @@ class TestCompletionProvider extends AnyFunSuite {
     *
     * Auto use/import completions should be lower than all other completions.
     *
+    * Note that a lower ranking means a larger sortText.
+    *
     * @param completions The completion list to check.
     * @param program     The original program string.
     * @param loc         The source location of the code that we are changing.
     */
   private def assertLowerOrderForUseImport(completions: CompletionList, program: String, loc: SourceLocation): Unit = {
     val (otherCompletions, useImportCompletions) = completions.items.partition(_.additionalTextEdits.isEmpty)
-    val lowestOtherCompletionSortText = otherCompletions.map(_.sortText).min
-    val highestUseImportCompletionSortText = useImportCompletions.map(_.sortText).max
-    if (lowestOtherCompletionSortText < highestUseImportCompletionSortText) {
+    val lowestOtherCompletionSortText = otherCompletions.map(_.sortText).max
+    val highestUseImportCompletionSortText = useImportCompletions.map(_.sortText).min
+    if (lowestOtherCompletionSortText > highestUseImportCompletionSortText) {
       println(s"Invalid Order: auto use/import completions are not lower than others for program:\n$program")
       println(code(loc, s"Here we have sortText($lowestOtherCompletionSortText) < sortText($highestUseImportCompletionSortText), which violates the invariant."))
       fail("Invalid Order for use/import completions")


### PR DESCRIPTION
fixes #10467
Here we first check this invariant for all DefSymUse.

The error we encounter:
<img width="909" alt="image" src="https://github.com/user-attachments/assets/8428240f-3c80-4be9-96e3-c7ce56c04a3a" />

Is that the `Console.println` ranks higher than `throw`(which is filtered out)
