### PR TITLE
fix: correct Order instance for shortest-path examples

### DIFF
--- a/examples/larger-examples/datalog/single-source-shortest-path-arbitrary.flix
+++ b/examples/larger-examples/datalog/single-source-shortest-path-arbitrary.flix
@@ -30,12 +30,18 @@ mod ShortestPathN {
         }
     }
 
-    instance Order[Path[a]] {
+    instance Order[Path[a]] with Order[a] {
         pub def compare(x: Path[a], y: Path[a]): Comparison = match (x, y) {
             case (Bot, Bot)                 => Comparison.EqualTo
             case (Bot, _)                   => Comparison.LessThan
             case (_, Bot)                   => Comparison.GreaterThan
-            case (Path(_, l1), Path(_, l2)) => l1 <=> l2
+            case (Path(list1, l1), Path(list2, l2)) => 
+                let comp1 = l1 <=> l2;
+                if(comp1 != Comparison.EqualTo) {
+                    comp1
+                } else {
+                    list1 <=> list2
+                }
         }
     }
 

--- a/examples/larger-examples/datalog/single-source-shortest-paths.flix
+++ b/examples/larger-examples/datalog/single-source-shortest-paths.flix
@@ -30,12 +30,12 @@ mod ShortestPath {
         }
     }
 
-    instance Order[Path[a]] {
+    instance Order[Path[a]] with Order[a] {
         pub def compare(x: Path[a], y: Path[a]): Comparison = match (x, y) {
-            case (Bot, Bot)           => Comparison.EqualTo
-            case (Bot, _)             => Comparison.LessThan
-            case (_, Bot)             => Comparison.GreaterThan
-            case (Path(xs), Path(ys)) => List.length(xs) <=> List.length(ys)
+            case (Bot, Bot)                 => Comparison.EqualTo
+            case (Bot, _)                   => Comparison.LessThan
+            case (_, Bot)                   => Comparison.GreaterThan
+            case (Path(list1), Path(list2)) => list1 <=> list2
         }
     }
 


### PR DESCRIPTION
The previous order defined paths to be equal if they had the same length. This was changed to a real total order.
Should not affect performance.