### PR TITLE
feat: postpone calling toCompletionItem

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
@@ -269,7 +269,11 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
 
     case Request.Complete(id, uri, pos) =>
       // Find the source of the given URI (which should always exist).
-      ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> CompletionProvider.autoComplete(uri, pos, currentErrors)(root, flix).toJSON)
+      val completions = CompletionProvider
+        .getCompletions(uri, pos, currentErrors)(root, flix)
+        .map(_.toCompletionItem(flix))
+      val completionList = CompletionList(isIncomplete = true, completions)
+      ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> completionList.toJSON)
 
     case Request.Highlight(id, uri, pos) =>
       val highlights = HighlightProvider.processHighlight(uri, pos)(root)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -38,15 +38,10 @@ import ca.uwaterloo.flix.language.errors.{ParseError, ResolutionError, TypeError
   */
 object CompletionProvider {
 
-  def autoComplete(uri: String, pos: Position, currentErrors: List[CompilationMessage])(implicit root: Root, flix: Flix): CompletionList = {
-      val items = getCompletions(uri, pos, currentErrors)(root, flix).map(_.toCompletionItem)
-      CompletionList(isIncomplete = true, items)
-  }
-
   /**
     * Returns all completions in the given `uri` at the given position `pos`.
     */
-  private def getCompletions(uri: String, pos: Position, currentErrors: List[CompilationMessage])(implicit root: Root, flix: Flix): List[Completion] = {
+  def getCompletions(uri: String, pos: Position, currentErrors: List[CompilationMessage])(implicit root: Root, flix: Flix): List[Completion] = {
     if (currentErrors.isEmpty)
       HoleCompleter.getHoleCompletion(uri, pos).toList
     else

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -141,13 +141,13 @@ class TestCompletionProvider extends AnyFunSuite {
     */
   private val Uri = "<test>"
 
-  test("No crashes when calling autoComplete anywhere") {
+  test("No crashes when calling getCompletions anywhere") {
     Programs.foreach(program => {
       val (root, errors) = compile(program)
       program.scanLeft(Position(1, 1))({
         case (Position(line, _), '\n') => Position(line + 1, 1)
         case (Position(line, col), _) => Position(line, col + 1)
-      }).foreach(pos => CompletionProvider.autoComplete(Uri, pos, errors)(root, Flix))
+      }).foreach(pos => CompletionProvider.getCompletions(Uri, pos, errors)(root, Flix).map(_.toCompletionItem(Flix)))
     })
   }
 
@@ -159,7 +159,7 @@ class TestCompletionProvider extends AnyFunSuite {
       keywordTokens.foreach { token =>
         // We will test all possible offsets in the keyword, including the start and end of the keyword
         getAllPositionsWithinToken(token).foreach { pos =>
-          val completions = CompletionProvider.autoComplete(Uri, pos, errors)(root, Flix)
+          val completions = CompletionProvider.getCompletions(Uri, pos, errors)(root, Flix).map(_.toCompletionItem(Flix))
           assertEmpty(completions, token.mkSourceLocation(), pos)
         }
       }
@@ -175,7 +175,7 @@ class TestCompletionProvider extends AnyFunSuite {
       literalTokens.foreach { token =>
         // We will test all possible offsets in the keyword, including the start and end of the keyword
         getAllPositionsWithinToken(token).foreach { pos =>
-          val completions = CompletionProvider.autoComplete(Uri, pos, errors)(root, Flix)
+          val completions = CompletionProvider.getCompletions(Uri, pos, errors)(root, Flix).map(_.toCompletionItem(Flix))
           assertEmpty(completions, token.mkSourceLocation(), pos)
         }
       }
@@ -191,7 +191,7 @@ class TestCompletionProvider extends AnyFunSuite {
       commentTokens.foreach { token =>
         // We will test all possible offsets in the keyword, including the start and end of the keyword
         getAllPositionsWithinToken(token).foreach { pos =>
-          val completions = CompletionProvider.autoComplete(Uri, pos, errors)(root, Flix)
+          val completions = CompletionProvider.getCompletions(Uri, pos, errors)(root, Flix).map(_.toCompletionItem(Flix))
           assertEmpty(completions, token.mkSourceLocation(), pos)
         }
       }
@@ -203,7 +203,7 @@ class TestCompletionProvider extends AnyFunSuite {
       val (root, errors) = compile(program)
       val allNameDefLocs = root.defs.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
       allNameDefLocs.foreach{ loc =>
-        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, Flix)
+        val completions = CompletionProvider.getCompletions(Uri, Position.from(loc.sp2), errors)(root, Flix).map(_.toCompletionItem(Flix))
         assertEmpty(completions, loc, Position.from(loc.sp2))
       }
     })
@@ -214,7 +214,7 @@ class TestCompletionProvider extends AnyFunSuite {
       val (root, errors) = compile(program)
       val allNameDefLocs = root.enums.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
       allNameDefLocs.foreach{ loc =>
-        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, Flix)
+        val completions = CompletionProvider.getCompletions(Uri, Position.from(loc.sp2), errors)(root, Flix).map(_.toCompletionItem(Flix))
         assertEmpty(completions, loc, Position.from(loc.sp2))
       }
     })
@@ -225,7 +225,7 @@ class TestCompletionProvider extends AnyFunSuite {
       val (root, errors) = compile(program)
       val allNameDefLocs = root.sigs.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
       allNameDefLocs.foreach{ loc =>
-        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, Flix)
+        val completions = CompletionProvider.getCompletions(Uri, Position.from(loc.sp2), errors)(root, Flix).map(_.toCompletionItem(Flix))
         assertEmpty(completions, loc, Position.from(loc.sp2))
       }
     })
@@ -236,7 +236,7 @@ class TestCompletionProvider extends AnyFunSuite {
       val (root, errors) = compile(program)
       val allNameDefLocs = root.traits.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
       allNameDefLocs.foreach{ loc =>
-        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, Flix)
+        val completions = CompletionProvider.getCompletions(Uri, Position.from(loc.sp2), errors)(root, Flix).map(_.toCompletionItem(Flix))
         assertEmpty(completions, loc, Position.from(loc.sp2))
       }
     })
@@ -247,7 +247,7 @@ class TestCompletionProvider extends AnyFunSuite {
       val (root, errors) = compile(program)
       val allNameDefLocs = root.effects.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
       allNameDefLocs.foreach{ loc =>
-        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, Flix)
+        val completions = CompletionProvider.getCompletions(Uri, Position.from(loc.sp2), errors)(root, Flix).map(_.toCompletionItem(Flix))
         assertEmpty(completions, loc, Position.from(loc.sp2))
       }
     })
@@ -258,7 +258,7 @@ class TestCompletionProvider extends AnyFunSuite {
       val (root, errors) = compile(program)
       val allNameDefLocs = root.structs.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
       allNameDefLocs.foreach{ loc =>
-        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, Flix)
+        val completions = CompletionProvider.getCompletions(Uri, Position.from(loc.sp2), errors)(root, Flix).map(_.toCompletionItem(Flix))
         assertEmpty(completions, loc, Position.from(loc.sp2))
       }
     })
@@ -269,7 +269,7 @@ class TestCompletionProvider extends AnyFunSuite {
       val (root, errors) = compile(program)
       val allNameDefLocs = root.typeAliases.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
       allNameDefLocs.foreach{ loc =>
-        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, Flix)
+        val completions = CompletionProvider.getCompletions(Uri, Position.from(loc.sp2), errors)(root, Flix).map(_.toCompletionItem(Flix))
         assertEmpty(completions, loc, Position.from(loc.sp2))
       }
     })
@@ -285,7 +285,7 @@ class TestCompletionProvider extends AnyFunSuite {
           val alteredProgram = trimAfter(program, defSymUse.loc, charToTrim)
           val triggerPosition = Position(defSymUse.loc.sp2.lineOneIndexed, defSymUse.loc.sp2.colOneIndexed - charToTrim)
           val (root, errors) = compile(alteredProgram)
-          val completions = CompletionProvider.autoComplete(Uri, triggerPosition, errors)(root, Flix)
+          val completions = CompletionProvider.getCompletions(Uri, triggerPosition, errors)(root, Flix).map(_.toCompletionItem(Flix))
           assertNoDuplicatedCompletions(completions, defSymUse.sym.toString, defSymUse.loc, program, charToTrim)
         case _ => ()
       }
@@ -302,7 +302,7 @@ class TestCompletionProvider extends AnyFunSuite {
           val alteredProgram = trimAfter(program, loc, numToTrim)
           val triggerPosition = Position(loc.sp2.lineOneIndexed, loc.sp2.colOneIndexed - numToTrim)
           val (root, errors) = compile(alteredProgram)
-          val completions = CompletionProvider.autoComplete(Uri, triggerPosition, errors)(root, Flix)
+          val completions = CompletionProvider.getCompletions(Uri, triggerPosition, errors)(root, Flix).map(_.toCompletionItem(Flix))
           assertNoDuplicatedCompletions(completions, varSym.text, loc, program, numToTrim)
         case _ => ()
       }
@@ -312,25 +312,25 @@ class TestCompletionProvider extends AnyFunSuite {
   /**
     * Asserts that the given completion list is empty at the given position.
     */
-  private def assertEmpty(completions: CompletionList, sourceLocation: SourceLocation, pos: Position): Unit = {
-    if (completions.items.nonEmpty) {
+  private def assertEmpty(completions: List[CompletionItem], sourceLocation: SourceLocation, pos: Position): Unit = {
+    if (completions.nonEmpty) {
       println(code(sourceLocation, s"Unexpected completions at $pos"))
-      println(s"Found completions: ${completions.items.map(_.label)}")
-      fail(s"Expected no completions at position $pos, but found ${completions.items.toList.length} completions.")
+      println(s"Found completions: ${completions.map(_.label)}")
+      fail(s"Expected no completions at position $pos, but found ${completions.length} completions.")
     }
   }
 
   /**
     * Asserts that there are no duplicated completions in the given completion list.
     *
-    * @param completions The completion list to check.
+    * @param completions The CompletionItem list to check.
     * @param codeLoc     The source location of the code that we are changing.
     * @param codeText    The text of the code that we are changing.
     * @param program     The original program string.
     */
-  private def assertNoDuplicatedCompletions(completions: CompletionList, codeText: String, codeLoc: SourceLocation, program: String, charToTrim: Int): Unit = {
+  private def assertNoDuplicatedCompletions(completions: List[CompletionItem], codeText: String, codeLoc: SourceLocation, program: String, charToTrim: Int): Unit = {
     // Two completion items are identical if all the immediately visible fields are identical.
-    completions.items.groupBy(item => (item.label, item.kind, item.labelDetails)).foreach {
+    completions.groupBy(item => (item.label, item.kind, item.labelDetails)).foreach {
       case (completion, duplicates) if duplicates.size > 1 =>
         println(s"Duplicated completions when selecting var \"$codeText\" at $codeLoc for program:\n $program")
         println(code(codeLoc, s"""Duplicated completion with label "${completion._1}" after deleting $charToTrim char here"""))


### PR DESCRIPTION
related to #10477

We just cancel `autoComplete` and distribute `toCompletionItem` to all call sites.