### PR TITLE
feat: add support for `ExtensibleMatch` to frontend

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -361,7 +361,12 @@ object Visitor {
 
       case Expr.RestrictableChoose(_, _, _, _, _, _) => () // Not visited, unsupported feature.
 
-      case Expr.ExtensibleMatch(_, _, _, _, _, _, _, _, _) => () // TODO: Ext-Variants
+      case Expr.ExtensibleMatch(_, exp1, bnd1, exp2, bnd2, exp3, _, _, _) =>
+        visitExpr(exp1)
+        visitBinder(bnd1)
+        visitExpr(exp2)
+        visitBinder(bnd2)
+        visitExpr(exp3)
 
       case Expr.Tag(symUse, exps, _, _, _) =>
         visitCaseSymUse(symUse)
@@ -369,7 +374,8 @@ object Visitor {
 
       case Expr.RestrictableTag(_, _, _, _, _) => () // Not visited, unsupported feature.
 
-      case Expr.ExtensibleTag(_, _, _, _, _) => () // TODO: Ext-Variants
+      case Expr.ExtensibleTag(_, exps, _, _, _) =>
+        exps.foreach(visitExpr)
 
       case Expr.Tuple(exps, _, _, _) =>
         exps.foreach(visitExpr)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -501,11 +501,11 @@ object SemanticTokensProvider {
           acc ++ visitRestrictableChoosePat(pat) ++ visitExp(exp)
       }
 
-    case Expr.ExtensibleMatch(_, exp1, bnd1, exp2, bnd2, exp3, _, _, _) =>
-      val o1 = getSemanticTokenType(bnd1.sym, exp1.tpe)
-      val o2 = getSemanticTokenType(bnd2.sym, exp1.tpe)
-      val t1 = SemanticToken(o1, Nil, bnd1.sym.loc)
-      val t2 = SemanticToken(o2, Nil, bnd2.sym.loc)
+    case Expr.ExtensibleMatch(_, exp1, bnd2, exp2, bnd3, exp3, _, _, _) =>
+      val o1 = getSemanticTokenType(bnd2.sym, exp1.tpe)
+      val o2 = getSemanticTokenType(bnd3.sym, exp1.tpe)
+      val t1 = SemanticToken(o1, Nil, bnd2.sym.loc)
+      val t2 = SemanticToken(o2, Nil, bnd3.sym.loc)
       Iterator(t1) ++ Iterator(t2) ++ visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
 
     case Expr.Tag(CaseSymUse(_, loc), exps, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -121,7 +121,7 @@ object DesugaredAst {
 
     case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
 
-    case class ExtensibleMatch(label: Name.Label, exp1: Expr, ident1: Name.Ident, exp2: Expr, ident2: Name.Ident, exp3: Expr, loc: SourceLocation) extends Expr
+    case class ExtensibleMatch(label: Name.Label, exp1: Expr, ident2: Name.Ident, exp2: Expr, ident3: Name.Ident, exp3: Expr, loc: SourceLocation) extends Expr
 
     case class ExtensibleTag(label: Name.Label, exps: List[Expr], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -121,6 +121,8 @@ object DesugaredAst {
 
     case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
 
+    case class ExtensibleMatch(label: Name.Label, exp1: Expr, ident1: Name.Ident, exp2: Expr, ident2: Name.Ident, exp3: Expr, loc: SourceLocation) extends Expr
+
     case class ExtensibleTag(label: Name.Label, exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class Tuple(exps: List[Expr], loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -119,6 +119,8 @@ object KindedAst {
 
     case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], tvar: Type.Var, loc: SourceLocation) extends Expr
 
+    case class ExtensibleMatch(label: Name.Label, exp1: Expr, sym2: Symbol.VarSym, exp2: Expr, sym3: Symbol.VarSym, exp3: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
+
     case class Tag(symUse: CaseSymUse, exps: List[Expr], tvar: Type.Var, loc: SourceLocation) extends Expr
 
     case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Expr], isOpen: Boolean, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -134,6 +134,8 @@ object NamedAst {
 
     case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
 
+    case class ExtensibleMatch(label: Name.Label, exp1: Expr, sym2: Symbol.VarSym, exp2: Expr, sym3: Symbol.VarSym, exp3: Expr, loc: SourceLocation) extends Expr
+
     case class ExtensibleTag(label: Name.Label, exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class Tuple(exps: List[Expr], loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -136,6 +136,8 @@ object ResolvedAst {
 
     case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
 
+    case class ExtensibleMatch(label: Name.Label, exp1: Expr, sym2: Symbol.VarSym, exp2: Expr, sym3: Symbol.VarSym, exp3: Expr, loc: SourceLocation) extends Expr
+
     case class Tag(symUse: CaseSymUse, exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Expr], isOpen: Boolean, loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -194,6 +194,8 @@ object SyntaxTree {
 
       case object CheckedTypeCast extends Expr
 
+      case object ExtensibleMatch extends Expr
+
       case object ExtensibleTag extends Expr
 
       case object Index extends Expr

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -143,6 +143,7 @@ sealed trait TokenKind {
       case TokenKind.KeywordWithout => "'without'"
       case TokenKind.KeywordYield => "'yield'"
       case TokenKind.KeywordXor => "'xor'"
+      case TokenKind.KeywordXmatch => "'xmatch'"
       case TokenKind.KeywordXvar => "'xvar'"
       case TokenKind.ListHash => "'List#'"
       case TokenKind.MapHash => "'Map#'"
@@ -295,6 +296,7 @@ sealed trait TokenKind {
     case TokenKind.KeywordWithout => true
     case TokenKind.KeywordYield => true
     case TokenKind.KeywordXor => true
+    case TokenKind.KeywordXmatch => true
     case TokenKind.KeywordXvar => true
     case TokenKind.Ampersand
          | TokenKind.AngleL
@@ -523,6 +525,8 @@ sealed trait TokenKind {
          | TokenKind.KeywordUnsafe
          | TokenKind.KeywordUnsafely
          | TokenKind.KeywordUse
+         | TokenKind.KeywordXmatch
+         | TokenKind.KeywordXvar
          | TokenKind.ListHash
          | TokenKind.LiteralBigDecimal
          | TokenKind.LiteralBigInt
@@ -627,7 +631,6 @@ sealed trait TokenKind {
          | TokenKind.KeywordWith
          | TokenKind.KeywordWithout
          | TokenKind.KeywordXor
-         | TokenKind.KeywordXvar
          | TokenKind.KeywordYield
          | TokenKind.LiteralDebugStringR
          | TokenKind.LiteralStringInterpolationR
@@ -1059,6 +1062,8 @@ object TokenKind {
   case object KeywordYield extends TokenKind
 
   case object KeywordXor extends TokenKind
+
+  case object KeywordXmatch extends TokenKind
 
   case object KeywordXvar extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -981,7 +981,7 @@ object Type {
   }
 
   /**
-    * Constructs a Variant type.
+    * Constructs an Extensible Variant type.
     */
   def mkExtensible(tpe: Type, loc: SourceLocation): Type = {
     Apply(Type.Cst(TypeConstructor.Extensible, loc), tpe, loc)

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -983,7 +983,7 @@ object Type {
   /**
     * Constructs a Variant type.
     */
-  def mkVariant(tpe: Type, loc: SourceLocation): Type = {
+  def mkExtensible(tpe: Type, loc: SourceLocation): Type = {
     Apply(Type.Cst(TypeConstructor.Extensible, loc), tpe, loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -125,7 +125,7 @@ object WeededAst {
 
     case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
 
-    case class ExtensibleMatch(ident: Name.Ident, exp1: Expr, ident1: Name.Ident, exp2: Expr, ident2: Name.Ident, exp3: Expr, loc: SourceLocation) extends Expr
+    case class ExtensibleMatch(ident1: Name.Ident, exp1: Expr, ident2: Name.Ident, exp2: Expr, ident3: Name.Ident, exp3: Expr, loc: SourceLocation) extends Expr
 
     case class ApplicativeFor(frags: List[ForFragment.Generator], exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -125,6 +125,8 @@ object WeededAst {
 
     case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
 
+    case class ExtensibleMatch(ident: Name.Ident, exp1: Expr, ident1: Name.Ident, exp2: Expr, ident2: Name.Ident, exp3: Expr, loc: SourceLocation) extends Expr
+
     case class ApplicativeFor(frags: List[ForFragment.Generator], exp: Expr, loc: SourceLocation) extends Expr
 
     case class ForEach(frags: List[ForFragment], exp: Expr, loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -70,6 +70,7 @@ object ResolvedAstPrinter {
       case ResolvedAst.TypeMatchRule(sym, tpe, exp, loc) => (printVarSym(sym), UnkindedTypePrinter.print(tpe), print(exp))
     })
     case Expr.RestrictableChoose(_, _, _, _) => DocAst.Expr.Unknown
+    case Expr.ExtensibleMatch(_, _, _, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.Tag(symUse, exps, _) => DocAst.Expr.Tag(symUse.sym, exps.map(print))
     case Expr.RestrictableTag(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.ExtensibleTag(label, exps, loc) => DocAst.Expr.Unknown // TODO: Ext-Variants

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -568,6 +568,13 @@ object Desugar {
       val rs = rules.map(visitRestrictableChooseRule)
       Expr.RestrictableChoose(star, e, rs, loc)
 
+    case WeededAst.Expr.ExtensibleMatch(ident, exp1, ident1, exp2, ident2, exp3, loc) =>
+      val label = Name.mkLabel(ident)
+      val e1 = visitExp(exp1)
+      val e2 = visitExp(exp2)
+      val e3 = visitExp(exp3)
+      Expr.ExtensibleMatch(label, e1, ident1, e2, ident2, e3, loc)
+
     case WeededAst.Expr.ApplicativeFor(frags, exp, loc) =>
       desugarApplicativeFor(frags, exp, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -568,12 +568,12 @@ object Desugar {
       val rs = rules.map(visitRestrictableChooseRule)
       Expr.RestrictableChoose(star, e, rs, loc)
 
-    case WeededAst.Expr.ExtensibleMatch(ident, exp1, ident1, exp2, ident2, exp3, loc) =>
-      val label = Name.mkLabel(ident)
+    case WeededAst.Expr.ExtensibleMatch(ident1, exp1, ident2, exp2, ident3, exp3, loc) =>
+      val label = Name.mkLabel(ident1)
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      Expr.ExtensibleMatch(label, e1, ident1, e2, ident2, e3, loc)
+      Expr.ExtensibleMatch(label, e1, ident2, e2, ident3, e3, loc)
 
     case WeededAst.Expr.ApplicativeFor(frags, exp, loc) =>
       desugarApplicativeFor(frags, exp, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -459,6 +459,13 @@ object Kinder {
       val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
       KindedAst.Expr.RestrictableChoose(star, exp, rules, tvar, loc)
 
+    case ResolvedAst.Expr.ExtensibleMatch(label, exp1, sym2, exp2, sym3, exp3, loc) =>
+      val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
+      val e1 = visitExp(exp1, kenv0, taenv, root)
+      val e2 = visitExp(exp2, kenv0, taenv, root)
+      val e3 = visitExp(exp3, kenv0, taenv, root)
+      KindedAst.Expr.ExtensibleMatch(label, e1, sym2, e2, sym3, e3, tvar, loc)
+
     case ResolvedAst.Expr.Tag(symUse, exps0, loc) =>
       val exps = exps0.map(visitExp(_, kenv0, taenv, root))
       val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -423,6 +423,7 @@ object Lexer {
       case _ if isKeyword("without") => TokenKind.KeywordWithout
       case _ if isKeyword("yield") => TokenKind.KeywordYield
       case _ if isKeyword("xor") => TokenKind.KeywordXor
+      case _ if isKeyword("xmatch") => TokenKind.KeywordXmatch
       case _ if isKeyword("xvar") => TokenKind.KeywordXvar
       case _ if isKeyword("Set#") => TokenKind.SetHash
       case _ if isKeyword("Array#") => TokenKind.ArrayHash

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -663,6 +663,14 @@ object Namer {
       val rs = rules.map(visitRestrictableChooseRule)
       NamedAst.Expr.RestrictableChoose(star, e, rs, loc)
 
+    case DesugaredAst.Expr.ExtensibleMatch(label, exp1, ident2, exp2, ident3, exp3, loc) =>
+      val sym2 = Symbol.freshVarSym(ident2, BoundBy.Pattern)
+      val sym3 = Symbol.freshVarSym(ident3, BoundBy.Pattern)
+      val e1 = visitExp(exp1)
+      val e2 = visitExp(exp2)
+      val e3 = visitExp(exp3)
+      NamedAst.Expr.ExtensibleMatch(label, e1, sym2, e2, sym3, e3, loc)
+
     case DesugaredAst.Expr.ExtensibleTag(label, exps, loc) =>
       val es = exps.map(visitExp(_))
       NamedAst.Expr.ExtensibleTag(label, es, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1667,6 +1667,7 @@ object Parser2 {
         case TokenKind.KeywordDebug
              | TokenKind.KeywordDebugBang
              | TokenKind.KeywordDebugBangBang => debugExpr()
+        case TokenKind.KeywordXmatch => extensibleMatchExpr()
         case TokenKind.KeywordXvar => extensibleTagExpr()
         case t =>
           val mark = open()
@@ -1823,6 +1824,34 @@ object Parser2 {
           expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
           close(mark, TreeKind.Expr.Paren)
       }
+    }
+
+    private def extensibleMatchExpr()(implicit s: State): Mark.Closed = {
+      assert(at(TokenKind.KeywordXmatch))
+      val mark = open()
+      expect(TokenKind.KeywordXmatch, SyntacticContext.Expr.OtherExpr)
+      expression()
+      expect(TokenKind.KeywordWith, SyntacticContext.Expr.OtherExpr)
+      nameUnqualified(NAME_TAG, SyntacticContext.Expr.OtherExpr)
+
+      expect(TokenKind.CurlyL)
+      val case1 = open()
+      expect(TokenKind.KeywordCase)
+      nameUnqualified(NAME_VARIABLE, SyntacticContext.Expr.OtherExpr)
+      expect(TokenKind.ArrowThickR)
+      expression()
+      close(case1, TreeKind.Case)
+
+      val case2 = open()
+      expect(TokenKind.KeywordCase)
+      nameUnqualified(NAME_VARIABLE, SyntacticContext.Expr.OtherExpr)
+      expect(TokenKind.ArrowThickR)
+      expression()
+      close(case2, TreeKind.Case)
+
+      expect(TokenKind.CurlyR)
+
+      close(mark, TreeKind.Expr.ExtensibleMatch)
     }
 
     private def extensibleTagExpr()(implicit s: State): Mark.Closed = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1059,6 +1059,12 @@ object Resolver {
         case (e, rs) => ResolvedAst.Expr.RestrictableChoose(star, e, rs, loc)
       }
 
+    case NamedAst.Expr.ExtensibleMatch(label, exp1, sym2, exp2, sym3, exp3, loc) =>
+      mapN(resolveExp(exp1, scp0), resolveExp(exp2, scp0 ++ mkVarScp(sym2)), resolveExp(exp3, scp0 ++ mkVarScp(sym3))) {
+        case (e1, e2, e3) =>
+          ResolvedAst.Expr.ExtensibleMatch(label, e1, sym2, e2, sym3, e3, loc)
+      }
+
     case NamedAst.Expr.ExtensibleTag(label, exps, loc) =>
       val esVal = traverse(exps)(e => resolveExp(e, scp0))
       mapN(esVal) {

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -245,6 +245,9 @@ object TypeReconstruction {
       val eff = Type.mkUnion(rs.map(_.exp.eff), loc)
       TypedAst.Expr.RestrictableChoose(star, e, rs, subst(tvar), eff, loc)
 
+    case KindedAst.Expr.ExtensibleMatch(label, exp1, sym2, exp2, sym3, exp3, tvar, loc) =>
+      ??? // TODO: Ext-Var
+
     case KindedAst.Expr.Tag(symUse, exps, tvar, loc) =>
       val es = exps.map(visitExp)
       val eff = Type.mkUnion(es.map(_.eff), loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -246,7 +246,14 @@ object TypeReconstruction {
       TypedAst.Expr.RestrictableChoose(star, e, rs, subst(tvar), eff, loc)
 
     case KindedAst.Expr.ExtensibleMatch(label, exp1, sym2, exp2, sym3, exp3, tvar, loc) =>
-      ??? // TODO: Ext-Var
+      val e1 = visitExp(exp1)
+      val e2 = visitExp(exp2)
+      val e3 = visitExp(exp3)
+      val b2 = TypedAst.Binder(sym2, subst(sym2.tvar))
+      val b3 = TypedAst.Binder(sym3, subst(sym3.tvar))
+      val tpe = subst(tvar)
+      val eff = Type.mkUnion(e1.eff, e2.eff, e3.eff, loc)
+      TypedAst.Expr.ExtensibleMatch(label, e1, b2, e2, b3, e3, tpe, eff, loc)
 
     case KindedAst.Expr.Tag(symUse, exps, tvar, loc) =>
       val es = exps.map(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -895,6 +895,7 @@ object Weeder2 {
         case TreeKind.Expr.FixpointSolveWithProject => visitFixpointSolveExpr(tree)
         case TreeKind.Expr.FixpointQuery => visitFixpointQueryExpr(tree)
         case TreeKind.Expr.Debug => visitDebugExpr(tree)
+        case TreeKind.Expr.ExtensibleMatch => visitExtensibleMatch(tree)
         case TreeKind.Expr.ExtensibleTag => visitExtensibleTag(tree)
         case TreeKind.Expr.Intrinsic =>
           // Intrinsics must be applied to check that they have the right amount of arguments.
@@ -1533,6 +1534,23 @@ object Weeder2 {
               Validation.Success((e, Expr.Error(error)))
           }
           mapN(exprs)(exprs => Expr.LetMatch(pattern, tpe, exprs._1, exprs._2, tree.loc))
+      }
+    }
+
+    private def visitExtensibleMatch(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
+      def visitCase(caze: Tree): Validation[(Name.Ident, Expr), CompilationMessage] =
+        mapN(pickNameIdent(caze), pickExpr(caze)) {
+          case (id, e) => (id, e)
+        }
+
+      expect(tree, TreeKind.Expr.ExtensibleMatch)
+
+      // TODO: Ext-Var
+      mapN(pickExpr(tree), pickNameIdent(tree), traverse(pickAll(TreeKind.Case, tree))(visitCase)) {
+        case (exp1, label, (ident2, exp2) :: (ident3, exp3) :: Nil) =>
+          Expr.ExtensibleMatch(label, exp1, ident2, exp2, ident3, exp3, tree.loc)
+        case _ =>
+          throw InternalCompilerException("Illegal extensible match", tree.loc)
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1545,7 +1545,6 @@ object Weeder2 {
 
       expect(tree, TreeKind.Expr.ExtensibleMatch)
 
-      // TODO: Ext-Var
       mapN(pickExpr(tree), pickNameIdent(tree), traverse(pickAll(TreeKind.Case, tree))(visitCase)) {
         case (exp1, label, (ident2, exp2) :: (ident3, exp3) :: Nil) =>
           Expr.ExtensibleMatch(label, exp1, ident2, exp2, ident3, exp3, tree.loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -480,7 +480,7 @@ object ConstraintGen {
         val pred = Name.Pred(label.name, label.loc)
         val (tpes, effs) = exps.map(visitExp).unzip
         val rest = Type.freshVar(Kind.SchemaRow, loc)
-        val tpe = Type.mkRelation(tpes, loc) // TODO: Ext-Var
+        val tpe = Type.mkRelation(tpes, loc)
         val row = Type.mkSchemaRowExtend(pred, tpe, rest, loc)
         val tagType = Type.mkExtensible(row, loc)
         c.unifyType(tvar, tagType, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -439,6 +439,9 @@ object ConstraintGen {
 
       case e: Expr.RestrictableChoose => RestrictableChooseConstraintGen.visitRestrictableChoose(e)
 
+      case Expr.ExtensibleMatch(label, exp1, sym2, exp2, sym3, exp3, tvar, loc) =>
+        ??? // TODO: Ext-Var
+
       case KindedAst.Expr.Tag(symUse, exps, tvar, loc) =>
         val decl = root.enums(symUse.sym.enumSym)
         val caze = decl.cases(symUse.sym)


### PR DESCRIPTION
```
def main(): Unit =
    let b = foo("bac");
    xmatch b with Foo {
        case x => x + 1
        case y => 2
    };
    ()

def foo(n: Int32): XVar[#(Foo(Int32))] = xvar Foo(n)
```