### PR TITLE
feat: consider local def as direct call in `Inliner`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -532,8 +532,9 @@ object Inliner {
     * Returns `true` if `exp0` is a function call with trivial arguments.
     */
   private def isDirectCall(exp0: MonoAst.Expr): Boolean = exp0 match {
-    case MonoAst.Expr.ApplyDef(_, exps, _, _, _, _) => exps.forall(isTrivial)
-    case MonoAst.Expr.ApplyClo(exp1, exp2, _, _, _) => isTrivial(exp1) && isTrivial(exp2)
+    case Expr.ApplyDef(_, exps, _, _, _, _) => exps.forall(isTrivial)
+    case Expr.ApplyClo(exp1, exp2, _, _, _) => isTrivial(exp1) && isTrivial(exp2)
+    case Expr.LocalDef(_, _, _, Expr.ApplyLocalDef(_, exps, _, _, _), _, _, _, _) => exps.forall(isTrivial)
     case _ => false
   }
 


### PR DESCRIPTION
This change makes it so that the inliner accounts for the fact that local defs are lifted at a later stage. Thus, it is okay to inline a function that simply defines a local def and immediately invokes it.