### PR TITLE
feat: only reduce lambda if single action

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -181,7 +181,7 @@ object Inliner {
 
     case Expr.ApplyClo(exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1, ctx0) match {
-        case Expr.Lambda(fparam, e1, _, _) =>
+        case Expr.Lambda(fparam, e1, _, _) if isSingleAction(e1) =>
           sctx.changed.putIfAbsent(sym0, ())
           val e2 = visitExp(exp2, ctx0)
           bindArgs(e1, List(fparam), List(e2), loc, ctx0)


### PR DESCRIPTION
I will benchmark this, but my hope is that it leads to smaller code size since some lambdas are not expanded. This is also more in-line with the idea that we should remove function calls that are easy to remove / add overhead to simple expressions.