### PR TITLE
chore: remove unused code in `MonoAst`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -233,15 +233,14 @@ object MonoAst {
   }
 
   /**
-    * A [[DefContext]] contains various pieces of information on a function that are relevant for making an inlining decision.
+    * A [[DefContext]] contains information relevant for inlining.
     *
-    * @param localDefs the number of local defs defined in a function.
-    * @param isSelfRef true if a function body expression refers to the function itself.
+    * @param isSelfRef true if a def refers to itself.
     */
-  case class DefContext(localDefs: Int, isSelfRef: Boolean)
+  case class DefContext(isSelfRef: Boolean)
 
   object DefContext {
-    val Unknown: DefContext = DefContext(localDefs = 0, isSelfRef = false)
+    val Unknown: DefContext = DefContext(isSelfRef = false)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -46,7 +46,7 @@ object OccurrenceAnalyzer {
   private def visitDef(defn: MonoAst.Def): MonoAst.Def = {
     val lctx: LocalContext = LocalContext.mk()
     val (exp, ctx) = visitExp(defn.exp)(defn.sym, lctx)
-    val defContext = DefContext(lctx.localDefs.get(), isSelfRef(ctx.selfOccur))
+    val defContext = DefContext(isSelfRef(ctx.selfOccur))
     val fparams = defn.spec.fparams.map(visitFormalParam(_, ctx))
     val spec = defn.spec.copy(fparams = fparams, defContext = defContext)
     MonoAst.Def(defn.sym, spec, exp, defn.loc)
@@ -139,7 +139,6 @@ object OccurrenceAnalyzer {
         val ctx5 = combineSeq(ctx3, ctx4)
         val occur = ctx5.get(sym)
         val ctx6 = ctx5.removeVar(sym)
-        lctx.localDefs.incrementAndGet()
         if ((e1 eq exp1) && (e2 eq exp2) && fparams.zip(fps).forall { case (fp1, fp2) => fp1 eq fp2 } && (occur eq occur0)) {
           (exp0, ctx6) // Reuse exp0.
         } else {
@@ -540,17 +539,10 @@ object OccurrenceAnalyzer {
     /**
       * Returns a fresh [[LocalContext]].
       */
-    def mk(): LocalContext = new LocalContext(new AtomicInteger(0))
+    def mk(): LocalContext = new LocalContext()
 
   }
 
-  /**
-    * A local context, scoped for each function definition.
-    * No requirements on thread-safety since it is scoped.
-    *
-    * @param localDefs The number of declared [[Expr.LocalDef]]s in the expression.
-    *                  Must be mutable.
-    */
-  private case class LocalContext(localDefs: AtomicInteger)
+  private case class LocalContext()
 
 }


### PR DESCRIPTION
I left `LocalContext` because I think you will soon use it.