### PR TITLE
refactor: rewrite red-black tree insert, insertWith and updateWith

### DIFF
--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -168,16 +168,16 @@ mod RedBlackTree {
     /// Otherwise, updates `t` with `k => v`.
     ///
     pub def insert(k: k, v: v, t: RedBlackTree[k, v]): RedBlackTree[k, v] with Order[k] =
-        def loop(tt, sk) = match tt {
-            case Leaf                  => sk(Node(Color.Red, Leaf, k, v, Leaf))
+        def loop(tt) = match tt {
+            case Leaf => Node(Color.Red, Leaf, k, v, Leaf)
             case Node(c, a, k1, v1, b) => match k <=> k1 {
-                case Comparison.LessThan    => loop(a, ks -> sk(balance(Node(c, ks, k1, v1, b))))
-                case Comparison.EqualTo     => sk(Node(c, a, k, v, b))
-                case Comparison.GreaterThan => loop(b, ks -> sk(balance(Node(c, a, k1, v1, ks))))
+                case Comparison.LessThan    => balance(Node(c, loop(a), k1, v1, b))
+                case Comparison.EqualTo     => Node(c, a, k, v, b)
+                case Comparison.GreaterThan => balance(Node(c, a, k1, v1, loop(b)))
             }
-            case _ => sk(tt)
+            case _ => unreachable!()
         };
-        blacken(loop(t, identity))
+        blacken(loop(t))
 
     ///
     /// Updates `t` with `k => f(k, v, v1)` if `k => v1` is in `t`.

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -185,16 +185,16 @@ mod RedBlackTree {
     /// Otherwise, updates `t` with `k => v`.
     ///
     pub def insertWith(f: (k, v, v) -> v \ ef, k: k, v: v, t: RedBlackTree[k, v]): RedBlackTree[k, v] \ ef with Order[k] =
-        def loop(tt, sk) = match tt {
-            case Leaf                  => sk(Node(Color.Red, Leaf, k, v, Leaf))
+        def loop(tt) = match tt {
+            case Leaf                  => Node(Color.Red, Leaf, k, v, Leaf)
             case Node(c, a, k1, v1, b) => match k <=> k1 {
-                case Comparison.LessThan    => loop(a, ks -> sk(balance(Node(c, ks, k1, v1, b))))
-                case Comparison.EqualTo     => sk(Node(c, a, k, f(k, v, v1), b))
-                case Comparison.GreaterThan => loop(b, ks -> sk(balance(Node(c, a, k1, v1, ks))))
+                case Comparison.LessThan    => balance(Node(c, loop(a), k1, v1, b))
+                case Comparison.EqualTo     => Node(c, a, k, f(k, v, v1), b)
+                case Comparison.GreaterThan => balance(Node(c, a, k1, v1, loop(b)))
             }
-            case _ => sk(tt)
+            case _ => unreachable!()
         };
-        blacken(loop(t, identity))
+        blacken(loop(t))
 
     ///
     /// Updates `t` with `k => v1` if `k => v` is in `t` and `f(k, v) = Some(v1)`.
@@ -202,19 +202,19 @@ mod RedBlackTree {
     /// Otherwise, returns `t`.
     ///
     pub def updateWith(f: (k, v) -> Option[v] \ ef, k: k, t: RedBlackTree[k, v]): RedBlackTree[k, v] \ ef with Order[k] =
-        def loop(tt, sk) = match tt {
-            case Leaf                  => sk(tt)
+        def loop(tt) = match tt {
+            case Leaf                  => Leaf
             case Node(c, a, k1, v1, b) => match k <=> k1 {
-                case Comparison.LessThan => loop(a, ks -> sk(balance(Node(c, ks, k1, v1, b))))
+                case Comparison.LessThan => balance(Node(c, loop(a), k1, v1, b))
                 case Comparison.EqualTo  => match f(k1, v1) {
-                    case None    => sk(tt)
-                    case Some(v) => sk(Node(c, a, k, v, b))
+                    case None    => tt
+                    case Some(v) => Node(c, a, k, v, b)
                 }
-                case Comparison.GreaterThan => loop(b, ks -> sk(balance(Node(c, a, k1, v1, ks))))
+                case Comparison.GreaterThan => balance(Node(c, a, k1, v1, loop(b)))
             }
-            case _ => sk(tt)
+            case _ => unreachable!()
         };
-        blacken(loop(t, identity))
+        blacken(loop(t))
 
     ///
     /// Removes `k => v` from `t` if `t` contains the key `k`.

--- a/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
@@ -198,6 +198,96 @@ mod TestRedBlackTree {
             List.map(_ -> rnd.nextInt(), List.range(0, n)))
     }
 
+    /////////////////////////////////////////////////////////////////////////////
+    // insert                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def insert01(): Bool =
+        let tree = (RedBlackTree.empty(): RedBlackTree[Int32, Int32]) |>
+            RedBlackTree.insert(0, 1);
+        RedBlackTree.get(0, tree) == Some(1) and
+            RedBlackTree.get(1, tree) == None
+
+    @test
+    def insert02(): Bool =
+        let tree = (RedBlackTree.empty(): RedBlackTree[Int32, Int32]) |>
+            RedBlackTree.insert(0, 1) |>
+            RedBlackTree.insert(1, 2);
+        RedBlackTree.get(0, tree) == Some(1) and
+            RedBlackTree.get(1, tree) == Some(2) and
+            RedBlackTree.get(2, tree) == None
+
+    @test
+    def insert03(): Bool =
+        let inserts = Vector#{(0, 1), (3, 4), (4, 5), (1, 2), (8, 9), (6, 7), (2, 3), (10, 11), (9, 10)};
+        let tree = inserts |> Vector.foldRight(match (k, v) -> RedBlackTree.insert(k, v), RedBlackTree.empty());
+        inserts |> Vector.forAll(match (k, v) -> RedBlackTree.get(k, tree) == Some(v))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // insertWith                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def insertWith01(): Bool =
+        let tree = (RedBlackTree.empty(): RedBlackTree[Int32, Int32]) |>
+            RedBlackTree.insertWith(_k -> _v -> _v1 -> -1, 0, 1);
+        RedBlackTree.get(0, tree) == Some(1) and
+            RedBlackTree.get(1, tree) == None
+
+    @test
+    def insertWith02(): Bool =
+        let tree = (RedBlackTree.empty(): RedBlackTree[Int32, Int32]) |>
+            RedBlackTree.insert(1, 10) |>
+            RedBlackTree.insertWith(k -> v -> v1 -> k + v + v1, 1, 100);
+        RedBlackTree.get(1, tree) == Some(1 + 10 + 100) and
+            RedBlackTree.get(0, tree) == None
+
+    @test
+    def insertWith03(): Bool =
+        let inserts = Vector#{(0, 1), (3, 4), (4, 5), (1, 2), (8, 9), (6, 7), (2, 3), (10, 11), (9, 10)};
+        let (kept, overWrite) = Vector.splitAt(Vector.length(inserts), inserts);
+        let treeWithInserts = inserts |> Vector.foldRight(match (k, v) -> RedBlackTree.insert(k, v), RedBlackTree.empty());
+        let treeWithUpdates = overWrite |> Vector.foldRight(match (k, _) -> RedBlackTree.insertWith(k_ -> v -> v1 -> k_ + v + v1, -1, k), treeWithInserts);
+        kept |> Vector.forAll(match (k, v) -> RedBlackTree.get(k, treeWithUpdates) == Some(v)) and
+            overWrite |> Vector.forAll(match (k, v) -> RedBlackTree.get(k, treeWithUpdates) == Some(k + v - 1))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // updateWith                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def updateWith01(): Bool =
+        let tree = (RedBlackTree.empty(): RedBlackTree[Int32, Int32]) |>
+            RedBlackTree.updateWith(_k -> _v -> Some(1), 0);
+        RedBlackTree.get(0, tree) == None and
+            RedBlackTree.get(1, tree) == None
+
+    @test
+    def updateWith02(): Bool =
+        let tree = (RedBlackTree.empty(): RedBlackTree[Int32, Int32]) |>
+            RedBlackTree.insert(1, 10) |>
+            RedBlackTree.insert(2, 11) |>
+            RedBlackTree.updateWith(k -> v -> Some(k + v), 1) |>
+            RedBlackTree.updateWith(k -> v -> Some(k + v), 3) |>
+            RedBlackTree.updateWith(_ -> _ -> None, 1);
+        RedBlackTree.get(1, tree) == Some(1 + 10) and
+            RedBlackTree.get(2, tree) == Some(11) and
+            RedBlackTree.get(3, tree) == None and
+            RedBlackTree.get(10, tree) == None and
+            RedBlackTree.get(11, tree) == None
+
+    @test
+    def updateWith03(): Bool =
+        let inserts = Vector#{(0, 1), (3, 4), (4, 5), (1, 2), (8, 9), (6, 7), (2, 3), (10, 11), (9, 10)};
+        let nonReplacingUpdates = Vector#{(11, 12), (12, 13), (13, 14), (-1, -2), (-2, -3)};
+        let (kept, overWrite) = Vector.splitAt(Vector.length(inserts), inserts);
+        let updates = Vector.append(nonReplacingUpdates, overWrite);
+        let treeWithInserts = inserts |> Vector.foldRight(match (k, v) -> RedBlackTree.insert(k, v), RedBlackTree.empty());
+        let treeWithUpdates = updates |> Vector.foldRight(match (k, _) -> RedBlackTree.updateWith(k_ -> v -> Some(k_ + v), k), treeWithInserts);
+        kept |> Vector.forAll(match (k, v) -> RedBlackTree.get(k, treeWithUpdates) == Some(v)) and
+            overWrite |> Vector.forAll(match (k, v) -> RedBlackTree.get(k, treeWithUpdates) == Some(k + v)) and
+            nonReplacingUpdates |> Vector.forAll(match (k, _) -> RedBlackTree.get(k, treeWithUpdates) == None)
 
     /////////////////////////////////////////////////////////////////////////////
     // parMapWithKey                                                           //


### PR DESCRIPTION
Refactor `insert`, `insertWith`, and `updateWith` from CPS to direct style. See #10519

Small tests for the methods were also added to verify correctness.