### PR TITLE
docs: fix `Graph` documentation

### DIFF
--- a/main/src/ca/uwaterloo/flix/util/Graph.scala
+++ b/main/src/ca/uwaterloo/flix/util/Graph.scala
@@ -21,8 +21,11 @@ object Graph {
     /**
       * A topologically sorted result.
       *
-      * Fewest incoming edges on the left.
-      * The node at the head of the list has no incoming edges.
+      * Fewest outgoing edges on the left.
+      * The node at the head of the list has no outgoing edges.
+      * The last element has no incoming edges.
+      * In other words, the edges point from right to left:
+      * `leaf <- n1 <- n2 <- n3`
       */
     case class Sorted[N](sorted: List[N]) extends TopologicalSort[N]
   }

--- a/main/src/ca/uwaterloo/flix/util/Graph.scala
+++ b/main/src/ca/uwaterloo/flix/util/Graph.scala
@@ -31,7 +31,8 @@ object Graph {
   }
 
   /**
-    * Topologically sort the nodes, using the `getAdj` function to find adjacent nodes.
+    * Topologically sort the nodes, using the `getAdj` function to find adjacent nodes,
+    * i.e., the outgoing edges of a node `n`.
     *
     * `N` must have a well-defined equality and hashcode.
     */

--- a/main/test/ca/uwaterloo/flix/util/TestGraph.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestGraph.scala
@@ -52,6 +52,8 @@ class TestGraph extends AnyFunSuite {
       2 -> List(1)
     )
     val result = Graph.topologicalSort(graph.keys, graph.apply)
+    // expected:
+    //     1 <- 2
     val expected = Graph.TopologicalSort.Sorted(List(1, 2))
 
     assert(result == expected)
@@ -64,6 +66,8 @@ class TestGraph extends AnyFunSuite {
       3 -> List(2)
     )
     val result = Graph.topologicalSort(graph.keys, graph.apply)
+    // expected:
+    //     1 <- 2 <- 3
     val expected = Graph.TopologicalSort.Sorted(List(1, 2, 3))
 
     assert(result == expected)
@@ -76,6 +80,9 @@ class TestGraph extends AnyFunSuite {
       3 -> List(1)
     )
     val result = Graph.topologicalSort(graph.keys, graph.apply)
+    // expected:
+    //     1 <- 2
+    //     1 <- 3
     val expected = Graph.TopologicalSort.Sorted(List(1, 2, 3))
 
     assert(result == expected)


### PR DESCRIPTION
The documentation says the opposite of the tests. This PR fixes that.

```scala
    /**
      * A topologically sorted result.
      *
      * Fewest incoming edges on the left.
      * The node at the head of the list has no incoming edges.
      */
    case class Sorted[N](sorted: List[N]) extends TopologicalSort[N]
```
However, the tests all have nonzero incoming edges on the left but zero outgoing:

```scala
  test("topSort.Sorted.01") {
    val graph = Map(
      1 -> List(),
      2 -> List(1)
    )
    val result = Graph.topologicalSort(graph.keys, graph.apply)
    val expected = Graph.TopologicalSort.Sorted(List(1, 2))

    assert(result == expected)
  }

  test("topSort.Sorted.02") {
    val graph = Map(
      1 -> List(),
      2 -> List(1),
      3 -> List(2)
    )
    val result = Graph.topologicalSort(graph.keys, graph.apply)
    val expected = Graph.TopologicalSort.Sorted(List(1, 2, 3))

    assert(result == expected)
  }

  test("topSort.Sorted.03") {
    val graph = Map(
      1 -> List(),
      2 -> List(1),
      3 -> List(1)
    )
    val result = Graph.topologicalSort(graph.keys, graph.apply)
    val expected = Graph.TopologicalSort.Sorted(List(1, 2, 3))

    assert(result == expected)
  }
```