### PR TITLE
refactor: cleanup `KeywordCompleter`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -32,21 +32,12 @@ sealed trait Completion {
     */
   def toCompletionItem(implicit flix: Flix): CompletionItem = this match {
 
-    case Completion.KeywordCompletion(name, range, priority) =>
+    case Completion.KeywordCompletion(name, range, priority, withSpace) =>
       CompletionItem(
         label    = name,
         sortText = Priority.toSortText(priority, name),
-        textEdit = TextEdit(range, s"$name "),
+        textEdit = TextEdit(range, if (withSpace) name + " " else name),
         kind     = CompletionItemKind.Keyword
-      )
-
-    case Completion.KeywordLiteralCompletion(name, range, priority) =>
-      CompletionItem(
-        label            = name,
-        sortText         = Priority.toSortText(priority, name),
-        textEdit         = TextEdit(range, name),
-        insertTextFormat = InsertTextFormat.PlainText,
-        kind             = CompletionItemKind.Keyword
       )
 
     case Completion.KindCompletion(kind, range) =>
@@ -541,32 +532,10 @@ object Completion {
     *
     * @param name      the name of the keyword.
     * @param range     the range of the completion.
-    * @param priority  the completion priority of the keyword.
+    * @param priority  the priority of the completion.
+    * @param withSpace whether the completion should be followed by a space.
     */
-  case class KeywordCompletion(name: String, range: Range, priority: Priority) extends Completion
-
-  /**
-    * Represents a keyword literal completion (i.e. `true`).
-    *
-    * The reason we differentiate bewteen normal keywords and these literals
-    * is because completions for the former should include a trailing space
-    * whereas completions for the latter we might not want one.
-    *
-    * To illustrate this consider the two following correct completions (where ˽ denotes a space)
-    *
-    * `de`      --->    `def˽`
-    * `f(fal)`  --->    `f(false)`
-    *
-    * After the keyword `def` we *always* want a space but if we were
-    * to add a trailing space after `false` we would get the unnatural completion
-    *
-    * `f(fal)`  --->    `f(false˽)`
-    *
-    * @param literal   the literal keyword text.
-    * @param range     the range of the completion.
-    * @param priority  the priority of the keyword.
-    */
-  case class KeywordLiteralCompletion(literal: String, range: Range, priority: Priority) extends Completion
+  case class KeywordCompletion(name: String, range: Range, priority: Priority, withSpace: Boolean = true) extends Completion
 
   /**
     * Represents a completion for a kind.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -18,12 +18,12 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.lsp.Range
 
 /**
-  * Completions for keywords.
+  * Completer for keywords.
   */
 object KeywordCompleter {
 
   /**
-    * Constraint keywords. These are keywords that can occur in datalog constraints.
+    * Returns keywords that may occur within Datalog constraints.
     */
   def getConstraintKeywords(range: Range): List[Completion] =
     List(
@@ -33,12 +33,19 @@ object KeywordCompleter {
     )
 
   /**
-    * Module keywords. These are keywords that can occur in a module.
+    * Returns keywords that may occur inside modules.
     */
   def getModKeywords(range: Range): List[Completion] =
     List(
-      // D
+      // @
       Completion.KeywordCompletion("@Deprecated"      , range, Priority.Low),
+      Completion.KeywordCompletion("@Lazy"            , range, Priority.High),
+      Completion.KeywordCompletion("@LazyWhenPure"    , range, Priority.Low),
+      Completion.KeywordCompletion("@Parallel"        , range, Priority.Low),
+      Completion.KeywordCompletion("@ParallelWhenPure", range, Priority.Lower),
+      Completion.KeywordCompletion("@Test"            , range, Priority.Low),
+
+      // D
       Completion.KeywordCompletion("def"              , range, Priority.High),
       // E
       Completion.KeywordCompletion("eff"              , range, Priority.Low),
@@ -46,20 +53,14 @@ object KeywordCompleter {
       // I
       Completion.KeywordCompletion("import"           , range, Priority.Low),
       Completion.KeywordCompletion("instance"         , range, Priority.High),
-      // L
-      Completion.KeywordCompletion("@Lazy"            , range, Priority.High),
-      Completion.KeywordCompletion("@LazyWhenPure"    , range, Priority.Low),
       // M
       Completion.KeywordCompletion("mod"              , range, Priority.Medium),
       // P
-      Completion.KeywordCompletion("@Parallel"        , range, Priority.Low),
-      Completion.KeywordCompletion("@ParallelWhenPure", range, Priority.Lower),
       Completion.KeywordCompletion("pub"              , range, Priority.High),
       // S
       Completion.KeywordCompletion("sealed"           , range, Priority.Low),
       Completion.KeywordCompletion("struct"           , range, Priority.High),
       // T
-      Completion.KeywordCompletion("@Test"            , range, Priority.Low),
       Completion.KeywordCompletion("trait"            , range, Priority.High),
       Completion.KeywordCompletion("type"             , range, Priority.Higher),
       // U
@@ -69,7 +70,7 @@ object KeywordCompleter {
     )
 
   /**
-    * Enum keywords. These are keywords that can appear within the declaration of an enum.
+    * Returns keywords that may occur inside enum declarations.
     */
   def getEnumKeywords(range: Range): List[Completion] =
     List(
@@ -77,7 +78,7 @@ object KeywordCompleter {
     )
 
   /**
-    * Effect keywords. These are keywords that can appear within the declaration of an effect.
+    * Returns keywords that may occur inside effect declarations.
     */
   def getEffectKeywords(range: Range): List[Completion] =
     List(
@@ -85,7 +86,7 @@ object KeywordCompleter {
     )
 
   /**
-    * Expression keywords. These are keywords that can appear within expressions (fx within the body of a function).
+    * Returns keywords that may occur inside expressions.
     */
   def getExprKeywords(range: Range): List[Completion] =
     List(
@@ -100,7 +101,7 @@ object KeywordCompleter {
       // E
       Completion.KeywordCompletion("else"        , range, Priority.Medium),
       // F
-      Completion.KeywordLiteralCompletion("false", range, Priority.Higher),
+      Completion.KeywordCompletion("false"       , range, Priority.Higher, withSpace = false),
       Completion.KeywordCompletion("forA"        , range, Priority.Lowest),
       Completion.KeywordCompletion("forM"        , range, Priority.Low),
       Completion.KeywordCompletion("force"       , range, Priority.High),
@@ -121,7 +122,7 @@ object KeywordCompleter {
       // N
       Completion.KeywordCompletion("new"         , range, Priority.Low),
       Completion.KeywordCompletion("not"         , range, Priority.High),
-      Completion.KeywordLiteralCompletion("null" , range, Priority.Lower),
+      Completion.KeywordCompletion("null"        , range, Priority.Lower, withSpace = false),
       // O
       Completion.KeywordCompletion("or"          , range, Priority.Medium),
       // P
@@ -138,7 +139,7 @@ object KeywordCompleter {
       Completion.KeywordCompletion("spawn"       , range, Priority.Low),
       // T
       Completion.KeywordCompletion("throw"       , range, Priority.Lowest),
-      Completion.KeywordLiteralCompletion("true" , range, Priority.Higher),
+      Completion.KeywordCompletion("true"        , range, Priority.Higher, withSpace = false),
       Completion.KeywordCompletion("try"         , range, Priority.High),
       Completion.KeywordCompletion("typematch"   , range, Priority.Low),
       // U
@@ -152,7 +153,7 @@ object KeywordCompleter {
     )
 
   /**
-    * Instance declaration keywords.
+    * Returns keywords that may occur inside instance declarations.
     */
   def getInstanceKeywords(range: Range): List[Completion] =
     List(
@@ -162,7 +163,7 @@ object KeywordCompleter {
     )
 
   /**
-    * Struct declaration keywords. These are keywords that occur within a struct declaration.
+    * Returns keywords that may occur inside struct declarations.
     */
   def getStructKeywords(range: Range): List[Completion] =
     List(
@@ -170,7 +171,7 @@ object KeywordCompleter {
     )
 
   /**
-    * Trait declaration keywords. These are keywords that occur within a trait declaration.
+    * Returns keywords that may occur inside trait declarations.
     */
   def getTraitKeywords(range: Range): List[Completion] =
     List(
@@ -179,8 +180,7 @@ object KeywordCompleter {
     )
 
   /**
-    * Type declaration keywords. These are the keywords that can occur
-    * within a type declaration.
+    * Returns keywords that may occur inside type declarations.
     */
   def getTypeKeywords(range: Range): List[Completion] =
     List(

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Priority.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Priority.scala
@@ -40,11 +40,11 @@ object Priority {
 
   case object High extends Priority
 
-  case object AboveMedium extends Priority
+  case object MediumHigh extends Priority
 
   case object Medium extends Priority
 
-  case object BelowMedium extends Priority
+  case object MediumLow extends Priority
 
   case object Low extends Priority
 
@@ -67,9 +67,9 @@ object Priority {
     case Priority.Highest => s"1$label"
     case Priority.Higher => s"2$label"
     case Priority.High => s"3$label"
-    case Priority.AboveMedium => s"4$label"
+    case Priority.MediumHigh => s"4$label"
     case Priority.Medium => s"5$label"
-    case Priority.BelowMedium => s"6$label"
+    case Priority.MediumLow => s"6$label"
     case Priority.Low => s"7$label"
     case Priority.Lower => s"8$label"
     case Priority.Lowest => s"9$label"


### PR DESCRIPTION
- Merge `KeywordCompletion` and `KeywordLiteralCompletion`
- Update documentation slightly
- Group annotations (will help for next PR)
- Rename `Medium` priorities (will be used in the next PR in `KeywordCompleter`)