### PR TITLE
fix: avoid spurious expression keyword suggestions

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -67,7 +67,7 @@ object CompletionProvider {
           val range = Range.from(err.loc)
           AutoImportCompleter.getCompletions(ident, range, ap, scp) ++
             LocalScopeCompleter.getCompletionsExpr(range, scp) ++
-            KeywordCompleter.getExprKeywords(range) ++
+            KeywordCompleter.getExprKeywords(Some(err.qn), range) ++
             DefCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             EnumCompleter.getCompletions(qn, range, ap, scp, withTypeParameters = false) ++
             EffectCompleter.getCompletions(qn, range, ap, scp, inHandler = false) ++
@@ -120,7 +120,7 @@ object CompletionProvider {
     else e.sctx match {
       // Expressions.
       case SyntacticContext.Expr.Constraint => (PredicateCompleter.getCompletions(uri, range) ++ KeywordCompleter.getConstraintKeywords(range)).toList
-      case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords(range)
+      case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords(None, range)
 
       // Declarations.
       case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords(range)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -16,6 +16,7 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.Range
+import ca.uwaterloo.flix.language.ast.Name
 
 /**
   * Completer for keywords.
@@ -87,8 +88,10 @@ object KeywordCompleter {
 
   /**
     * Returns keywords that may occur inside expressions.
+    *
+    * Returns only those keywords that are a prefix of the given `qname` (if present).
     */
-  def getExprKeywords(range: Range): List[Completion] =
+  def getExprKeywords(qname: Option[Name.QName], range: Range): List[Completion] =
     List(
       // A
       Completion.KeywordCompletion("and"         , range, Priority.Medium),
@@ -150,7 +153,12 @@ object KeywordCompleter {
       Completion.KeywordCompletion("without"     , range, Priority.Medium),
       // Y
       Completion.KeywordCompletion("yield"       , range, Priority.Medium)
-    )
+    ).filter {
+      case c => qname match {
+        case None => true
+        case Some(qn) => qn.isUnqualified && c.name.startsWith(qn.ident.name)
+      }
+    }
 
   /**
     * Returns keywords that may occur inside instance declarations.


### PR DESCRIPTION
If the user has typed "le" we suggest "let" but not "match". 

The fix for expressions is easy, but the general fix in other cases is hard and will have to wait.