### PR TITLE
feat: drop usage of delta set in `Inliner`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -69,8 +69,8 @@ import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
 object Inliner {
 
   /** Performs inlining on the given AST `root`. */
-  def run(root: MonoAst.Root, delta: Set[Symbol.DefnSym])(implicit flix: Flix): (MonoAst.Root, Set[Symbol.DefnSym]) = {
-    val sctx: SharedContext = SharedContext.mk(delta)
+  def run(root: MonoAst.Root)(implicit flix: Flix): (MonoAst.Root, Set[Symbol.DefnSym]) = {
+    val sctx: SharedContext = SharedContext.mk()
     val defs = ParOps.parMapValues(root.defs)(visitDef(_)(sctx, root, flix))
     val newDelta = sctx.changed.asScala.keys.toSet
     val liveSyms = root.entryPoints ++ sctx.live.asScala.keys.toSet
@@ -498,16 +498,12 @@ object Inliner {
     * @param exps the arguments to the function.
     * @param ctx0 the local context.
     */
-  private def shouldInlineDef(defn: MonoAst.Def, exps: List[Expr], ctx0: LocalContext)(implicit sym0: Symbol.DefnSym, sctx: SharedContext): Boolean = {
+  private def shouldInlineDef(defn: MonoAst.Def, exps: List[Expr], ctx0: LocalContext)(implicit sym0: Symbol.DefnSym): Boolean = {
     if (ctx0.currentlyInlining) {
       return false
     }
 
     if (defn.spec.ann.isDontInline) {
-      return false
-    }
-
-    if (sctx.delta.contains(defn.sym)) {
       return false
     }
 
@@ -735,20 +731,17 @@ object Inliner {
 
     /**
       * Returns a fresh [[SharedContext]].
-      *
-      * The delta set does not change during the lifetime of the shared context.
       */
-    def mk(delta: Set[Symbol.DefnSym]): SharedContext = new SharedContext(delta, new ConcurrentHashMap(), new ConcurrentHashMap())
+    def mk(): SharedContext = new SharedContext(new ConcurrentHashMap(), new ConcurrentHashMap())
 
   }
 
   /**
     * A globally shared thread-safe context.
     *
-    * @param delta   the set of symbols that changed in the last iteration.
     * @param changed the set of symbols of changed functions.
     * @param live    the set of symbols of live functions.
     */
-  private case class SharedContext(delta: Set[Symbol.DefnSym], changed: ConcurrentHashMap[Symbol.DefnSym, Unit], live: ConcurrentHashMap[Symbol.DefnSym, Unit])
+  private case class SharedContext(changed: ConcurrentHashMap[Symbol.DefnSym, Unit], live: ConcurrentHashMap[Symbol.DefnSym, Unit])
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Optimizer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Optimizer.scala
@@ -35,7 +35,7 @@ object Optimizer {
     for (_ <- 0 until MaxRounds) {
       if (currentDelta.nonEmpty) {
         val afterOccurrenceAnalyzer = OccurrenceAnalyzer.run(currentRoot, currentDelta)
-        val (newRoot, newDelta) = Inliner.run(afterOccurrenceAnalyzer, currentDelta)
+        val (newRoot, newDelta) = Inliner.run(afterOccurrenceAnalyzer)
         currentRoot = newRoot
         currentDelta = newDelta
       }


### PR DESCRIPTION
This PR drops usage of the delta set in the inliner.

This makes it simpler to understand the inliner.

In theory this could increase work because inlining is repeated. 

In practice this seems not to be the case:

```
Master
~~~~ Flix Compiler Performance ~~~~

Throughput (best): 72.277 lines/sec (with 24 threads.)

  min:  9.088, max: 72.277, avg: 60.475, median: 62.102

Finished 100 iterations on 69.994 lines of code in 123 seconds.


PR
~~~~ Flix Compiler Performance ~~~~

Throughput (best): 72.698 lines/sec (with 24 threads.)

  min:  8.575, max: 72.698, avg: 67.482, median: 70.518

Finished 100 iterations on 69.994 lines of code in 111 seconds.
```