### PR TITLE
fix: perform checked cast on struct put and get

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -790,6 +790,8 @@ object GenExpression {
         val structType = BackendObjType.Struct(JvmOps.instantiateStruct(sym, targs))
         // evaluating the `base`
         compileExpr(exp)
+        // Cast operand to struct type
+        BytecodeInstructions.CHECKCAST(structType.jvmName)(new BytecodeInstructions.F(mv))
         // Retrieving the field `field${offset}`
         mv.visitFieldInsn(GETFIELD, structType.jvmName.toInternalName, s"field$idx", JvmOps.asErasedJvmType(tpe).toDescriptor)
 
@@ -800,6 +802,8 @@ object GenExpression {
         val structType = BackendObjType.Struct(JvmOps.instantiateStruct(sym, targs))
         // evaluating the `base`
         compileExpr(exp1)
+        // Cast operand to struct type
+        BytecodeInstructions.CHECKCAST(structType.jvmName)(new BytecodeInstructions.F(mv))
         // evaluating the `rhs`
         compileExpr(exp2)
         // set the field `field${offset}`


### PR DESCRIPTION
It is safer to cast to struct type locally rather than relying on the variable being cast to struct from object somewhere else in the method. This is also important for static methods since the type of the parameters will be erased, i.e., primitive or `Object`, which means struct put and get should cast the object to the desired type.
Also, they are *atomic* operations so they should be self-contained, right? :)