### PR TITLE
fix: do not increment offset counter in `VarOffsets`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/VarOffsets.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/VarOffsets.scala
@@ -38,7 +38,6 @@ object VarOffsets {
   /** Assigns a stack offset to each variable binder in the program. */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("VarOffsets") {
     ParOps.parMapValues(root.defs)(visitDef)
-
     root
   }
 
@@ -48,7 +47,6 @@ object VarOffsets {
     for (FormalParam(sym, _, tpe, _) <- defn.cparams ++ defn.fparams) {
       offset += setStackOffset(sym, tpe, offset)
     }
-
     visitExp(defn.expr, offset)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/VarOffsets.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/VarOffsets.scala
@@ -45,7 +45,7 @@ object VarOffsets {
   private def visitDef(defn: Def): Unit = {
     var offset = 0
     for (FormalParam(sym, _, tpe, _) <- defn.cparams ++ defn.fparams) {
-      offset += setStackOffset(sym, tpe, offset)
+      offset = setStackOffset(sym, tpe, offset)
     }
     visitExp(defn.expr, offset)
   }


### PR DESCRIPTION
The `setStackOffset` function computes *the next offset* not how much the offset should grow. Thus, in `visitDef` the mutable variable `offset` should just be reassigned, not added to