### PR TITLE
feat: castIfNotPrim

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -56,9 +56,11 @@ object GenExpression {
         BytecodeInstructions.GETSTATIC(BackendObjType.Unit.SingletonField)
       })(new BytecodeInstructions.F(mv))
 
-      case Constant.Null =>
-        mv.visitInsn(ACONST_NULL)
-        AsmOps.castIfNotPrim(mv, JvmOps.getJvmType(tpe))
+      case Constant.Null => ({
+        import BytecodeInstructions.*
+        ACONST_NULL() ~
+          castIfNotPrim(BackendType.toBackendType(tpe))
+      })(new BytecodeInstructions.F(mv))
 
       case Constant.Bool(true) =>
         mv.visitInsn(ICONST_1)


### PR DESCRIPTION
This is conceptually a pure refactor, but `AsmOps.getJvmType` returns Object for some types like Arrays and Enums. They are used precisely in this PR