### PR TITLE
fix: Backend types of records

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -185,8 +185,8 @@ object BackendType {
       case MonoType.Enum(_, _) => BackendObjType.Tagged.toTpe
       case MonoType.Struct(sym, targs) => BackendObjType.Struct(JvmOps.instantiateStruct(sym, targs)).toTpe
       case MonoType.Arrow(args, result) => BackendObjType.Arrow(args.map(toBackendType), toBackendType(result)).toTpe
-      case MonoType.RecordEmpty => BackendObjType.RecordEmpty.toTpe
-      case MonoType.RecordExtend(_, value, _) => BackendObjType.RecordExtend(toBackendType(value)).toTpe
+      case MonoType.RecordEmpty => BackendObjType.Record.toTpe
+      case MonoType.RecordExtend(_, _, _) => BackendObjType.Record.toTpe
       case MonoType.ExtensibleEmpty => BackendObjType.Tagged.toTpe
       case MonoType.ExtensibleExtend(_, _, _) => BackendObjType.Tagged.toTpe
       case MonoType.Native(clazz) => BackendObjType.Native(JvmName.ofClass(clazz)).toTpe


### PR DESCRIPTION
if you have
```
let x = {q = 42}
```
then currently it is ... kind of typed like
```
let x: RecordExtend$Int = {q = 42}
```
but this PR fixes it such that it is
```
let x: Record = {q = 42}
```

This bug is currently not observable, but was revealed because im doing another fix