### PR TITLE
fix: remove ad hoc erasure in the backend

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -185,8 +185,8 @@ object BackendType {
       case MonoType.Enum(_, _) => BackendObjType.Tagged.toTpe
       case MonoType.Struct(sym, targs) => BackendObjType.Struct(JvmOps.instantiateStruct(sym, targs)).toTpe
       case MonoType.Arrow(args, result) => BackendObjType.Arrow(args.map(toBackendType), toBackendType(result)).toTpe
-      case MonoType.RecordEmpty => BackendObjType.RecordEmpty.toTpe
-      case MonoType.RecordExtend(_, value, _) => BackendObjType.RecordExtend(toBackendType(value)).toTpe
+      case MonoType.RecordEmpty => BackendObjType.Record.toTpe
+      case MonoType.RecordExtend(_, value, _) => BackendObjType.Record.toTpe
       case MonoType.ExtensibleEmpty => BackendObjType.Tagged.toTpe
       case MonoType.ExtensibleExtend(_, _, _) => BackendObjType.Tagged.toTpe
       case MonoType.Native(clazz) => BackendObjType.Native(JvmName.ofClass(clazz)).toTpe

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -248,34 +248,6 @@ object BackendType {
       throw InternalCompilerException(s"Unexpected type $tpe", SourceLocation.Unknown)
   }
 
-  /**
-    * Computes the `BackendType` based on the given `MonoType`.
-    * Types are erased except for the types that have built-in support in
-    * the Java standard library.
-    * Additionally, [[MonoType.Native]] is <b>not</b> erased.
-    */
-  def toFlixErasedBackendType(tpe: MonoType): BackendType = tpe match {
-    case MonoType.Bool => BackendType.Bool
-    case MonoType.Char => BackendType.Char
-    case MonoType.Int8 => BackendType.Int8
-    case MonoType.Int16 => BackendType.Int16
-    case MonoType.Int32 => BackendType.Int32
-    case MonoType.Int64 => BackendType.Int64
-    case MonoType.Float32 => BackendType.Float32
-    case MonoType.Float64 => BackendType.Float64
-    case MonoType.Array(t) => BackendType.Array(toFlixErasedBackendType(t))
-    case MonoType.BigDecimal => BackendObjType.BigDecimal.toTpe
-    case MonoType.BigInt => BackendObjType.BigInt.toTpe
-    case MonoType.String => BackendObjType.String.toTpe
-    case MonoType.Regex => BackendObjType.Regex.toTpe
-    case MonoType.Native(clazz) => JvmName.ofClass(clazz).toTpe
-    case MonoType.Void | MonoType.AnyType | MonoType.Unit | MonoType.Lazy(_) | MonoType.Tuple(_) |
-         MonoType.Arrow(_, _) | MonoType.RecordEmpty | MonoType.RecordExtend(_, _, _) |
-        MonoType.ExtensibleExtend(_, _, _) | MonoType.ExtensibleEmpty |
-         MonoType.Region | MonoType.Enum(_, _) | MonoType.Struct(_, _) | MonoType.Null =>
-      BackendObjType.JavaObject.toTpe
-  }
-
   sealed trait PrimitiveType extends BackendType {
     def toArrayTypeCode: Int = this match {
       case Bool => Opcodes.T_BOOLEAN

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -233,5 +233,4 @@ object BackendType {
   }
 
   sealed trait PrimitiveType extends BackendType
-
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -98,9 +98,8 @@ object GenAnonymousClasses {
     * Hacked to half-work for array types. In the new backend we should handle all types, including multidim arrays.
     */
   private def getDescriptorHacked(tpe: MonoType)(implicit root: Root): String = tpe match {
-    case MonoType.Array(t) => s"[${JvmOps.getJvmType(t).toDescriptor}"
-    case MonoType.Unit => JvmType.Void.toDescriptor
-    case _ => JvmOps.getJvmType(tpe).toDescriptor
+    case MonoType.Unit => VoidableType.Void.toDescriptor
+    case _ => BackendType.toBackendType(tpe).toDescriptor
   }
 
   /**
@@ -143,9 +142,9 @@ object GenAnonymousClasses {
       var offset = 0
       fparams.zipWithIndex.foreach { case (arg, i) =>
         methodVisitor.visitInsn(DUP)
-        val argType = JvmOps.getJvmType(arg.tpe)
-        methodVisitor.visitVarInsn(AsmOps.getLoadInstruction(argType), offset)
-        offset += AsmOps.getStackSize(argType)
+        val argType = BackendType.toBackendType(arg.tpe)
+        methodVisitor.visitByteIns(BytecodeInstructions.xLoad(argType, offset))
+        offset += (if (argType.is64BitWidth) 2 else 1)
         methodVisitor.visitFieldInsn(PUTFIELD, functionInterface.toInternalName,
           s"arg$i", JvmOps.getErasedJvmType(arg.tpe).toDescriptor)
       }
@@ -153,17 +152,13 @@ object GenAnonymousClasses {
       // Invoke the closure
       methodVisitor.visitByteIns(BackendObjType.Result.unwindSuspensionFreeThunkToType(BackendType.toErasedBackendType(tpe), s"in anonymous class method ${ident.name} of ${obj.clazz.getSimpleName}", loc))
 
-      tpe match {
-        case MonoType.Array(_) => methodVisitor.visitTypeInsn(CHECKCAST, getDescriptorHacked(tpe))
-        case _ => AsmOps.castIfNotPrim(methodVisitor, JvmOps.getJvmType(tpe))
-      }
+      methodVisitor.visitByteIns(BytecodeInstructions.castIfNotPrim(BackendType.toBackendType(tpe)))
 
       val returnInstruction = tpe match {
-        case MonoType.Unit => RETURN
-        case MonoType.Array(_) => ARETURN
-        case _ => AsmOps.getReturnInstruction(JvmOps.getJvmType(tpe))
+        case MonoType.Unit => BytecodeInstructions.RETURN()
+        case _ => BytecodeInstructions.xReturn(BackendType.toBackendType(tpe))
       }
-      methodVisitor.visitInsn(returnInstruction)
+      methodVisitor.visitByteIns(returnInstruction)
 
       methodVisitor.visitMaxs(999, 999)
       methodVisitor.visitEnd()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -258,10 +258,9 @@ object GenFunAndClosureClasses {
     m.visitVarInsn(ALOAD, 0)
     m.visitFieldInsn(GETFIELD, className.toInternalName, name, erasedVarType.toDescriptor)
     // cast the value and store it
-    val varType = JvmOps.getJvmType(tpe)
-    AsmOps.castIfNotPrim(m, varType)
-    val xStore = AsmOps.getStoreInstruction(varType)
-    m.visitVarInsn(xStore, localIndex)
+    val bType = BackendType.toBackendType(tpe)
+    m.visitByteIns(BytecodeInstructions.castIfNotPrim(bType))
+    m.visitByteIns(BytecodeInstructions.xStore(bType, localIndex))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -29,54 +29,6 @@ import java.nio.file.{Files, LinkOption, Path}
 object JvmOps {
 
   /**
-    * Returns the given Flix type `tpe` as JVM type.
-    *
-    * For example, if the type is:
-    *
-    * Bool                  =>      Boolean
-    * Char                  =>      Char
-    * Option$42             =>      Option$42
-    * Result$123            =>      Result$123
-    * Int -> Bool           =>      Fn1$Int$Bool
-    * (Int, Int) -> Bool    =>      Fn2$Int$Int$Bool
-    */
-  def getJvmType(tpe: MonoType)(implicit root: ReducedAst.Root): JvmType = tpe match {
-    // Primitives
-    case MonoType.Void => JvmType.Object
-    case MonoType.AnyType => JvmType.Object
-    case MonoType.Unit => JvmType.Unit
-    case MonoType.Bool => JvmType.PrimBool
-    case MonoType.Char => JvmType.PrimChar
-    case MonoType.Float32 => JvmType.PrimFloat
-    case MonoType.Float64 => JvmType.PrimDouble
-    case MonoType.BigDecimal => JvmType.BigDecimal
-    case MonoType.Int8 => JvmType.PrimByte
-    case MonoType.Int16 => JvmType.PrimShort
-    case MonoType.Int32 => JvmType.PrimInt
-    case MonoType.Int64 => JvmType.PrimLong
-    case MonoType.BigInt => JvmType.BigInteger
-    case MonoType.String => JvmType.String
-    case MonoType.Regex => JvmType.Regex
-    case MonoType.Region => JvmType.Object
-    case MonoType.Null => JvmType.Object
-    // Compound
-    case MonoType.Array(_) => JvmType.Object
-    case MonoType.Lazy(_) => JvmType.Object
-    case MonoType.Tuple(elms) => JvmType.Reference(BackendObjType.Tuple(elms.map(BackendType.asErasedBackendType)).jvmName)
-    case MonoType.RecordEmpty => JvmType.Reference(BackendObjType.Record.jvmName)
-    case MonoType.RecordExtend(_, _, _) => JvmType.Reference(BackendObjType.Record.jvmName)
-    case MonoType.ExtensibleExtend(_, _, _) => JvmType.Reference(BackendObjType.Tagged.jvmName)
-    case MonoType.ExtensibleEmpty => JvmType.Reference(BackendObjType.Tagged.jvmName)
-    case MonoType.Enum(_, _) => JvmType.Object
-    case MonoType.Struct(sym, targs) =>
-      val elms = instantiateStruct(sym, targs.map(MonoType.erase))
-      JvmType.Reference(BackendObjType.Struct(elms).jvmName)
-    case MonoType.Arrow(_, _) => JvmType.Reference(getFunctionInterfaceName(tpe))
-    case MonoType.Native(clazz) => JvmType.Reference(JvmName.ofClass(clazz))
-  }
-
-
-  /**
     * Returns the erased JvmType of the given Flix type `tpe`.
     *
     * Every primitive type is mapped to itself and every other type is mapped to Object.


### PR DESCRIPTION
This removes ad hoc erasure of a few things, but notably arrays. This PR should fix our long standing issue around array types in the backend.

As a bonus, this PR conceptually eliminates JvmType - but follow up PRs will actually weed it out