### PR TITLE
feat: remove runtime debugging

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1141,7 +1141,6 @@ object GenExpression {
                 mv.visitJumpInsn(GOTO, afterUnboxing)
 
                 mv.visitLabel(pcPointLabel)
-                printPc(mv, pcPoint)
 
                 mv.visitVarInsn(ALOAD, 1)
 
@@ -1203,7 +1202,6 @@ object GenExpression {
               mv.visitJumpInsn(GOTO, afterUnboxing)
 
               mv.visitLabel(pcPointLabel)
-              printPc(mv, pcPoint)
               mv.visitVarInsn(ALOAD, 1)
 
               mv.visitLabel(afterUnboxing)
@@ -1430,7 +1428,6 @@ object GenExpression {
           mv.visitJumpInsn(GOTO, afterUnboxing)
 
           mv.visitLabel(pcPointLabel)
-          printPc(mv, pcPoint)
           mv.visitVarInsn(ALOAD, 1)
           mv.visitLabel(afterUnboxing)
       }} else {
@@ -1481,7 +1478,6 @@ object GenExpression {
         mv.visitByteIns(ins)
 
         mv.visitLabel(pcPointLabel)
-        printPc(mv, pcPoint)
         mv.visitVarInsn(ALOAD, 1)
         mv.visitByteIns(BytecodeInstructions.GETFIELD(BackendObjType.Value.fieldFromType(erasedResult)))
 
@@ -1550,15 +1546,6 @@ object GenExpression {
       CHECKCAST(tagType.jvmName) ~ GETFIELD(tagType.IndexField(idx))
     }
     mv.visitByteIns(ins)
-  }
-
-  private def printPc(mv: MethodVisitor, pcPoint: Int): Unit = if (!GenFunAndClosureClasses.onCallDebugging) () else {
-    mv.visitFieldInsn(GETSTATIC, JvmName.System.toInternalName, "out", JvmName.PrintStream.toDescriptor)
-    mv.visitLdcInsn("pc = ")
-    compileInt(pcPoint)(mv)
-    mv.visitByteIns(BytecodeInstructions.xToString(BackendType.Int32))
-    mv.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.String.jvmName.toInternalName, "concat", MethodDescriptor.mkDescriptor(BackendObjType.String.toTpe)(BackendObjType.String.toTpe).toDescriptor, false)
-    mv.visitMethodInsn(INVOKEVIRTUAL, JvmName.PrintStream.toInternalName, "println", MethodDescriptor.mkDescriptor(BackendObjType.String.toTpe)(VoidableType.Void).toDescriptor, false)
   }
 
   /**


### PR DESCRIPTION
This is never run (`val onCallDebugging = false` is never true) and partially broken

If we need it, we should just readd it in a proper way