### PR TITLE
refactor: remove `BackendType.asErasedBackendType`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -199,24 +199,5 @@ object BackendType {
       BackendObjType.JavaObject.toTpe
   }
 
-  def asErasedBackendType(tpe: MonoType): BackendType = tpe match {
-    case MonoType.Bool => BackendType.Bool
-    case MonoType.Char => BackendType.Char
-    case MonoType.Int8 => BackendType.Int8
-    case MonoType.Int16 => BackendType.Int16
-    case MonoType.Int32 => BackendType.Int32
-    case MonoType.Int64 => BackendType.Int64
-    case MonoType.Float32 => BackendType.Float32
-    case MonoType.Float64 => BackendType.Float64
-    case MonoType.Native(clazz) if clazz == classOf[Object] => BackendObjType.JavaObject.toTpe
-    case MonoType.Void | MonoType.AnyType | MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt |
-         MonoType.String | MonoType.Regex | MonoType.Array(_) | MonoType.Lazy(_) |
-         MonoType.Tuple(_) | MonoType.Enum(_, _) | MonoType.Struct(_, _) | MonoType.Arrow(_, _) |
-         MonoType.RecordEmpty | MonoType.RecordExtend(_, _, _) |
-         MonoType.ExtensibleExtend(_, _, _) | MonoType.ExtensibleEmpty | MonoType.Native(_) |
-         MonoType.Region | MonoType.Null =>
-      throw InternalCompilerException(s"Unexpected type $tpe", SourceLocation.Unknown)
-  }
-
   sealed trait PrimitiveType extends BackendType
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -622,7 +622,7 @@ object GenExpression {
       case AtomicOp.Tuple => mv.visitByteIns({
         import BytecodeInstructions.*
         val MonoType.Tuple(elmTypes) = tpe
-        val tupleType = BackendObjType.Tuple(elmTypes.map(BackendType.asErasedBackendType))
+        val tupleType = BackendObjType.Tuple(elmTypes.map(BackendType.toBackendType))
         NEW(tupleType.jvmName) ~
           DUP() ~
           composeN(exps.map(pushExpr)) ~
@@ -689,12 +689,12 @@ object GenExpression {
 
       case AtomicOp.ExtensibleIs(sym) => mv.visitByteIns({
         val List(exp) = exps
-        val tpes = MonoType.findExtensibleTermTypes(sym, exp.tpe).map(BackendType.asErasedBackendType)
+        val tpes = MonoType.findExtensibleTermTypes(sym, exp.tpe).map(BackendType.toBackendType)
         compileIsTag(sym.name, exp, tpes)
       })
 
       case AtomicOp.ExtensibleTag(sym) => mv.visitByteIns({
-        val tpes = MonoType.findExtensibleTermTypes(sym, tpe).map(BackendType.asErasedBackendType)
+        val tpes = MonoType.findExtensibleTermTypes(sym, tpe).map(BackendType.toBackendType)
         compileTag(sym.name, exps, tpes)
       })
 
@@ -702,7 +702,7 @@ object GenExpression {
         import BytecodeInstructions.*
 
         val List(exp) = exps
-        val tpes = MonoType.findExtensibleTermTypes(sym, exp.tpe).map(BackendType.asErasedBackendType)
+        val tpes = MonoType.findExtensibleTermTypes(sym, exp.tpe).map(BackendType.toBackendType)
 
         compileUntag(exp, idx, tpes) ~
           castIfNotPrim(BackendType.toBackendType(tpe))
@@ -829,7 +829,7 @@ object GenExpression {
         val List(exp) = exps
         pushExpr(exp) ~
           CHECKCAST(BackendObjType.Value.jvmName) ~
-          GETFIELD(BackendObjType.Value.fieldFromType(BackendType.asErasedBackendType(tpe)))
+          GETFIELD(BackendObjType.Value.fieldFromType(BackendType.toBackendType(tpe)))
       })
 
       case AtomicOp.Box => mv.visitByteIns({
@@ -990,7 +990,7 @@ object GenExpression {
 
         // Find the Lazy class name (Lazy$tpe).
         val MonoType.Lazy(elmType) = tpe
-        val lazyType = BackendObjType.Lazy(BackendType.asErasedBackendType(elmType))
+        val lazyType = BackendObjType.Lazy(BackendType.toBackendType(elmType))
 
         NEW(lazyType.jvmName) ~
           DUP() ~
@@ -1003,7 +1003,7 @@ object GenExpression {
 
         // Find the Lazy class type (Lazy$tpe) and the inner value type.
         val MonoType.Lazy(elmType) = exp.tpe
-        val erasedElmType = BackendType.asErasedBackendType(elmType)
+        val erasedElmType = BackendType.toBackendType(elmType)
         val lazyType = BackendObjType.Lazy(erasedElmType)
 
         // Emit code for the lazy expression.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenNamespaceClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenNamespaceClasses.scala
@@ -70,7 +70,7 @@ object GenNamespaceClasses {
   /**
     * Adding a shim for the function `defn` on namespace `ns`
     */
-  private def compileShimMethod(visitor: ClassWriter, defn: Def): Unit = {
+  private def compileShimMethod(visitor: ClassWriter, defn: Def)(implicit root: Root): Unit = {
     // Name of the shim
     val name = JvmOps.getDefMethodNameInNamespaceClass(defn)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -64,7 +64,7 @@ object JvmBackend {
     }.map(bt => genClass(bt, bt.genByteCode())).toMap
 
     val taggedAbstractClass = Map(genClass(BackendObjType.Tagged, BackendObjType.Tagged.genByteCode()))
-    val tagClasses = JvmOps.getErasedTagTypesOf(root, allTypes).map(bt => genClass(bt, bt.genByteCode())).toMap
+    val tagClasses = JvmOps.getErasedTagTypesOf(allTypes).map(bt => genClass(bt, bt.genByteCode())).toMap
     val extensibleTagClasses = JvmOps.getErasedExtensibleTagTypesOf(allTypes).map(bt => genClass(bt, bt.genByteCode())).toMap
 
     val tupleClasses = JvmOps.getErasedTupleTypesOf(allTypes).map(bt => genClass(bt, bt.genByteCode())).toMap

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -62,9 +62,9 @@ object JvmOps {
     *
     * NB: The given type `tpe` must be an arrow type.
     */
-  def getFunctionInterfaceType(tpe: MonoType): BackendObjType.Arrow = tpe match {
+  def getFunctionInterfaceType(tpe: MonoType)(implicit root: Root): BackendObjType.Arrow = tpe match {
     case MonoType.Arrow(targs, tresult) =>
-      BackendObjType.Arrow(targs.map(BackendType.toErasedBackendType), BackendType.asErasedBackendType(tresult))
+      BackendObjType.Arrow(targs.map(BackendType.toErasedBackendType), BackendType.toBackendType(tresult))
     case _ =>
       throw InternalCompilerException(s"Unexpected type: '$tpe'.", SourceLocation.Unknown)
   }
@@ -198,19 +198,19 @@ object JvmOps {
   /**
     * Returns the set of erased lazy types in `types` without searching recursively.
     */
-  def getErasedLazyTypesOf(types: Iterable[MonoType]): Set[BackendObjType.Lazy] =
+  def getErasedLazyTypesOf(types: Iterable[MonoType])(implicit root: Root): Set[BackendObjType.Lazy] =
     types.foldLeft(Set.empty[BackendObjType.Lazy]) {
-      case (acc, MonoType.Lazy(tpe)) => acc + BackendObjType.Lazy(BackendType.asErasedBackendType(tpe))
+      case (acc, MonoType.Lazy(tpe)) => acc + BackendObjType.Lazy(BackendType.toBackendType(tpe))
       case (acc, _) => acc
     }
 
   /**
     * Returns the set of erased record extend types in `types` without searching recursively.
     */
-  def getErasedRecordExtendsOf(types: Iterable[MonoType]): Set[BackendObjType.RecordExtend] =
+  def getErasedRecordExtendsOf(types: Iterable[MonoType])(implicit root: Root): Set[BackendObjType.RecordExtend] =
     types.foldLeft(Set.empty[BackendObjType.RecordExtend]) {
       case (acc, MonoType.RecordExtend(_, value, _)) =>
-        acc + BackendObjType.RecordExtend(BackendType.asErasedBackendType(value))
+        acc + BackendObjType.RecordExtend(BackendType.toBackendType(value))
       case (acc, _) => acc
     }
 
@@ -227,10 +227,10 @@ object JvmOps {
   /**
     * Returns the set of erased tuple types in `types` without searching recursively.
     */
-  def getErasedTupleTypesOf(types: Iterable[MonoType]): Set[BackendObjType.Tuple] =
+  def getErasedTupleTypesOf(types: Iterable[MonoType])(implicit root: Root): Set[BackendObjType.Tuple] =
     types.foldLeft(Set.empty[BackendObjType.Tuple]) {
       case (acc, MonoType.Tuple(elms)) =>
-        acc + BackendObjType.Tuple(elms.map(BackendType.asErasedBackendType))
+        acc + BackendObjType.Tuple(elms.map(BackendType.toBackendType))
       case (acc, _) => acc
     }
 
@@ -262,7 +262,7 @@ object JvmOps {
   /**
     * Returns the set of erased tag types in `types` without searching recursively.
     */
-  def getErasedTagTypesOf(root: Root, types: Iterable[MonoType]): Set[BackendObjType.TagType] =
+  def getErasedTagTypesOf(types: Iterable[MonoType])(implicit root: ReducedAst.Root): Set[BackendObjType.TagType] =
     types.foldLeft(Set.empty[BackendObjType.TagType]) {
       case (acc0, MonoType.Enum(sym, targs)) =>
         val tags = instantiateEnum(root.enums(sym), targs)
@@ -281,7 +281,7 @@ object JvmOps {
     *   - `instantiateEnum(E, List(Char)) = Map(A -> List(Char, Object), B -> List(Int32))`
     *     for `enum E[t] { case A(t, Object) case B(Int32) }`
     */
-  def instantiateEnum(enm: ReducedAst.Enum, targs: List[MonoType]): Map[Symbol.CaseSym, List[BackendType]] = {
+  def instantiateEnum(enm: ReducedAst.Enum, targs: List[MonoType])(implicit root: Root): Map[Symbol.CaseSym, List[BackendType]] = {
     assert(enm.tparams.length == targs.length)
     val map = enm.tparams.map(_.sym).zip(targs).toMap
     enm.cases.map {
@@ -304,8 +304,8 @@ object JvmOps {
     * @param tpe the type to instantiate, must be a polymorphic erased type
     *            (either [[Type.Var]], a primitive type, or `java.lang.Object`)
     */
-  private def instantiateType(m: Map[Symbol.KindedTypeVarSym, MonoType], tpe: Type): BackendType = tpe match {
-    case Type.Var(sym, _) => BackendType.asErasedBackendType(m(sym))
+  private def instantiateType(m: Map[Symbol.KindedTypeVarSym, MonoType], tpe: Type)(implicit root: Root): BackendType = tpe match {
+    case Type.Var(sym, _) => BackendType.toBackendType(m(sym))
     case Type.Cst(tc, _) => tc match {
       case TypeConstructor.Bool => BackendType.Bool
       case TypeConstructor.Char => BackendType.Char
@@ -329,12 +329,12 @@ object JvmOps {
   /**
     * Returns the set of erased extensible tag types in `types` without searching recursively.
     */
-  def getErasedExtensibleTagTypesOf(types: Iterable[MonoType]): Set[BackendObjType.TagType] =
+  def getErasedExtensibleTagTypesOf(types: Iterable[MonoType])(implicit root: Root): Set[BackendObjType.TagType] =
     types.foldLeft(Set.empty[BackendObjType.TagType]) {
       case (acc, MonoType.ExtensibleExtend(cons, targs, _)) =>
         targs match {
           case Nil => acc + BackendObjType.NullaryTag(cons.name)
-          case nary => acc + BackendObjType.Tag(nary.map(BackendType.asErasedBackendType))
+          case nary => acc + BackendObjType.Tag(nary.map(BackendType.toBackendType))
         }
       case (acc, _) => acc
     }


### PR DESCRIPTION
This function is the same as `toBackendType` but with an assert that the type is an erased type. This was merely a stepping stone since `toBackendType` is newer.

This is a step towards the backend to be erasure oblivious