### PR TITLE
fix: purity cast in `Assert.flix` after handling AE

### DIFF
--- a/main/src/library/Assert.flix
+++ b/main/src/library/Assert.flix
@@ -25,11 +25,13 @@ mod Assert {
             true
         else {
             use Chalk.{green, red};
-            println("Assertion Error");
-            println("  Expected: ${green(expected)}");
-            println("  Actual:   ${red(actual)}");
-            println("");
-            ?assertEq
+            Environment.runWithIO(() -> {
+                println("Assertion Error");
+                println("  Expected: ${green(expected)}");
+                println("  Actual:   ${red(actual)}");
+                println("");
+                ?assertEq
+            })
         }
     } as _ \ {})
 


### PR DESCRIPTION
The cast comes **after** control impure effects have been handled so now only effect "annotations", i.e., the primitive effects are cast to pure.