### PR TITLE
feat: inlay hints to show effects

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -410,7 +410,7 @@ object LspServer {
     override def inlayHint(params: InlayHintParams): CompletableFuture[util.List[InlayHint]] = {
       val uri = params.getTextDocument.getUri
       val range = Range.fromLsp4j(params.getRange)
-      val hints = InlayHintProvider.getInlayHints(uri, range)
+      val hints = InlayHintProvider.getInlayHints(uri, range)(flixLanguageServer.root)
       CompletableFuture.completedFuture(hints.map(_.toLsp4j).asJava)
     }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
@@ -123,7 +123,7 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
     parseRequest(data) match {
       case Ok(request) =>
         val t = System.nanoTime()
-        val result = processRequest(request)(ws)
+        val result = processRequest(request)(ws, root)
         if (ws.isOpen) {
           val jsonCompact = JsonMethods.compact(JsonMethods.render(result))
           // val jsonPretty = JsonMethods.pretty(JsonMethods.render(result))
@@ -212,7 +212,7 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
   /**
     * Process the request.
     */
-  private def processRequest(request: Request)(implicit ws: WebSocket): JValue = request match {
+  private def processRequest(request: Request)(implicit ws: WebSocket, root: Root): JValue = request match {
 
     case Request.AddUri(id, uri, src) =>
       addSourceCode(uri, src)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -15,13 +15,33 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider
 
-import ca.uwaterloo.flix.api.lsp.{InlayHint, Range}
+import ca.uwaterloo.flix.api.lsp.acceptors.{FileAcceptor}
+import ca.uwaterloo.flix.language.ast.shared.SymUse
+import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, Root}
+import ca.uwaterloo.flix.api.lsp.{Consumer, InlayHint, InlayHintKind, Position, Range}
+import ca.uwaterloo.flix.api.lsp.Visitor
 
 object InlayHintProvider {
+  def getInlayHints(uri: String, range: Range)(implicit root: Root): List[InlayHint] = {
+    var inlayHints: List[InlayHint] = Nil
+    object opSymUseConsumer extends Consumer {
+      override def consumeOpSymUse(opSymUse: SymUse.OpSymUse): Unit = {
+        val line = opSymUse.loc.beginLine
+        var hint = InlayHint(
+          position = Position(line, 100),
+          label = opSymUse.sym.eff.name,
+          kind = Some(InlayHintKind.Type),
+          textEdits = List.empty,
+          tooltip = s"Effect: ${opSymUse.sym.eff.name}",
+          paddingLeft = true,
+          paddingRight = true
+        )
+      inlayHints = hint :: inlayHints
+      }
+    }
 
-  def getInlayHints(uri: String, range: Range): List[InlayHint] = {
-    // We currently do not support any inlay hints.
-    Nil
+    Visitor.visitRoot(root, opSymUseConsumer, FileAcceptor(uri))
+
+    inlayHints
   }
-
 }


### PR DESCRIPTION
Adds inlay hints to show effects as discussed in #10772. Currently, in only displays hints for operations defined in the effect's definition. Example screenshot:

![image](https://github.com/user-attachments/assets/8d8e080e-aead-4c19-9994-5c740e3e6677)
