### PR TITLE
feat: simplify ReifiedSourceLocation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -432,8 +432,6 @@ object BytecodeInstructions {
     pushString(loc.source.name)
     pushInt(loc.beginLine)
     pushInt(loc.beginCol)
-    pushInt(loc.endLine)
-    pushInt(loc.endCol)
     INVOKESPECIAL(BackendObjType.ReifiedSourceLocation.Constructor)
   }
 


### PR DESCRIPTION
Instead of storing 5 fields, we just construct the string immediately.

Additionally, the end line and column were unused.