### PR TITLE
feat: transformer from Flix PredSym to Fixpoint PredSym

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -280,6 +280,7 @@ class Flix {
     "Fixpoint3/Ast/Ram.flix" -> LocalResource.get("/src/library/Fixpoint3/Ast/Ram.flix"),
     "Fixpoint3/Ast/ExecutableRam.flix" -> LocalResource.get("/src/library/Fixpoint3/Ast/ExecutableRam.flix"),
 
+    "Fixpoint3/Phase/RenamePredSyms.flix" -> LocalResource.get("/src/library/Fixpoint3/Phase/RenamePredSyms.flix"),
 
     "Abort.flix" -> LocalResource.get("/src/library/Abort.flix"),
     "Clock.flix" -> LocalResource.get("/src/library/Clock.flix"),

--- a/main/src/library/Fixpoint/Ast/Datalog.flix
+++ b/main/src/library/Fixpoint/Ast/Datalog.flix
@@ -21,10 +21,10 @@ mod Fixpoint.Ast.Datalog {
     use Fixpoint.PredSymsOf.predSymsOf
     use Fixpoint.SubstitutePredSym
     use Fixpoint.SubstitutePredSym.substitute
-    use Fixpoint.Ast.Ram.RamSym
     use Fixpoint.Ast.Shared.{Denotation, PredSym}
     use Fixpoint.Ast.Shared.{BoxedDenotation => Denotation}
     use Fixpoint.Boxed
+    use Fixpoint3.Ast.Ram.RelSym
 
     /////////////////////////////////////////////////////////////////////////////
     // Datalog                                                                 //
@@ -33,7 +33,7 @@ mod Fixpoint.Ast.Datalog {
     @Internal
     pub enum Datalog {
         case Datalog(Vector[Constraint], Vector[Constraint])
-        case Model(Map[RamSym, Map[Vector[Boxed], Boxed]])
+        case Model(Map[RelSym, Map[Vector[Boxed], Boxed]])
         case Join(Datalog, Datalog)
     }
 
@@ -71,14 +71,14 @@ mod Fixpoint.Ast.Datalog {
                     |> Iterator.join(String.lineSeparator())
             }
             case Datalog.Model(db) => region rc {
-                use Fixpoint.Ast.Ram.toDenotation;
+                use Fixpoint3.Ast.Ram.toDenotation;
                 Map.iterator(rc, db)
-                    |> Iterator.flatMap(match (ramSym, rel) -> {
+                    |> Iterator.flatMap(match (relSym, rel) -> {
                         Map.iterator(rc, rel) |> Iterator.map(match (tuple, lat) -> {
                             let tupleString = tuple |> Vector.map(Debug.stringify) |> Vector.join(", ");
-                            match toDenotation(ramSym) {
-                                case Denotation.Relational => "${ramSym}(${tupleString})."
-                                case Denotation.Latticenal(_, _, _, _) => "${ramSym}(${tupleString}; %{lat})."
+                            match toDenotation(relSym) {
+                                case Denotation.Relational => "${relSym}(${tupleString})."
+                                case Denotation.Latticenal(_, _, _, _) => "${relSym}(${tupleString}; %{lat})."
                             }
                         })
                     })

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -30,6 +30,7 @@ mod Fixpoint.Solver {
     use Fixpoint.Boxable.{box, unbox}
     use Fixpoint.Boxed
     use Fixpoint.Interpreter.Database
+    use Fixpoint3.Ast.Ram.RelSym
 
     ///
     /// Returns the minimal model of the given Datalog program `d`.
@@ -59,7 +60,8 @@ mod Fixpoint.Solver {
                 compiler(d) |> Fixpoint.Interpreter.interpret(rc) |> toModel
             }
             case Model(_) => d
-            case Join(Model(m), cs) => region rc {
+            case Join(Model(m_), cs) => region rc {
+                let m = Map.foldRightWithKey(match RelSym.Symbol(pred, arr, den) -> v -> Map.insert(RamSym.Full(pred, arr, den), v), Map#{}, m_);
                 let db = Map.map(Map.toMutMap(rc), m) |> Map.toMutMap(rc);
                 compiler(cs) |> Fixpoint.Interpreter.interpretWithDatabase(rc, db) |> toModel
             }
@@ -79,7 +81,7 @@ mod Fixpoint.Solver {
         case (Datalog(edb1, idb1), Datalog(edb2, idb2)) =>
             Datalog(Vector.append(edb1, edb2), Vector.append(idb1, idb2))
         case (Model(db1), Model(db2)) =>
-            use Fixpoint.Ast.Ram.toDenotation;
+            use Fixpoint3.Ast.Ram.toDenotation;
             let union = ramSym -> match toDenotation(ramSym) {
                 case Relational => Map.union
                 case Latticenal(_, _, lub, _) => Map.unionWith(lub)
@@ -104,7 +106,7 @@ mod Fixpoint.Solver {
             Datalog(pFacts, Vector.empty())
         case Model(db) =>
             Map.rangeQuery(ramSym -> match ramSym {
-                case RamSym.Full(predSym, _, _) => match predSym <=> p {
+                case RelSym.Symbol(predSym, _, _) => match predSym <=> p {
                     case Comparison.EqualTo => Comparison.EqualTo
                     case cmp => cmp
                 }
@@ -710,10 +712,10 @@ mod Fixpoint.Solver {
             pFacts |> MutList.toVector
         }
         case Model(db) => region rc {
-            use Fixpoint.Ast.Ram.toDenotation;
+            use Fixpoint3.Ast.Ram.toDenotation;
             let pFacts = MutList.empty(rc);
             let qquery = ramSym -> match ramSym {
-                case RamSym.Full(predSym, _, _) => match predSym <=> p {
+                case RelSym.Symbol(predSym, _, _) => match predSym <=> p {
                     case Comparison.EqualTo => Comparison.EqualTo
                     case cmp => cmp
                 }
@@ -753,7 +755,11 @@ mod Fixpoint.Solver {
     /// Returns the given database `db` as a Datalog value.
     ///
     def toModel(db: Database[r]): Datalog \ r =
-        MutMap.toMap(db) |>
+        db |> 
+        MutMap.foldRightWithKey(k -> v -> match k {
+            case RamSym.Full(pred, arr, den) => Map.insert(RelSym.Symbol(pred, arr, den), v)
+            case _ => identity
+        }, Map#{}) |>
         Map.map(MutMap.toMap) |>
         Model
 }

--- a/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
+++ b/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 
-//
-/// For the rest of the compiler we expect a PredSym, `PredSym(name, id)`, to have unique `id`.
-/// This phase passes over the Datalog-Ast and replaces the id and after everything is done
+///
+/// Purpose of phase: For `PredSym(name, id)` we want `id` to be unique, for the whole program.
+/// This phase passes over the Datalog-Ast and replaces the `id` and after everything is done
 /// recreates the old `PredSym`s for the resulting model.
-/// 
-/// It also contains method for recreating the original PredSyms such that the model given to Flix
-/// is correct.
-//
+///
+/// This is necessary as Flix uses the id-part for generating local predicates, not as unique identifiers.
+///
 mod Fixpoint3.Phase.RenamePredSyms {
     use Fixpoint.Ast.Datalog.{Datalog, Constraint, BodyPredicate, BodyTerm, HeadTerm, Polarity, VarSym}
     use Fixpoint.Ast.Datalog.Datalog.{Datalog, Model, Join}
@@ -40,18 +39,18 @@ mod Fixpoint3.Phase.RenamePredSyms {
 
     ///
     /// Maps all `PredSym`s in `d` to have unique ids. Returns the resulting
-    /// program and information which `renamePredSymToFlixStyle` can use to recreate the original program.
+    /// program and information which `renamePredSyms` can use to recreate the original program.
     ///
     @Internal
-    pub def renamePredSyms(rc: Region[r], d: Datalog): (Datalog, FixInformation) \ r =
+    pub def assignUniqueIdentifiersToPredSyms(rc: Region[r], d: Datalog): (Datalog, FixInformation) \ r =
         let mapping = UniqueInts.empty(rc);
-        let fixed = renamePredSymsInternal(d, mapping);
+        let fixed = fixPredSymsInternal(d, mapping);
         (fixed, UniqueInts.reverse(mapping))
 
     ///
     /// Recursively applies `mapping` to the different Datalog enums to make `PredSym`s unique.
     ///
-    def renamePredSymsInternal(d: Datalog, mapping: UniqueInts[PredSym, r]): Datalog \ r = match d {
+    def fixPredSymsInternal(d: Datalog, mapping: UniqueInts[PredSym, r]): Datalog \ r = match d {
         case Datalog(facts, rules) =>
             let transformer = mapForward(mapping);
             Datalog(remapConstraints(facts, transformer), remapConstraints(rules, transformer))
@@ -62,15 +61,15 @@ mod Fixpoint3.Phase.RenamePredSyms {
                     Map.insert(newSym, v, acc)
             }, Map#{}, facts))
         case Join(d1, d2) =>
-            Join(renamePredSymsInternal(d1, mapping), renamePredSymsInternal(d2, mapping))
+            Join(fixPredSymsInternal(d1, mapping), fixPredSymsInternal(d2, mapping))
         case _ => bug!("PredSym error")
     }
 
     ///
-    /// Applies `fixing` to the `d` to restore the `PredSym`s to the original values.
+    /// Replaces `PredSym(name, id)` in `d` with `Map.get(id, fixing)`.
     ///
     @Internal
-    pub def renamePredSymToFlixStyle(d: Datalog, fixing: FixInformation): Datalog = match d {
+    pub def renamePredSyms(d: Datalog, fixing: FixInformation): Datalog = match d {
         case Datalog(facts, rules) => 
             let transformer = mapBack(fixing);
             Datalog(remapConstraints(facts, transformer), remapConstraints(rules, transformer))

--- a/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
+++ b/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
@@ -22,6 +22,10 @@
 ///
 /// This is necessary as Flix uses the id-part for generating local predicates, not as unique identifiers.
 ///
+///
+/// This purpose of this module is to transform `PredSym`s defined by `(name, id)`, to `PredSym`s
+/// uniquely defined by their `id`.
+///
 mod Fixpoint3.Phase.RenamePredSyms {
     use Fixpoint.Ast.Datalog.{Datalog, Constraint, BodyPredicate, BodyTerm, HeadTerm, Polarity, VarSym}
     use Fixpoint.Ast.Datalog.Datalog.{Datalog, Model, Join}
@@ -40,6 +44,9 @@ mod Fixpoint3.Phase.RenamePredSyms {
     ///
     /// Maps all `PredSym`s in `d` to have unique ids. Returns the resulting
     /// program and information which `renamePredSyms` can use to recreate the original program.
+    ///
+    /// This function expects `PredSym`s to be defined by their `(name, id)`, while afterwards they
+    /// will be uniquely defined by their `id`.
     ///
     @Internal
     pub def assignUniqueIdentifiersToPredSyms(rc: Region[r], d: Datalog): (Datalog, FixInformation) \ r =
@@ -86,6 +93,9 @@ mod Fixpoint3.Phase.RenamePredSyms {
     /// Maps `pred` back to its original `PredSym` according to `reversing`.
     ///
     def mapBack(reversing: FixInformation, pred: PredSym): PredSym = 
+        // The `id`s are assigned 0 to n for `n` `PredSym`s. They should
+        // be well within the range for `Int32`. Also no new `PredSym`s should
+        // have been created. There is no recovery for either.
         let PredSym(_, id) = pred;
         getOrCrash(Map.get(getOrCrash(Int64.tryToInt32(id)), reversing))
 

--- a/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
+++ b/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 Casper Dalgaard Nielsen
+ *                Adam Yasser Tallouzi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+/// For the rest of the compiler we expect a PredSym, `PredSym(name, id)`, to have unique `id`.
+/// This phase passes over the Datalog-Ast and replaces the id and after everything is done
+/// recreates the old `PredSym`s for the resulting model.
+/// 
+/// It also contains method for recreating the original PredSyms such that the model given to Flix
+/// is correct.
+//
+mod Fixpoint3.Phase.RenamePredSyms {
+    use Fixpoint.Ast.Datalog.{Datalog, Constraint, BodyPredicate, BodyTerm, HeadTerm, Polarity, VarSym}
+    use Fixpoint.Ast.Datalog.Datalog.{Datalog, Model, Join}
+    use Fixpoint.Ast.Datalog.Constraint.Constraint
+    use Fixpoint.Ast.Datalog.HeadPredicate
+    use Fixpoint.Ast.Datalog.HeadPredicate.HeadAtom
+    use Fixpoint.Ast.Datalog.BodyPredicate.{BodyAtom, Functional, Guard1, Guard2, Guard3, Guard4, Guard5}
+    use Fixpoint3.Ast.Ram.RelSym
+    use Fixpoint.Ast.Shared.{Denotation, isRelational, PredSym}
+    use Fixpoint.Ast.Shared.PredSym.PredSym
+    use Fixpoint3.UniqueInts
+    use Fixpoint3.Util.getOrCrash
+
+    type alias FixInformation = Map[Int32, PredSym]
+
+    ///
+    /// Maps all `PredSym`s in `d` to have unique ids. Returns the resulting
+    /// program and information which `renamePredSymToFlixStyle` can use to recreate the original program.
+    ///
+    @Internal
+    pub def renamePredSyms(rc: Region[r], d: Datalog): (Datalog, FixInformation) \ r =
+        let mapping = UniqueInts.empty(rc);
+        let fixed = renamePredSymsInternal(d, mapping);
+        (fixed, UniqueInts.reverse(mapping))
+
+    ///
+    /// Recursively applies `mapping` to the different Datalog enums to make `PredSym`s unique.
+    ///
+    def renamePredSymsInternal(d: Datalog, mapping: UniqueInts[PredSym, r]): Datalog \ r = match d {
+        case Datalog(facts, rules) =>
+            let transformer = mapForward(mapping);
+            Datalog(remapConstraints(facts, transformer), remapConstraints(rules, transformer))
+        case Model(facts) =>
+            Model(Map.foldLeftWithKey(acc -> k -> v -> match k {
+                case RelSym.Symbol(predSym, arity, den) =>
+                    let newSym = RelSym.Symbol(mapForward(mapping, predSym), arity, den);
+                    Map.insert(newSym, v, acc)
+            }, Map#{}, facts))
+        case Join(d1, d2) =>
+            Join(renamePredSymsInternal(d1, mapping), renamePredSymsInternal(d2, mapping))
+        case _ => bug!("PredSym error")
+    }
+
+    ///
+    /// Applies `fixing` to the `d` to restore the `PredSym`s to the original values.
+    ///
+    @Internal
+    pub def renamePredSymToFlixStyle(d: Datalog, fixing: FixInformation): Datalog = match d {
+        case Datalog(facts, rules) => 
+            let transformer = mapBack(fixing);
+            Datalog(remapConstraints(facts, transformer), remapConstraints(rules, transformer))
+        case Model(map) => 
+            let transformer = mapBack(fixing);
+            Map.foldLeftWithKey(newMap -> k -> v -> match k {
+                case RelSym.Symbol(p, arity, den) => Map.insert(RelSym.Symbol(transformer(p), arity, den), v, newMap)
+            }, Map#{}, map) |> 
+            Model
+        case _ => bug!("Bad argument of type 'Join' in PredSym renaming")
+    }
+    
+    ///
+    /// Maps `pred` back to its original `PredSym` according to `reversing`.
+    ///
+    def mapBack(reversing: FixInformation, pred: PredSym): PredSym = 
+        let PredSym(_, id) = pred;
+        getOrCrash(Map.get(getOrCrash(Int64.tryToInt32(id)), reversing))
+
+    ///
+    /// Maps `pred` back to its new `PredSym` according to `state`.
+    ///
+    def mapForward(state: UniqueInts[PredSym, r], pred: PredSym): PredSym \ r = 
+        let PredSym(name, _) = pred;
+        let index = UniqueInts.getIndex(pred, state);
+        PredSym(name, Int32.toInt64(index))
+
+    ///
+    /// Maps `PredSym`s of `constraints` according to `transformer`.
+    ///
+    def remapConstraints(constraints: Vector[Constraint], transformer: PredSym -> PredSym \ r): Vector[Constraint] \ r = {
+        Vector.map(match Constraint(head, body) -> Constraint(remapHead(transformer, head), Vector.map(remapBody(transformer), body)), constraints)
+    }
+
+    ///
+    /// Maps `PredSym`s of `head` according to `transformer`.
+    ///
+    def remapHead(transformer: PredSym -> PredSym \ r, head: HeadPredicate): HeadPredicate \ r = match head {
+        case HeadAtom(pred, den, terms) => HeadAtom(transformer(pred), den, terms)
+    }
+    
+    ///
+    /// Maps `PredSym`s of `body` according to `transformer`.
+    ///
+    def remapBody(transformer: PredSym -> PredSym \ r, body: BodyPredicate): BodyPredicate \ r = match body {
+        case BodyAtom(pred, den, pol, fixed, terms) => BodyAtom(transformer(pred), den, pol, fixed, terms)
+        case _ => body
+    }
+}


### PR DESCRIPTION
This phase simply transforms PredSym as Flix understands them into PredSyms with unique integer parts as our solver uses this.
To keep ensure the old Datalog engine and ours can work on `Datalog.flix` at the same time we have modified the old engine's `Solver.flix`.