### PR TITLE
refactor: make clampToX functions subject-last

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -79,3 +79,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Casper Dalgaard Nielsen](https://github.com/CasperDN)
 - [Gagan Chandan](https://github.com/gaganchandan)
 - [Cade Lueker](https://github.com/cademichael)
+- [Ry Wiese](https://github.com/rywiese)

--- a/main/src/library/BigInt.flix
+++ b/main/src/library/BigInt.flix
@@ -275,91 +275,91 @@ mod BigInt {
     ///
     /// Helper function for the `clamp` conversion functions.
     ///
-    def clamp(x: BigInt, minimum: BigInt, maximum: BigInt): BigInt =
-        if (x < minimum)
-             minimum
+    def clamp(min: {min = BigInt}, max: {max = BigInt}, x: BigInt): BigInt =
+        if (x < min#min)
+             min#min
         else
-            if (x > maximum)
-                maximum
+            if (x > max#max)
+                max#max
             else
                 x
 
     ///
     /// Convert `x` to an `Int8`.
     ///
-    /// Returns `x` clamped within the Int8 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int8 range `min` to `max`.
     ///
-    pub def clampToInt8(x: BigInt, minimum: Int8, maximum: Int8): Int8 =
-        let minii = Int8.toBigInt(minimum);
-        let maxii = Int8.toBigInt(maximum);
+    pub def clampToInt8(min: {min = Int8}, max: {max = Int8}, x: BigInt): Int8 =
+        let minii = Int8.toBigInt(min#min);
+        let maxii = Int8.toBigInt(max#max);
         try {
-            let y = clamp(x, minii, maxii);
+            let y = clamp(min = minii, max = maxii, x);
             unsafe y.byteValueExact()
         } catch {
             // This should be impossible!
-            case _ : ArithmeticException => minimum
+            case _ : ArithmeticException => min#min
         }
 
     ///
     /// Convert `x` to an `Int16`.
     ///
-    /// Returns `x` clamped within the Int16 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int16 range `min` to `max`.
     ///
-    pub def clampToInt16(x: BigInt, minimum: Int16, maximum: Int16): Int16 =
-        let minii = Int16.toBigInt(minimum);
-        let maxii = Int16.toBigInt(maximum);
+    pub def clampToInt16(min: {min = Int16}, max: {max = Int16}, x: BigInt): Int16 =
+        let minii = Int16.toBigInt(min#min);
+        let maxii = Int16.toBigInt(max#max);
         try {
-            let y = clamp(x, minii, maxii);
+            let y = clamp(min = minii, max = maxii, x);
             unsafe y.shortValueExact()
         } catch {
             // This should be impossible!
-            case _ : ArithmeticException => minimum
+            case _ : ArithmeticException => min#min
         }
 
     ///
     /// Convert `x` to an `Int32`.
     ///
-    /// Returns `x` clamped within the Int32 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int32 range `min` to `max`.
     ///
-    pub def clampToInt32(x: BigInt, minimum: Int32, maximum: Int32): Int32 =
-        let minii = Int32.toBigInt(minimum);
-        let maxii = Int32.toBigInt(maximum);
+    pub def clampToInt32(min: {min = Int32}, max: {max = Int32}, x: BigInt): Int32 =
+        let minii = Int32.toBigInt(min#min);
+        let maxii = Int32.toBigInt(max#max);
         try {
-            let y = clamp(x, minii, maxii);
+            let y = clamp(min = minii, max = maxii, x);
             unsafe y.intValueExact()
         } catch {
             // This should be impossible!
-            case _ : ArithmeticException => minimum
+            case _ : ArithmeticException => min#min
         }
 
     ///
     /// Convert `x` to an `Int64`.
     ///
-    /// Returns `x` clamped within the Int64 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int64 range `min` to `max`.
     ///
-    pub def clampToInt64(x: BigInt, minimum: Int64, maximum: Int64): Int64 =
-        let minii = Int64.toBigInt(minimum);
-        let maxii = Int64.toBigInt(maximum);
+    pub def clampToInt64(min: {min = Int64}, max: {max = Int64}, x: BigInt): Int64 =
+        let minii = Int64.toBigInt(min#min);
+        let maxii = Int64.toBigInt(max#max);
         try {
-            let y = clamp(x, minii, maxii);
+            let y = clamp(min = minii, max = maxii, x);
             unsafe y.longValueExact()
         } catch {
             // This should be impossible!
-            case _ : ArithmeticException => minimum
+            case _ : ArithmeticException => min#min
         }
 
     ///
     /// Convert `x` to a `Float32`.
     ///
-    /// Returns `x` clamped within the Float32 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Float32 range `min` to `max`.
     ///
-    pub def clampToFloat32(x: BigInt, minimum: Float32, maximum: Float32): Float32 =
+    pub def clampToFloat32(min: {min = Float32}, max: {max = Float32}, x: BigInt): Float32 =
         let step = () -> {
             forM (
-                f32min <- Float32.tryToBigInt(minimum);
-                f32max <- Float32.tryToBigInt(maximum)
+                f32min <- Float32.tryToBigInt(min#min);
+                f32max <- Float32.tryToBigInt(max#max)
             ) yield {
-                let x1 = clamp(x, f32min, f32max);
+                let x1 = clamp(min = f32min, max = f32max, x);
                 let xd = unsafe new BigDecimal(x1);
                 unsafe xd.floatValue()
             }
@@ -372,15 +372,15 @@ mod BigInt {
     ///
     /// Convert `x` to a `Float64`.
     ///
-    /// Returns `x` clamped within the Float64 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Float64 range `min` to `max`.
     ///
-    pub def clampToFloat64(x: BigInt, minimum: Float64, maximum: Float64): Float64 =
+    pub def clampToFloat64(min: {min = Float64}, max: {max = Float64}, x: BigInt): Float64 =
         let step = () -> {
             forM (
-                f64min <- Float64.tryToBigInt(minimum);
-                f64max <- Float64.tryToBigInt(maximum)
+                f64min <- Float64.tryToBigInt(min#min);
+                f64max <- Float64.tryToBigInt(max#max)
             ) yield {
-                let x1 = clamp(x, f64min, f64max);
+                let x1 = clamp(min = f64min, max = f64max, x);
                 let xd = unsafe new BigDecimal(x1);
                 unsafe xd.doubleValue()
             }

--- a/main/src/library/Float32.flix
+++ b/main/src/library/Float32.flix
@@ -210,78 +210,78 @@ mod Float32 {
     ///
     /// Helper function for the `clamp` conversion functions.
     ///
-    def clamp(x: Float32, minimum: Float32, maximum: Float32): Float32 =
-        if (x < minimum)
-             minimum
+    def clamp(min: {min = Float32}, max: {max = Float32}, x: Float32): Float32 =
+        if (x < min#min)
+             min#min
         else
-            if (x > maximum)
-                maximum
+            if (x > max#max)
+                max#max
             else
                 x
 
     ///
     /// Convert `x` to an `Int8`.
     ///
-    /// Returns `x` clamped within the Int8 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int8 range `min` to `max`.
     ///
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int8 risks masking it.
     ///
-    pub def clampToInt8(x: Float32, minimum: Int8, maximum: Int8, nanValue: Int8): Int8 =
-        let minf32 = Int8.toFloat32(minimum);
-        let maxf32 = Int8.toFloat32(maximum);
+    pub def clampToInt8(min: {min = Int8}, max: {max = Int8}, nanValue: {nanValue = Int8}, x: Float32): Int8 =
+        let minf32 = Int8.toFloat32(min#min);
+        let maxf32 = Int8.toFloat32(max#max);
         if (isNan(x))
-            nanValue
+            nanValue#nanValue
         else
-            Float.valueOf(clamp(x, minf32, maxf32)).byteValue()
+            Float.valueOf(clamp(min = minf32, max = maxf32, x)).byteValue()
 
     ///
     /// Convert `x` to an `Int16`.
     ///
-    /// Returns `x` clamped within the Int16 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int16 range `min` to `max`.
     ///
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int16 risks masking it.
     ///
-    pub def clampToInt16(x: Float32, minimum: Int16, maximum: Int16, nanValue: Int16): Int16 =
-        let minf32 = Int16.toFloat32(minimum);
-        let maxf32 = Int16.toFloat32(maximum);
+    pub def clampToInt16(min: {min = Int16}, max: {max = Int16}, nanValue: {nanValue = Int16}, x: Float32): Int16 =
+        let minf32 = Int16.toFloat32(min#min);
+        let maxf32 = Int16.toFloat32(max#max);
         if (isNan(x))
-            nanValue
+            nanValue#nanValue
         else
-            Float.valueOf(clamp(x, minf32, maxf32)).shortValue()
+            Float.valueOf(clamp(min = minf32, max = maxf32, x)).shortValue()
 
     ///
     /// Convert `x` to an `Int32`.
     ///
-    /// Returns `x` clamped within the Int32 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int32 range `min` to `max`.
     ///
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int32 risks masking it.
     ///
-    pub def clampToInt32(x: Float32, minimum: Int32, maximum: Int32, nanValue: Int32): Int32 =
-        let minf32 = Int32.toFloat32(minimum);
-        let maxf32 = Int32.toFloat32(maximum);
+    pub def clampToInt32(min: {min = Int32}, max: {max = Int32}, nanValue: {nanValue = Int32}, x: Float32): Int32 =
+        let minf32 = Int32.toFloat32(min#min);
+        let maxf32 = Int32.toFloat32(max#max);
         if (isNan(x))
-            nanValue
+            nanValue#nanValue
         else
-            Float.valueOf(clamp(x, minf32, maxf32)).intValue()
+            Float.valueOf(clamp(min = minf32, max = maxf32, x)).intValue()
 
     ///
     /// Convert `x` to an `Int64`.
     ///
-    /// Returns `x` clamped within the Int64 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int64 range `min` to `max`.
     ///
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int64 risks masking it.
     ///
-    pub def clampToInt64(x: Float32, minimum: Int64, maximum: Int64, nanValue: Int64): Int64 =
-        let minf32 = Int64.toFloat32(minimum);
-        let maxf32 = Int64.toFloat32(maximum);
+    pub def clampToInt64(min: {min = Int64}, max: {max = Int64}, nanValue: {nanValue = Int64}, x: Float32): Int64 =
+        let minf32 = Int64.toFloat32(min#min);
+        let maxf32 = Int64.toFloat32(max#max);
         if (isNan(x))
-            nanValue
+            nanValue#nanValue
         else
-            Float.valueOf(clamp(x, minf32, maxf32)).longValue()
+            Float.valueOf(clamp(min = minf32, max = maxf32, x)).longValue()
 
     ///
     /// Returns the absolute value of `x`.

--- a/main/src/library/Float64.flix
+++ b/main/src/library/Float64.flix
@@ -228,91 +228,91 @@ mod Float64 {
     ///
     /// Helper function for the `clamp` conversion functions.
     ///
-    def clamp(x: Float64, minimum: Float64, maximum: Float64): Float64 =
-        if (x < minimum)
-             minimum
+    def clamp(min: {min = Float64}, max: {max = Float64}, x: Float64): Float64 =
+        if (x < min#min)
+             min#min
         else
-            if (x > maximum)
-                maximum
+            if (x > max#max)
+                max#max
             else
                 x
 
     ///
     /// Convert `x` to an `Int8`.
     ///
-    /// Returns `x` clamped within the Int8 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int8 range `min` to `max`.
     ///
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int8 risks masking it.
     ///
-    pub def clampToInt8(x: Float64, minimum: Int8, maximum: Int8, nanValue: Int8): Int8 =
-        let minf64 = Int8.toFloat64(minimum);
-        let maxf64 = Int8.toFloat64(maximum);
+    pub def clampToInt8(min: {min = Int8}, max: {max = Int8}, nanValue: {nanValue = Int8}, x: Float64): Int8 =
+        let minf64 = Int8.toFloat64(min#min);
+        let maxf64 = Int8.toFloat64(max#max);
         if (isNan(x))
-            nanValue
+            nanValue#nanValue
         else
-            Double.valueOf(clamp(x, minf64, maxf64)).byteValue()
+            Double.valueOf(clamp(min = minf64, max = maxf64, x)).byteValue()
 
     ///
     /// Convert `x` to an `Int16`.
     ///
-    /// Returns `x` clamped within the Int16 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int16 range `min` to `max`.
     ///
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int16 risks masking it.
     ///
-    pub def clampToInt16(x: Float64, minimum: Int16, maximum: Int16, nanValue: Int16): Int16 =
-        let minf64 = Int16.toFloat64(minimum);
-        let maxf64 = Int16.toFloat64(maximum);
+    pub def clampToInt16(min: {min = Int16}, max: {max = Int16}, nanValue: {nanValue = Int16}, x: Float64): Int16 =
+        let minf64 = Int16.toFloat64(min#min);
+        let maxf64 = Int16.toFloat64(max#max);
         if (isNan(x))
-            nanValue
+            nanValue#nanValue
         else
-            Double.valueOf(clamp(x, minf64, maxf64)).shortValue()
+            Double.valueOf(clamp(min = minf64, max = maxf64, x)).shortValue()
 
     ///
     /// Convert `x` to an `Int32`.
     ///
-    /// Returns `x` clamped within the Int32 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int32 range `min` to `max`.
     ///
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int32 risks masking it.
     ///
-    pub def clampToInt32(x: Float64, minimum: Int32, maximum: Int32, nanValue: Int32): Int32 =
-        let minf64 = Int32.toFloat64(minimum);
-        let maxf64 = Int32.toFloat64(maximum);
+    pub def clampToInt32(min: {min = Int32}, max: {max = Int32}, nanValue: {nanValue = Int32}, x: Float64): Int32 =
+        let minf64 = Int32.toFloat64(min#min);
+        let maxf64 = Int32.toFloat64(max#max);
         if (isNan(x))
-            nanValue
+            nanValue#nanValue
         else
-            Double.valueOf(clamp(x, minf64, maxf64)).intValue()
+            Double.valueOf(clamp(min = minf64, max = maxf64, x)).intValue()
 
     ///
     /// Convert `x` to an `Int64`.
     ///
-    /// Returns `x` clamped within the Int64 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Int64 range `min` to `max`.
     ///
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int64 risks masking it.
     ///
-    pub def clampToInt64(x: Float64, minimum: Int64, maximum: Int64, nanValue: Int64): Int64 =
-        let minf64 = Int64.toFloat64(minimum);
-        let maxf64 = Int64.toFloat64(maximum);
+    pub def clampToInt64(min: {min = Int64}, max: {max = Int64}, nanValue: {nanValue = Int64}, x: Float64): Int64 =
+        let minf64 = Int64.toFloat64(min#min);
+        let maxf64 = Int64.toFloat64(max#max);
         if (isNan(x))
-            nanValue
+            nanValue#nanValue
         else
-            Double.valueOf(clamp(x, minf64, maxf64)).longValue()
+            Double.valueOf(clamp(min = minf64, max = maxf64, x)).longValue()
 
     ///
     /// Convert `x` to a `Float32`.
     ///
-    /// Returns `x` clamped within the Float32 range `minimum` to `maximum`.
+    /// Returns `x` clamped within the Float32 range `min` to `max`.
     ///
-    pub def clampToFloat32(x: Float64, minimum: Float32, maximum: Float32): Float32 =
-        let minf64 = Float32.toFloat64(minimum);
-        let maxf64 = Float32.toFloat64(maximum);
+    pub def clampToFloat32(min: {min = Float32}, max: {max = Float32}, x: Float64): Float32 =
+        let minf64 = Float32.toFloat64(min#min);
+        let maxf64 = Float32.toFloat64(max#max);
         if (isNan(x))
             Float32.nan()
         else
-            Double.valueOf(clamp(x, minf64, maxf64)).floatValue()
+            Double.valueOf(clamp(min = minf64, max = maxf64, x)).floatValue()
 
     ///
     /// Returns the absolute value of `x`.

--- a/main/test/ca/uwaterloo/flix/library/TestBigInt.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestBigInt.flix
@@ -823,144 +823,144 @@ mod TestBigInt {
     // clampToInt8                                                             //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt801(): Bool = BigInt.clampToInt8(0ii, -100i8, 100i8) == 0i8
+    def clampToInt801(): Bool = BigInt.clampToInt8(min = -100i8, max = 100i8, 0ii) == 0i8
 
     @test
-    def clampToInt802(): Bool = BigInt.clampToInt8(100ii, -100i8, 100i8) == 100i8
+    def clampToInt802(): Bool = BigInt.clampToInt8(min = -100i8, max = 100i8, 100ii) == 100i8
 
     @test
-    def clampToInt803(): Bool = BigInt.clampToInt8(101ii, -100i8, 100i8) == 100i8
+    def clampToInt803(): Bool = BigInt.clampToInt8(min = -100i8, max = 100i8, 101ii) == 100i8
 
     @test
-    def clampToInt804(): Bool = BigInt.clampToInt8(-100ii, -100i8, 100i8) == -100i8
+    def clampToInt804(): Bool = BigInt.clampToInt8(min = -100i8, max = 100i8, -100ii) == -100i8
 
     @test
-    def clampToInt805(): Bool = BigInt.clampToInt8(-101ii, -100i8, 100i8) == -100i8
+    def clampToInt805(): Bool = BigInt.clampToInt8(min = -100i8, max = 100i8, -101ii) == -100i8
 
     @test
-    def clampToInt806(): Bool = BigInt.clampToInt8(8982741234134123419879712341ii, -100i8, 100i8) == 100i8
+    def clampToInt806(): Bool = BigInt.clampToInt8(min = -100i8, max = 100i8, 8982741234134123419879712341ii) == 100i8
 
     @test
-    def clampToInt807(): Bool = BigInt.clampToInt8(-8982741234134123419879712341ii, -100i8, 100i8) == -100i8
+    def clampToInt807(): Bool = BigInt.clampToInt8(min = -100i8, max = 100i8, -8982741234134123419879712341ii) == -100i8
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToInt16                                                            //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt1601(): Bool = BigInt.clampToInt16(0ii, -100i16, 100i16) == 0i16
+    def clampToInt1601(): Bool = BigInt.clampToInt16(min = -100i16, max = 100i16, 0ii) == 0i16
 
     @test
-    def clampToInt1602(): Bool = BigInt.clampToInt16(100ii, -100i16, 100i16) == 100i16
+    def clampToInt1602(): Bool = BigInt.clampToInt16(min = -100i16, max = 100i16, 100ii) == 100i16
 
     @test
-    def clampToInt1603(): Bool = BigInt.clampToInt16(101ii, -100i16, 100i16) == 100i16
+    def clampToInt1603(): Bool = BigInt.clampToInt16(min = -100i16, max = 100i16, 101ii) == 100i16
 
     @test
-    def clampToInt1604(): Bool = BigInt.clampToInt16(-100ii, -100i16, 100i16) == -100i16
+    def clampToInt1604(): Bool = BigInt.clampToInt16(min = -100i16, max = 100i16, -100ii) == -100i16
 
     @test
-    def clampToInt1605(): Bool = BigInt.clampToInt16(-101ii, -100i16, 100i16) == -100i16
+    def clampToInt1605(): Bool = BigInt.clampToInt16(min = -100i16, max = 100i16, -101ii) == -100i16
 
     @test
-    def clampToInt1606(): Bool = BigInt.clampToInt16(8982741234134123419879712341ii, -100i16, 100i16) == 100i16
+    def clampToInt1606(): Bool = BigInt.clampToInt16(min = -100i16, max = 100i16, 8982741234134123419879712341ii) == 100i16
 
     @test
-    def clampToInt1607(): Bool = BigInt.clampToInt16(-8982741234134123419879712341ii, -100i16, 100i16) == -100i16
+    def clampToInt1607(): Bool = BigInt.clampToInt16(min = -100i16, max = 100i16, -8982741234134123419879712341ii) == -100i16
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToInt32                                                            //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt3201(): Bool = BigInt.clampToInt32(0ii, -100, 100) == 0
+    def clampToInt3201(): Bool = BigInt.clampToInt32(min = -100, max = 100, 0ii) == 0
 
     @test
-    def clampToInt3202(): Bool = BigInt.clampToInt32(100ii, -100, 100) == 100
+    def clampToInt3202(): Bool = BigInt.clampToInt32(min = -100, max = 100, 100ii) == 100
 
     @test
-    def clampToInt3203(): Bool = BigInt.clampToInt32(101ii, -100, 100) == 100
+    def clampToInt3203(): Bool = BigInt.clampToInt32(min = -100, max = 100, 101ii) == 100
 
     @test
-    def clampToInt3204(): Bool = BigInt.clampToInt32(-100ii, -100, 100) == -100
+    def clampToInt3204(): Bool = BigInt.clampToInt32(min = -100, max = 100, -100ii) == -100
 
     @test
-    def clampToInt3205(): Bool = BigInt.clampToInt32(-101ii, -100, 100) == -100
+    def clampToInt3205(): Bool = BigInt.clampToInt32(min = -100, max = 100, -101ii) == -100
 
     @test
-    def clampToInt3206(): Bool = BigInt.clampToInt32(8982741234134123419879712341ii, -100i32, 100i32) == 100i32
+    def clampToInt3206(): Bool = BigInt.clampToInt32(min = -100i32, max = 100i32, 8982741234134123419879712341ii) == 100i32
 
     @test
-    def clampToInt3207(): Bool = BigInt.clampToInt32(-8982741234134123419879712341ii, -100i32, 100i32) == -100i32
+    def clampToInt3207(): Bool = BigInt.clampToInt32(min = -100i32, max = 100i32, -8982741234134123419879712341ii) == -100i32
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToInt64                                                            //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt6401(): Bool = BigInt.clampToInt64(0ii, -100i64, 100i64) == 0i64
+    def clampToInt6401(): Bool = BigInt.clampToInt64(min = -100i64, max = 100i64, 0ii) == 0i64
 
     @test
-    def clampToInt6402(): Bool = BigInt.clampToInt64(100ii, -100i64, 100i64) == 100i64
+    def clampToInt6402(): Bool = BigInt.clampToInt64(min = -100i64, max = 100i64, 100ii) == 100i64
 
     @test
-    def clampToInt6403(): Bool = BigInt.clampToInt64(101ii, -100i64, 100i64) == 100i64
+    def clampToInt6403(): Bool = BigInt.clampToInt64(min = -100i64, max = 100i64, 101ii) == 100i64
 
     @test
-    def clampToInt6404(): Bool = BigInt.clampToInt64(-100ii, -100i64, 100i64) == -100i64
+    def clampToInt6404(): Bool = BigInt.clampToInt64(min = -100i64, max = 100i64, -100ii) == -100i64
 
     @test
-    def clampToInt6405(): Bool = BigInt.clampToInt64(-101ii, -100i64, 100i64) == -100i64
+    def clampToInt6405(): Bool = BigInt.clampToInt64(min = -100i64, max = 100i64, -101ii) == -100i64
 
     @test
-    def clampToInt6406(): Bool = BigInt.clampToInt64(8982741234134123419879712341ii, -100i64, 100i64) == 100i64
+    def clampToInt6406(): Bool = BigInt.clampToInt64(min = -100i64, max = 100i64, 8982741234134123419879712341ii) == 100i64
 
     @test
-    def clampToInt6407(): Bool = BigInt.clampToInt64(-8982741234134123419879712341ii, -100i64, 100i64) == -100i64
+    def clampToInt6407(): Bool = BigInt.clampToInt64(min = -100i64, max = 100i64, -8982741234134123419879712341ii) == -100i64
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToFloat32                                                          //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToFloat3201(): Bool = BigInt.clampToFloat32(0ii, -100.0f32, 100.0f32) == 0.0f32
+    def clampToFloat3201(): Bool = BigInt.clampToFloat32(min = -100.0f32, max = 100.0f32, 0ii) == 0.0f32
 
     @test
-    def clampToFloat3202(): Bool = BigInt.clampToFloat32(100ii, -100.0f32, 100.0f32) == 100.0f32
+    def clampToFloat3202(): Bool = BigInt.clampToFloat32(min = -100.0f32, max = 100.0f32, 100ii) == 100.0f32
 
     @test
-    def clampToFloat3203(): Bool = BigInt.clampToFloat32(101ii, -100.0f32, 100.0f32) == 100.0f32
+    def clampToFloat3203(): Bool = BigInt.clampToFloat32(min = -100.0f32, max = 100.0f32, 101ii) == 100.0f32
 
     @test
-    def clampToFloat3204(): Bool = BigInt.clampToFloat32(-100ii, -100.0f32, 100.0f32) == -100.0f32
+    def clampToFloat3204(): Bool = BigInt.clampToFloat32(min = -100.0f32, max = 100.0f32, -100ii) == -100.0f32
 
     @test
-    def clampToFloat3205(): Bool = BigInt.clampToFloat32(-101ii, -100.0f32, 100.0f32) == -100.0f32
+    def clampToFloat3205(): Bool = BigInt.clampToFloat32(min = -100.0f32, max = 100.0f32, -101ii) == -100.0f32
 
     @test
-    def clampToFloat3206(): Bool = BigInt.clampToFloat32(8982741234134123419879712341ii, -100.0f32, 100.0f32) == 100.0f32
+    def clampToFloat3206(): Bool = BigInt.clampToFloat32(min = -100.0f32, max = 100.0f32, 8982741234134123419879712341ii) == 100.0f32
 
     @test
-    def clampToFloat3207(): Bool = BigInt.clampToFloat32(-8982741234134123419879712341ii, -100.0f32, 100.0f32) == -100.0f32
+    def clampToFloat3207(): Bool = BigInt.clampToFloat32(min = -100.0f32, max = 100.0f32, -8982741234134123419879712341ii) == -100.0f32
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToFloat64                                                          //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToFloat6401(): Bool = BigInt.clampToFloat64(0ii, -100.0f64, 100.0f64) == 0.0f64
+    def clampToFloat6401(): Bool = BigInt.clampToFloat64(min = -100.0f64, max = 100.0f64, 0ii) == 0.0f64
 
     @test
-    def clampToFloat6402(): Bool = BigInt.clampToFloat64(100ii, -100.0f64, 100.0f64) == 100.0f64
+    def clampToFloat6402(): Bool = BigInt.clampToFloat64(min = -100.0f64, max = 100.0f64, 100ii) == 100.0f64
 
     @test
-    def clampToFloat6403(): Bool = BigInt.clampToFloat64(101ii, -100.0f64, 100.0f64) == 100.0f64
+    def clampToFloat6403(): Bool = BigInt.clampToFloat64(min = -100.0f64, max = 100.0f64, 101ii) == 100.0f64
 
     @test
-    def clampToFloat6404(): Bool = BigInt.clampToFloat64(-100ii, -100.0f64, 100.0f64) == -100.0f64
+    def clampToFloat6404(): Bool = BigInt.clampToFloat64(min = -100.0f64, max = 100.0f64, -100ii) == -100.0f64
 
     @test
-    def clampToFloat6405(): Bool = BigInt.clampToFloat64(-101ii, -100.0f64, 100.0f64) == -100.0f64
+    def clampToFloat6405(): Bool = BigInt.clampToFloat64(min = -100.0f64, max = 100.0f64, -101ii) == -100.0f64
 
     @test
-    def clampToFloat6406(): Bool = BigInt.clampToFloat64(8982741234134123419879712341ii, -100.0f64, 100.0f64) == 100.0f64
+    def clampToFloat6406(): Bool = BigInt.clampToFloat64(min = -100.0f64, max = 100.0f64, 8982741234134123419879712341ii) == 100.0f64
 
     @test
-    def clampToFloat6407(): Bool = BigInt.clampToFloat64(-8982741234134123419879712341ii, -100.0f64, 100.0f64) == -100.0f64
+    def clampToFloat6407(): Bool = BigInt.clampToFloat64(min = -100.0f64, max = 100.0f64, -8982741234134123419879712341ii) == -100.0f64
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
@@ -436,109 +436,109 @@ mod TestFloat32 {
     // clampToInt8                                                             //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt801(): Bool = Float32.clampToInt8(0.0f32, -100i8, 100i8, -127i8) == 0i8
+    def clampToInt801(): Bool = Float32.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, 0.0f32) == 0i8
 
     @test
-    def clampToInt802(): Bool = Float32.clampToInt8(100.0f32, -100i8, 100i8, -127i8) == 100i8
+    def clampToInt802(): Bool = Float32.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, 100.0f32) == 100i8
 
     @test
-    def clampToInt803(): Bool = Float32.clampToInt8(101.0f32, -100i8, 100i8, -127i8) == 100i8
+    def clampToInt803(): Bool = Float32.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, 101.0f32) == 100i8
 
     @test
-    def clampToInt804(): Bool = Float32.clampToInt8(-100.0f32, -100i8, 100i8, -127i8) == -100i8
+    def clampToInt804(): Bool = Float32.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, -100.0f32) == -100i8
 
     @test
-    def clampToInt805(): Bool = Float32.clampToInt8(-101.0f32, -100i8, 100i8, -127i8) == -100i8
+    def clampToInt805(): Bool = Float32.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, -101.0f32) == -100i8
 
     @test
-    def clampToInt806(): Bool = Float32.clampToInt8(Float32.maxValue(), -100i8, 100i8, -127i8) == 100i8
+    def clampToInt806(): Bool = Float32.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, Float32.maxValue()) == 100i8
 
     @test
-    def clampToInt807(): Bool = Float32.clampToInt8(Float32.minValue(), -100i8, 100i8, -127i8) == -100i8
+    def clampToInt807(): Bool = Float32.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, Float32.minValue()) == -100i8
 
     @test
-    def clampToInt808(): Bool = Float32.clampToInt8(Float32.nan(), -100i8, 100i8, -127i8) == -127i8
+    def clampToInt808(): Bool = Float32.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, Float32.nan()) == -127i8
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToInt16                                                            //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt1601(): Bool = Float32.clampToInt16(0.0f32, -100i16, 100i16, -127i16) == 0i16
+    def clampToInt1601(): Bool = Float32.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, 0.0f32) == 0i16
 
     @test
-    def clampToInt1602(): Bool = Float32.clampToInt16(100.0f32, -100i16, 100i16, -127i16) == 100i16
+    def clampToInt1602(): Bool = Float32.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, 100.0f32) == 100i16
 
     @test
-    def clampToInt1603(): Bool = Float32.clampToInt16(101.0f32, -100i16, 100i16, -127i16) == 100i16
+    def clampToInt1603(): Bool = Float32.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, 101.0f32) == 100i16
 
     @test
-    def clampToInt1604(): Bool = Float32.clampToInt16(-100.0f32, -100i16, 100i16, -127i16) == -100i16
+    def clampToInt1604(): Bool = Float32.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, -100.0f32) == -100i16
 
     @test
-    def clampToInt1605(): Bool = Float32.clampToInt16(-101.0f32, -100i16, 100i16, -127i16) == -100i16
+    def clampToInt1605(): Bool = Float32.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, -101.0f32) == -100i16
 
     @test
-    def clampToInt1606(): Bool = Float32.clampToInt16(Float32.maxValue(), -100i16, 100i16, -127i16) == 100i16
+    def clampToInt1606(): Bool = Float32.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, Float32.maxValue()) == 100i16
 
     @test
-    def clampToInt1607(): Bool = Float32.clampToInt16(Float32.minValue(), -100i16, 100i16, -127i16) == -100i16
+    def clampToInt1607(): Bool = Float32.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, Float32.minValue()) == -100i16
 
     @test
-    def clampToInt1608(): Bool = Float32.clampToInt16(Float32.nan(), -100i16, 100i16, -127i16) == -127i16
+    def clampToInt1608(): Bool = Float32.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, Float32.nan()) == -127i16
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToInt32                                                            //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt3201(): Bool = Float32.clampToInt32(0.0f32, -100i32, 100i32, -127i32) == 0i32
+    def clampToInt3201(): Bool = Float32.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, 0.0f32) == 0i32
 
     @test
-    def clampToInt3202(): Bool = Float32.clampToInt32(100.0f32, -100i32, 100i32, -127i32) == 100i32
+    def clampToInt3202(): Bool = Float32.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, 100.0f32) == 100i32
 
     @test
-    def clampToInt3203(): Bool = Float32.clampToInt32(101.0f32, -100i32, 100i32, -127i32) == 100i32
+    def clampToInt3203(): Bool = Float32.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, 101.0f32) == 100i32
 
     @test
-    def clampToInt3204(): Bool = Float32.clampToInt32(-100.0f32, -100i32, 100i32, -127i32) == -100i32
+    def clampToInt3204(): Bool = Float32.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, -100.0f32) == -100i32
 
     @test
-    def clampToInt3205(): Bool = Float32.clampToInt32(-101.0f32, -100i32, 100i32, -127i32) == -100i32
+    def clampToInt3205(): Bool = Float32.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, -101.0f32) == -100i32
 
     @test
-    def clampToInt3206(): Bool = Float32.clampToInt32(Float32.maxValue(), -100i32, 100i32, -127i32) == 100i32
+    def clampToInt3206(): Bool = Float32.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, Float32.maxValue()) == 100i32
 
     @test
-    def clampToInt3207(): Bool = Float32.clampToInt32(Float32.minValue(), -100i32, 100i32, -127i32) == -100i32
+    def clampToInt3207(): Bool = Float32.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, Float32.minValue()) == -100i32
 
     @test
-    def clampToInt3208(): Bool = Float32.clampToInt32(Float32.nan(), -100i32, 100i32, -127i32) == -127i32
+    def clampToInt3208(): Bool = Float32.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, Float32.nan()) == -127i32
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToInt64                                                            //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt6401(): Bool = Float32.clampToInt64(0.0f32, -100i64, 100i64, -127i64) == 0i64
+    def clampToInt6401(): Bool = Float32.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, 0.0f32) == 0i64
 
     @test
-    def clampToInt6402(): Bool = Float32.clampToInt64(100.0f32, -100i64, 100i64, -127i64) == 100i64
+    def clampToInt6402(): Bool = Float32.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, 100.0f32) == 100i64
 
     @test
-    def clampToInt6403(): Bool = Float32.clampToInt64(101.0f32, -100i64, 100i64, -127i64) == 100i64
+    def clampToInt6403(): Bool = Float32.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, 101.0f32) == 100i64
 
     @test
-    def clampToInt6404(): Bool = Float32.clampToInt64(-100.0f32, -100i64, 100i64, -127i64) == -100i64
+    def clampToInt6404(): Bool = Float32.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, -100.0f32) == -100i64
 
     @test
-    def clampToInt6405(): Bool = Float32.clampToInt64(-101.0f32, -100i64, 100i64, -127i64) == -100i64
+    def clampToInt6405(): Bool = Float32.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, -101.0f32) == -100i64
 
     @test
-    def clampToInt6406(): Bool = Float32.clampToInt64(Float32.maxValue(), -100i64, 100i64, -127i64) == 100i64
+    def clampToInt6406(): Bool = Float32.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, Float32.maxValue()) == 100i64
 
     @test
-    def clampToInt6407(): Bool = Float32.clampToInt64(Float32.minValue(), -100i64, 100i64, -127i64) == -100i64
+    def clampToInt6407(): Bool = Float32.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, Float32.minValue()) == -100i64
 
     @test
-    def clampToInt6408(): Bool = Float32.clampToInt64(Float32.nan(), -100i64, 100i64, -127i64) == -127i64
+    def clampToInt6408(): Bool = Float32.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, Float32.nan()) == -127i64
 
     /////////////////////////////////////////////////////////////////////////////
     // abs                                                                     //

--- a/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
@@ -437,137 +437,137 @@ mod TestFloat64 {
     // clampToInt8                                                             //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt801(): Bool = Float64.clampToInt8(0.0f64, -100i8, 100i8, -127i8) == 0i8
+    def clampToInt801(): Bool = Float64.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, 0.0f64) == 0i8
 
     @test
-    def clampToInt802(): Bool = Float64.clampToInt8(100.0f64, -100i8, 100i8, -127i8) == 100i8
+    def clampToInt802(): Bool = Float64.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, 100.0f64) == 100i8
 
     @test
-    def clampToInt803(): Bool = Float64.clampToInt8(101.0f64, -100i8, 100i8, -127i8) == 100i8
+    def clampToInt803(): Bool = Float64.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, 101.0f64) == 100i8
 
     @test
-    def clampToInt804(): Bool = Float64.clampToInt8(-100.0f64, -100i8, 100i8, -127i8) == -100i8
+    def clampToInt804(): Bool = Float64.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, -100.0f64) == -100i8
 
     @test
-    def clampToInt805(): Bool = Float64.clampToInt8(-101.0f64, -100i8, 100i8, -127i8) == -100i8
+    def clampToInt805(): Bool = Float64.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, -101.0f64) == -100i8
 
     @test
-    def clampToInt806(): Bool = Float64.clampToInt8(Float64.maxValue(), -100i8, 100i8, -127i8) == 100i8
+    def clampToInt806(): Bool = Float64.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, Float64.maxValue()) == 100i8
 
     @test
-    def clampToInt807(): Bool = Float64.clampToInt8(Float64.minValue(), -100i8, 100i8, -127i8) == -100i8
+    def clampToInt807(): Bool = Float64.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, Float64.minValue()) == -100i8
 
     @test
-    def clampToInt808(): Bool = Float64.clampToInt8(Float64.nan(), -100i8, 100i8, -127i8) == -127i8
+    def clampToInt808(): Bool = Float64.clampToInt8(min = -100i8, max = 100i8, nanValue = -127i8, Float64.nan()) == -127i8
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToInt16                                                            //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt1601(): Bool = Float64.clampToInt16(0.0f64, -100i16, 100i16, -127i16) == 0i16
+    def clampToInt1601(): Bool = Float64.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, 0.0f64) == 0i16
 
     @test
-    def clampToInt1602(): Bool = Float64.clampToInt16(100.0f64, -100i16, 100i16, -127i16) == 100i16
+    def clampToInt1602(): Bool = Float64.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, 100.0f64) == 100i16
 
     @test
-    def clampToInt1603(): Bool = Float64.clampToInt16(101.0f64, -100i16, 100i16, -127i16) == 100i16
+    def clampToInt1603(): Bool = Float64.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, 101.0f64) == 100i16
 
     @test
-    def clampToInt1604(): Bool = Float64.clampToInt16(-100.0f64, -100i16, 100i16, -127i16) == -100i16
+    def clampToInt1604(): Bool = Float64.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, -100.0f64) == -100i16
 
     @test
-    def clampToInt1605(): Bool = Float64.clampToInt16(-101.0f64, -100i16, 100i16, -127i16) == -100i16
+    def clampToInt1605(): Bool = Float64.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, -101.0f64) == -100i16
 
     @test
-    def clampToInt1606(): Bool = Float64.clampToInt16(Float64.maxValue(), -100i16, 100i16, -127i16) == 100i16
+    def clampToInt1606(): Bool = Float64.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, Float64.maxValue()) == 100i16
 
     @test
-    def clampToInt1607(): Bool = Float64.clampToInt16(Float64.minValue(), -100i16, 100i16, -127i16) == -100i16
+    def clampToInt1607(): Bool = Float64.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, Float64.minValue()) == -100i16
 
     @test
-    def clampToInt1608(): Bool = Float64.clampToInt16(Float64.nan(), -100i16, 100i16, -127i16) == -127i16
+    def clampToInt1608(): Bool = Float64.clampToInt16(min = -100i16, max = 100i16, nanValue = -127i16, Float64.nan()) == -127i16
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToInt32                                                            //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt3201(): Bool = Float64.clampToInt32(0.0f64, -100i32, 100i32, -127i32) == 0i32
+    def clampToInt3201(): Bool = Float64.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, 0.0f64) == 0i32
 
     @test
-    def clampToInt3202(): Bool = Float64.clampToInt32(100.0f64, -100i32, 100i32, -127i32) == 100i32
+    def clampToInt3202(): Bool = Float64.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, 100.0f64) == 100i32
 
     @test
-    def clampToInt3203(): Bool = Float64.clampToInt32(101.0f64, -100i32, 100i32, -127i32) == 100i32
+    def clampToInt3203(): Bool = Float64.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, 101.0f64) == 100i32
 
     @test
-    def clampToInt3204(): Bool = Float64.clampToInt32(-100.0f64, -100i32, 100i32, -127i32) == -100i32
+    def clampToInt3204(): Bool = Float64.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, -100.0f64) == -100i32
 
     @test
-    def clampToInt3205(): Bool = Float64.clampToInt32(-101.0f64, -100i32, 100i32, -127i32) == -100i32
+    def clampToInt3205(): Bool = Float64.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, -101.0f64) == -100i32
 
     @test
-    def clampToInt3206(): Bool = Float64.clampToInt32(Float64.maxValue(), -100i32, 100i32, -127i32) == 100i32
+    def clampToInt3206(): Bool = Float64.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, Float64.maxValue()) == 100i32
 
     @test
-    def clampToInt3207(): Bool = Float64.clampToInt32(Float64.minValue(), -100i32, 100i32, -127i32) == -100i32
+    def clampToInt3207(): Bool = Float64.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, Float64.minValue()) == -100i32
 
     @test
-    def clampToInt3208(): Bool = Float64.clampToInt32(Float64.nan(), -100i32, 100i32, -127i32) == -127i32
+    def clampToInt3208(): Bool = Float64.clampToInt32(min = -100i32, max = 100i32, nanValue = -127i32, Float64.nan()) == -127i32
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToInt64                                                            //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToInt6401(): Bool = Float64.clampToInt64(0.0f64, -100i64, 100i64, -127i64) == 0i64
+    def clampToInt6401(): Bool = Float64.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, 0.0f64) == 0i64
 
     @test
-    def clampToInt6402(): Bool = Float64.clampToInt64(100.0f64, -100i64, 100i64, -127i64) == 100i64
+    def clampToInt6402(): Bool = Float64.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, 100.0f64) == 100i64
 
     @test
-    def clampToInt6403(): Bool = Float64.clampToInt64(101.0f64, -100i64, 100i64, -127i64) == 100i64
+    def clampToInt6403(): Bool = Float64.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, 101.0f64) == 100i64
 
     @test
-    def clampToInt6404(): Bool = Float64.clampToInt64(-100.0f64, -100i64, 100i64, -127i64) == -100i64
+    def clampToInt6404(): Bool = Float64.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, -100.0f64) == -100i64
 
     @test
-    def clampToInt6405(): Bool = Float64.clampToInt64(-101.0f64, -100i64, 100i64, -127i64) == -100i64
+    def clampToInt6405(): Bool = Float64.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, -101.0f64) == -100i64
 
     @test
-    def clampToInt6406(): Bool = Float64.clampToInt64(Float64.maxValue(), -100i64, 100i64, -127i64) == 100i64
+    def clampToInt6406(): Bool = Float64.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, Float64.maxValue()) == 100i64
 
     @test
-    def clampToInt6407(): Bool = Float64.clampToInt64(Float64.minValue(), -100i64, 100i64, -127i64) == -100i64
+    def clampToInt6407(): Bool = Float64.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, Float64.minValue()) == -100i64
 
     @test
-    def clampToInt6408(): Bool = Float64.clampToInt64(Float64.nan(), -100i64, 100i64, -127i64) == -127i64
+    def clampToInt6408(): Bool = Float64.clampToInt64(min = -100i64, max = 100i64, nanValue = -127i64, Float64.nan()) == -127i64
 
     /////////////////////////////////////////////////////////////////////////////
     // clampToFloat32                                                          //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def clampToFloat3201(): Bool = Float64.clampToFloat32(0.0f64, -100.0f32, 100.0f32) == 0.0f32
+    def clampToFloat3201(): Bool = Float64.clampToFloat32(min = -100.0f32, max = 100.0f32, 0.0f64) == 0.0f32
 
     @test
-    def clampToFloat3202(): Bool = Float64.clampToFloat32(100.0f64, -100.0f32, 100.0f32) == 100.0f32
+    def clampToFloat3202(): Bool = Float64.clampToFloat32(min = -100.0f32, max = 100.0f32, 100.0f64) == 100.0f32
 
     @test
-    def clampToFloat3203(): Bool = Float64.clampToFloat32(101.0f64, -100.0f32, 100.0f32) == 100.0f32
+    def clampToFloat3203(): Bool = Float64.clampToFloat32(min = -100.0f32, max = 100.0f32, 101.0f64) == 100.0f32
 
     @test
-    def clampToFloat3204(): Bool = Float64.clampToFloat32(-100.0f64, -100.0f32, 100.0f32) == -100.0f32
+    def clampToFloat3204(): Bool = Float64.clampToFloat32(min = -100.0f32, max = 100.0f32, -100.0f64) == -100.0f32
 
     @test
-    def clampToFloat3205(): Bool = Float64.clampToFloat32(-101.0f64, -100.0f32, 100.0f32) == -100.0f32
+    def clampToFloat3205(): Bool = Float64.clampToFloat32(min = -100.0f32, max = 100.0f32, -101.0f64) == -100.0f32
 
     @test
-    def clampToFloat3206(): Bool = Float64.clampToFloat32(Float64.maxValue(), -100.0f32, 100.0f32) == 100.0f32
+    def clampToFloat3206(): Bool = Float64.clampToFloat32(min = -100.0f32, max = 100.0f32, Float64.maxValue()) == 100.0f32
 
     @test
-    def clampToFloat3207(): Bool = Float64.clampToFloat32(Float64.minValue(), -100.0f32, 100.0f32) == -100.0f32
+    def clampToFloat3207(): Bool = Float64.clampToFloat32(min = -100.0f32, max = 100.0f32, Float64.minValue()) == -100.0f32
 
     @test
     def clampToFloat3208(): Bool =
-        let ans = Float64.clampToFloat32(Float64.nan(), -100.0f32, 100.0f32);
+        let ans = Float64.clampToFloat32(min = -100.0f32, max = 100.0f32, Float64.nan());
         Float32.isNan(ans) == true
 
     /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
For the various `clampToX` functions in `BigInt`, `Float32`, and `Float64`:
* makes the function subject-last
* uses record arguments
* renames `minimum`/`maximum` to `min`/`max`

These changes are consistent with (and were already made in) `Int16`, `Int32`, and `Int64`.

(fixes #6123)

@mlutze 