### PR TITLE
refactor: remove BOT FlixError

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -53,7 +53,6 @@ sealed trait BackendObjType {
     case BackendObjType.Record => JvmName(RootPackage, mkClassName("Record"))
     case BackendObjType.ReifiedSourceLocation => JvmName(DevFlixRuntime, mkClassName("ReifiedSourceLocation"))
     case BackendObjType.Global => JvmName(DevFlixRuntime, "Global") // "Global" is fixed in source code, so should not be mangled and $ suffixed
-    case BackendObjType.FlixError => JvmName(DevFlixRuntime, mkClassName("FlixError"))
     case BackendObjType.HoleError => JvmName(DevFlixRuntime, mkClassName("HoleError"))
     case BackendObjType.MatchError => JvmName(DevFlixRuntime, mkClassName("MatchError"))
     case BackendObjType.CastError => JvmName(DevFlixRuntime, mkClassName("CastError"))
@@ -1103,28 +1102,9 @@ object BackendObjType {
     }
   }
 
-  case object FlixError extends BackendObjType {
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkAbstractClass(this.jvmName, JvmName.Error)
-
-      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, List(BackendType.String))
-
-    private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      thisLoad()
-      ALOAD(1)
-      invokeConstructor(JvmName.Error, mkDescriptor(BackendType.String)(VoidableType.Void))
-      RETURN()
-    }
-  }
-
   case object HoleError extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, FlixError.jvmName)
+      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, JvmName.FlixError)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
       // These fields allow external equality checking.
@@ -1175,7 +1155,7 @@ object BackendObjType {
   case object MatchError extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(MatchError.jvmName, IsFinal, superClass = FlixError.jvmName)
+      val cm = ClassMaker.mkClass(MatchError.jvmName, IsFinal, superClass = JvmName.FlixError)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
       // This field allows external equality checking.
@@ -1211,7 +1191,7 @@ object BackendObjType {
   case object CastError extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = FlixError.jvmName)
+      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = JvmName.FlixError)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
 
@@ -1243,7 +1223,7 @@ object BackendObjType {
   case object UnhandledEffectError extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = FlixError.jvmName)
+      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = JvmName.FlixError)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
       // This field allows external equality checking.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -281,7 +281,29 @@ object ClassMaker {
 
   sealed case class StaticInterfaceMethod(clazz: JvmName, name: String, d: MethodDescriptor) extends Method
 
-  // Constants.
+  // Flix Constants.
+
+  object FlixError {
+
+    def Constructor: ConstructorMethod = ConstructorMethod(JvmName.FlixError, List(BackendType.String))
+
+    def genByteCode()(implicit flix: Flix): Array[Byte] = {
+      val cm = ClassMaker.mkAbstractClass(JvmName.FlixError, JvmName.Error)
+      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
+      cm.closeClassMaker()
+    }
+
+    private def constructorIns(implicit mv: MethodVisitor): Unit = {
+      import BytecodeInstructions.*
+      thisLoad()
+      ALOAD(1)
+      invokeConstructor(JvmName.Error, mkDescriptor(BackendType.String)(VoidableType.Void))
+      RETURN()
+    }
+
+  }
+
+  // Java Constants.
 
   object Arrays {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -78,7 +78,7 @@ object JvmBackend {
 
     val unitClass = List(JvmClass(BackendObjType.Unit.jvmName, BackendObjType.Unit.genByteCode()))
 
-    val flixErrorClass = List(JvmClass(BackendObjType.FlixError.jvmName, BackendObjType.FlixError.genByteCode()))
+    val flixErrorClass = List(JvmClass(JvmName.FlixError, ClassMaker.FlixError.genByteCode()))
     val rslClass = List(JvmClass(BackendObjType.ReifiedSourceLocation.jvmName, BackendObjType.ReifiedSourceLocation.genByteCode()))
     val holeErrorClass = List(JvmClass(BackendObjType.HoleError.jvmName, BackendObjType.HoleError.genByteCode()))
     val matchErrorClass = List(JvmClass(BackendObjType.MatchError.jvmName, BackendObjType.MatchError.genByteCode()))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -198,6 +198,8 @@ object JvmName {
 
   val DevFlixRuntime: List[String] = List("dev", "flix", "runtime")
 
+  val FlixError: JvmName = JvmName(DevFlixRuntime, mkClassName("FlixError"))
+
 }
 
 /**


### PR DESCRIPTION
@magnus-madsen I don't know if you agree with that approach

this `FlixError` object basically corresponds to the old `GenFlixError` class. These objects have no reason to be a part of BOT so i will extract them to be their own ClassMaker thing, makes both simpler in the process. 

This means that most of `BOT` gets extracted into `ClassMaker` which is maybe fine but i could also add `ClassConstants` to cut in in two, or have `FlixError` be its own file. 