### PR TITLE
fix: bug in putWith

### DIFF
--- a/main/src/library/BPlusTree.flix
+++ b/main/src/library/BPlusTree.flix
@@ -1046,15 +1046,15 @@ mod BPlusTree {
         /// Thread-safe.
         ///
         pub def putWith(f: v -> v -> v \ ef, key: k, val: v, tree: BPlusTree[k, v, r], node: Node[k, v, r], stamp: Int64): Option[(Node[k, v, r], Int64)] \ r + ef with Order[k], Eq[v] =
-            let index = binarySearch(key, BPlusTree.search(tree), node);
-            if (index < 0) {
-                insertIntoLeafPropagate(key, val, index, node, stamp, tree)
+            let writeStamp = Lock.tryConvertToWrite(stamp, node->lock);
+            if(not Lock.valid(writeStamp, node->lock)) {
+                // Restart
+                Lock.yieldBasedOn(node->lock);
+                BPlusTree.putWithInternal(f, key, val, tree)
             } else {
-                let writeStamp = Lock.tryConvertToWrite(stamp, node->lock);
-                if(not Lock.valid(writeStamp, node->lock)) {
-                    // Restart
-                    Lock.yieldBasedOn(node->lock);
-                    BPlusTree.putWithInternal(f, key, val, tree)
+                let index = binarySearch(key, BPlusTree.search(tree), node);
+                if (index < 0) {
+                    insertIntoLeafPropagate(key, val, index, node, writeStamp, tree)
                 } else {
                     let v1 = Array.get(index, node->values);
                     Array.put(f(val, v1), index, node->values);

--- a/main/test/ca/uwaterloo/flix/library/TestBPlusTree.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestBPlusTree.flix
@@ -24,6 +24,11 @@ mod TestBPlusTree {
     def listToMap(l: List[(k, v)]): Map[k, v] with Order[k] =
         List.foldLeft(acc -> p -> let (x, y) = p; Map.insert(x, y, acc), Map#{}, l)
 
+    def preferSome(l: Option[Int32], r: Option[Int32]): Option[Int32] = match l {
+        case None => r
+        case Some(_) => l
+    }
+
     /////////////////////////////////////////////////////////////////////////////
     // Test concurrency                                                        //
     /////////////////////////////////////////////////////////////////////////////
@@ -42,6 +47,8 @@ mod TestBPlusTree {
         repeatNInternal(callNum, true)
 
     def totalInsertNum(): Int64 = 300_000i64
+
+    def totalInsertNumInt32(): Int32 = 300_000
 
     ///
     /// `gen` and `inserted` are the functions that generate the inserted values.
@@ -542,6 +549,24 @@ mod TestBPlusTree {
         let tree = BPlusTree.empty(rc);
         BPlusTree.putWith(v1 -> v2 -> v1 - v2, 1, 2, tree);
         BPlusTree.memberOfPair(1, 2, tree)
+    }
+
+    @test
+    pub def putWith04(): Bool \ IO = region rc {
+        let tree = BPlusTree.empty(rc);
+        let _: Unit = region rc2 {
+            (spawn unchecked_cast((
+                List.range(0, totalInsertNumInt32()) |>
+                    List.forEach(i -> 
+                        BPlusTree.putWith(preferSome, i, None, tree)
+                    ): _ \ rc) as _ \ IO) @ rc2);
+            (spawn unchecked_cast((
+                List.range(0, totalInsertNumInt32()) |>
+                    List.forEach(i -> 
+                        BPlusTree.putWith(preferSome, i, Some(1), tree)
+            ): _ \ rc) as _ \ IO) @ rc2)
+        };
+        List.range(0, totalInsertNumInt32()) |> List.forAll(i -> BPlusTree.memberOfPair(i, Some(1), tree))
     }
 
     /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`putWith` could be treated like `put` under concurrent execution.