### PR TITLE
feat: first iteration of EffectProvenance

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -19,6 +19,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint.Provenance
+import ca.uwaterloo.flix.language.phase.typer.EffectProvenance
 import ca.uwaterloo.flix.language.phase.typer.TypeReduction2.reduce
 import ca.uwaterloo.flix.language.phase.unification.*
 import ca.uwaterloo.flix.util.Result
@@ -31,6 +32,12 @@ import scala.annotation.tailrec
   * The result of constraint solving is a substitution and a list of constraints that could not be resolved.
   */
 object ConstraintSolver2 {
+
+  /**
+    * Whether to enable effect provenance debugging.
+    *
+    */
+  private val enableEffectProvenance: Boolean = false
 
   /**
     * A container for a constraint set and a substitution tree.
@@ -446,6 +453,11 @@ object ConstraintSolver2 {
     val (eqConstrs, rest0) = constrs0.partitionMap {
       case eq@TypeConstraint.Equality(tpe1, _, _) if tpe1.kind == Kind.Eff => Left(eq)
       case other => Right(other)
+    }
+
+    // Effect Provenance prototype
+    if (enableEffectProvenance) {
+      EffectProvenance.debug(eqConstrs)
     }
 
     // First solve all the top-level constraints together

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/EffectProvenance.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/EffectProvenance.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 Gagan Chandan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.typer
+
+import ca.uwaterloo.flix.language.ast.Type
+import ca.uwaterloo.flix.language.ast.Symbol
+import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
+import ca.uwaterloo.flix.language.phase.typer.TypeConstraint.Provenance
+import scala.collection.immutable.SortedSet
+
+object EffectProvenance {
+  // First, we find all equality constraints that have a provenance of type
+  // Provenance.Match with a concrete effect on one side and an effect variable
+  // on the other side.
+  //
+  // For each such variable and set of concrete effects , we track a path
+  // through the constraints until we reach a constraint that has a
+  // provenance of type Provenance.ExpectEffect and an effect in the
+  // in the concrete set is not in the expected effects.
+  def debug(constrs0: List[TypeConstraint]): Unit = {
+    printConstrs(constrs0)
+    constrs0.foreach {
+      case TypeConstraint.Equality(tpe1, tpe2, prov) => {
+        prov match {
+          case Provenance.Match(_, _, loc) => {
+            // Variables on the left with concrete effects on the right.
+            if (tpe1.typeVars.nonEmpty && tpe2.effects.nonEmpty) {
+              tpe1.typeVars.foreach { tpeVar => tpeVar match { case _ =>
+                println(s"Finding path for variable $tpeVar  of constraint ${TypeConstraint.Equality(tpe1, tpe2, prov)} at location $loc")
+                findPath(tpeVar, tpe2.effects, (tpeVar, TypeConstraint.Equality(tpe1, tpe2, prov)) :: Nil, constrs0)
+                }
+              }
+            }
+            // Variables on the right with concrete effects on the left.
+            if (tpe2.typeVars.nonEmpty && tpe1.effects.nonEmpty) {
+              tpe2.typeVars.foreach { tpeVar => tpeVar match { case _ =>
+                println(s"Finding path for variable $tpeVar  of constraint ${TypeConstraint.Equality(tpe1, tpe2, prov)} at location $loc")
+                findPath(tpeVar, tpe1.effects, (tpeVar, TypeConstraint.Equality(tpe1, tpe2, prov)) :: Nil, constrs0)
+                }
+              }
+            }
+          }
+          case _ => ()
+        }
+      }
+      case _ => ()
+    }
+  }
+  // Finds the next constraint in the path given the effect variable `eff`,
+  // the set of concrete effects `concreteEff`, the current path `path`,
+  // and the list of all constraints `constrs`.
+  // If Provenance.ExpectEffect is found, it checks if all the concrete
+  // effects are contained in the expected effects. If not, a path has
+  // been found and it is printed.
+  private def findPath(eff: Type.Var, concreteEff: SortedSet[Symbol.EffectSym],  path: List[(Type.Var, TypeConstraint)], constrs: List[TypeConstraint]): Unit = {
+    // Only consider constraints that are not already in the path.
+    constrs.filter(!path.map(p => p._2).contains(_)).foreach {
+      case TypeConstraint.Equality(tpe1, tpe2, prov) => {
+        prov match {
+          case Provenance.Match(_, _, loc) => {
+            // Effect variable found on the left.
+            if (tpe1.typeVars.contains(eff)) {
+              tpe2.typeVars.foreach { tpeVar => tpeVar match {
+                  case Type.Var(_, _) =>
+                    findPath(tpeVar, concreteEff, (tpeVar, TypeConstraint.Equality(tpe1, tpe2, prov)) :: path, constrs)
+                  case _ => ()
+                }
+              }
+            }
+            // Effect variable found on the right.
+            if (tpe2.typeVars.contains(eff)) {
+              tpe1.typeVars.foreach { tpeVar => tpeVar match {
+                  case Type.Var(_, _) =>
+                    findPath(tpeVar, concreteEff, (tpeVar, TypeConstraint.Equality(tpe1, tpe2, prov)) :: path, constrs)
+                  case _ => ()
+                }
+              }
+            }
+          }
+          // If Provenance.ExpectEffect is found, check if the concrete effects
+          // are contained in the expected effects. If not, print the path.
+          case Provenance.ExpectEffect(expected, actual, loc) => {
+            if(expected.typeVars.isEmpty && actual.typeVars.contains(eff)) {
+              if(!concreteEff.intersect(expected.effects).equals(concreteEff)) {
+                printPath((eff, TypeConstraint.Equality(tpe1, tpe2, prov)) :: path)
+              }
+            }
+          }
+          case _ => ()
+        }
+      }
+      case _ => ()
+    }
+  }
+
+  // Prints the full path of constraints indicating which variables
+  // were traversed and the constraints at each step.
+  private def printPath(path: List[(Type.Var, TypeConstraint)]): Unit = {
+    val revPath = path.reverse
+    var msg: String = "///////////////////////////////////////////////////////////////////////////////\n"
+    msg += s"Found path from constraint ${revPath.head._2} through variable ${revPath.head._1} to constraint ${path.head._2}\n"
+    msg += "///////////////////////////////////////////////////////////////////////////////\n"
+    revPath.foreach {
+      case (tpeVar, constr) => msg += s"At location ${constr.loc}:\nGot constraint: $constr and found variable: $tpeVar\n"
+    }
+    msg += "///////////////////////////////////////////////////////////////////////////////\n"
+    println(msg)
+  }
+
+  // Dump all the constraints with their provenance.
+  private def printConstrs(constrs: List[TypeConstraint]): Unit = {
+    constrs.foreach {
+      case TypeConstraint.Equality(tpe1, tpe2, prov) => prov match {
+        case _ => println(s"$tpe1 ~ $tpe2 with Provenance $prov at ${prov.loc}")
+      }
+      case _ => ()
+    }
+  }
+}


### PR DESCRIPTION
First steps towards adding effect provenance as discussed in #10785. Currently, it is just a huge info dump for us containing all constraints and found paths through the constraints. It prints these for all files including standard library files, so it requires some sifting through. 

Currently, all equality constraints with `Provenance.Match` with one or more type variables on one side and one or more concrete effects on the other are identified and paths are found starting from each of these variables until a constraint with `Provenance.ExpectEffect` is found and not all concrete effects initially identified are expected. Considering the following example discussed in the issue:

```scala
def main(): Unit \ {Net, IO} =
    run {
        let url = "http://example.com/";
        Logger.info("Downloading URL: '${url}'");
        match HttpWithResult.get(url, Map.empty()) {
            case Result.Ok(response) =>
                let file = "data.txt";
                Logger.info("Saving response to file: '${file}'");
                let body = Http.Response.body(response);
                Console.println("fdsa"); // oops
                match FileWriteWithResult.write(str = body, file) {
                    case Result.Ok(_) =>
                        Logger.info("Response saved to file: '${file}'")
                    case Result.Err(err) =>
                        Logger.fatal("Unable to write file: '${err}'")
                }
            case Result.Err(err) =>
                Logger.fatal("Unable to download URL: '${err}'")
        }
    } with FileWriteWithResult.runWithIO
      with HttpWithResult.runWithIO
      with Logger.runWithIO
```

The constraints found are as follows:

```
Net + IO ~ e60183
e60191 ~ Pure
e60197 ~ Logger + e60191
e60207 ~ Pure
e60210 ~ HttpWithResult + e60207
e60234 ~ Pure
e60245 ~ Logger + e60234
e60250 ~ Pure
e60303 ~ Pure
e60326 ~ Logger + e60303
e60360 ~ Pure
e60378 ~ Logger + e60360
e60403 ~ Pure
e60408 ~ Logger + e60403
e60420 ~ (e117422 - FileWriteWithResult) + IO
e60187 ~ e60420
e60197 + e60210 + e60245 + e60250 + Console + FileWriteWithResult + e60326 + e60378 + e60408 ~ e117422
e60434 ~ (e117424 - HttpWithResult) + Net + IO
e60185 ~ e60434
e60187 ~ e117424
e60448 ~ (e117426 - Logger) + IO
e60183 ~ e60448
e60185 ~ e117426
```

As an example, the path found for the constraint mentioned in the issue by @magnus-madsen (which here is the constraint `e60326 ~ Logger + e60303`) is currently printed as follows:

```
///////////////////////////////////////////////////////////////////////////////
Found path from constraint e60326 ~ Logger + e60303 through variable e60326 to constraint Net + IO ~ e60183
///////////////////////////////////////////////////////////////////////////////
At location running-multiple-effects.flix:13:25:
Got constraint: e60326 ~ Logger + e60303 and found variable: e60326
At location running-multiple-effects.flix:2:5:
Got constraint: e60197 + e60210 + e60245 + e60250 + Console + FileWriteWithResult + e60326 + e60378 + e60408 ~ e117422 and found variable: e117422
At location running-multiple-effects.flix:20:12:
Got constraint: e60420 ~ (e117422 - FileWriteWithResult) + IO and found variable: e60420
At location running-multiple-effects.flix:2:5:
Got constraint: e60187 ~ e60420 and found variable: e60187
At location running-multiple-effects.flix:2:5:
Got constraint: e60187 ~ e117424 and found variable: e117424
At location running-multiple-effects.flix:21:12:
Got constraint: e60434 ~ (e117424 - HttpWithResult) + Net + IO and found variable: e60434
At location running-multiple-effects.flix:2:5:
Got constraint: e60185 ~ e60434 and found variable: e60185
At location running-multiple-effects.flix:2:5:
Got constraint: e60185 ~ e117426 and found variable: e117426
At location running-multiple-effects.flix:22:12:
Got constraint: e60448 ~ (e117426 - Logger) + IO and found variable: e60448
At location running-multiple-effects.flix:2:5:
Got constraint: e60183 ~ e60448 and found variable: e60183
At location running-multiple-effects.flix:1:1:
Got constraint: Net + IO ~ e60183 and found variable: e60183
///////////////////////////////////////////////////////////////////////////////
```