### PR TITLE
chore: clean up Typer.scala

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -21,10 +21,10 @@ import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{AssocTypeSymUse, TraitSymUse}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.TypeError
-import ca.uwaterloo.flix.language.phase.typer.{ConstraintGen, ConstraintSolverInterface, InfResult, SubstitutionTree, TypeContext}
+import ca.uwaterloo.flix.language.phase.typer.*
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, Substitution, TraitEnv}
 import ca.uwaterloo.flix.util.*
-import ca.uwaterloo.flix.util.collection.ListMap
+import ca.uwaterloo.flix.util.collection.{ListMap, MapOps}
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
@@ -121,7 +121,7 @@ object Typer {
   /**
     * Creates a trait environment from the traits and instances in the root.
     */
-  private def mkTraitEnv(traits0: Map[Symbol.TraitSym, KindedAst.Trait], instances0: ListMap[Symbol.TraitSym, KindedAst.Instance])(implicit flix: Flix): TraitEnv = {
+  private def mkTraitEnv(traits0: Map[Symbol.TraitSym, KindedAst.Trait], instances0: ListMap[Symbol.TraitSym, KindedAst.Instance]): TraitEnv = {
     val m = traits0.map {
       case (traitSym, trt) =>
         val instances = instances0.get(traitSym)
@@ -141,7 +141,7 @@ object Typer {
   /**
     * Creates an equality environment from the traits and instances in the root.
     */
-  private def mkEqualityEnv(traits0: Map[Symbol.TraitSym, KindedAst.Trait], instances0: ListMap[Symbol.TraitSym, KindedAst.Instance])(implicit flix: Flix): EqualityEnv = {
+  private def mkEqualityEnv(traits0: Map[Symbol.TraitSym, KindedAst.Trait], instances0: ListMap[Symbol.TraitSym, KindedAst.Instance]): EqualityEnv = {
     val assocs = for {
       (traitSym, trt) <- traits0.iterator
       inst <- instances0.get(traitSym)
@@ -172,7 +172,7 @@ object Typer {
     changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_) {
       case defn =>
         // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs.
-        val enableSubeffects = shouldSubeffect(defn.exp, defn.spec.eff, Subeffecting.ModDefs)
+        val enableSubeffects = shouldSubeffect(defn.spec.eff, Subeffecting.ModDefs)
         visitDef(defn, tconstrs0 = Nil, RigidityEnv.empty, root, traitEnv, eqEnv, enableSubeffects)
     })
   }
@@ -212,13 +212,13 @@ object Typer {
     */
   private def visitTrait(trt: KindedAst.Trait, root: KindedAst.Root, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): TypedAst.Trait = trt match {
     case KindedAst.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, sigs0, laws0, loc) =>
-      val tparam = visitTypeParam(tparam0, root) // TODO ASSOC-TYPES redundant?
+      val tparam = visitTypeParam(tparam0)
       val renv = RigidityEnv.empty.markRigid(tparam0.sym)
       val superTraits = superTraits0 // no subst to be done
       val assocs = assocs0.map {
-        case KindedAst.AssocTypeSig(doc, mod, sym, tp0, kind, tpe, loc) =>
-          val tp = visitTypeParam(tp0, root) // TODO ASSOC-TYPES redundant?
-          TypedAst.AssocTypeSig(doc, mod, sym, tp, kind, tpe, loc) // TODO ASSOC-TYPES trivial
+        case KindedAst.AssocTypeSig(sigDoc, sigMod, sigSym, tp0, kind, tpe, sigLoc) =>
+          val tp = visitTypeParam(tp0)
+          TypedAst.AssocTypeSig(sigDoc, sigMod, sigSym, tp, kind, tpe, sigLoc)
       }
       val tconstr = TraitConstraint(TraitSymUse(sym, sym.loc), Type.Var(tparam.sym, tparam.loc), sym.loc)
       val sigs = sigs0.values.map(visitSig(_, renv, List(tconstr), root, traitEnv, eqEnv)).toList
@@ -242,7 +242,7 @@ object Typer {
 
         // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs. Note: We consider signatures implemented in traits to be module-level.
         // A small optimization: If the signature is pure there is no room for subeffecting.
-        val open = shouldSubeffect(exp, sig.spec.eff, Subeffecting.ModDefs)
+        val open = shouldSubeffect(sig.spec.eff, Subeffecting.ModDefs)
         val eff = if (open) Type.mkUnion(eff0, Type.freshEffSlackVar(eff0.loc), eff0.loc) else eff0
 
         val infResult = InfResult(constrs, tpe, eff, renv)
@@ -269,19 +269,18 @@ object Typer {
     * Reassembles a single instance.
     */
   private def visitInstance(inst: KindedAst.Instance, root: KindedAst.Root, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): TypedAst.Instance = inst match {
-    case KindedAst.Instance(doc, ann, mod, symUse, tparams0, tpe0, tconstrs0, assocs0, defs0, ns, loc) =>
-      val tpe = tpe0 // TODO ASSOC-TYPES redundant?
-      val renv = tparams0.map(_.sym).foldLeft(RigidityEnv.empty)(_.markRigid(_)) // MATT use tparams0
+    case KindedAst.Instance(doc, ann, mod, symUse, tparams0, tpe, tconstrs0, assocs0, defs0, ns, loc) =>
+      val renv = tparams0.map(_.sym).foldLeft(RigidityEnv.empty)(_.markRigid(_))
       val tconstrs = tconstrs0 // no subst to be done
       val assocs = assocs0.map {
-        case KindedAst.AssocTypeDef(doc, mod, symUse, args, tpe, loc) =>
-          TypedAst.AssocTypeDef(doc, mod, symUse, args, tpe, loc) // TODO ASSOC-TYPES trivial
+        case KindedAst.AssocTypeDef(defDoc, defMod, defSymUse, args, defTpe, defLoc) =>
+          TypedAst.AssocTypeDef(defDoc, defMod, defSymUse, args, defTpe, defLoc)
       }
 
       val defs = defs0.map {
         defn =>
           // SUB-EFFECTING: Check if sub-effecting is enabled for instance-level defs.
-          val open = shouldSubeffect(defn.exp, defn.spec.eff, Subeffecting.InsDefs)
+          val open = shouldSubeffect(defn.spec.eff, Subeffecting.InsDefs)
           visitDef(defn, tconstrs, renv, root, traitEnv, eqEnv, open)
       }
       TypedAst.Instance(doc, ann, mod, symUse, tpe, tconstrs, assocs, defs, ns, loc)
@@ -290,98 +289,78 @@ object Typer {
   /**
     * Reconstructs types in the given enums.
     */
-  private def visitEnums(root: KindedAst.Root)(implicit flix: Flix): Map[Symbol.EnumSym, TypedAst.Enum] = {
-    // Visit every enum in the ast.
-    val result = root.enums.toList.map {
-      case (_, enum0) => visitEnum(enum0, root)
-    }
-
-    // Sequence the results and convert them back to a map.
-    result.toMap
+  private def visitEnums(root: KindedAst.Root): Map[Symbol.EnumSym, TypedAst.Enum] = {
+    MapOps.mapValues(root.enums)(visitEnum)
   }
 
   /**
     * Reconstructs types in the given enum.
     */
-  private def visitEnum(enum0: KindedAst.Enum, root: KindedAst.Root)(implicit flix: Flix): (Symbol.EnumSym, TypedAst.Enum) = enum0 match {
+  private def visitEnum(enum0: KindedAst.Enum): TypedAst.Enum = enum0 match {
     case KindedAst.Enum(doc, ann, mod, enumSym, tparams0, derives, cases0, _, loc) =>
-      val tparams = tparams0.map(visitTypeParam(_, root))
-      val cases = cases0 map {
-        case (name, KindedAst.Case(caseSym, tagTypes, sc, caseLoc)) =>
-          name -> TypedAst.Case(caseSym, tagTypes, sc, caseLoc)
+      val tparams = tparams0.map(visitTypeParam)
+      val cases = MapOps.mapValues(cases0) {
+        case KindedAst.Case(caseSym, tagTypes, sc, caseLoc) =>
+          TypedAst.Case(caseSym, tagTypes, sc, caseLoc)
       }
 
-      enumSym -> TypedAst.Enum(doc, ann, mod, enumSym, tparams, derives, cases, loc)
+      TypedAst.Enum(doc, ann, mod, enumSym, tparams, derives, cases, loc)
   }
 
   /**
     * Reconstructs types in the given structs.
     */
-  private def visitStructs(root: KindedAst.Root)(implicit flix: Flix): Map[Symbol.StructSym, TypedAst.Struct] = {
-    // Visit every struct in the ast.
-    val result = root.structs.map {
-      case (_, struct) => visitStruct(struct, root)
-    }
-
-    // Sequence the results and convert them back to a map.
-    result
+  private def visitStructs(root: KindedAst.Root): Map[Symbol.StructSym, TypedAst.Struct] = {
+    MapOps.mapValues(root.structs)(visitStruct)
   }
 
   /**
     * Reconstructs types in the given struct.
     */
-  private def visitStruct(struct0: KindedAst.Struct, root: KindedAst.Root)(implicit flix: Flix): (Symbol.StructSym, TypedAst.Struct) = struct0 match {
+  private def visitStruct(struct0: KindedAst.Struct): TypedAst.Struct = struct0 match {
     case KindedAst.Struct(doc, ann, mod, sym, tparams0, sc, fields0, loc) =>
-      val tparams = tparams0.map(visitTypeParam(_, root))
+      val tparams = tparams0.map(visitTypeParam)
       val fields = fields0.zipWithIndex.map {
         case (field, _) =>
           field.sym -> TypedAst.StructField(field.sym, field.tpe, field.loc)
       }
 
-      sym -> TypedAst.Struct(doc, ann, mod, sym, tparams, sc, fields.toMap, loc)
+      TypedAst.Struct(doc, ann, mod, sym, tparams, sc, fields.toMap, loc)
   }
 
   /**
     * Reconstructs types in the given restrictable enums.
     */
-  private def visitRestrictableEnums(root: KindedAst.Root)(implicit flix: Flix): Map[Symbol.RestrictableEnumSym, TypedAst.RestrictableEnum] = {
-    // Visit every restrictable enum in the ast.
-    val result = root.restrictableEnums.toList.map {
-      case (_, re) => visitRestrictableEnum(re, root)
-    }
-
-    // Sequence the results and convert them back to a map.
-    result.toMap
+  private def visitRestrictableEnums(root: KindedAst.Root): Map[Symbol.RestrictableEnumSym, TypedAst.RestrictableEnum] = {
+    MapOps.mapValues(root.restrictableEnums)(visitRestrictableEnum)
   }
 
   /**
     * Reconstructs types in the given restrictable enum.
     */
-  private def visitRestrictableEnum(enum0: KindedAst.RestrictableEnum, root: KindedAst.Root)(implicit flix: Flix): (Symbol.RestrictableEnumSym, TypedAst.RestrictableEnum) = enum0 match {
+  private def visitRestrictableEnum(enum0: KindedAst.RestrictableEnum): TypedAst.RestrictableEnum = enum0 match {
     case KindedAst.RestrictableEnum(doc, ann, mod, enumSym, index0, tparams0, derives, cases0, _, loc) =>
       val index = TypedAst.TypeParam(index0.name, index0.sym, index0.loc)
-      val tparams = tparams0.map(visitTypeParam(_, root))
-      val cases = cases0 map {
-        case (name, KindedAst.RestrictableCase(caseSym, tagTypes, sc, caseLoc)) =>
-          name -> TypedAst.RestrictableCase(caseSym, tagTypes, sc, caseLoc)
+      val tparams = tparams0.map(visitTypeParam)
+      val cases = MapOps.mapValues(cases0) {
+        case KindedAst.RestrictableCase(caseSym, tagTypes, sc, caseLoc) =>
+          TypedAst.RestrictableCase(caseSym, tagTypes, sc, caseLoc)
       }
 
-      enumSym -> TypedAst.RestrictableEnum(doc, ann, mod, enumSym, index, tparams, derives, cases, loc)
+      TypedAst.RestrictableEnum(doc, ann, mod, enumSym, index, tparams, derives, cases, loc)
   }
 
   /**
     * Reconstructs types in the given effects.
     */
-  private def visitEffs(root: KindedAst.Root)(implicit flix: Flix): Map[Symbol.EffectSym, TypedAst.Effect] = {
-    root.effects.map {
-      case (sym, eff) => sym -> visitEff(eff, root)
-    }
+  private def visitEffs(root: KindedAst.Root): Map[Symbol.EffectSym, TypedAst.Effect] = {
+    MapOps.mapValues(root.effects)(visitEff)
   }
 
   /**
     * Reconstructs types in the given effect.
     */
-  private def visitEff(eff: KindedAst.Effect, root: KindedAst.Root)(implicit flix: Flix): TypedAst.Effect = eff match {
+  private def visitEff(eff: KindedAst.Effect): TypedAst.Effect = eff match {
     case KindedAst.Effect(doc, ann, mod, sym, ops0, loc) =>
       val ops = ops0.map(TypeReconstruction.visitOp)
       TypedAst.Effect(doc, ann, mod, sym, ops, loc)
@@ -390,20 +369,23 @@ object Typer {
   /**
     * Reconstructs types in the given type aliases.
     */
-  private def visitTypeAliases(root: KindedAst.Root)(implicit flix: Flix): Map[Symbol.TypeAliasSym, TypedAst.TypeAlias] = {
-    def visitTypeAlias(alias: KindedAst.TypeAlias): (Symbol.TypeAliasSym, TypedAst.TypeAlias) = alias match {
-      case KindedAst.TypeAlias(doc, ann, mod, sym, tparams0, tpe, loc) =>
-        val tparams = tparams0.map(visitTypeParam(_, root))
-        sym -> TypedAst.TypeAlias(doc, ann, mod, sym, tparams, tpe, loc)
-    }
+  private def visitTypeAliases(root: KindedAst.Root): Map[Symbol.TypeAliasSym, TypedAst.TypeAlias] = {
+    MapOps.mapValues(root.typeAliases)(visitTypeAlias)
+  }
 
-    root.typeAliases.values.map(visitTypeAlias).toMap
+  /**
+    * Reconstructs types in the given type alias.
+    */
+  private def visitTypeAlias(alias: KindedAst.TypeAlias): TypedAst.TypeAlias = alias match {
+    case KindedAst.TypeAlias(doc, ann, mod, sym, tparams0, tpe, loc) =>
+      val tparams = tparams0.map(visitTypeParam)
+      TypedAst.TypeAlias(doc, ann, mod, sym, tparams, tpe, loc)
   }
 
   /**
     * Reconstructs types in the given tparams.
     */
-  private def visitTypeParam(tparam: KindedAst.TypeParam, root: KindedAst.Root): TypedAst.TypeParam = tparam match {
+  private def visitTypeParam(tparam: KindedAst.TypeParam): TypedAst.TypeParam = tparam match {
     case KindedAst.TypeParam(name, sym, loc) => TypedAst.TypeParam(name, sym, loc)
   }
 
@@ -451,7 +433,7 @@ object Typer {
             }
 
           // Resiliency: If the associated type is ill-formed, then we ignore it.
-          case otherType => ()
+          case _ => ()
         }
     }
   }
@@ -472,10 +454,10 @@ object Typer {
   }
 
   /**
-    * Returns `true` if if `subeffecting` is enabled by [[Flix]] and it is not redundant for a
-    * function with `body` and `eff`.
+    * Returns `true` if `subeffecting` is enabled by [[Flix]] and it is not redundant for a
+    * function with effect `eff`.
     */
-  private def shouldSubeffect(body: KindedAst.Expr, eff: Type, subeffecting: Subeffecting)(implicit flix: Flix): Boolean = {
+  private def shouldSubeffect(eff: Type, subeffecting: Subeffecting)(implicit flix: Flix): Boolean = {
     val enabled = flix.options.xsubeffecting.contains(subeffecting)
     val useless = eff == Type.Pure
     enabled && !useless
@@ -498,6 +480,5 @@ object Typer {
     * @param errors the [[TypeError]]s in the AST, if any.
     */
   private case class SharedContext(errors: ConcurrentLinkedQueue[TypeError])
-
 
 }


### PR DESCRIPTION
Pure refactor. Removes unused parameters and makes use of some existing helpers to make everything more DRY.