### PR TITLE
chore: rename Weeder2 to Weeder

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -570,7 +570,7 @@ class Flix {
     val (afterParser, parserErrors) = Parser2.run(afterLexer, cachedParserCst, changeSet)
     errors ++= parserErrors
 
-    val (weederValidation, weederErrors) = Weeder2.run(afterReader, entryPoint, afterParser, cachedWeederAst, changeSet)
+    val (weederValidation, weederErrors) = Weeder.run(afterReader, entryPoint, afterParser, cachedWeederAst, changeSet)
     errors ++= weederErrors
 
     val result = weederValidation match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -45,7 +45,7 @@ import scala.jdk.CollectionConverters.*
   *   1. tryPick* : Works like pick* but only runs the visitor if the child of kind is found. Returns an option containing the result.
   *   1. pickAll* : These will pick all subtrees of a specified kind and run a visitor on it.
   */
-object Weeder2 {
+object Weeder {
 
   import WeededAst.*
 


### PR DESCRIPTION
There was a reason we didn't do this before, but I don't remember what it was, so I am trying again.