### PR TITLE
chore: rename Parser2 to Parser

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -567,7 +567,7 @@ class Flix {
     val (afterLexer, lexerErrors) = Lexer.run(afterReader, cachedLexerTokens, changeSet)
     errors ++= lexerErrors
 
-    val (afterParser, parserErrors) = Parser2.run(afterLexer, cachedParserCst, changeSet)
+    val (afterParser, parserErrors) = Parser.run(afterLexer, cachedParserCst, changeSet)
     errors ++= parserErrors
 
     val (weederValidation, weederErrors) = Weeder2.run(afterReader, entryPoint, afterParser, cachedWeederAst, changeSet)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -47,7 +47,7 @@ import scala.collection.mutable.ArrayBuffer
   * rust-analyzer. The tutorial is also a great resource for understanding this parser (and a great
   * read to boot!) [[https://matklad.github.io/2023/05/21/resilient-ll-parsing-tutorial.html]]
   */
-object Parser2 {
+object Parser {
 
   /** An event emitted by the parser while traversing a list of [[Token]]s. */
   private sealed trait Event


### PR DESCRIPTION
There was a reason we didn't do this before, but I don't remember what it was, so I am trying again.