### PR TITLE
feat: add functionality to and refactor `IpAddr`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -299,6 +299,8 @@ class Flix {
     "FileWrite.flix" -> LocalResource.get("/src/library/FileWrite.flix"),
     "FileWriteWithResult.flix" -> LocalResource.get("/src/library/FileWriteWithResult.flix"),
     "IpAddr.flix" -> LocalResource.get("/src/library/IpAddr.flix"),
+    "Ipv4Addr.flix" -> LocalResource.get("/src/library/Ipv4Addr.flix"),
+    "Ipv6Addr.flix" -> LocalResource.get("/src/library/Ipv6Addr.flix"),
     "Ping.flix" -> LocalResource.get("/src/library/Ping.flix"),
     "PingWithResult.flix" -> LocalResource.get("/src/library/PingWithResult.flix"),
     "ProcessHandle.flix" -> LocalResource.get("/src/library/ProcessHandle.flix"),

--- a/main/src/library/IpAddr.flix
+++ b/main/src/library/IpAddr.flix
@@ -70,11 +70,11 @@ mod IpAddr {
     ///
     pub def fromString(s: String): Option[IpAddr] = try {
         match Ipv6Addr.fromString(s) {
-          case Some(v6) => Some(IpAddr.V6(v6))
-          case None => match Ipv4Addr.fromString(s) {
-            case Some(v4) => Some(IpAddr.V4(v4))
-            case None => None
-          }
+            case Some(v6) => Some(IpAddr.V6(v6))
+            case None => match Ipv4Addr.fromString(s) {
+              case Some(v4) => Some(IpAddr.V4(v4))
+              case None => None
+            }
         }
         } catch {
             case _ : UnknownHostException => None

--- a/main/src/library/IpAddr.flix
+++ b/main/src/library/IpAddr.flix
@@ -14,20 +14,26 @@
  *  limitations under the License.
  */
 
+
+
 ///
-/// Represents an IP address
+/// Represents an IP address.
 ///
 enum IpAddr with Eq, ToString {
-  case V4(Ipv4Addr),
-  case V6(Ipv6Addr)
+    case V4(Ipv4Addr),
+    case V6(Ipv6Addr)
+}
+
+instance FromString[IpAddr] {
+    pub def fromString(x: String): Option[IpAddr] = IpAddr.fromString(x)
 }
 
 mod IpAddr {
 
-    import java.net.UnknownHostException
-
     use Ipv4Addr.Ipv4Addr
     use Ipv6Addr.Ipv6Addr
+
+    import java.net.UnknownHostException
 
     ///
     /// Converts a `List[Int8]` into `IpAddr`
@@ -35,10 +41,10 @@ mod IpAddr {
     /// an Ipv4 is 4 bytes and Ipv6 is 16 bytes
     ///
     pub def fromBytes(l: List[Int8]): IpAddr = match l {
-        case b1 :: b2 :: b3 :: b4 :: Nil => {
+        case b1::b2::b3::b4::Nil => {
             IpAddr.V4(Ipv4Addr(b1, b2, b3, b4))
         }
-        case b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 :: b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: Nil => {
+        case b1::b2::b3::b4::b5::b6::b7::b8::b9::b10::b11::b12::b13::b14::b15::b16::Nil => {
             IpAddr.V6(Ipv6Addr(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16))
         }
         case _ => unreachable!()
@@ -58,25 +64,21 @@ mod IpAddr {
         }
 
     ///
-    /// Parse the string `s` as an IpAddr, either V4 or V6.
-    /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
+    /// Attempts to parse the given String `s` as an `IpAddr`.
     ///
-    pub def fromString(s: String): Option[IpAddr] =
-        try {
-            match Ipv6Addr.fromString(s) {
-              case Some(v6) => Some(IpAddr.V6(v6))
-              case None => match Ipv4Addr.fromString(s) {
-                case Some(v4) => Some(IpAddr.V4(v4))
-                case None => None
-              }
-            }
+    /// Returns `Some(addr)` if the string was successfully parsed. Otherwise returns `None`.
+    ///
+    pub def fromString(s: String): Option[IpAddr] = try {
+        match Ipv6Addr.fromString(s) {
+          case Some(v6) => Some(IpAddr.V6(v6))
+          case None => match Ipv4Addr.fromString(s) {
+            case Some(v4) => Some(IpAddr.V4(v4))
+            case None => None
+          }
+        }
         } catch {
             case _ : UnknownHostException => None
         }
 
-}
-
-instance FromString[IpAddr] {
-    pub def fromString(x: String): Option[IpAddr] = IpAddr.fromString(x)
 }
 

--- a/main/src/library/IpAddr.flix
+++ b/main/src/library/IpAddr.flix
@@ -24,6 +24,8 @@ enum IpAddr with Eq, ToString {
 
 mod IpAddr {
 
+    import java.net.UnknownHostException
+
     use Ipv4Addr.Ipv4Addr
     use Ipv6Addr.Ipv6Addr
 
@@ -55,5 +57,26 @@ mod IpAddr {
                 Array#{b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16} @ rc
         }
 
+    ///
+    /// Parse the string `s` as an IpAddr, either V4 or V6.
+    /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
+    ///
+    pub def fromString(s: String): Option[IpAddr] =
+        try {
+            match Ipv6Addr.fromString(s) {
+              case Some(v6) => Some(IpAddr.V6(v6))
+              case None => match Ipv4Addr.fromString(s) {
+                case Some(v4) => Some(IpAddr.V4(v4))
+                case None => None
+              }
+            }
+        } catch {
+            case _ : UnknownHostException => None
+        }
+
+}
+
+instance FromString[IpAddr] {
+    pub def fromString(x: String): Option[IpAddr] = IpAddr.fromString(x)
 }
 

--- a/main/src/library/IpAddr.flix
+++ b/main/src/library/IpAddr.flix
@@ -18,11 +18,15 @@
 /// Represents an IP address
 ///
 enum IpAddr with Eq, ToString {
-    case IPv4(Int8, Int8, Int8, Int8), // 32 bits
-    case IPv6(Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8) // 128 bits
+  case V4(Ipv4Addr),
+  case V6(Ipv6Addr)
 }
 
 mod IpAddr {
+
+    use Ipv4Addr.Ipv4Addr
+    use Ipv6Addr.Ipv6Addr
+
     ///
     /// Converts a `List[Int8]` into `IpAddr`
     ///
@@ -30,10 +34,10 @@ mod IpAddr {
     ///
     pub def fromBytes(l: List[Int8]): IpAddr = match l {
         case b1 :: b2 :: b3 :: b4 :: Nil => {
-            IpAddr.IPv4(b1, b2, b3, b4)
+            IpAddr.V4(Ipv4Addr(b1, b2, b3, b4))
         }
         case b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 :: b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: Nil => {
-            IpAddr.IPv6(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16)
+            IpAddr.V6(Ipv6Addr(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16))
         }
         case _ => unreachable!()
     }
@@ -45,9 +49,9 @@ mod IpAddr {
     ///
     pub def toByteArray(rc: Region[r], ip: IpAddr): Array[Int8, r] \ r =
         match ip {
-            case IpAddr.IPv4(b1, b2, b3, b4) =>
+            case IpAddr.V4(Ipv4Addr(b1, b2, b3, b4)) =>
                 Array#{b1, b2, b3, b4} @ rc
-            case IpAddr.IPv6(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16) =>
+            case IpAddr.V6(Ipv6Addr(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16)) =>
                 Array#{b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16} @ rc
         }
 

--- a/main/src/library/Ipv4Addr.flix
+++ b/main/src/library/Ipv4Addr.flix
@@ -21,3 +21,28 @@ enum Ipv4Addr with Eq, ToString { // 32 bits
   case Ipv4Addr(Int8, Int8, Int8, Int8)
 }
 
+mod Ipv4Addr {
+    import java.net.InetAddress
+    import java.net.UnknownHostException
+
+    use Ipv4Addr.Ipv4Addr
+
+    ///
+    /// Parse the string `s` as an Ipv4Addr.
+    /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
+    ///
+    pub def fromString(s: String): Option[Ipv4Addr] = try {
+          let addr = unsafe InetAddress.getByName(s);
+          match unsafe Array.toList(addr.getAddress()) {
+            case b1::b2::b3::b4::Nil => Some(Ipv4Addr(b1, b2, b3, b4))
+            case _ => None
+          }
+        } catch {
+          case _ : UnknownHostException => None
+        }
+}
+
+instance FromString[Ipv4Addr] {
+  pub def fromString(x: String): Option[Ipv4Addr] = Ipv4Addr.fromString(x)
+}
+

--- a/main/src/library/Ipv4Addr.flix
+++ b/main/src/library/Ipv4Addr.flix
@@ -15,7 +15,7 @@
  */
 
 ///
-///Represents a V4 Ip Address.
+/// Represents a V4 Ip Address.
 ///
 enum Ipv4Addr with Eq, ToString { // 32 bits
     case Ipv4Addr(Int8, Int8, Int8, Int8)
@@ -38,13 +38,13 @@ mod Ipv4Addr {
     ///
     pub def fromString(s: String): Option[Ipv4Addr] =
         unsafe try {
-          let addr = InetAddress.getByName(s);
-          match Array.toList(addr.getAddress()) {
-            case b1::b2::b3::b4::Nil => Some(Ipv4Addr(b1, b2, b3, b4))
-            case _ => None
-          }
+            let addr = InetAddress.getByName(s);
+            match Array.toList(addr.getAddress()) {
+              case b1::b2::b3::b4::Nil => Some(Ipv4Addr(b1, b2, b3, b4))
+              case _ => None
+            }
         } catch {
-          case _ : UnknownHostException => None
+            case _ : UnknownHostException => None
         }
 }
 

--- a/main/src/library/Ipv4Addr.flix
+++ b/main/src/library/Ipv4Addr.flix
@@ -18,32 +18,33 @@
 ///Represents a V4 Ip Address.
 ///
 enum Ipv4Addr with Eq, ToString { // 32 bits
-  case Ipv4Addr(Int8, Int8, Int8, Int8)
-}
-
-mod Ipv4Addr {
-    use Ipv4Addr.Ipv4Addr
-
-    import java.net.InetAddress
-    import java.net.UnknownHostException
-
-    ///
-    /// Parse the string `s` as an Ipv4Addr.
-    /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
-    ///
-    pub def fromString(s: String): Option[Ipv4Addr] =
-        try {
-            let addr = unsafe InetAddress.getByName(s);
-            match unsafe Array.toList(addr.getAddress()) {
-              case b1::b2::b3::b4::Nil => Some(Ipv4Addr(b1, b2, b3, b4))
-              case _ => None
-            }
-        } catch {
-            case _ : UnknownHostException => None
-        }
+    case Ipv4Addr(Int8, Int8, Int8, Int8)
 }
 
 instance FromString[Ipv4Addr] {
     pub def fromString(x: String): Option[Ipv4Addr] = Ipv4Addr.fromString(x)
+}
+
+mod Ipv4Addr {
+    import java.net.InetAddress
+    import java.net.UnknownHostException
+
+    use Ipv4Addr.Ipv4Addr
+
+    ///
+    /// Attempts to parse the given String `s` as an `Ipv4Addr`.
+    ///
+    /// Returns `Some(addr)` if the string was successfully parsed. Otherwise returns `None`.
+    ///
+    pub def fromString(s: String): Option[Ipv4Addr] =
+        unsafe try {
+          let addr = InetAddress.getByName(s);
+          match Array.toList(addr.getAddress()) {
+            case b1::b2::b3::b4::Nil => Some(Ipv4Addr(b1, b2, b3, b4))
+            case _ => None
+          }
+        } catch {
+          case _ : UnknownHostException => None
+        }
 }
 

--- a/main/src/library/Ipv4Addr.flix
+++ b/main/src/library/Ipv4Addr.flix
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2025 Cade Lueker
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+///
+///Represents a V4 Ip Address.
+///
+enum Ipv4Addr with Eq, ToString { // 32 bits
+  case Ipv4Addr(Int8, Int8, Int8, Int8)
+}
+

--- a/main/src/library/Ipv4Addr.flix
+++ b/main/src/library/Ipv4Addr.flix
@@ -22,27 +22,28 @@ enum Ipv4Addr with Eq, ToString { // 32 bits
 }
 
 mod Ipv4Addr {
+    use Ipv4Addr.Ipv4Addr
+
     import java.net.InetAddress
     import java.net.UnknownHostException
-
-    use Ipv4Addr.Ipv4Addr
 
     ///
     /// Parse the string `s` as an Ipv4Addr.
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
-    pub def fromString(s: String): Option[Ipv4Addr] = try {
-          let addr = unsafe InetAddress.getByName(s);
-          match unsafe Array.toList(addr.getAddress()) {
-            case b1::b2::b3::b4::Nil => Some(Ipv4Addr(b1, b2, b3, b4))
-            case _ => None
-          }
+    pub def fromString(s: String): Option[Ipv4Addr] =
+        try {
+            let addr = unsafe InetAddress.getByName(s);
+            match unsafe Array.toList(addr.getAddress()) {
+              case b1::b2::b3::b4::Nil => Some(Ipv4Addr(b1, b2, b3, b4))
+              case _ => None
+            }
         } catch {
-          case _ : UnknownHostException => None
+            case _ : UnknownHostException => None
         }
 }
 
 instance FromString[Ipv4Addr] {
-  pub def fromString(x: String): Option[Ipv4Addr] = Ipv4Addr.fromString(x)
+    pub def fromString(x: String): Option[Ipv4Addr] = Ipv4Addr.fromString(x)
 }
 

--- a/main/src/library/Ipv6Addr.flix
+++ b/main/src/library/Ipv6Addr.flix
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2025 Cade Lueker
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+///
+///Represents a V6 Ip Address.
+///
+enum Ipv6Addr with Eq, ToString {
+  case Ipv6Addr( // 128 bits
+    Int8, Int8, Int8, Int8, // 32 bits
+    Int8, Int8, Int8, Int8, // 32 bits
+    Int8, Int8, Int8, Int8, // 32 bits
+    Int8, Int8, Int8, Int8  // 32 bits
+  )
+}
+

--- a/main/src/library/Ipv6Addr.flix
+++ b/main/src/library/Ipv6Addr.flix
@@ -18,44 +18,44 @@
 ///Represents a V6 Ip Address.
 ///
 enum Ipv6Addr with Eq, ToString {
-  case Ipv6Addr( // 128 bits
-    Int8, Int8, Int8, Int8, // 32 bits
-    Int8, Int8, Int8, Int8, // 32 bits
-    Int8, Int8, Int8, Int8, // 32 bits
-    Int8, Int8, Int8, Int8  // 32 bits
-  )
-}
-
-mod Ipv6Addr {
-
-    use Ipv6Addr.Ipv6Addr
-
-    import java.net.InetAddress
-    import java.net.UnknownHostException
-
-    ///
-    /// Parse the string `s` as an Ipv6Addr.
-    /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
-    ///
-    pub def fromString(s: String): Option[Ipv6Addr] =
-        try {
-            let addr = unsafe InetAddress.getByName(s);
-            match unsafe Array.toList(addr.getAddress()) {
-              case b1::b2::b3::b4::b5::b6::b7::b8::b9::b10::b11::b12::b13::b14::b15::b16::Nil =>
-                Some(Ipv6Addr(
-                  b1,  b2,  b3,  b4,
-                  b5,  b6,  b7,  b8,
-                  b9,  b10, b11, b12,
-                  b13, b14, b15, b16
-                ))
-              case _ => None
-            }
-        } catch {
-            case _ : UnknownHostException => None
-        }
+    case Ipv6Addr( // 128 bits
+      Int8, Int8, Int8, Int8, // 32 bits
+      Int8, Int8, Int8, Int8, // 32 bits
+      Int8, Int8, Int8, Int8, // 32 bits
+      Int8, Int8, Int8, Int8  // 32 bits
+    )
 }
 
 instance FromString[Ipv6Addr] {
     pub def fromString(x: String): Option[Ipv6Addr] = Ipv6Addr.fromString(x)
+}
+
+mod Ipv6Addr {
+    import java.net.InetAddress
+    import java.net.UnknownHostException
+
+    use Ipv6Addr.Ipv6Addr
+
+    ///
+    /// Attempts to parse the given String `s` as an `Ipv6Addr`.
+    ///
+    /// Returns `Some(addr)` if the string was successfully parsed. Otherwise returns `None`.
+    ///
+    pub def fromString(s: String): Option[Ipv6Addr] =
+        unsafe try {
+          let addr = InetAddress.getByName(s);
+          match Array.toList(addr.getAddress()) {
+            case b1::b2::b3::b4::b5::b6::b7::b8::b9::b10::b11::b12::b13::b14::b15::b16::Nil =>
+            Some(Ipv6Addr(
+              b1,  b2,  b3,  b4,
+              b5,  b6,  b7,  b8,
+              b9,  b10, b11, b12,
+              b13, b14, b15, b16
+            ))
+            case _ => None
+          }
+        } catch {
+          case _ : UnknownHostException => None
+        }
 }
 

--- a/main/src/library/Ipv6Addr.flix
+++ b/main/src/library/Ipv6Addr.flix
@@ -27,33 +27,35 @@ enum Ipv6Addr with Eq, ToString {
 }
 
 mod Ipv6Addr {
-    import java.net.InetAddress
-    import java.net.UnknownHostException
 
     use Ipv6Addr.Ipv6Addr
+
+    import java.net.InetAddress
+    import java.net.UnknownHostException
 
     ///
     /// Parse the string `s` as an Ipv6Addr.
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
-    pub def fromString(s: String): Option[Ipv6Addr] = try {
-          let addr = unsafe InetAddress.getByName(s);
-          match unsafe Array.toList(addr.getAddress()) {
-            case b1::b2::b3::b4::b5::b6::b7::b8::b9::b10::b11::b12::b13::b14::b15::b16::Nil =>
-              Some(Ipv6Addr(
-                b1,  b2,  b3,  b4,
-                b5,  b6,  b7,  b8,
-                b9,  b10, b11, b12,
-                b13, b14, b15, b16
-              ))
-            case _ => None
-          }
+    pub def fromString(s: String): Option[Ipv6Addr] =
+        try {
+            let addr = unsafe InetAddress.getByName(s);
+            match unsafe Array.toList(addr.getAddress()) {
+              case b1::b2::b3::b4::b5::b6::b7::b8::b9::b10::b11::b12::b13::b14::b15::b16::Nil =>
+                Some(Ipv6Addr(
+                  b1,  b2,  b3,  b4,
+                  b5,  b6,  b7,  b8,
+                  b9,  b10, b11, b12,
+                  b13, b14, b15, b16
+                ))
+              case _ => None
+            }
         } catch {
-          case _ : UnknownHostException => None
+            case _ : UnknownHostException => None
         }
 }
 
 instance FromString[Ipv6Addr] {
-  pub def fromString(x: String): Option[Ipv6Addr] = Ipv6Addr.fromString(x)
+    pub def fromString(x: String): Option[Ipv6Addr] = Ipv6Addr.fromString(x)
 }
 

--- a/main/src/library/Ipv6Addr.flix
+++ b/main/src/library/Ipv6Addr.flix
@@ -26,3 +26,34 @@ enum Ipv6Addr with Eq, ToString {
   )
 }
 
+mod Ipv6Addr {
+    import java.net.InetAddress
+    import java.net.UnknownHostException
+
+    use Ipv6Addr.Ipv6Addr
+
+    ///
+    /// Parse the string `s` as an Ipv6Addr.
+    /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
+    ///
+    pub def fromString(s: String): Option[Ipv6Addr] = try {
+          let addr = unsafe InetAddress.getByName(s);
+          match unsafe Array.toList(addr.getAddress()) {
+            case b1::b2::b3::b4::b5::b6::b7::b8::b9::b10::b11::b12::b13::b14::b15::b16::Nil =>
+              Some(Ipv6Addr(
+                b1,  b2,  b3,  b4,
+                b5,  b6,  b7,  b8,
+                b9,  b10, b11, b12,
+                b13, b14, b15, b16
+              ))
+            case _ => None
+          }
+        } catch {
+          case _ : UnknownHostException => None
+        }
+}
+
+instance FromString[Ipv6Addr] {
+  pub def fromString(x: String): Option[Ipv6Addr] = Ipv6Addr.fromString(x)
+}
+

--- a/main/src/library/Ipv6Addr.flix
+++ b/main/src/library/Ipv6Addr.flix
@@ -15,7 +15,7 @@
  */
 
 ///
-///Represents a V6 Ip Address.
+/// Represents a V6 Ip Address.
 ///
 enum Ipv6Addr with Eq, ToString {
     case Ipv6Addr( // 128 bits
@@ -43,19 +43,19 @@ mod Ipv6Addr {
     ///
     pub def fromString(s: String): Option[Ipv6Addr] =
         unsafe try {
-          let addr = InetAddress.getByName(s);
-          match Array.toList(addr.getAddress()) {
-            case b1::b2::b3::b4::b5::b6::b7::b8::b9::b10::b11::b12::b13::b14::b15::b16::Nil =>
-            Some(Ipv6Addr(
-              b1,  b2,  b3,  b4,
-              b5,  b6,  b7,  b8,
-              b9,  b10, b11, b12,
-              b13, b14, b15, b16
-            ))
-            case _ => None
-          }
+            let addr = InetAddress.getByName(s);
+            match Array.toList(addr.getAddress()) {
+                case b1::b2::b3::b4::b5::b6::b7::b8::b9::b10::b11::b12::b13::b14::b15::b16::Nil =>
+                Some(Ipv6Addr(
+                  b1,  b2,  b3,  b4,
+                  b5,  b6,  b7,  b8,
+                  b9,  b10, b11, b12,
+                  b13, b14, b15, b16
+                ))
+                case _ => None
+            }
         } catch {
-          case _ : UnknownHostException => None
+            case _ : UnknownHostException => None
         }
 }
 


### PR DESCRIPTION
Addresses #10855.

First push separates `IpAddr` into two enums for v6 and v4. Next step is adding functionality.