### PR TITLE
fix: CompilerPerf with zero runs

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/CompilerPerf.scala
+++ b/main/src/ca/uwaterloo/flix/tools/CompilerPerf.scala
@@ -470,7 +470,7 @@ object CompilerPerf {
     */
   private def aggregate(l: IndexedSeq[Run]): Runs = {
     if (l.isEmpty) {
-      return Runs(0, List(0), Nil)
+      return Runs(0, Nil, Nil)
     }
 
     val lines = l.head.lines


### PR DESCRIPTION
This function returns one instantaneous run instead of no runs