### PR TITLE
refactor: make `isReachable` take `IpAddr` instead of `String`

### DIFF
--- a/main/src/library/Ping.flix
+++ b/main/src/library/Ping.flix
@@ -18,7 +18,7 @@
 /// The effect used to determine if an address is reachable.
 ///
 eff Ping {
-    def isReachable(host: String, timeout: Int32, u: TimeUnit): Bool
+    def isReachable(host: IpAddr, timeout: Int32, u: TimeUnit): Bool
 }
 
 mod Ping {
@@ -43,8 +43,11 @@ mod Ping {
                 try {
                     let ms = TimeUnit.toMilliseconds(u);
                     let timeoutMs = ms * timeout;
-                    let addr = InetAddress.getByName(host);
-                    k(addr.isReachable(timeoutMs))
+                    region rc {
+                        let ipBytes = IpAddr.toByteArray(rc, host);
+                        let addr = InetAddress.getByAddress(ipBytes);
+                        k(addr.isReachable(timeoutMs))
+                    }
                 } catch {
                     case ex: UnknownHostException     => Err(IoError(ErrorKind.UnknownHost, ex.getMessage()))
                     case ex: IllegalArgumentException => Err(IoError(ErrorKind.InvalidInput, ex.getMessage()))
@@ -61,3 +64,4 @@ mod Ping {
     pub def runWithIO(f: Unit -> a \ ef): Result[IoError, a] \ ef - Ping + {Net, IO} = handle(f)()
 
 }
+

--- a/main/src/library/PingWithResult.flix
+++ b/main/src/library/PingWithResult.flix
@@ -18,7 +18,7 @@
 /// The effect used to determine if an address is reachable.
 ///
 eff PingWithResult {
-    def isReachable(host: String, timeout: Int32, u: TimeUnit): Result[IoError, Bool]
+    def isReachable(host: IpAddr, timeout: Int32, u: TimeUnit): Result[IoError, Bool]
 }
 
 mod PingWithResult {
@@ -43,8 +43,11 @@ mod PingWithResult {
                 try {
                     let ms = TimeUnit.toMilliseconds(u);
                     let timeoutMs = ms * timeout;
-                    let addr = InetAddress.getByName(host);
-                    k(Ok(addr.isReachable(timeoutMs)))
+                    region rc {
+                        let ipBytes = IpAddr.toByteArray(rc, host);
+                        let addr = InetAddress.getByAddress(ipBytes);
+                        k(Ok(addr.isReachable(timeoutMs)))
+                    }
                 } catch {
                     case ex: UnknownHostException     => k(Err(IoError(ErrorKind.UnknownHost, ex.getMessage())))
                     case ex: IllegalArgumentException => k(Err(IoError(ErrorKind.InvalidInput, ex.getMessage())))
@@ -61,3 +64,4 @@ mod PingWithResult {
     pub def runWithIO(f: Unit -> a \ ef):  a \ ef - PingWithResult + {Net, IO} = handle(f)()
 
 }
+


### PR DESCRIPTION
Addresses #10854.

example main function

```
def main(): Result[IoError, Unit] \ {Net, IO} = run {
        let host = IpAddr.fromString("localhost");
        match host {
            case Some(ip) => {
                let reachable = Ping.isReachable(ip, 100, TimeUnit.Milliseconds);
                println("${host} is ${reachable}")
            }
            case None => println("bad address")
        }
    } with Ping.runWithIO

Some(V4(Ipv4Addr(127, 0, 0, 1))) is true                                        
Ok(())
```