### PR TITLE
fix: correctly load primitive package effects

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/PrimitiveEffects.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/PrimitiveEffects.scala
@@ -139,7 +139,7 @@ object PrimitiveEffects {
     val m = json \\ "packages" match {
       case JObject(l) => l.map {
         case (packageName, JString(s)) =>
-          val pkg = ClassLoader.getPlatformClassLoader.getDefinedPackage(packageName)
+          val pkg = Package.getPackages.filter(p => p.getName == packageName).head
           val effSet = parseEffSet(s)
           (pkg, effSet)
         case _ => throw InternalCompilerException("Unexpected field value.", SourceLocation.Unknown)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/PrimitiveEffects.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/PrimitiveEffects.scala
@@ -139,9 +139,9 @@ object PrimitiveEffects {
     val m = json \\ "packages" match {
       case JObject(l) => l.map {
         case (packageName, JString(s)) =>
-          val clazz = ClassLoader.getPlatformClassLoader.getDefinedPackage(packageName)
+          val pkg = ClassLoader.getPlatformClassLoader.getDefinedPackage(packageName)
           val effSet = parseEffSet(s)
-          (clazz, effSet)
+          (pkg, effSet)
         case _ => throw InternalCompilerException("Unexpected field value.", SourceLocation.Unknown)
       }
       case _ => throw InternalCompilerException("Unexpected JSON format.", SourceLocation.Unknown)

--- a/main/src/library/Time/Instant.flix
+++ b/main/src/library/Time/Instant.flix
@@ -35,7 +35,7 @@ mod Time {
         /// Returns the current time from the system clock.
         ///
         @Experimental
-        pub def now(): Time.Instant \ IO =
+        pub def now(): Time.Instant \ { NonDet, IO } =
             Time.Instant.Instant(JInstant.now())
 
         ///


### PR DESCRIPTION
Before, it returned `Map(null -> effset)`, just choosing the last occuring effect set in the `json` file.