### PR TITLE
refactor: improve type errors for record types

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -412,6 +412,33 @@ object TypeError {
   }
 
   /**
+    * Extra label error.
+    *
+    * @param label      the name of the extra label.
+    * @param labelType  the type of the extra label.
+    * @param recordType the record type where the label is missing.
+    * @param renv       the rigidity environment.
+    * @param loc        the location where the error occurred.
+    */
+  case class ExtraLabel(label: Name.Label, labelType: Type, recordType: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+    def summary: String = s"Extra label '$label' of type '$labelType'."
+
+    def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Extra label '${red(label.name)}' of type '${cyan(formatType(labelType, Some(renv)))}'.
+         |
+         |${code(loc, "extra label.")}
+         |
+         |The record type:
+         |
+         |  ${formatType(recordType, Some(renv))}
+         |
+         |contains the extra label '${red(label.name)}' of type ${cyan(formatType(labelType, Some(renv)))}.
+         |""".stripMargin
+    }
+  }
+
+  /**
     * Undefined predicate error.
     *
     * @param pred       the missing predicate.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1732,4 +1732,253 @@ class TestTyper extends AnyFunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     rejectError[TypeError](result)
   }
+
+  test("UndefinedLabel.01") {
+    val input =
+      """
+        |def foo(): Unit \ IO = {
+        |  let r: {x = Int32, y = Int32} = {x = 1};
+        |  println(r#x)
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+  }
+
+  test("UndefinedLabel.02") {
+    val input =
+      """
+        |def foo(): Unit \ IO = {
+        |  let r: {x = Int32, y = Int32} = {y = 2};
+        |  println(r#x)
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+  }
+
+  test("UndefinedLabel.03") {
+    val input =
+      """
+        |def foo(): Unit \ IO = {
+        |  let r: {x = Int32, x = String} = {x = 1};
+        |  println(r#x)
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+  }
+
+  test("UndefinedLabel.04") {
+    val input =
+      """
+        |def foo(r: {x = Int32, y = Int32}): Unit \ IO = {
+        |  println(r#x)
+        |}
+        |
+        |def bar(): Unit \ IO = {
+        |  foo({x = 42})
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+  }
+
+  test("UndefinedLabel.05") {
+    val input =
+      """
+        |def foo(r: {x = Int32, y = Int32}): Unit \ IO = {
+        |  println(r#x)
+        |}
+        |
+        |def bar(): Unit \ IO = {
+        |  foo({y = 42})
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+  }
+
+  test("UndefinedLabel.06") {
+    val input =
+      """
+        |def foo(r: {x = Int32, x = String}): Unit \ IO = {
+        |  println(r#x)
+        |}
+        |
+        |def bar(): Unit \ IO = {
+        |  foo({x = 42})
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+  }
+
+  test("ExtraLabel.01") {
+    val input =
+      """
+        |def foo(): Unit \ IO = {
+        |  let r: {x = Int32, y = Int32} = {x = 1, y = 2, z = 3};
+        |  println(r#x)
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("ExtraLabel.02") {
+    val input =
+      """
+        |def foo(): Unit \ IO = {
+        |  let r: {x = Int32, y = Int32} = {w = 0, x = 1, y = 2, z = 3};
+        |  println(r#x)
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("ExtraLabel.03") {
+    val input =
+      """
+        |def foo(): Unit \ IO = {
+        |  let r: {x = Int32, y = Int32} = {x = 1, y = 2, z = 3, z = "foo"};
+        |  println(r#x)
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("ExtraLabel.04") {
+    val input =
+      """
+        |def foo(r: {x = Int32, y = Int32}): Unit \ IO = {
+        |  println(r#x)
+        |}
+        |
+        |def bar(): Unit \ IO = {
+        |  foo({x = 1, y = 2, z = 3})
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("ExtraLabel.05") {
+    val input =
+      """
+        |def foo(r: {x = Int32, y = Int32}): Unit \ IO = {
+        |  println(r#x)
+        |}
+        |
+        |def bar(): Unit \ IO = {
+        |  foo({w = 0, x = 1, y = 2, z = 3})
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("ExtraLabel.06") {
+    val input =
+      """
+        |def foo(r: {x = Int32, y = Int32}): Unit \ IO = {
+        |  println(r#x)
+        |}
+        |
+        |def bar(): Unit \ IO = {
+        |  foo({x = 1, y = 2, z = 3, z = "foo"})
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("UndefinedAndExtraLabel.01") {
+    val input =
+      """
+        |def foo(): Unit \ IO = {
+        |  let r: {x = Int32, y = Int32} = {x = 1, z = 3};
+        |  println(r#x)
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("UndefinedAndExtraLabel.02") {
+    val input =
+      """
+        |def foo(): Unit \ IO = {
+        |  let r: {x = Int32, y = Int32} = {w = 0, z = 3};
+        |  println(r#x)
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("UndefinedAndExtraLabel.03") {
+    val input =
+      """
+        |def foo(): Unit \ IO = {
+        |  let r: {x = Int32, x = String} = {x = 1, z = 3, z = "foo"};
+        |  println(r#x)
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("UndefinedAndExtraLabel.04") {
+    val input =
+      """
+        |def foo(r: {x = Int32, y = Int32}): Unit \ IO = {
+        |  println(r#x)
+        |}
+        |
+        |def bar(): Unit \ IO = {
+        |  foo({x = 1, z = 3})
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("UndefinedAndExtraLabel.05") {
+    val input =
+      """
+        |def foo(r: {x = Int32, y = Int32}): Unit \ IO = {
+        |  println(r#x)
+        |}
+        |
+        |def bar(): Unit \ IO = {
+        |  foo({w = 0, z = 3})
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+    expectError[TypeError.ExtraLabel](result)
+  }
+
+  test("UndefinedAndExtraLabel.06") {
+    val input =
+      """
+        |def foo(r: {x = Int32, x = String}): Unit \ IO = {
+        |  println(r#x)
+        |}
+        |
+        |def bar(): Unit \ IO = {
+        |  foo({x = 1, z = 3, z = "foo"})
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+    expectError[TypeError.ExtraLabel](result)
+  }
 }


### PR DESCRIPTION
Adds undefined label and extra label errors as discussed in #10722. 

A couple of comments:
i) Currently, it produces the same old error in the case of open records. 

ii) It seems difficult to fit the code into the design of the `toTypeErrors` function creating a list from a `TypeError` since there can now be multiple error messages generated from the same constraint. So `mkErrorsFromRecords` returns the list.