### PR TITLE
feat: add join profiler

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -271,6 +271,8 @@ class Flix {
     "Fixpoint3/Boxed.flix" -> LocalResource.get("/src/library/Fixpoint3/Boxed.flix"),
     "Fixpoint3/BoxingType.flix" -> LocalResource.get("/src/library/Fixpoint3/BoxingType.flix"),
     "Fixpoint3/Counter.flix" -> LocalResource.get("/src/library/Fixpoint3/Counter.flix"),
+    "Fixpoint3/Debugging.flix" -> LocalResource.get("/src/library/Fixpoint3/Debugging.flix"),
+    "Fixpoint3/JoinProfiler.flix" -> LocalResource.get("/src/library/Fixpoint3/JoinProfiler.flix"),
     "Fixpoint3/Options.flix" -> LocalResource.get("/src/library/Fixpoint3/Options.flix"),
     "Fixpoint3/Predicates.flix" -> LocalResource.get("/src/library/Fixpoint3/Predicates.flix"),
     "Fixpoint3/PredSymsOf.flix" -> LocalResource.get("/src/library/Fixpoint3/PredSymsOf.flix"),

--- a/main/src/library/Fixpoint3/Debugging.flix
+++ b/main/src/library/Fixpoint3/Debugging.flix
@@ -17,32 +17,16 @@
  */
 
 mod Fixpoint3.Debugging {
-    use Fixpoint3.Ast.Ram
+    use Fixpoint3.Ast.Ram.RamProgram
     use Fixpoint3.Options
-
-    ///
-    /// Write `s` to standard file. Overwrite if `overwrite` is true, otherwise append.
-    ///
-    def flush(s: String, overwrite: Bool): Unit \ IO =
-        if (Options.enableDebugToFile()) {
-            let res =
-                if (overwrite)
-                    FileWrite.runWithIO(() -> FileWrite.write(str = s, Options.debugFileName()))
-                else
-                    FileWrite.runWithIO(() -> FileWrite.append(str = s, Options.debugFileName()));
-            match res {
-                case Ok(_) => ()
-                case Err(e) => println(e)
-            }
-        } else println(s)
 
     ///
     /// Invoked after every phase during the fixpoint computation.
     ///
-    /// Note: Returns `d` to ensure it is not erased.
+    /// Note: Returns `program` to ensure it is not erased.
     ///
     @Internal
-    pub def notifyPreLowering(phase: String, program: Ram.RamProgram): Ram.RamProgram = match program {
+    pub def notifyPreLowering(phase: String, program: RamProgram): Ram.RamProgram = match program {
         case Ram.RamProgram.Program(stmt, _, _, _) => unchecked_cast({
             if (Options.enableDebugging()) region rc {
                 let strings = MutList.empty(rc);
@@ -60,5 +44,21 @@ mod Fixpoint3.Debugging {
             }
         } as _ \ {})
     }
+
+    ///
+    /// Write `s` to standard file. Overwrite if `overwrite` is true, otherwise append.
+    ///
+    def flush(s: String, overwrite: Bool): Unit \ IO =
+        if (Options.enableDebugToFile()) {
+            let res =
+                if (overwrite)
+                    FileWrite.runWithIO(() -> FileWrite.write(str = s, Options.debugFileName()))
+                else
+                    FileWrite.runWithIO(() -> FileWrite.append(str = s, Options.debugFileName()));
+            match res {
+                case Ok(_) => ()
+                case Err(e) => println(e)
+            }
+        } else println(s)
 
 }

--- a/main/src/library/Fixpoint3/Debugging.flix
+++ b/main/src/library/Fixpoint3/Debugging.flix
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Magnus Madsen
+ * Copyright 2025 Casper Dalgaard Nielsen
+ *                Adam Yasser Tallouzi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod Fixpoint3.Debugging {
+    use Fixpoint3.Ast.Ram
+    use Fixpoint3.Options
+
+    ///
+    /// Write `s` to standard file. Overwrite if `overwrite` is true, otherwise append.
+    ///
+    def flush(s: String, overwrite: Bool): Unit \ IO =
+        if (Options.enableDebugToFile()) {
+            let res =
+                if (overwrite)
+                    FileWrite.runWithIO(() -> FileWrite.write(str = s, Options.debugFileName()))
+                else
+                    FileWrite.runWithIO(() -> FileWrite.append(str = s, Options.debugFileName()));
+            match res {
+                case Ok(_) => ()
+                case Err(e) => println(e)
+            }
+        } else println(s)
+
+    ///
+    /// Invoked after every phase during the fixpoint computation.
+    ///
+    /// Note: Returns `d` to ensure it is not erased.
+    ///
+    @Internal
+    pub def notifyPreLowering(phase: String, program: Ram.RamProgram): Ram.RamProgram = match program {
+        case Ram.RamProgram.Program(stmt, _, _, _) => unchecked_cast({
+            if (Options.enableDebugging()) region rc {
+                let strings = MutList.empty(rc);
+                let psh = s -> MutList.push(s, strings);
+                String.repeat(80, "*") |> psh;
+                "** (${phase}) Relation Algebra Machine AST" |> psh;
+                String.repeat(80, "*") |> psh;
+                "" |> psh;
+                String.indent(4, "${stmt}") |> psh;
+                ""  |> psh;
+                flush(MutList.join("\n", strings), false);
+                program
+            } else {
+                program
+            }
+        } as _ \ {})
+    }
+
+}

--- a/main/src/library/Fixpoint3/JoinProfiler.flix
+++ b/main/src/library/Fixpoint3/JoinProfiler.flix
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2025 Casper Dalgaard Nielsen
+ *                Adam Yasser Tallouzi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod Fixpoint3.JoinProfiler {
+    use Fixpoint3.Ast.ExecutableRam.{RamProgram => ERamProgram, RamStmt => ERamStmt}
+    use Fixpoint3.Ast.Ram.{RamProgram, RamStmt, RelOp, RelSym, RowVar, Search}
+    use Fixpoint3.Counter
+    use Fixpoint3.Util.{collectRowVarRelSymOp, getOrCrash, unifyEqualitiesOp}
+    use Fixpoint3.Solver
+
+    ///
+    /// Contains estimates on relation sizes and the expected number of tuples resulting
+    /// from a particular join as a result of program execution. The estimates are generated
+    /// by `EstimateJoinSize` statements. Since they can appear in loops, we collect
+    /// estimates for each loop iteration.
+    ///
+    /// The first map maps relations represented by `RowVar`'s to their estimated size in
+    /// each iteration.
+    ///
+    /// The second map maps a particular join to the expected number of resulting tuples.
+    /// This is done by projecting the tuples in the relation to the join attributes and
+    /// counting the number of duplicates.
+    ///
+    @Internal
+    pub enum JoinProfile {
+        case Profile(
+            Map[RowVar, Vector[Int64]],
+            Map[(RowVar, Vector[Int32]), Vector[Int64]]
+        )
+    }
+
+    instance ToString[JoinProfile] {
+        pub def toString(x: JoinProfile): String = match x {
+            case JoinProfile.Profile(sizePerIter, expectedJoinSize) =>
+                let sizePerIterStr = sizePerIter |>
+                    Map.joinWith(k -> v -> "    ${k} => ${v}", "\n");
+                let expectedJoinSizeStr = expectedJoinSize |>
+                    Map.joinWith(k -> v -> "    ${k} => ${v}", "\n");
+                "JoinProfile(\n  ${sizePerIterStr}\n  ${expectedJoinSizeStr}\n)"
+        }
+    }
+
+    // Type alias for non-recursive and recursive rules, respectively.
+    type alias Rules = (List[RelOp], List[RelOp])
+
+    ///
+    /// Returns a profile on `program` by running `program` instrumented with
+    /// `EstimateJoinSize` statements. Additionally, returns a map used to infer which
+    /// `RowVar`'s bind which attributes in another `RowVar`.
+    ///
+    @Internal
+    pub def profileProgram(program: RamProgram): (JoinProfile, Map[RowVar, Map[RowVar, Set[Int32]]]) = region rc {
+        let (instrumentedProgram, attributeMap, rowVarToPos) = instrumentProgram(rc, program);
+        let vec = instrumentedProgram |>
+            Fixpoint3.Debugging.notifyPreLowering("Join Profiler") |>
+            Solver.runJoinProfiler;
+        let joinToSizeDup = Map.map(i -> Vector.get(i, vec), rowVarToPos);
+        let sizePerIter = joinToSizeDup |>
+            Map.foldLeftWithKey(acc -> k1 -> v1 -> {
+                let k2 = fst(k1);
+                let v2 = Vector.map(fst >> Int32.toInt64, v1);
+                Map.insert(k2, v2, acc)
+            }, Map#{});
+        let expectedJoinSize = joinToSizeDup |>
+            Map.map(
+                Vector.map(match (size, dup) ->
+                    Int32.toInt64(size) / (Int32.toInt64(size) - Int32.toInt64(dup)))
+            );
+        let profile = JoinProfile.Profile(sizePerIter, expectedJoinSize);
+        (profile, attributeMap)
+    }
+
+    ///
+    /// Adds join attributes to `attributeMap`. Conceptually, this is similar to collecting
+    /// the bound variables in the Datalog rule corresponding to the `RelOp` `rule`.
+    ///
+    /// `vars` is the list of all `RowVar`'s and their `RelSym`'s in `op`.
+    ///
+    /// `attributeMap` represents a SIP-graph. Given a `RowVar` `rv1`, a lookup returns another
+    /// map which, given a different `RowVar` `rv2`, returns the join attributes indexed by
+    /// their position in the corresponding relation for `rv1`. Conceptually, this gives us
+    /// the attributes that `rv1` binds in `rv2`,
+    ///
+    def collectBoundVars(
+        rc: Region[r],
+        vars: List[(RowVar, RelSym)],
+        attributeMap: MutMap[RowVar, MutMap[RowVar, MutSet[Int32, r], r], r],
+        rule: RelOp
+    ): Map[(RowVar, RelSym), List[Vector[Int32]]] \ r =
+        let equalities =  MutDisjointSets.empty(rc);
+        let constEqualities =  MutMap.empty(rc);
+        unifyEqualitiesOp(equalities, constEqualities, rule);
+        // equivalentMap is basically a SIP-graph.
+        let equivalentMap = MutMap.empty(rc);
+        vars |> List.forEach(match (rv, RelSym.Symbol(_, arity, _)) -> {
+            Vector.range(0, arity) |>
+            Vector.forEach(i ->
+                let load = (rv, i);
+                let rep = getOrCrash(MutDisjointSets.find(load, equalities));
+                MutMap.putWith(_ -> oldVal -> load :: oldVal, rep, load :: Nil, equivalentMap)
+            )
+        });
+        let attributesForRelSym = MutMap.empty(rc);
+        vars |> List.forEach(match (rvi, relSym) -> {
+            let mapForI = MutMap.getOrElsePut(rvi, MutMap.empty(rc), attributeMap);
+            let boundForI = MutSet.empty(rc);
+            vars |> List.filter(match (rvj, _) -> rvj != rvi) |>
+            List.forEach(aj -> {
+                let (rvj, RelSym.Symbol(_, arity, _)) = aj;
+                let boundByJ = MutSet.empty(rc);
+                Vector.range(0, arity) |>
+                Vector.forEach(i -> {
+                    let rep = getOrCrash(MutDisjointSets.find((rvj, i), equalities));
+                    match MutMap.get(rep, equivalentMap) {
+                        case None => ()
+                        case Some(v) =>
+                            v |> List.forEach(match (rv, index) ->
+                                if(rv == rvi) MutSet.add(index, boundByJ)
+                                else ()
+                            )
+                    }
+                });
+                MutMap.put(rvj, boundByJ, mapForI);
+                MutSet.add(MutSet.toList(boundByJ), boundForI)
+            });
+            let result = MutSet.empty(rc);
+            updateWithPowersetOf(List.toVector(MutSet.toList(boundForI)), result);
+            let collectedSoFar = MutMap.getOrElsePut((rvi, relSym), MutSet.empty(rc), attributesForRelSym);
+            MutSet.addAll(MutSet.toSet(result), collectedSoFar)
+        });
+        attributesForRelSym |> MutMap.toMap |> Map.map(MutSet.toList >> List.map(List.toVector))
+
+    ///
+    /// Updates `setForJ` with all elements in the powerset of `values`.
+    ///
+    def updateWithPowersetOf(values: Vector[List[Int32]], setForJ: MutSet[List[Int32], r]): Unit \ r =
+        def loop(index, val) =
+            if(Vector.size(values) == index) {
+                let toInsert = Set.foldRight(boundVar -> acc -> boundVar :: acc, Nil, val);
+                MutSet.add(toInsert, setForJ)
+            } else {
+                Vector.range(index + 1, Vector.length(values) + 1) |>
+                Vector.forEach(nextIndex -> {
+                    let newVal = List.foldLeft(acc -> boundVar ->
+                        Set.insert(boundVar, acc), val, Vector.get(index, values)
+                    );
+                    loop(nextIndex, newVal)
+                })
+            };
+        Vector.range(0, Vector.length(values) + 1) |>
+        Vector.forEach(i -> loop(i, Set.empty()))
+
+    ///
+    /// Populates `collectFor` with the estimates given by relations and join attributes in
+    /// `toEstimate`. A `Search` is used to represent the join attributes, which is
+    /// coincidentally also used later to construct an index conforming with that search.
+    ///
+    def estimateToCollect(
+        rc: Region[r],
+        toEstimate: Map[(RowVar, RelSym), List[Search]],
+        collectFor: MutMap[(RelSym, Search), MutSet[RowVar, r], r]
+    ): Unit \ r =
+        Map.forEach(match (rowVar, relSym) -> val -> {
+            val |> List.forEach(search ->
+                MutMap.getOrElsePut((relSym, search), MutSet.empty(rc), collectFor) |>
+                MutSet.add(rowVar)
+            )
+        }, toEstimate)
+
+    ///
+    /// Create appropriate `EstimateJoinSize` statements based on write-positions in
+    /// `rowVarToPos` and estimate information in `collectFor`.
+    ///
+    def collectedToEstimateStmts(
+        counter: Counter[r],
+        rowVarToPos: MutMap[(RowVar, Search), Int32, r],
+        collectFor: MutMap[(RelSym, Search), MutSet[RowVar, r], r]
+    ): List[RamStmt] \ r =
+        collectFor |> MutMap.foldLeftWithKey(acc -> match (relSym, search) -> rowVars -> {
+            let savePos = Counter.getAndIncrement(counter);
+            MutSet.forEach(rowVar -> MutMap.put((rowVar, search), savePos, rowVarToPos), rowVars);
+            RamStmt.EstimateJoinSize(relSym, -1, savePos, search) :: acc
+        }, Nil)
+
+    ///
+    /// Returns a `Seq` statement containing `EstimateJoinSize` statements created based
+    /// on `rowVarToPos` and `collectFor` and places it immediately before `stmt`.
+    ///
+    def combineStmtWithEstimate(
+        counter: Counter[r],
+        rowVarToPos: MutMap[(RowVar, Search), Int32, r],
+        collectFor: MutMap[(RelSym, Search), MutSet[RowVar, r], r],
+        stmt: RamStmt
+    ): RamStmt \ r =
+        let estimateStmts = collectedToEstimateStmts(counter, rowVarToPos, collectFor);
+        if(List.isEmpty(estimateStmts)) stmt
+        else RamStmt.Seq(Vector#{RamStmt.Par(List.toVector(estimateStmts)), stmt})
+
+    ///
+    /// Instruments `program` with `EstimateJoinSize` statements.
+    ///
+    def instrumentProgram(
+        rc: Region[r],
+        program: RamProgram
+    ): (RamProgram, Map[RowVar, Map[RowVar, Set[Int32]]], Map[(RowVar, Vector[Int32]), Int32]) \ r = {
+        let counter = Counter.fresh(rc);
+        let rowVarToPos = MutMap.empty(rc);
+        let attributeMap = MutMap.empty(rc);
+        def collectUntilBody(collectFor, s) = match s {
+            case RamStmt.Insert(op) =>
+                let toEstimate = collectBoundVars(rc, collectRowVarRelSymOp(op), attributeMap, op);
+                estimateToCollect(rc, toEstimate, collectFor)
+            case RamStmt.MergeInto(_, _) => ()
+            case RamStmt.Swap(_, _) => ()
+            case RamStmt.Purge(_) => ()
+            case RamStmt.Seq(stmts) => Vector.forEach(collectUntilBody(collectFor), stmts)
+            case RamStmt.Par(stmts) => Vector.forEach(collectUntilBody(collectFor), stmts)
+            case RamStmt.Until(_, _) => bug!("bug in Fixpoint.JoinProfiler: Nested until statements should not exist")
+            case RamStmt.Comment(_) => ()
+            case RamStmt.EstimateJoinSize(_, _, _, _) =>
+                bug!("bug in Fixpoint.JoinProfiler: EstimateJoinSize should not exist at this point")
+        };
+
+        // Note that estimation can be done in parallel with the expressions using them.
+        // Even for statements outside the until blocks they only write to the new versions.
+        // This means that we require the compiler to not change any indexes used in a given
+        // par statement. This might seem self evident, but it would not necessarily be
+        // unsafe to do so from a compilers perspective.
+        def instrumentStmt(s: RamStmt): RamStmt = match s {
+            case RamStmt.Insert(op) =>
+                // We estimate the size immediately before the insert-loop
+                let toEstimate = collectBoundVars(rc, collectRowVarRelSymOp(op), attributeMap, op);
+                // Collect information for RelSym with search and save it for RowVar.
+                let collectFor = MutMap.empty(rc);
+                estimateToCollect(rc, toEstimate, collectFor);
+                combineStmtWithEstimate(counter, rowVarToPos, collectFor, s)
+            case RamStmt.MergeInto(_, _) => s
+            case RamStmt.Swap(_, _) => s
+            case RamStmt.Purge(_) => s
+            case RamStmt.Seq(stmts) => Vector.map(instrumentStmt, stmts) |> RamStmt.Seq
+            case RamStmt.Par(stmts) => Vector.map(instrumentStmt, stmts) |> RamStmt.Par
+            case RamStmt.Until(conditions, body) =>
+                let collectFor = MutMap.empty(rc);
+                collectUntilBody(collectFor, body);
+                let newBody = combineStmtWithEstimate(counter, rowVarToPos, collectFor, body);
+                RamStmt.Until(conditions, newBody)
+            case RamStmt.Comment(_) => s
+            case RamStmt.EstimateJoinSize(_, _, _, _) => bug!("bug in Fixpoint.JoinProfiler: EstimateJoinSize should not exist at this point")
+        };
+        let RamProgram.Program(mainStmt, facts, predState, indexes) = program;
+        let instrumentedStmt = instrumentStmt(mainStmt);
+        let collectedAttributeMap = attributeMap |>
+            MutMap.map(rc, innerMap -> innerMap |> MutMap.map(rc, MutSet.toSet) |> MutMap.toMap) |>
+            MutMap.toMap;
+        let instrumentedProgram = RamProgram.Program(instrumentedStmt, facts, predState, indexes);
+        (instrumentedProgram, collectedAttributeMap, rowVarToPos |> MutMap.toMap)
+    }
+
+    ///
+    /// Returns the number of distinct `EstimateJoinSize` statements in `program`. This is
+    /// used by the interpreter to create an array which stores the results of those
+    /// statements.
+    ///
+    @Internal
+    pub def getJoinEstimateNum(program: ERamProgram): Int32 =
+        let ERamProgram.Program(stmt, _, _, _, _, _) = program;
+        getJoinEstimateMaxPos(stmt) + 1
+
+    ///
+    /// Returns the highest write-position of `EstimateJoinSize` statements in `s`.
+    ///
+    def getJoinEstimateMaxPos(s: ERamStmt): Int32 = match s {
+        case ERamStmt.Insert(_) => -1
+        case ERamStmt.MergeInto(_, _, _) => -1
+        case ERamStmt.Swap(_, _) => -1
+        case ERamStmt.Purge(_) => -1
+        case ERamStmt.Seq(stmts) => Vector.map(getJoinEstimateMaxPos, stmts) |> Vector.foldLeft(Int32.max, -1)
+        case ERamStmt.Par(stmts) => Vector.map(getJoinEstimateMaxPos, stmts) |> Vector.foldLeft(Int32.max, -1)
+        case ERamStmt.Until(_, stmt) => getJoinEstimateMaxPos(stmt)
+        case ERamStmt.Comment(_) => -1
+        case ERamStmt.EstimateJoinSize(_, writeTo, _) => writeTo
+    }
+
+}

--- a/main/src/library/Fixpoint3/Solver.flix
+++ b/main/src/library/Fixpoint3/Solver.flix
@@ -3,6 +3,7 @@ mod Fixpoint3.Solver {
     import dev.flix.runtime.Global
 
     use Fixpoint3.Ast.Datalog.Datalog
+    use Fixpoint3.Ast.Ram.{RamProgram => ARamProgram}
     use Fixpoint3.Ast.Shared.PredSym
     use Fixpoint3.Ast.Shared.PredSym.PredSym
     use Fixpoint3.Boxed
@@ -14,6 +15,12 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def runSolver(d: Datalog): Datalog = ???
+
+    ///
+    /// Executes `program` and returns estimates on relation and join sizes.
+    ///
+    @Internal
+    pub def runJoinProfiler(program: ARamProgram): Vector[Vector[(Int32, Int32)]] = ???
 
     ///
     /// Returns the pairwise union of `d1` and `d2`.

--- a/main/src/library/Fixpoint3/Util.flix
+++ b/main/src/library/Fixpoint3/Util.flix
@@ -16,6 +16,7 @@
  */
 
 mod Fixpoint3.Util {
+    use Fixpoint3.Ast.Ram.{BoolExp, RamId, RamProgram, RamStmt, RamTerm, RelSym, RelOp, RowVar}
     use Fixpoint3.Boxed
 
     ///
@@ -28,5 +29,76 @@ mod Fixpoint3.Util {
         case Some(v) => v
         case None => bug!("Attempted unwrapping none in getOrCrash")
     }
+
+    ///
+    /// Returns a list of pairs `(RowVar, RelSym)` in `op` in the order of nesting.
+    ///
+    @Internal
+    pub def collectRowVarRelSymOp(op: RelOp): List[(RowVar, RelSym)] \ r = match op {
+        case RelOp.Search(rv, relSym, rest) => (rv, relSym) :: collectRowVarRelSymOp(rest)
+        case RelOp.Query(rv, relSym, _, _, rest) => (rv, relSym) :: collectRowVarRelSymOp(rest)
+        case RelOp.Functional(_, _, _, rest, _) => collectRowVarRelSymOp(rest)
+        case RelOp.Project(_, _) => Nil
+        case RelOp.If(_, rest) => collectRowVarRelSymOp(rest)
+    }
+
+    ///
+    /// Collects equality information in `op` and save it in `equalitySets` and `constEqualities`.
+    /// Equalities between 2 `RowLoad`s are added to `equalitySets` and equalities between `RowLoad`
+    /// and `Lit` are added to `constEqualities`.
+    ///
+    /// In `equalitySets` we unify `(rv1, i1)` with `(rv2, i2)` if they occur together
+    /// in an equaltiy statement.
+    ///
+    /// In `constEqualities` we save a list of which literals a `(rv, i)` were equal to.
+    ///
+    @Internal
+    pub def unifyEqualitiesOp(
+        equalitySets: MutDisjointSets[(RowVar, Int32), r],
+        constEqualities: MutMap[(RowVar, Int32), List[(Boxed, RamId)], r],
+        op: RelOp
+    ): Unit \ r = match op {
+        case RelOp.Search(rowVar, RelSym.Symbol(_, arity, _), body) =>
+            collectLoads(rowVar, arity, equalitySets);
+            unifyEqualitiesOp(equalitySets, constEqualities, body)
+        case RelOp.Query(_, _, _, _, _) =>
+            bug!("In Fixpoint.Phase.Hoisting.unifyEqualitiesOp: Query should not exist at this point!")
+        case RelOp.Functional(rowVar, _, _, body, arity) =>
+            collectLoads(rowVar, arity, equalitySets);
+            unifyEqualitiesOp(equalitySets, constEqualities, body)
+        case RelOp.Project(_, _) => ()
+        case RelOp.If(boolExps, body) =>
+            Vector.forEach(unifyBoolExp(equalitySets, constEqualities), boolExps);
+            unifyEqualitiesOp(equalitySets, constEqualities, body)
+    }
+
+    ///
+    /// Collects equality information in `boolExp` and save it in `equalitySets` and `constEqualities`.
+    ///
+    /// See `unifyEqualitiesOp`.
+    ///
+    def unifyBoolExp(
+        equalitySets: MutDisjointSets[(RowVar, Int32), r],
+        constEqualities: MutMap[(RowVar, Int32), List[(Boxed, RamId)], r],
+        boolExp: BoolExp
+    ): Unit \ r = match boolExp {
+        case BoolExp.Eq(RamTerm.RowLoad(rv1, i1, _), RamTerm.RowLoad(rv2, i2, _)) =>
+            MutDisjointSets.makeSet((rv1, i1), equalitySets);
+            MutDisjointSets.makeSet((rv2, i2), equalitySets);
+            MutDisjointSets.union((rv1, i1), (rv2, i2), equalitySets)
+        case BoolExp.Eq(RamTerm.RowLoad(rv, i, _), RamTerm.Lit(val, id)) =>
+            MutMap.putWith(_ -> list -> (val, id) :: list, (rv, i), (val, id) :: Nil, constEqualities)
+        case BoolExp.Eq(RamTerm.Lit(val, id), RamTerm.RowLoad(rv, i, _)) =>
+            MutMap.putWith(_ -> list -> (val, id) :: list, (rv, i), (val, id) :: Nil, constEqualities)
+        case _ => ()
+    }
+
+    ///
+    /// Add `(rowVar, i)` for all `i` between `0` (inclusive) and `arity` (exlusive)
+    /// to `equalitySets`.
+    ///
+    def collectLoads(rowVar: RowVar, arity: Int32, equalitySets: MutDisjointSets[(RowVar, Int32), r]): Unit \ r =
+        Vector.forEach(i -> MutDisjointSets.makeSet((rowVar, i), equalitySets), Vector.range(0, arity))
+
 
 }


### PR DESCRIPTION
The join profiler estimates the sizes of relations and joins in Datalog programs. The estimates are used to optimize join orders in rules and are necessary since relations are dynamic (their sizes increase) throughout fixpoint computation, meaning static analysis is insufficient to determine optimal join orders.