### PR TITLE
feat: remove redundant SafetyError.IllegalSpawnEffect

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -160,24 +160,6 @@ object SafetyError {
   }
 
   /**
-    * An error raised to indicate an illegal effect in a spawn expression.
-    *
-    * @param eff the illegal effect.
-    * @param loc the source location of the spawn.
-    */
-  case class IllegalSpawnEffect(eff: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
-    override def summary: String = "Illegal spawn effect"
-
-    override def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> Illegal spawn effect: '${red(FormatType.formatType(eff, None))}'. A spawn expression must be pure or have a primitive effect.
-         |
-         |${code(loc, "illegal effect.")}
-         |""".stripMargin
-    }
-  }
-
-  /**
     * An error raised to indicate that the Java class in a catch clause is not a Throwable.
     *
     * @param loc the location of the catch parameter.

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -64,7 +64,6 @@ object Safety {
     *   - [[Expr.UncheckedCast]] are not impossible.
     *   - [[Expr.Throw]] only throws exceptions.
     *   - [[Expr.NewObject]] are valid (see [[checkObjectImplementation]]).
-    *   - [[Expr.Spawn]] only performs primitive effects.
     *   - [[Expr.FixpointConstraintSet]] are valid (see [[checkConstraint]]).
     */
   private def visitExp(exp0: Expr)(implicit renv: RigidityEnv, sctx: SharedContext, flix: Flix): Unit = exp0 match {
@@ -331,7 +330,6 @@ object Safety {
       default.map(visitExp).getOrElse(Nil)
 
     case Expr.Spawn(exp1, exp2, _, _, _) =>
-      if (hasControlEffects(exp1.eff)) sctx.errors.add(IllegalSpawnEffect(exp1.eff, exp1.loc))
       visitExp(exp1)
       visitExp(exp2)
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -892,22 +892,4 @@ class TestSafety extends AnyFunSuite with TestUtils {
     val result = compile(input, Options.DefaultTest)
     expectError[IllegalMethodEffect](result)
   }
-
-  test("IllegalSpawnEffect.01") {
-    val input =
-      """
-        |eff Ask {
-        |    pub def ask(): String
-        |}
-        |
-        |def main(): Unit \ IO =
-        |    region rc {
-        |        spawn Ask.ask() @ rc
-        |    }
-        |
-      """.stripMargin
-    val result = compile(input, Options.DefaultTest)
-    expectError[IllegalSpawnEffect](result)
-  }
-
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.{EntryPointError, SafetyError}
-import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalCatchType, IllegalMethodEffect, IllegalNegativelyBoundWildCard, IllegalNonPositivelyBoundVar, IllegalPatternInBodyAtom, IllegalRelationalUseOfLatticeVar, IllegalSpawnEffect, IllegalThrowType}
+import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalCatchType, IllegalMethodEffect, IllegalNegativelyBoundWildCard, IllegalNonPositivelyBoundVar, IllegalPatternInBodyAtom, IllegalRelationalUseOfLatticeVar, IllegalThrowType}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1648,6 +1648,23 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
+  test("TypeError.IllegalSpawn.01") {
+    val input =
+      """
+        |eff Ask {
+        |    pub def ask(): String
+        |}
+        |
+        |def foo(): Unit \ Ask =
+        |    region rc {
+        |        spawn Ask.ask() @ rc
+        |    }
+        |
+      """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError](result)
+  }
+
   test("Subeffecting.Def.01") {
     val input =
       """


### PR DESCRIPTION
This property is already checked more robustly in the Typer. 