### PR TITLE
chore: rename SimpleType to DisplayType

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
@@ -25,9 +25,9 @@ import java.lang.reflect.{Constructor, Field, Method}
 /**
   * A well-kinded type in an easily-printable format.
   */
-sealed trait TypeView
+sealed trait DisplayType
 
-object TypeView {
+object DisplayType {
 
   private class OverAppliedType(loc: SourceLocation) extends InternalCompilerException("Unexpected over-applied type.", loc)
 
@@ -39,67 +39,67 @@ object TypeView {
     * An unfilled parameter in a partially-applied type-level function.
     * For example, `Not` (applied to nothing) is `Not(Hole)`.
     */
-  case object Hole extends TypeView
+  case object Hole extends DisplayType
 
   /////////////
   // Primitives
   /////////////
 
-  case object Void extends TypeView
+  case object Void extends DisplayType
 
-  case object AnyType extends TypeView
+  case object AnyType extends DisplayType
 
-  case object Unit extends TypeView
+  case object Unit extends DisplayType
 
-  case object Null extends TypeView
+  case object Null extends DisplayType
 
-  case object Bool extends TypeView
+  case object Bool extends DisplayType
 
-  case object Char extends TypeView
+  case object Char extends DisplayType
 
-  case object Float32 extends TypeView
+  case object Float32 extends DisplayType
 
-  case object Float64 extends TypeView
+  case object Float64 extends DisplayType
 
-  case object BigDecimal extends TypeView
+  case object BigDecimal extends DisplayType
 
-  case object Int8 extends TypeView
+  case object Int8 extends DisplayType
 
-  case object Int16 extends TypeView
+  case object Int16 extends DisplayType
 
-  case object Int32 extends TypeView
+  case object Int32 extends DisplayType
 
-  case object Int64 extends TypeView
+  case object Int64 extends DisplayType
 
-  case object BigInt extends TypeView
+  case object BigInt extends DisplayType
 
-  case object Str extends TypeView
+  case object Str extends DisplayType
 
-  case object Regex extends TypeView
+  case object Regex extends DisplayType
 
-  case object Array extends TypeView
+  case object Array extends DisplayType
 
-  case object ArrayWithoutRegion extends TypeView
+  case object ArrayWithoutRegion extends DisplayType
 
-  case object Vector extends TypeView
+  case object Vector extends DisplayType
 
-  case object Sender extends TypeView
+  case object Sender extends DisplayType
 
-  case object Receiver extends TypeView
+  case object Receiver extends DisplayType
 
-  case object Lazy extends TypeView
+  case object Lazy extends DisplayType
 
-  case object Pure extends TypeView
+  case object Pure extends DisplayType
 
-  case object Univ extends TypeView
+  case object Univ extends DisplayType
 
-  case object False extends TypeView
+  case object False extends DisplayType
 
-  case object True extends TypeView
+  case object True extends DisplayType
 
-  case object RegionToStar extends TypeView
+  case object RegionToStar extends DisplayType
 
-  case object RegionWithoutRegion extends TypeView
+  case object RegionWithoutRegion extends DisplayType
 
   //////////
   // Records
@@ -108,27 +108,27 @@ object TypeView {
   /**
     * A record constructor. `arg` should be a variable or a Hole.
     */
-  case class RecordConstructor(arg: TypeView) extends TypeView
+  case class RecordConstructor(arg: DisplayType) extends DisplayType
 
   /**
     * An unextended record.
     */
-  case class Record(labels: List[RecordLabelType]) extends TypeView
+  case class Record(labels: List[RecordLabelType]) extends DisplayType
 
   /**
     * An extended record. `arg` should be a variable or a Hole.
     */
-  case class RecordExtend(labels: List[RecordLabelType], rest: TypeView) extends TypeView
+  case class RecordExtend(labels: List[RecordLabelType], rest: DisplayType) extends DisplayType
 
   /**
     * An unextended record row.
     */
-  case class RecordRow(labels: List[RecordLabelType]) extends TypeView
+  case class RecordRow(labels: List[RecordLabelType]) extends DisplayType
 
   /**
     * An extended record row. `arg` should be a variable or a Hole.
     */
-  case class RecordRowExtend(labels: List[RecordLabelType], rest: TypeView) extends TypeView
+  case class RecordRowExtend(labels: List[RecordLabelType], rest: DisplayType) extends DisplayType
 
   //////////
   // Schemas
@@ -137,27 +137,27 @@ object TypeView {
   /**
     * A schema constructor. `arg` should be a variable or a Hole.
     */
-  case class SchemaConstructor(arg: TypeView) extends TypeView
+  case class SchemaConstructor(arg: DisplayType) extends DisplayType
 
   /**
     * An unextended schema.
     */
-  case class Schema(fields: List[PredicateFieldType]) extends TypeView
+  case class Schema(fields: List[PredicateFieldType]) extends DisplayType
 
   /**
     * An extended schema. `arg` should be a variable or a Hole.
     */
-  case class SchemaExtend(fields: List[PredicateFieldType], rest: TypeView) extends TypeView
+  case class SchemaExtend(fields: List[PredicateFieldType], rest: DisplayType) extends DisplayType
 
   /**
     * An unextended schema row.
     */
-  case class SchemaRow(fields: List[PredicateFieldType]) extends TypeView
+  case class SchemaRow(fields: List[PredicateFieldType]) extends DisplayType
 
   /**
     * An extended schema row. `arg` should be a variable or a Hole.
     */
-  case class SchemaRowExtend(fields: List[PredicateFieldType], rest: TypeView) extends TypeView
+  case class SchemaRowExtend(fields: List[PredicateFieldType], rest: DisplayType) extends DisplayType
 
   ////////////////////
   // Boolean Operators
@@ -166,17 +166,17 @@ object TypeView {
   /**
     * Boolean negation.
     */
-  case class Not(tpe: TypeView) extends TypeView
+  case class Not(tpe: DisplayType) extends DisplayType
 
   /**
     * A chain of types connected by `and`.
     */
-  case class And(tpes: List[TypeView]) extends TypeView
+  case class And(tpes: List[DisplayType]) extends DisplayType
 
   /**
     * A chain of types connected by `or`.
     */
-  case class Or(tpes: List[TypeView]) extends TypeView
+  case class Or(tpes: List[DisplayType]) extends DisplayType
 
   ////////////////
   // Set Operators
@@ -185,50 +185,50 @@ object TypeView {
   /**
     * Set complement.
     */
-  case class Complement(tpe: TypeView) extends TypeView
+  case class Complement(tpe: DisplayType) extends DisplayType
 
   /**
     * A chain of types in a set.
     */
-  case class Union(tpes: List[TypeView]) extends TypeView
+  case class Union(tpes: List[DisplayType]) extends DisplayType
 
   /**
     * A chain of types connected by `&`.
     */
-  case class Plus(tpes: List[TypeView]) extends TypeView
+  case class Plus(tpes: List[DisplayType]) extends DisplayType
 
   /**
     * A chain of types connected by `&`.
     */
-  case class Intersection(tpes: List[TypeView]) extends TypeView
+  case class Intersection(tpes: List[DisplayType]) extends DisplayType
 
   /**
     * A chain of types connected by `⊕`.
     */
-  case class SymmetricDiff(tpes: List[TypeView]) extends TypeView
+  case class SymmetricDiff(tpes: List[DisplayType]) extends DisplayType
 
   /**
     * A chain of types connected by `-`.
     */
-  case class Difference(tpes: List[TypeView]) extends TypeView
+  case class Difference(tpes: List[DisplayType]) extends DisplayType
 
   /////////////
   // Predicates
   /////////////
 
-  case object RelationConstructor extends TypeView
+  case object RelationConstructor extends DisplayType
 
   /**
     * A relation over a list of types.
     */
-  case class Relation(tpes: List[TypeView]) extends TypeView
+  case class Relation(tpes: List[DisplayType]) extends DisplayType
 
-  case object LatticeConstructor extends TypeView
+  case object LatticeConstructor extends DisplayType
 
   /**
     * A lattice over a list of types.
     */
-  case class Lattice(tpes: List[TypeView], lat: TypeView) extends TypeView
+  case class Lattice(tpes: List[DisplayType], lat: DisplayType) extends DisplayType
 
   ////////////
   // Functions
@@ -237,45 +237,45 @@ object TypeView {
   /**
     * A pure function.
     */
-  case class PureArrow(arg: TypeView, ret: TypeView) extends TypeView
+  case class PureArrow(arg: DisplayType, ret: DisplayType) extends DisplayType
 
   /**
     * A function with a purity.
     */
-  case class PolyArrow(arg: TypeView, eff: TypeView, ret: TypeView) extends TypeView
+  case class PolyArrow(arg: DisplayType, eff: DisplayType, ret: DisplayType) extends DisplayType
 
   /**
     * A backend function (no effect).
     */
-  case class ArrowWithoutEffect(arg: TypeView, ret: TypeView) extends TypeView
+  case class ArrowWithoutEffect(arg: DisplayType, ret: DisplayType) extends DisplayType
 
   ///////
   // Tags
   ///////
 
-  case class TagConstructor(name: String) extends TypeView
+  case class TagConstructor(name: String) extends DisplayType
 
   ////////////
   // JVM Types
   ////////////
 
-  case class JvmToType(tpe: TypeView) extends TypeView
+  case class JvmToType(tpe: DisplayType) extends DisplayType
 
-  case class JvmToEff(tpe: TypeView) extends TypeView
+  case class JvmToEff(tpe: DisplayType) extends DisplayType
 
-  case class JvmUnresolvedConstructor(name: String, tpes: List[TypeView]) extends TypeView
+  case class JvmUnresolvedConstructor(name: String, tpes: List[DisplayType]) extends DisplayType
 
-  case class JvmUnresolvedField(tpe: TypeView, name: String) extends TypeView
+  case class JvmUnresolvedField(tpe: DisplayType, name: String) extends DisplayType
 
-  case class JvmUnresolvedMethod(tpe: TypeView, name: String, tpes: List[TypeView]) extends TypeView
+  case class JvmUnresolvedMethod(tpe: DisplayType, name: String, tpes: List[DisplayType]) extends DisplayType
 
-  case class JvmUnresolvedStaticMethod(clazz: String, name: String, tpes: List[TypeView]) extends TypeView
+  case class JvmUnresolvedStaticMethod(clazz: String, name: String, tpes: List[DisplayType]) extends DisplayType
 
-  case class JvmConstructor(constructor: Constructor[?]) extends TypeView
+  case class JvmConstructor(constructor: Constructor[?]) extends DisplayType
 
-  case class JvmField(field: Field) extends TypeView
+  case class JvmField(field: Field) extends DisplayType
 
-  case class JvmMethod(method: Method) extends TypeView
+  case class JvmMethod(method: Method) extends DisplayType
 
   //////////////////////
   // Miscellaneous Types
@@ -284,32 +284,32 @@ object TypeView {
   /**
     * A simple named type (e.g., enum or type alias).
     */
-  case class Name(name: String) extends TypeView
+  case class Name(name: String) extends DisplayType
 
   /**
     * A type applied to one or more types.
     */
-  case class Apply(tpe: TypeView, tpes: List[TypeView]) extends TypeView
+  case class Apply(tpe: DisplayType, tpes: List[DisplayType]) extends DisplayType
 
   /**
     * A type variable.
     */
-  case class Var(id: Int, kind: Kind, text: VarText) extends TypeView
+  case class Var(id: Int, kind: Kind, text: VarText) extends DisplayType
 
   /**
     * A tuple.
     */
-  case class Tuple(tpes: List[TypeView]) extends TypeView
+  case class Tuple(tpes: List[DisplayType]) extends DisplayType
 
   /**
     * A region.
     */
-  case class Region(name: String) extends TypeView
+  case class Region(name: String) extends DisplayType
 
   /**
     * An error type.
     */
-  case object Error extends TypeView
+  case object Error extends DisplayType
 
   /////////
   // Fields
@@ -318,7 +318,7 @@ object TypeView {
   /**
     * A record label name and its type.
     */
-  case class RecordLabelType(name: String, tpe: TypeView)
+  case class RecordLabelType(name: String, tpe: DisplayType)
 
   /**
     * A common supertype for schema predicates.
@@ -330,24 +330,24 @@ object TypeView {
   /**
     * A relation field name and its types.
     */
-  case class RelationFieldType(name: String, tpes: List[TypeView]) extends PredicateFieldType
+  case class RelationFieldType(name: String, tpes: List[DisplayType]) extends PredicateFieldType
 
   /**
     * A lattice field name, its types, and its lattice.
     */
-  case class LatticeFieldType(name: String, tpes: List[TypeView], lat: TypeView) extends PredicateFieldType
+  case class LatticeFieldType(name: String, tpes: List[DisplayType], lat: DisplayType) extends PredicateFieldType
 
   /**
     * A predicate field type that's not actually a predicate.
     */
-  case class NonPredFieldType(name: String, tpe: TypeView) extends PredicateFieldType
+  case class NonPredFieldType(name: String, tpe: DisplayType) extends PredicateFieldType
 
   /**
     * Creates a simple type from the well-kinded type `t`.
     */
-  def fromWellKindedType(t0: Type): TypeView = {
+  def fromWellKindedType(t0: Type): DisplayType = {
 
-    def visit(t: Type): TypeView = t.baseType match {
+    def visit(t: Type): DisplayType = t.baseType match {
       case Type.Var(sym, _) =>
         mkApply(Var(sym.id, sym.kind, sym.text), t.typeArguments.map(visit))
       case Type.Alias(cst, args, _, _) =>
@@ -355,14 +355,14 @@ object TypeView {
       case Type.AssocType(cst, arg, _, _) =>
         mkApply(Name(cst.sym.name), (arg :: t.typeArguments).map(visit))
       case Type.JvmToType(tpe, _) =>
-        mkApply(TypeView.JvmToType(visit(tpe)), t.typeArguments.map(visit))
+        mkApply(DisplayType.JvmToType(visit(tpe)), t.typeArguments.map(visit))
       case Type.JvmToEff(tpe, _) =>
-        mkApply(TypeView.JvmToEff(visit(tpe)), t.typeArguments.map(visit))
+        mkApply(DisplayType.JvmToEff(visit(tpe)), t.typeArguments.map(visit))
       case Type.UnresolvedJvmType(member, _) => member match {
-        case JvmMember.JvmConstructor(clazz, tpes) => TypeView.JvmUnresolvedConstructor(clazz.getSimpleName, tpes.map(visit))
-        case JvmMember.JvmMethod(tpe, name, tpes) => TypeView.JvmUnresolvedMethod(visit(tpe), name.name, tpes.map(visit))
-        case JvmMember.JvmField(_, tpe, name) => TypeView.JvmUnresolvedField(visit(tpe), name.name)
-        case JvmMember.JvmStaticMethod(clazz, name, tpes) => TypeView.JvmUnresolvedStaticMethod(clazz.getSimpleName, name.name, tpes.map(visit))
+        case JvmMember.JvmConstructor(clazz, tpes) => DisplayType.JvmUnresolvedConstructor(clazz.getSimpleName, tpes.map(visit))
+        case JvmMember.JvmMethod(tpe, name, tpes) => DisplayType.JvmUnresolvedMethod(visit(tpe), name.name, tpes.map(visit))
+        case JvmMember.JvmField(_, tpe, name) => DisplayType.JvmUnresolvedField(visit(tpe), name.name)
+        case JvmMember.JvmStaticMethod(clazz, name, tpes) => DisplayType.JvmUnresolvedStaticMethod(clazz.getSimpleName, name.name, tpes.map(visit))
       }
       case Type.Cst(tc, _) => tc match {
         case TypeConstructor.Void => Void
@@ -387,7 +387,7 @@ object TypeView {
           args match {
             // Case 1: No args. Fill everything with a hole.
             case Nil =>
-              val lastArrow: TypeView = PolyArrow(Hole, Hole, Hole)
+              val lastArrow: DisplayType = PolyArrow(Hole, Hole, Hole)
               // NB: safe to subtract 2 since arity is always at least 2
               List.fill(arity - 2)(Hole).foldRight(lastArrow)(PureArrow.apply)
 
@@ -401,7 +401,7 @@ object TypeView {
               // NB: safe to take last 2 because arity is always at least 2
               val allTpes = tpes.padTo(arity, Hole)
               val List(lastArg, ret) = allTpes.takeRight(2)
-              val lastArrow: TypeView = PolyArrow(lastArg, eff, ret)
+              val lastArrow: DisplayType = PolyArrow(lastArg, eff, ret)
               allTpes.dropRight(2).foldRight(lastArrow)(PureArrow.apply)
           }
 
@@ -545,7 +545,7 @@ object TypeView {
             case _ :: _ :: _ :: _ => throw new OverAppliedType(t.loc)
           }
 
-        case TypeConstructor.Not => TypeView.Not(visit(t.typeArguments.head))
+        case TypeConstructor.Not => DisplayType.Not(visit(t.typeArguments.head))
 
         case TypeConstructor.Complement =>
           t.typeArguments.map(visit) match {
@@ -599,8 +599,8 @@ object TypeView {
           SymmetricDiff(args)
 
         case TypeConstructor.CaseSet(syms, _) =>
-          val names = syms.toList.map(sym => TypeView.Name(sym.name))
-          val set = TypeView.Union(names)
+          val names = syms.toList.map(sym => DisplayType.Name(sym.name))
+          val set = DisplayType.Union(names)
           mkApply(set, t.typeArguments.map(visit))
 
         case TypeConstructor.CaseComplement(_) =>
@@ -626,12 +626,12 @@ object TypeView {
             case _ => throw new OverAppliedType(t.loc)
           }
 
-        case TypeConstructor.Effect(sym, _) => mkApply(TypeView.Name(sym.name), t.typeArguments.map(visit))
-        case TypeConstructor.Region(sym) => mkApply(TypeView.Region(sym.text), t.typeArguments.map(visit))
+        case TypeConstructor.Effect(sym, _) => mkApply(DisplayType.Name(sym.name), t.typeArguments.map(visit))
+        case TypeConstructor.Region(sym) => mkApply(DisplayType.Region(sym.text), t.typeArguments.map(visit))
         case TypeConstructor.RegionToStar => mkApply(RegionToStar, t.typeArguments.map(visit))
         case TypeConstructor.RegionWithoutRegion => mkApply(RegionWithoutRegion, t.typeArguments.map(visit))
 
-        case TypeConstructor.Error(_, _) => TypeView.Error
+        case TypeConstructor.Error(_, _) => DisplayType.Error
       }
     }
 
@@ -641,7 +641,7 @@ object TypeView {
   /**
     * Builds an Apply type.
     */
-  private def mkApply(base: TypeView, args: List[TypeView]): TypeView = args match {
+  private def mkApply(base: DisplayType, args: List[DisplayType]): DisplayType = args match {
     case Nil => base
     case _ :: _ => Apply(base, args)
   }
@@ -649,7 +649,7 @@ object TypeView {
   /**
     * Extracts the types from a tuple, treating non-tuples as singletons.
     */
-  private def destructTuple(tpe: TypeView): List[TypeView] = tpe match {
+  private def destructTuple(tpe: DisplayType): List[DisplayType] = tpe match {
     case Tuple(fields) => fields
     case Unit => Nil
     case t => t :: Nil
@@ -658,21 +658,21 @@ object TypeView {
   /**
     * Transforms the given type, assuming it is a record row.
     */
-  private def fromRecordRow(row0: Type): TypeView = {
-    def visit(row: Type): TypeView = row match {
+  private def fromRecordRow(row0: Type): DisplayType = {
+    def visit(row: Type): DisplayType = row match {
       // Case 1: A fully applied record row.
       case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(name), _), tpe, _), rest, _) =>
         val labelType = RecordLabelType(name.name, fromWellKindedType(tpe))
         visit(rest) match {
           // Case 1.1: Unextended row. Put the labels together.
-          case TypeView.RecordRow(labels) => TypeView.RecordRow(labelType :: labels)
+          case DisplayType.RecordRow(labels) => DisplayType.RecordRow(labelType :: labels)
           // Case 1.2: Extended row. Put the labels together.
-          case TypeView.RecordRowExtend(labels, restOfRest) => TypeView.RecordRowExtend(labelType :: labels, restOfRest)
+          case DisplayType.RecordRowExtend(labels, restOfRest) => DisplayType.RecordRowExtend(labelType :: labels, restOfRest)
           // Case 1.3: Non-row. Put it in the "rest" position.
-          case nonRecord => TypeView.RecordRowExtend(labelType :: Nil, nonRecord)
+          case nonRecord => DisplayType.RecordRowExtend(labelType :: Nil, nonRecord)
         }
       // Case 2: Empty record row.
-      case Type.Cst(TypeConstructor.RecordRowEmpty, _) => TypeView.RecordRow(Nil)
+      case Type.Cst(TypeConstructor.RecordRowEmpty, _) => DisplayType.RecordRow(Nil)
       // Case 3: Non-row.
       case nonRecord => fromWellKindedType(nonRecord)
     }
@@ -688,8 +688,8 @@ object TypeView {
   /**
     * Transforms the given type, assuming it is a schema row.
     */
-  private def fromSchemaRow(row0: Type): TypeView = {
-    def visit(row: Type): TypeView = row match {
+  private def fromSchemaRow(row0: Type): DisplayType = {
+    def visit(row: Type): DisplayType = row match {
       // Case 1: A fully applied record row.
       case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(name), _), tpe, _), rest, _) =>
         // create the right field/type for the field
@@ -701,14 +701,14 @@ object TypeView {
         }
         visit(rest) match {
           // Case 1.1: Unextended row. Put the fields together.
-          case TypeView.SchemaRow(fields) => TypeView.SchemaRow(fieldType :: fields)
+          case DisplayType.SchemaRow(fields) => DisplayType.SchemaRow(fieldType :: fields)
           // Case 1.2: Extended row. Put the fields together.
-          case TypeView.SchemaRowExtend(fields, restOfRest) => TypeView.SchemaRowExtend(fieldType :: fields, restOfRest)
+          case DisplayType.SchemaRowExtend(fields, restOfRest) => DisplayType.SchemaRowExtend(fieldType :: fields, restOfRest)
           // Case 1.3: Non-row. Put it in the "rest" position.
-          case nonSchema => TypeView.SchemaRowExtend(fieldType :: Nil, nonSchema)
+          case nonSchema => DisplayType.SchemaRowExtend(fieldType :: Nil, nonSchema)
         }
       // Case 2: Empty record row.
-      case Type.Cst(TypeConstructor.SchemaRowEmpty, _) => TypeView.SchemaRow(Nil)
+      case Type.Cst(TypeConstructor.SchemaRowEmpty, _) => DisplayType.SchemaRow(Nil)
       // Case 3: Non-row.
       case nonSchema => fromWellKindedType(nonSchema)
     }
@@ -725,7 +725,7 @@ object TypeView {
     * Splits `t1 and t2` into `t1 :: t2 :: Nil`,
     * and leaves non-and types as singletons.
     */
-  private def splitAnds(tpe: TypeView): List[TypeView] = tpe match {
+  private def splitAnds(tpe: DisplayType): List[DisplayType] = tpe match {
     case And(tpes) => tpes
     case t => List(t)
   }
@@ -734,7 +734,7 @@ object TypeView {
     * Splits `t1 or t2` into `t1 :: t2 :: Nil`,
     * and leaves non-or types as singletons.
     */
-  private def splitOrs(tpe: TypeView): List[TypeView] = tpe match {
+  private def splitOrs(tpe: DisplayType): List[DisplayType] = tpe match {
     case Or(tpes) => tpes
     case t => List(t)
   }
@@ -743,7 +743,7 @@ object TypeView {
     * Splits `t1 + t2` into `t1 :: t2 :: Nil`,
     * and leaves non-plus types as singletons.
     */
-  private def splitPluses(tpe: TypeView): List[TypeView] = tpe match {
+  private def splitPluses(tpe: DisplayType): List[DisplayType] = tpe match {
     case Plus(tpes) => tpes
     case t => List(t)
   }
@@ -752,7 +752,7 @@ object TypeView {
     * Splits `t1 & t2` into `t1 :: t2 :: Nil`,
     * and leaves other types as singletons.
     */
-  private def splitIntersections(tpe: TypeView): List[TypeView] = tpe match {
+  private def splitIntersections(tpe: DisplayType): List[DisplayType] = tpe match {
     case Intersection(tpes) => tpes
     case t => List(t)
   }
@@ -761,7 +761,7 @@ object TypeView {
     * Splits `t1 - t2` into `t1 :: t2 :: Nil`,
     * and leaves other types as singletons.
     */
-  private def splitDifference(tpe: TypeView): List[TypeView] = tpe match {
+  private def splitDifference(tpe: DisplayType): List[DisplayType] = tpe match {
     case Difference(tpes) => tpes
     case t => List(t)
   }
@@ -770,7 +770,7 @@ object TypeView {
     * Splits `t1 ⊕ t2` into `t1 :: t2 :: Nil`,
     * and leaves other types as singletons.
     */
-  private def splitSymmetricDiff(tpe: TypeView): List[TypeView] = tpe match {
+  private def splitSymmetricDiff(tpe: DisplayType): List[DisplayType] = tpe match {
     case SymmetricDiff(tpes) => tpes
     case t => List(t)
   }

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -69,7 +69,7 @@ object FormatType {
     */
   def formatTypeWithOptions(tpe: Type, fmt: FormatOptions): String = {
     try {
-      format(SimpleType.fromWellKindedType(tpe))(fmt)
+      format(TypeView.fromWellKindedType(tpe))(fmt)
     } catch {
       case _: Throwable => "ERR_UNABLE_TO_FORMAT_TYPE"
     }
@@ -84,21 +84,21 @@ object FormatType {
   }
 
   /**
-    * Transforms the given simple type into a string.
+    * Transforms the given type view into a string.
     */
-  def formatSimpleType(tpe: SimpleType)(implicit flix: Flix): String =
-    formatSimpleTypeWithOptions(tpe, flix.getFormatOptions)
+  def formatTypeView(tpe: TypeView)(implicit flix: Flix): String =
+    formatTypeViewWithOptions(tpe, flix.getFormatOptions)
 
   /**
-    * Transforms the given simple type into a string, using the given format options.
+    * Transforms the given type view into a string, using the given format options.
     */
-  def formatSimpleTypeWithOptions(tpe: SimpleType, fmt: FormatOptions): String =
+  def formatTypeViewWithOptions(tpe: TypeView, fmt: FormatOptions): String =
     format(tpe)(fmt)
 
   /**
     * Transforms the given type into a string.
     */
-  private def format(tpe00: SimpleType)(implicit fmt: FormatOptions): String = {
+  private def format(tpe00: TypeView)(implicit fmt: FormatOptions): String = {
 
     /**
       * Wraps the given type with parentheses.
@@ -108,22 +108,22 @@ object FormatType {
     /**
       * Transforms the given record `labelType` pair into a string.
       */
-    def visitRecordLabelType(labelType: SimpleType.RecordLabelType): String = labelType match {
-      case SimpleType.RecordLabelType(label, tpe) => s"$label = ${visit(tpe, Mode.Type)}"
+    def visitRecordLabelType(labelType: TypeView.RecordLabelType): String = labelType match {
+      case TypeView.RecordLabelType(label, tpe) => s"$label = ${visit(tpe, Mode.Type)}"
     }
 
     /**
       * Transforms the given schema `fieldType` pair into a string.
       */
-    def visitSchemaFieldType(fieldType: SimpleType.PredicateFieldType): String = fieldType match {
-      case SimpleType.RelationFieldType(field, tpes) =>
+    def visitSchemaFieldType(fieldType: TypeView.PredicateFieldType): String = fieldType match {
+      case TypeView.RelationFieldType(field, tpes) =>
         val tpeString = tpes.map(visit(_, Mode.Type)).mkString(", ")
         s"$field($tpeString)"
-      case SimpleType.LatticeFieldType(field, tpes, lat) =>
+      case TypeView.LatticeFieldType(field, tpes, lat) =>
         val tpeString = tpes.map(visit(_, Mode.Type)).mkString(", ")
         val latString = visit(lat, Mode.Type)
         s"$field($tpeString; $latString)"
-      case SimpleType.NonPredFieldType(field, tpe) =>
+      case TypeView.NonPredFieldType(field, tpe) =>
         val tpeString = visit(tpe, Mode.Type)
         s"$field(<$tpeString>)"
     }
@@ -132,9 +132,9 @@ object FormatType {
       * Transforms the given type into a string,
       * delimiting it as appropriate for display as a function argument.
       */
-    def delimitFunctionArg(arg: SimpleType): String = arg match {
+    def delimitFunctionArg(arg: TypeView): String = arg match {
       // Tuples get an extra set of parentheses
-      case tuple: SimpleType.Tuple => parenthesize(visit(tuple, Mode.Type))
+      case tuple: TypeView.Tuple => parenthesize(visit(tuple, Mode.Type))
       case tpe => delimit(tpe, Mode.Type)
     }
 
@@ -142,87 +142,87 @@ object FormatType {
       * Returns `true` iff the given `tpe` is innately delimited,
       * meaning that it never needs parenthesization.
       */
-    def isDelimited(tpe: SimpleType): Boolean = tpe match {
+    def isDelimited(tpe: TypeView): Boolean = tpe match {
       // non-delimited types
-      case SimpleType.Not(_) => false
-      case SimpleType.And(_) => false
-      case SimpleType.Or(_) => false
-      case SimpleType.Complement(_) => false
-      case SimpleType.Intersection(_) => false
-      case SimpleType.SymmetricDiff(_) => false
-      case SimpleType.Difference(_) => false
-      case SimpleType.Plus(_) => false
-      case SimpleType.PureArrow(_, _) => false
-      case SimpleType.PolyArrow(_, _, _) => false
-      case SimpleType.ArrowWithoutEffect(_, _) => false
+      case TypeView.Not(_) => false
+      case TypeView.And(_) => false
+      case TypeView.Or(_) => false
+      case TypeView.Complement(_) => false
+      case TypeView.Intersection(_) => false
+      case TypeView.SymmetricDiff(_) => false
+      case TypeView.Difference(_) => false
+      case TypeView.Plus(_) => false
+      case TypeView.PureArrow(_, _) => false
+      case TypeView.PolyArrow(_, _, _) => false
+      case TypeView.ArrowWithoutEffect(_, _) => false
 
       // delimited types
-      case SimpleType.Hole => true
-      case SimpleType.Void => true
-      case SimpleType.AnyType => true
-      case SimpleType.Unit => true
-      case SimpleType.Null => true
-      case SimpleType.Bool => true
-      case SimpleType.Char => true
-      case SimpleType.Float32 => true
-      case SimpleType.Float64 => true
-      case SimpleType.BigDecimal => true
-      case SimpleType.Int8 => true
-      case SimpleType.Int16 => true
-      case SimpleType.Int32 => true
-      case SimpleType.Int64 => true
-      case SimpleType.BigInt => true
-      case SimpleType.Str => true
-      case SimpleType.Regex => true
-      case SimpleType.Array => true
-      case SimpleType.ArrayWithoutRegion => true
-      case SimpleType.Vector => true
-      case SimpleType.Sender => true
-      case SimpleType.Receiver => true
-      case SimpleType.Lazy => true
-      case SimpleType.True => true
-      case SimpleType.False => true
-      case SimpleType.Pure => true
-      case SimpleType.Univ => true
-      case SimpleType.Region(_) => true
-      case SimpleType.RegionToStar => true
-      case SimpleType.RegionWithoutRegion => true
-      case SimpleType.RecordConstructor(_) => true
-      case SimpleType.Record(_) => true
-      case SimpleType.RecordExtend(_, _) => true
-      case SimpleType.RecordRow(_) => true
-      case SimpleType.RecordRowExtend(_, _) => true
-      case SimpleType.SchemaConstructor(_) => true
-      case SimpleType.Schema(_) => true
-      case SimpleType.SchemaExtend(_, _) => true
-      case SimpleType.SchemaRow(_) => true
-      case SimpleType.SchemaRowExtend(_, _) => true
-      case SimpleType.RelationConstructor => true
-      case SimpleType.Relation(_) => true
-      case SimpleType.LatticeConstructor => true
-      case SimpleType.Lattice(_, _) => true
-      case SimpleType.TagConstructor(_) => true
-      case SimpleType.Name(_) => true
-      case SimpleType.Apply(_, _) => true
-      case SimpleType.Var(_, _, _) => true
-      case SimpleType.Tuple(_) => true
-      case SimpleType.JvmToType(_) => true
-      case SimpleType.JvmToEff(_) => true
-      case SimpleType.JvmUnresolvedConstructor(_, _) => true
-      case SimpleType.JvmUnresolvedField(_, _) => true
-      case SimpleType.JvmUnresolvedMethod(_, _, _) => true
-      case SimpleType.JvmUnresolvedStaticMethod(_, _, _) => true
-      case SimpleType.JvmConstructor(_) => true
-      case SimpleType.JvmField(_) => true
-      case SimpleType.JvmMethod(_) => true
-      case SimpleType.Union(_) => true
-      case SimpleType.Error => true
+      case TypeView.Hole => true
+      case TypeView.Void => true
+      case TypeView.AnyType => true
+      case TypeView.Unit => true
+      case TypeView.Null => true
+      case TypeView.Bool => true
+      case TypeView.Char => true
+      case TypeView.Float32 => true
+      case TypeView.Float64 => true
+      case TypeView.BigDecimal => true
+      case TypeView.Int8 => true
+      case TypeView.Int16 => true
+      case TypeView.Int32 => true
+      case TypeView.Int64 => true
+      case TypeView.BigInt => true
+      case TypeView.Str => true
+      case TypeView.Regex => true
+      case TypeView.Array => true
+      case TypeView.ArrayWithoutRegion => true
+      case TypeView.Vector => true
+      case TypeView.Sender => true
+      case TypeView.Receiver => true
+      case TypeView.Lazy => true
+      case TypeView.True => true
+      case TypeView.False => true
+      case TypeView.Pure => true
+      case TypeView.Univ => true
+      case TypeView.Region(_) => true
+      case TypeView.RegionToStar => true
+      case TypeView.RegionWithoutRegion => true
+      case TypeView.RecordConstructor(_) => true
+      case TypeView.Record(_) => true
+      case TypeView.RecordExtend(_, _) => true
+      case TypeView.RecordRow(_) => true
+      case TypeView.RecordRowExtend(_, _) => true
+      case TypeView.SchemaConstructor(_) => true
+      case TypeView.Schema(_) => true
+      case TypeView.SchemaExtend(_, _) => true
+      case TypeView.SchemaRow(_) => true
+      case TypeView.SchemaRowExtend(_, _) => true
+      case TypeView.RelationConstructor => true
+      case TypeView.Relation(_) => true
+      case TypeView.LatticeConstructor => true
+      case TypeView.Lattice(_, _) => true
+      case TypeView.TagConstructor(_) => true
+      case TypeView.Name(_) => true
+      case TypeView.Apply(_, _) => true
+      case TypeView.Var(_, _, _) => true
+      case TypeView.Tuple(_) => true
+      case TypeView.JvmToType(_) => true
+      case TypeView.JvmToEff(_) => true
+      case TypeView.JvmUnresolvedConstructor(_, _) => true
+      case TypeView.JvmUnresolvedField(_, _) => true
+      case TypeView.JvmUnresolvedMethod(_, _, _) => true
+      case TypeView.JvmUnresolvedStaticMethod(_, _, _) => true
+      case TypeView.JvmConstructor(_) => true
+      case TypeView.JvmField(_) => true
+      case TypeView.JvmMethod(_) => true
+      case TypeView.Union(_) => true
+      case TypeView.Error => true
     }
 
     /**
       * Delimits the given `tpe`, parenthesizing it if needed.
       */
-    def delimit(tpe: SimpleType, mode: Mode): String = {
+    def delimit(tpe: TypeView, mode: Mode): String = {
       if (isDelimited(tpe)) {
         visit(tpe, mode)
       } else {
@@ -233,122 +233,122 @@ object FormatType {
     /**
       * Converts the given `tpe0` to a string.
       */
-    def visit(tpe0: SimpleType, mode: Mode): String = tpe0 match {
-      case SimpleType.Hole => "?"
-      case SimpleType.Void => "Void"
-      case SimpleType.AnyType => "AnyType"
-      case SimpleType.Unit => "Unit"
-      case SimpleType.Null => "Null"
-      case SimpleType.Bool => "Bool"
-      case SimpleType.Char => "Char"
-      case SimpleType.Float32 => "Float32"
-      case SimpleType.Float64 => "Float64"
-      case SimpleType.BigDecimal => "BigDecimal"
-      case SimpleType.Int8 => "Int8"
-      case SimpleType.Int16 => "Int16"
-      case SimpleType.Int32 => "Int32"
-      case SimpleType.Int64 => "Int64"
-      case SimpleType.BigInt => "BigInt"
-      case SimpleType.Str => "String"
-      case SimpleType.Regex => "Regex"
-      case SimpleType.Array => "Array"
-      case SimpleType.ArrayWithoutRegion => "ArrayWithoutRegion"
-      case SimpleType.Vector => "Vector"
-      case SimpleType.Sender => "Sender"
-      case SimpleType.Receiver => "Receiver"
-      case SimpleType.Lazy => "Lazy"
-      case SimpleType.False => "false"
-      case SimpleType.True => "true"
-      case SimpleType.Pure => mode match {
+    def visit(tpe0: TypeView, mode: Mode): String = tpe0 match {
+      case TypeView.Hole => "?"
+      case TypeView.Void => "Void"
+      case TypeView.AnyType => "AnyType"
+      case TypeView.Unit => "Unit"
+      case TypeView.Null => "Null"
+      case TypeView.Bool => "Bool"
+      case TypeView.Char => "Char"
+      case TypeView.Float32 => "Float32"
+      case TypeView.Float64 => "Float64"
+      case TypeView.BigDecimal => "BigDecimal"
+      case TypeView.Int8 => "Int8"
+      case TypeView.Int16 => "Int16"
+      case TypeView.Int32 => "Int32"
+      case TypeView.Int64 => "Int64"
+      case TypeView.BigInt => "BigInt"
+      case TypeView.Str => "String"
+      case TypeView.Regex => "Regex"
+      case TypeView.Array => "Array"
+      case TypeView.ArrayWithoutRegion => "ArrayWithoutRegion"
+      case TypeView.Vector => "Vector"
+      case TypeView.Sender => "Sender"
+      case TypeView.Receiver => "Receiver"
+      case TypeView.Lazy => "Lazy"
+      case TypeView.False => "false"
+      case TypeView.True => "true"
+      case TypeView.Pure => mode match {
         case Mode.Type => "Pure"
         case Mode.Purity => "{}"
       }
-      case SimpleType.Univ => "Univ"
-      case SimpleType.Region(name) => name
-      case SimpleType.RegionToStar => "Region"
-      case SimpleType.RegionWithoutRegion => "RegionWithoutRegion"
-      case SimpleType.Record(labels) =>
+      case TypeView.Univ => "Univ"
+      case TypeView.Region(name) => name
+      case TypeView.RegionToStar => "Region"
+      case TypeView.RegionWithoutRegion => "RegionWithoutRegion"
+      case TypeView.Record(labels) =>
         val labelString = labels.map(visitRecordLabelType).mkString(", ")
         s"{ $labelString }"
-      case SimpleType.RecordExtend(labels, rest) =>
+      case TypeView.RecordExtend(labels, rest) =>
         val labelString = labels.map(visitRecordLabelType).mkString(", ")
         val restString = visit(rest, mode)
         s"{ $labelString | $restString }"
-      case SimpleType.RecordRow(labels) =>
+      case TypeView.RecordRow(labels) =>
         val labelString = labels.map(visitRecordLabelType).mkString(", ")
         s"( $labelString )"
-      case SimpleType.RecordRowExtend(labels, rest) =>
+      case TypeView.RecordRowExtend(labels, rest) =>
         val labelString = labels.map(visitRecordLabelType).mkString(", ")
         val restString = visit(rest, Mode.Type)
         s"( $labelString | $restString )"
-      case SimpleType.RecordConstructor(arg) => s"{ ${visit(arg, Mode.Type)} }"
-      case SimpleType.Schema(fields) =>
+      case TypeView.RecordConstructor(arg) => s"{ ${visit(arg, Mode.Type)} }"
+      case TypeView.Schema(fields) =>
         val fieldString = fields.map(visitSchemaFieldType).mkString(", ")
         s"#{ $fieldString }"
-      case SimpleType.SchemaExtend(fields, rest) =>
+      case TypeView.SchemaExtend(fields, rest) =>
         val fieldString = fields.map(visitSchemaFieldType).mkString(", ")
         val restString = visit(rest, Mode.Type)
         s"#{ $fieldString | $restString }"
-      case SimpleType.SchemaRow(fields) =>
+      case TypeView.SchemaRow(fields) =>
         val fieldString = fields.map(visitSchemaFieldType).mkString(", ")
         s"#( $fieldString )"
-      case SimpleType.SchemaRowExtend(fields, rest) =>
+      case TypeView.SchemaRowExtend(fields, rest) =>
         val fieldString = fields.map(visitSchemaFieldType).mkString(", ")
         val restString = visit(rest, Mode.Type)
         s"#( $fieldString | $restString )"
-      case SimpleType.SchemaConstructor(arg) => s"#{ ${visit(arg, Mode.Type)} }"
-      case SimpleType.Not(tpe) => s"not ${delimit(tpe, mode)}"
-      case SimpleType.And(tpes) =>
+      case TypeView.SchemaConstructor(arg) => s"#{ ${visit(arg, Mode.Type)} }"
+      case TypeView.Not(tpe) => s"not ${delimit(tpe, mode)}"
+      case TypeView.And(tpes) =>
         val strings = tpes.map(delimit(_, mode))
         strings.mkString(" and ")
-      case SimpleType.Or(tpes) =>
+      case TypeView.Or(tpes) =>
         val strings = tpes.map(delimit(_, mode))
         strings.mkString(" or ")
-      case SimpleType.Complement(tpe) => s"~${delimit(tpe, mode)}"
-      case SimpleType.Union(tpes) =>
+      case TypeView.Complement(tpe) => s"~${delimit(tpe, mode)}"
+      case TypeView.Union(tpes) =>
         val strings = tpes.map(visit(_, mode))
         strings.mkString("{", ", ", "}")
-      case SimpleType.Plus(tpes) =>
+      case TypeView.Plus(tpes) =>
         val strings = tpes.map(delimit(_, mode))
         strings.mkString(" + ")
-      case SimpleType.Intersection(tpes) =>
+      case TypeView.Intersection(tpes) =>
         val strings = tpes.map(delimit(_, mode))
         strings.mkString(" & ")
-      case SimpleType.SymmetricDiff(tpes) =>
+      case TypeView.SymmetricDiff(tpes) =>
         val strings = tpes.map(delimit(_, mode))
         strings.mkString(" ⊕ ")
-      case SimpleType.Difference(tpes) =>
+      case TypeView.Difference(tpes) =>
         val strings = tpes.map(delimit(_, mode))
         strings.mkString(" - ")
-      case SimpleType.RelationConstructor => "Relation"
-      case SimpleType.Relation(tpes) =>
+      case TypeView.RelationConstructor => "Relation"
+      case TypeView.Relation(tpes) =>
         val terms = tpes.map(visit(_, Mode.Type)).mkString(", ")
         s"Relation($terms)"
-      case SimpleType.LatticeConstructor => "Lattice"
-      case SimpleType.Lattice(tpes0, lat0) =>
+      case TypeView.LatticeConstructor => "Lattice"
+      case TypeView.Lattice(tpes0, lat0) =>
         val lat = visit(lat0, Mode.Type)
         val tpes = tpes0.map(visit(_, Mode.Type)).mkString(", ")
         s"Lattice($tpes; $lat)"
-      case SimpleType.PureArrow(arg, ret) =>
+      case TypeView.PureArrow(arg, ret) =>
         val argString = delimitFunctionArg(arg)
         val retString = delimit(ret, Mode.Type)
         s"$argString -> $retString"
-      case SimpleType.PolyArrow(arg, eff, ret) =>
+      case TypeView.PolyArrow(arg, eff, ret) =>
         val argString = delimitFunctionArg(arg)
         val effString = visit(eff, Mode.Purity)
         val retString = delimit(ret, Mode.Type)
         s"$argString -> $retString \\ $effString"
-      case SimpleType.ArrowWithoutEffect(arg, ret) =>
+      case TypeView.ArrowWithoutEffect(arg, ret) =>
         val argString = delimitFunctionArg(arg)
         val retString = delimit(ret, Mode.Type)
         s"$argString --> $retString"
-      case SimpleType.TagConstructor(name) => name
-      case SimpleType.Name(name) => name
-      case SimpleType.Apply(tpe, tpes) =>
+      case TypeView.TagConstructor(name) => name
+      case TypeView.Name(name) => name
+      case TypeView.Apply(tpe, tpes) =>
         val string = visit(tpe, Mode.Type)
         val strings = tpes.map(visit(_, Mode.Type))
         string + strings.mkString("[", ", ", "]")
-      case SimpleType.Var(id, kind, text) =>
+      case TypeView.Var(id, kind, text) =>
         val string: String = kind match {
           case Kind.Wild => "_" + id.toString
           case Kind.WildCaseSet => "_c" + id.toString
@@ -371,44 +371,44 @@ object FormatType {
           }
         }
 
-      case SimpleType.Tuple(elms) =>
+      case TypeView.Tuple(elms) =>
         elms.map(visit(_, Mode.Type)).mkString("(", ", ", ")")
 
-      case SimpleType.JvmToType(tpe) =>
+      case TypeView.JvmToType(tpe) =>
         val arg = visit(tpe, Mode.Type)
         "JvmToType(" + arg + ")"
 
-      case SimpleType.JvmToEff(tpe) =>
+      case TypeView.JvmToEff(tpe) =>
         val arg = visit(tpe, Mode.Type)
         "JvmToEff(" + arg + ")"
 
-      case SimpleType.JvmUnresolvedConstructor(name, tpes0) =>
+      case TypeView.JvmUnresolvedConstructor(name, tpes0) =>
         val tpes = tpes0.map(visit(_, Mode.Type))
         "JvmUnresolvedConstructor(" + name + ", " + tpes.mkString(", ") + ")"
 
-      case SimpleType.JvmUnresolvedField(t0, name) =>
+      case TypeView.JvmUnresolvedField(t0, name) =>
         val t = visit(t0, Mode.Type)
         "JvmUnresolvedField(" + t + ", " + name + ")"
 
-      case SimpleType.JvmUnresolvedMethod(t0, name, ts0) =>
+      case TypeView.JvmUnresolvedMethod(t0, name, ts0) =>
         val t = visit(t0, Mode.Type)
         val ts = ts0.map(visit(_, Mode.Type))
         "JvmUnresolvedMethod(" + t + ", " + name + ", " + ts.mkString(", ") + ")"
 
-      case SimpleType.JvmUnresolvedStaticMethod(clazz, name, ts0) =>
+      case TypeView.JvmUnresolvedStaticMethod(clazz, name, ts0) =>
         val ts = ts0.map(visit(_, Mode.Type))
         "JvmUnresolvedStaticMethod(" + clazz + ", " + name + ", " + ts.mkString(", ") + ")"
 
-      case SimpleType.JvmConstructor(constructor) =>
+      case TypeView.JvmConstructor(constructor) =>
         s"JvmConstructor($constructor)"
 
-      case SimpleType.JvmField(field) =>
+      case TypeView.JvmField(field) =>
         s"JvmField($field)"
 
-      case SimpleType.JvmMethod(method) =>
+      case TypeView.JvmMethod(method) =>
         s"JvmMethod($method)"
 
-      case SimpleType.Error => "Error"
+      case TypeView.Error => "Error"
 
     }
 

--- a/main/src/ca/uwaterloo/flix/language/fmt/TypeView.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/TypeView.scala
@@ -25,9 +25,9 @@ import java.lang.reflect.{Constructor, Field, Method}
 /**
   * A well-kinded type in an easily-printable format.
   */
-sealed trait SimpleType
+sealed trait TypeView
 
-object SimpleType {
+object TypeView {
 
   private class OverAppliedType(loc: SourceLocation) extends InternalCompilerException("Unexpected over-applied type.", loc)
 
@@ -39,67 +39,67 @@ object SimpleType {
     * An unfilled parameter in a partially-applied type-level function.
     * For example, `Not` (applied to nothing) is `Not(Hole)`.
     */
-  case object Hole extends SimpleType
+  case object Hole extends TypeView
 
   /////////////
   // Primitives
   /////////////
 
-  case object Void extends SimpleType
+  case object Void extends TypeView
 
-  case object AnyType extends SimpleType
+  case object AnyType extends TypeView
 
-  case object Unit extends SimpleType
+  case object Unit extends TypeView
 
-  case object Null extends SimpleType
+  case object Null extends TypeView
 
-  case object Bool extends SimpleType
+  case object Bool extends TypeView
 
-  case object Char extends SimpleType
+  case object Char extends TypeView
 
-  case object Float32 extends SimpleType
+  case object Float32 extends TypeView
 
-  case object Float64 extends SimpleType
+  case object Float64 extends TypeView
 
-  case object BigDecimal extends SimpleType
+  case object BigDecimal extends TypeView
 
-  case object Int8 extends SimpleType
+  case object Int8 extends TypeView
 
-  case object Int16 extends SimpleType
+  case object Int16 extends TypeView
 
-  case object Int32 extends SimpleType
+  case object Int32 extends TypeView
 
-  case object Int64 extends SimpleType
+  case object Int64 extends TypeView
 
-  case object BigInt extends SimpleType
+  case object BigInt extends TypeView
 
-  case object Str extends SimpleType
+  case object Str extends TypeView
 
-  case object Regex extends SimpleType
+  case object Regex extends TypeView
 
-  case object Array extends SimpleType
+  case object Array extends TypeView
 
-  case object ArrayWithoutRegion extends SimpleType
+  case object ArrayWithoutRegion extends TypeView
 
-  case object Vector extends SimpleType
+  case object Vector extends TypeView
 
-  case object Sender extends SimpleType
+  case object Sender extends TypeView
 
-  case object Receiver extends SimpleType
+  case object Receiver extends TypeView
 
-  case object Lazy extends SimpleType
+  case object Lazy extends TypeView
 
-  case object Pure extends SimpleType
+  case object Pure extends TypeView
 
-  case object Univ extends SimpleType
+  case object Univ extends TypeView
 
-  case object False extends SimpleType
+  case object False extends TypeView
 
-  case object True extends SimpleType
+  case object True extends TypeView
 
-  case object RegionToStar extends SimpleType
+  case object RegionToStar extends TypeView
 
-  case object RegionWithoutRegion extends SimpleType
+  case object RegionWithoutRegion extends TypeView
 
   //////////
   // Records
@@ -108,27 +108,27 @@ object SimpleType {
   /**
     * A record constructor. `arg` should be a variable or a Hole.
     */
-  case class RecordConstructor(arg: SimpleType) extends SimpleType
+  case class RecordConstructor(arg: TypeView) extends TypeView
 
   /**
     * An unextended record.
     */
-  case class Record(labels: List[RecordLabelType]) extends SimpleType
+  case class Record(labels: List[RecordLabelType]) extends TypeView
 
   /**
     * An extended record. `arg` should be a variable or a Hole.
     */
-  case class RecordExtend(labels: List[RecordLabelType], rest: SimpleType) extends SimpleType
+  case class RecordExtend(labels: List[RecordLabelType], rest: TypeView) extends TypeView
 
   /**
     * An unextended record row.
     */
-  case class RecordRow(labels: List[RecordLabelType]) extends SimpleType
+  case class RecordRow(labels: List[RecordLabelType]) extends TypeView
 
   /**
     * An extended record row. `arg` should be a variable or a Hole.
     */
-  case class RecordRowExtend(labels: List[RecordLabelType], rest: SimpleType) extends SimpleType
+  case class RecordRowExtend(labels: List[RecordLabelType], rest: TypeView) extends TypeView
 
   //////////
   // Schemas
@@ -137,27 +137,27 @@ object SimpleType {
   /**
     * A schema constructor. `arg` should be a variable or a Hole.
     */
-  case class SchemaConstructor(arg: SimpleType) extends SimpleType
+  case class SchemaConstructor(arg: TypeView) extends TypeView
 
   /**
     * An unextended schema.
     */
-  case class Schema(fields: List[PredicateFieldType]) extends SimpleType
+  case class Schema(fields: List[PredicateFieldType]) extends TypeView
 
   /**
     * An extended schema. `arg` should be a variable or a Hole.
     */
-  case class SchemaExtend(fields: List[PredicateFieldType], rest: SimpleType) extends SimpleType
+  case class SchemaExtend(fields: List[PredicateFieldType], rest: TypeView) extends TypeView
 
   /**
     * An unextended schema row.
     */
-  case class SchemaRow(fields: List[PredicateFieldType]) extends SimpleType
+  case class SchemaRow(fields: List[PredicateFieldType]) extends TypeView
 
   /**
     * An extended schema row. `arg` should be a variable or a Hole.
     */
-  case class SchemaRowExtend(fields: List[PredicateFieldType], rest: SimpleType) extends SimpleType
+  case class SchemaRowExtend(fields: List[PredicateFieldType], rest: TypeView) extends TypeView
 
   ////////////////////
   // Boolean Operators
@@ -166,17 +166,17 @@ object SimpleType {
   /**
     * Boolean negation.
     */
-  case class Not(tpe: SimpleType) extends SimpleType
+  case class Not(tpe: TypeView) extends TypeView
 
   /**
     * A chain of types connected by `and`.
     */
-  case class And(tpes: List[SimpleType]) extends SimpleType
+  case class And(tpes: List[TypeView]) extends TypeView
 
   /**
     * A chain of types connected by `or`.
     */
-  case class Or(tpes: List[SimpleType]) extends SimpleType
+  case class Or(tpes: List[TypeView]) extends TypeView
 
   ////////////////
   // Set Operators
@@ -185,50 +185,50 @@ object SimpleType {
   /**
     * Set complement.
     */
-  case class Complement(tpe: SimpleType) extends SimpleType
+  case class Complement(tpe: TypeView) extends TypeView
 
   /**
     * A chain of types in a set.
     */
-  case class Union(tpes: List[SimpleType]) extends SimpleType
+  case class Union(tpes: List[TypeView]) extends TypeView
 
   /**
     * A chain of types connected by `&`.
     */
-  case class Plus(tpes: List[SimpleType]) extends SimpleType
+  case class Plus(tpes: List[TypeView]) extends TypeView
 
   /**
     * A chain of types connected by `&`.
     */
-  case class Intersection(tpes: List[SimpleType]) extends SimpleType
+  case class Intersection(tpes: List[TypeView]) extends TypeView
 
   /**
     * A chain of types connected by `⊕`.
     */
-  case class SymmetricDiff(tpes: List[SimpleType]) extends SimpleType
+  case class SymmetricDiff(tpes: List[TypeView]) extends TypeView
 
   /**
     * A chain of types connected by `-`.
     */
-  case class Difference(tpes: List[SimpleType]) extends SimpleType
+  case class Difference(tpes: List[TypeView]) extends TypeView
 
   /////////////
   // Predicates
   /////////////
 
-  case object RelationConstructor extends SimpleType
+  case object RelationConstructor extends TypeView
 
   /**
     * A relation over a list of types.
     */
-  case class Relation(tpes: List[SimpleType]) extends SimpleType
+  case class Relation(tpes: List[TypeView]) extends TypeView
 
-  case object LatticeConstructor extends SimpleType
+  case object LatticeConstructor extends TypeView
 
   /**
     * A lattice over a list of types.
     */
-  case class Lattice(tpes: List[SimpleType], lat: SimpleType) extends SimpleType
+  case class Lattice(tpes: List[TypeView], lat: TypeView) extends TypeView
 
   ////////////
   // Functions
@@ -237,45 +237,45 @@ object SimpleType {
   /**
     * A pure function.
     */
-  case class PureArrow(arg: SimpleType, ret: SimpleType) extends SimpleType
+  case class PureArrow(arg: TypeView, ret: TypeView) extends TypeView
 
   /**
     * A function with a purity.
     */
-  case class PolyArrow(arg: SimpleType, eff: SimpleType, ret: SimpleType) extends SimpleType
+  case class PolyArrow(arg: TypeView, eff: TypeView, ret: TypeView) extends TypeView
 
   /**
     * A backend function (no effect).
     */
-  case class ArrowWithoutEffect(arg: SimpleType, ret: SimpleType) extends SimpleType
+  case class ArrowWithoutEffect(arg: TypeView, ret: TypeView) extends TypeView
 
   ///////
   // Tags
   ///////
 
-  case class TagConstructor(name: String) extends SimpleType
+  case class TagConstructor(name: String) extends TypeView
 
   ////////////
   // JVM Types
   ////////////
 
-  case class JvmToType(tpe: SimpleType) extends SimpleType
+  case class JvmToType(tpe: TypeView) extends TypeView
 
-  case class JvmToEff(tpe: SimpleType) extends SimpleType
+  case class JvmToEff(tpe: TypeView) extends TypeView
 
-  case class JvmUnresolvedConstructor(name: String, tpes: List[SimpleType]) extends SimpleType
+  case class JvmUnresolvedConstructor(name: String, tpes: List[TypeView]) extends TypeView
 
-  case class JvmUnresolvedField(tpe: SimpleType, name: String) extends SimpleType
+  case class JvmUnresolvedField(tpe: TypeView, name: String) extends TypeView
 
-  case class JvmUnresolvedMethod(tpe: SimpleType, name: String, tpes: List[SimpleType]) extends SimpleType
+  case class JvmUnresolvedMethod(tpe: TypeView, name: String, tpes: List[TypeView]) extends TypeView
 
-  case class JvmUnresolvedStaticMethod(clazz: String, name: String, tpes: List[SimpleType]) extends SimpleType
+  case class JvmUnresolvedStaticMethod(clazz: String, name: String, tpes: List[TypeView]) extends TypeView
 
-  case class JvmConstructor(constructor: Constructor[?]) extends SimpleType
+  case class JvmConstructor(constructor: Constructor[?]) extends TypeView
 
-  case class JvmField(field: Field) extends SimpleType
+  case class JvmField(field: Field) extends TypeView
 
-  case class JvmMethod(method: Method) extends SimpleType
+  case class JvmMethod(method: Method) extends TypeView
 
   //////////////////////
   // Miscellaneous Types
@@ -284,32 +284,32 @@ object SimpleType {
   /**
     * A simple named type (e.g., enum or type alias).
     */
-  case class Name(name: String) extends SimpleType
+  case class Name(name: String) extends TypeView
 
   /**
     * A type applied to one or more types.
     */
-  case class Apply(tpe: SimpleType, tpes: List[SimpleType]) extends SimpleType
+  case class Apply(tpe: TypeView, tpes: List[TypeView]) extends TypeView
 
   /**
     * A type variable.
     */
-  case class Var(id: Int, kind: Kind, text: VarText) extends SimpleType
+  case class Var(id: Int, kind: Kind, text: VarText) extends TypeView
 
   /**
     * A tuple.
     */
-  case class Tuple(tpes: List[SimpleType]) extends SimpleType
+  case class Tuple(tpes: List[TypeView]) extends TypeView
 
   /**
     * A region.
     */
-  case class Region(name: String) extends SimpleType
+  case class Region(name: String) extends TypeView
 
   /**
     * An error type.
     */
-  case object Error extends SimpleType
+  case object Error extends TypeView
 
   /////////
   // Fields
@@ -318,7 +318,7 @@ object SimpleType {
   /**
     * A record label name and its type.
     */
-  case class RecordLabelType(name: String, tpe: SimpleType)
+  case class RecordLabelType(name: String, tpe: TypeView)
 
   /**
     * A common supertype for schema predicates.
@@ -330,24 +330,24 @@ object SimpleType {
   /**
     * A relation field name and its types.
     */
-  case class RelationFieldType(name: String, tpes: List[SimpleType]) extends PredicateFieldType
+  case class RelationFieldType(name: String, tpes: List[TypeView]) extends PredicateFieldType
 
   /**
     * A lattice field name, its types, and its lattice.
     */
-  case class LatticeFieldType(name: String, tpes: List[SimpleType], lat: SimpleType) extends PredicateFieldType
+  case class LatticeFieldType(name: String, tpes: List[TypeView], lat: TypeView) extends PredicateFieldType
 
   /**
     * A predicate field type that's not actually a predicate.
     */
-  case class NonPredFieldType(name: String, tpe: SimpleType) extends PredicateFieldType
+  case class NonPredFieldType(name: String, tpe: TypeView) extends PredicateFieldType
 
   /**
     * Creates a simple type from the well-kinded type `t`.
     */
-  def fromWellKindedType(t0: Type): SimpleType = {
+  def fromWellKindedType(t0: Type): TypeView = {
 
-    def visit(t: Type): SimpleType = t.baseType match {
+    def visit(t: Type): TypeView = t.baseType match {
       case Type.Var(sym, _) =>
         mkApply(Var(sym.id, sym.kind, sym.text), t.typeArguments.map(visit))
       case Type.Alias(cst, args, _, _) =>
@@ -355,14 +355,14 @@ object SimpleType {
       case Type.AssocType(cst, arg, _, _) =>
         mkApply(Name(cst.sym.name), (arg :: t.typeArguments).map(visit))
       case Type.JvmToType(tpe, _) =>
-        mkApply(SimpleType.JvmToType(visit(tpe)), t.typeArguments.map(visit))
+        mkApply(TypeView.JvmToType(visit(tpe)), t.typeArguments.map(visit))
       case Type.JvmToEff(tpe, _) =>
-        mkApply(SimpleType.JvmToEff(visit(tpe)), t.typeArguments.map(visit))
+        mkApply(TypeView.JvmToEff(visit(tpe)), t.typeArguments.map(visit))
       case Type.UnresolvedJvmType(member, _) => member match {
-        case JvmMember.JvmConstructor(clazz, tpes) => SimpleType.JvmUnresolvedConstructor(clazz.getSimpleName, tpes.map(visit))
-        case JvmMember.JvmMethod(tpe, name, tpes) => SimpleType.JvmUnresolvedMethod(visit(tpe), name.name, tpes.map(visit))
-        case JvmMember.JvmField(_, tpe, name) => SimpleType.JvmUnresolvedField(visit(tpe), name.name)
-        case JvmMember.JvmStaticMethod(clazz, name, tpes) => SimpleType.JvmUnresolvedStaticMethod(clazz.getSimpleName, name.name, tpes.map(visit))
+        case JvmMember.JvmConstructor(clazz, tpes) => TypeView.JvmUnresolvedConstructor(clazz.getSimpleName, tpes.map(visit))
+        case JvmMember.JvmMethod(tpe, name, tpes) => TypeView.JvmUnresolvedMethod(visit(tpe), name.name, tpes.map(visit))
+        case JvmMember.JvmField(_, tpe, name) => TypeView.JvmUnresolvedField(visit(tpe), name.name)
+        case JvmMember.JvmStaticMethod(clazz, name, tpes) => TypeView.JvmUnresolvedStaticMethod(clazz.getSimpleName, name.name, tpes.map(visit))
       }
       case Type.Cst(tc, _) => tc match {
         case TypeConstructor.Void => Void
@@ -387,7 +387,7 @@ object SimpleType {
           args match {
             // Case 1: No args. Fill everything with a hole.
             case Nil =>
-              val lastArrow: SimpleType = PolyArrow(Hole, Hole, Hole)
+              val lastArrow: TypeView = PolyArrow(Hole, Hole, Hole)
               // NB: safe to subtract 2 since arity is always at least 2
               List.fill(arity - 2)(Hole).foldRight(lastArrow)(PureArrow.apply)
 
@@ -401,7 +401,7 @@ object SimpleType {
               // NB: safe to take last 2 because arity is always at least 2
               val allTpes = tpes.padTo(arity, Hole)
               val List(lastArg, ret) = allTpes.takeRight(2)
-              val lastArrow: SimpleType = PolyArrow(lastArg, eff, ret)
+              val lastArrow: TypeView = PolyArrow(lastArg, eff, ret)
               allTpes.dropRight(2).foldRight(lastArrow)(PureArrow.apply)
           }
 
@@ -545,7 +545,7 @@ object SimpleType {
             case _ :: _ :: _ :: _ => throw new OverAppliedType(t.loc)
           }
 
-        case TypeConstructor.Not => SimpleType.Not(visit(t.typeArguments.head))
+        case TypeConstructor.Not => TypeView.Not(visit(t.typeArguments.head))
 
         case TypeConstructor.Complement =>
           t.typeArguments.map(visit) match {
@@ -599,8 +599,8 @@ object SimpleType {
           SymmetricDiff(args)
 
         case TypeConstructor.CaseSet(syms, _) =>
-          val names = syms.toList.map(sym => SimpleType.Name(sym.name))
-          val set = SimpleType.Union(names)
+          val names = syms.toList.map(sym => TypeView.Name(sym.name))
+          val set = TypeView.Union(names)
           mkApply(set, t.typeArguments.map(visit))
 
         case TypeConstructor.CaseComplement(_) =>
@@ -626,12 +626,12 @@ object SimpleType {
             case _ => throw new OverAppliedType(t.loc)
           }
 
-        case TypeConstructor.Effect(sym, _) => mkApply(SimpleType.Name(sym.name), t.typeArguments.map(visit))
-        case TypeConstructor.Region(sym) => mkApply(SimpleType.Region(sym.text), t.typeArguments.map(visit))
+        case TypeConstructor.Effect(sym, _) => mkApply(TypeView.Name(sym.name), t.typeArguments.map(visit))
+        case TypeConstructor.Region(sym) => mkApply(TypeView.Region(sym.text), t.typeArguments.map(visit))
         case TypeConstructor.RegionToStar => mkApply(RegionToStar, t.typeArguments.map(visit))
         case TypeConstructor.RegionWithoutRegion => mkApply(RegionWithoutRegion, t.typeArguments.map(visit))
 
-        case TypeConstructor.Error(_, _) => SimpleType.Error
+        case TypeConstructor.Error(_, _) => TypeView.Error
       }
     }
 
@@ -641,7 +641,7 @@ object SimpleType {
   /**
     * Builds an Apply type.
     */
-  private def mkApply(base: SimpleType, args: List[SimpleType]): SimpleType = args match {
+  private def mkApply(base: TypeView, args: List[TypeView]): TypeView = args match {
     case Nil => base
     case _ :: _ => Apply(base, args)
   }
@@ -649,7 +649,7 @@ object SimpleType {
   /**
     * Extracts the types from a tuple, treating non-tuples as singletons.
     */
-  private def destructTuple(tpe: SimpleType): List[SimpleType] = tpe match {
+  private def destructTuple(tpe: TypeView): List[TypeView] = tpe match {
     case Tuple(fields) => fields
     case Unit => Nil
     case t => t :: Nil
@@ -658,21 +658,21 @@ object SimpleType {
   /**
     * Transforms the given type, assuming it is a record row.
     */
-  private def fromRecordRow(row0: Type): SimpleType = {
-    def visit(row: Type): SimpleType = row match {
+  private def fromRecordRow(row0: Type): TypeView = {
+    def visit(row: Type): TypeView = row match {
       // Case 1: A fully applied record row.
       case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(name), _), tpe, _), rest, _) =>
         val labelType = RecordLabelType(name.name, fromWellKindedType(tpe))
         visit(rest) match {
           // Case 1.1: Unextended row. Put the labels together.
-          case SimpleType.RecordRow(labels) => SimpleType.RecordRow(labelType :: labels)
+          case TypeView.RecordRow(labels) => TypeView.RecordRow(labelType :: labels)
           // Case 1.2: Extended row. Put the labels together.
-          case SimpleType.RecordRowExtend(labels, restOfRest) => SimpleType.RecordRowExtend(labelType :: labels, restOfRest)
+          case TypeView.RecordRowExtend(labels, restOfRest) => TypeView.RecordRowExtend(labelType :: labels, restOfRest)
           // Case 1.3: Non-row. Put it in the "rest" position.
-          case nonRecord => SimpleType.RecordRowExtend(labelType :: Nil, nonRecord)
+          case nonRecord => TypeView.RecordRowExtend(labelType :: Nil, nonRecord)
         }
       // Case 2: Empty record row.
-      case Type.Cst(TypeConstructor.RecordRowEmpty, _) => SimpleType.RecordRow(Nil)
+      case Type.Cst(TypeConstructor.RecordRowEmpty, _) => TypeView.RecordRow(Nil)
       // Case 3: Non-row.
       case nonRecord => fromWellKindedType(nonRecord)
     }
@@ -688,8 +688,8 @@ object SimpleType {
   /**
     * Transforms the given type, assuming it is a schema row.
     */
-  private def fromSchemaRow(row0: Type): SimpleType = {
-    def visit(row: Type): SimpleType = row match {
+  private def fromSchemaRow(row0: Type): TypeView = {
+    def visit(row: Type): TypeView = row match {
       // Case 1: A fully applied record row.
       case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(name), _), tpe, _), rest, _) =>
         // create the right field/type for the field
@@ -701,14 +701,14 @@ object SimpleType {
         }
         visit(rest) match {
           // Case 1.1: Unextended row. Put the fields together.
-          case SimpleType.SchemaRow(fields) => SimpleType.SchemaRow(fieldType :: fields)
+          case TypeView.SchemaRow(fields) => TypeView.SchemaRow(fieldType :: fields)
           // Case 1.2: Extended row. Put the fields together.
-          case SimpleType.SchemaRowExtend(fields, restOfRest) => SimpleType.SchemaRowExtend(fieldType :: fields, restOfRest)
+          case TypeView.SchemaRowExtend(fields, restOfRest) => TypeView.SchemaRowExtend(fieldType :: fields, restOfRest)
           // Case 1.3: Non-row. Put it in the "rest" position.
-          case nonSchema => SimpleType.SchemaRowExtend(fieldType :: Nil, nonSchema)
+          case nonSchema => TypeView.SchemaRowExtend(fieldType :: Nil, nonSchema)
         }
       // Case 2: Empty record row.
-      case Type.Cst(TypeConstructor.SchemaRowEmpty, _) => SimpleType.SchemaRow(Nil)
+      case Type.Cst(TypeConstructor.SchemaRowEmpty, _) => TypeView.SchemaRow(Nil)
       // Case 3: Non-row.
       case nonSchema => fromWellKindedType(nonSchema)
     }
@@ -725,7 +725,7 @@ object SimpleType {
     * Splits `t1 and t2` into `t1 :: t2 :: Nil`,
     * and leaves non-and types as singletons.
     */
-  private def splitAnds(tpe: SimpleType): List[SimpleType] = tpe match {
+  private def splitAnds(tpe: TypeView): List[TypeView] = tpe match {
     case And(tpes) => tpes
     case t => List(t)
   }
@@ -734,7 +734,7 @@ object SimpleType {
     * Splits `t1 or t2` into `t1 :: t2 :: Nil`,
     * and leaves non-or types as singletons.
     */
-  private def splitOrs(tpe: SimpleType): List[SimpleType] = tpe match {
+  private def splitOrs(tpe: TypeView): List[TypeView] = tpe match {
     case Or(tpes) => tpes
     case t => List(t)
   }
@@ -743,7 +743,7 @@ object SimpleType {
     * Splits `t1 + t2` into `t1 :: t2 :: Nil`,
     * and leaves non-plus types as singletons.
     */
-  private def splitPluses(tpe: SimpleType): List[SimpleType] = tpe match {
+  private def splitPluses(tpe: TypeView): List[TypeView] = tpe match {
     case Plus(tpes) => tpes
     case t => List(t)
   }
@@ -752,7 +752,7 @@ object SimpleType {
     * Splits `t1 & t2` into `t1 :: t2 :: Nil`,
     * and leaves other types as singletons.
     */
-  private def splitIntersections(tpe: SimpleType): List[SimpleType] = tpe match {
+  private def splitIntersections(tpe: TypeView): List[TypeView] = tpe match {
     case Intersection(tpes) => tpes
     case t => List(t)
   }
@@ -761,7 +761,7 @@ object SimpleType {
     * Splits `t1 - t2` into `t1 :: t2 :: Nil`,
     * and leaves other types as singletons.
     */
-  private def splitDifference(tpe: SimpleType): List[SimpleType] = tpe match {
+  private def splitDifference(tpe: TypeView): List[TypeView] = tpe match {
     case Difference(tpes) => tpes
     case t => List(t)
   }
@@ -770,7 +770,7 @@ object SimpleType {
     * Splits `t1 ⊕ t2` into `t1 :: t2 :: Nil`,
     * and leaves other types as singletons.
     */
-  private def splitSymmetricDiff(tpe: SimpleType): List[SimpleType] = tpe match {
+  private def splitSymmetricDiff(tpe: TypeView): List[TypeView] = tpe match {
     case SymmetricDiff(tpes) => tpes
     case t => List(t)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.{Flix, Version}
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
-import ca.uwaterloo.flix.language.fmt.{FormatType, SimpleType}
+import ca.uwaterloo.flix.language.fmt.{FormatType, TypeView}
 import ca.uwaterloo.flix.tools.pkg.PackageModules
 import ca.uwaterloo.flix.util.LocalResource
 import com.github.rjeschke.txtmark
@@ -1248,12 +1248,12 @@ object HtmlDocumentor {
       sb.append("<span class='keyword'>case</span> ")
       sb.append(s"<span class='case-tag'>${esc(c.sym.name)}</span>")
 
-      c.tpes.map(SimpleType.fromWellKindedType) match {
+      c.tpes.map(TypeView.fromWellKindedType) match {
         case Nil => // Nothing
         case elms =>
           sb.append("(")
           docList(elms) { t =>
-            sb.append(s"<span class='type'>${esc(FormatType.formatSimpleType(t))}</span>")
+            sb.append(s"<span class='type'>${esc(FormatType.formatTypeView(t))}</span>")
           }
           sb.append(")")
       }
@@ -1415,13 +1415,13 @@ object HtmlDocumentor {
     * The result will be appended to the given `StringBuilder`, `sb`.
     */
   private def docEffectType(eff: Type)(implicit flix: Flix, sb: StringBuilder): Unit = {
-    val simpleEff = SimpleType.fromWellKindedType(eff)
-    simpleEff match {
-      case SimpleType.Pure => // No op
+    val effView = TypeView.fromWellKindedType(eff)
+    effView match {
+      case TypeView.Pure => // No op
       case _ =>
         sb.append(" \\ ")
         sb.append("<span class='effect'>")
-        sb.append(esc(FormatType.formatSimpleType(simpleEff)))
+        sb.append(esc(FormatType.formatTypeView(effView)))
         sb.append("</span>")
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.{Flix, Version}
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
-import ca.uwaterloo.flix.language.fmt.{FormatType, TypeView}
+import ca.uwaterloo.flix.language.fmt.{FormatType, DisplayType}
 import ca.uwaterloo.flix.tools.pkg.PackageModules
 import ca.uwaterloo.flix.util.LocalResource
 import com.github.rjeschke.txtmark
@@ -1248,12 +1248,12 @@ object HtmlDocumentor {
       sb.append("<span class='keyword'>case</span> ")
       sb.append(s"<span class='case-tag'>${esc(c.sym.name)}</span>")
 
-      c.tpes.map(TypeView.fromWellKindedType) match {
+      c.tpes.map(DisplayType.fromWellKindedType) match {
         case Nil => // Nothing
         case elms =>
           sb.append("(")
           docList(elms) { t =>
-            sb.append(s"<span class='type'>${esc(FormatType.formatTypeView(t))}</span>")
+            sb.append(s"<span class='type'>${esc(FormatType.formatDisplayType(t))}</span>")
           }
           sb.append(")")
       }
@@ -1415,13 +1415,13 @@ object HtmlDocumentor {
     * The result will be appended to the given `StringBuilder`, `sb`.
     */
   private def docEffectType(eff: Type)(implicit flix: Flix, sb: StringBuilder): Unit = {
-    val effView = TypeView.fromWellKindedType(eff)
-    effView match {
-      case TypeView.Pure => // No op
+    val displayEff = DisplayType.fromWellKindedType(eff)
+    displayEff match {
+      case DisplayType.Pure => // No op
       case _ =>
         sb.append(" \\ ")
         sb.append("<span class='effect'>")
-        sb.append(esc(FormatType.formatTypeView(effView)))
+        sb.append(esc(FormatType.formatDisplayType(displayEff)))
         sb.append("</span>")
     }
   }


### PR DESCRIPTION
I decided against `FormattedType` because it's confusing with our typical terminology, where `formatX` means turn it into a string. Plus then we would need a `formatFormattedType` function which seemed silly to me.

related to #11005