### PR TITLE
fix: remove dependency on determinism in old Datalog engine

### DIFF
--- a/examples/larger-examples/datalog/single-source-shortest-paths.flix
+++ b/examples/larger-examples/datalog/single-source-shortest-paths.flix
@@ -265,24 +265,93 @@ mod ShortestPath {
 
     @Test
     def testExampleGraphShortestPaths01(): Bool =
-        Assert.eq(Map#{1 => Vector#{0, 1}, 2 => Vector#{0, 1, 2}, 3 => Vector#{0, 3}, 4 => Vector#{0, 3, 4}, 5 => Vector#{0, 3, 4, 5}}, sssp(0, exampleGraph01()))
+        sssp(0, exampleGraph01()) |> 
+        Map.forAll(k -> v -> match k {
+            case 1 => Assert.eq(Vector#{0, 1}, v)
+            case 2 => Assert.eq(Vector#{0, 1, 2}, v)
+            case 3 => Assert.eq(Vector#{0, 3}, v)
+            case 4 =>
+                let shortestPathFound = v == Vector#{0, 3, 4} or v == Vector#{0, 1, 4};
+                Assert.eq(true, shortestPathFound)
+            case 5 =>
+                let shortestPathFound = v == Vector#{0, 1, 2, 5} or v == Vector#{0, 3, 4, 5} or v == Vector#{0, 1, 4, 5};
+                Assert.eq(true, shortestPathFound)
+            case _ => unreachable!()
+        })
 
     @Test
     def testExampleGraphShortestPaths02(): Bool =
-        Assert.eq(Map#{1 => Vector#{0, 1}, 2 => Vector#{0, 1, 2}, 3 => Vector#{0, 3}, 4 => Vector#{0, 3, 4}, 5 => Vector#{0, 3, 4, 5}}, sssp(0, exampleGraph02()))
+        sssp(0, exampleGraph02()) |>
+        Map.forAll(k -> v -> match k {
+            case 1 => Assert.eq(Vector#{0, 1}, v)
+            case 2 => Assert.eq(Vector#{0, 1, 2}, v)
+            case 3 => Assert.eq(Vector#{0, 3}, v)
+            case 4 =>
+                let shortestPathFound = v == Vector#{0, 1, 4} or v == Vector#{0, 3, 4};
+                Assert.eq(true, shortestPathFound)
+            case 5 =>
+                let shortestPathFound = v == Vector#{0, 1, 4, 5} or v == Vector#{0, 1, 2, 5} or v == Vector#{0, 3, 4, 5};
+                Assert.eq(true, shortestPathFound)
+            case _ => unreachable!()
+        })
 
     @Test
     def testExampleGraphShortestPaths03(): Bool =
-        Assert.eq(Map#{1 => Vector#{0, 1}, 2 => Vector#{0, 2}, 3 => Vector#{0, 2, 3}}, sssp(0, exampleGraph03()))
+        sssp(0, exampleGraph03()) |>
+            Map.forAll(k -> v -> match k {
+                case 1 => Assert.eq(Vector#{0, 1}, v)
+                case 2 => Assert.eq(Vector#{0, 2}, v)
+                case 3 =>
+                    let shortestPathFound = v == Vector#{0, 2, 3} or v == Vector#{0, 1, 3};
+                    Assert.eq(true, shortestPathFound)
+                case _ => unreachable!()                
+            })
 
     @Test
     def testExampleGraphShortestPaths04(): Bool =
-        Assert.eq(Map#{1 => Vector#{0 ,1}, 2 => Vector#{0, 1, 2}, 3 => Vector#{0, 1, 2, 3}, 4 => Vector#{0, 4},
-            5 => Vector#{0, 4, 5}, 6 => Vector#{0, 7, 8, 6}, 7 => Vector#{0, 7}, 8 => Vector#{0, 7, 8},
-            9 => Vector#{0, 7, 8, 9}, 10 => Vector#{0, 7, 8, 9, 10}}, sssp(0, exampleGraph04()))
+        sssp(0, exampleGraph04()) |>
+        Map.forAll(k -> v -> match k {
+            case 1 => Assert.eq(Vector#{0, 1}, v)
+            case 2 => Assert.eq(Vector#{0, 1, 2}, v)
+            case 3 => Assert.eq(Vector#{0, 1, 2, 3}, v)
+            case 4 => Assert.eq(Vector#{0, 4}, v)
+            case 5 => Assert.eq(Vector#{0, 4, 5}, v)
+            case 6 =>
+                let shortestPathFound = v == 
+                Vector#{0, 4, 5, 6} or
+                v == Vector#{0, 1, 2, 6} or
+                v == Vector#{0, 7, 8, 6} or
+                v == Vector#{0, 7, 5, 6};
+                Assert.eq(true, shortestPathFound)
+            case 7 => Assert.eq(Vector#{0, 7}, v)
+            case 8 => Assert.eq(Vector#{0, 7, 8}, v)
+            case 9 => Assert.eq(Vector#{0, 7, 8, 9}, v)
+            case 10 =>
+                let shortestPathFound = 
+                    v == Vector#{0, 1, 2, 3, 10} or
+                    v == Vector#{0, 1, 2, 6, 10} or
+                    v == Vector#{0, 4, 5, 6, 10} or
+                    v == Vector#{0, 7, 5, 6, 10} or
+                    v == Vector#{0, 7, 8, 6, 10} or
+                    v == Vector#{0, 7, 8, 9, 10};
+                Assert.eq(true, shortestPathFound)
+            case _ => unreachable!()
+        })
 
     @Test
     def testExampleGraphShortestPaths05(): Bool =
-        Assert.eq(Map#{1 => Vector#{0, 1}, 2 => Vector#{0, 1, 2}, 3 => Vector#{0, 3}, 4 => Vector#{0, 3, 4}, 5 => Vector#{0, 3, 5}, 6 => Vector#{0, 3, 5, 6}}, sssp(0, exampleGraph05()))
-
+        sssp(0, exampleGraph05()) |>
+        Map.forAll(k -> v -> match k {
+            case 1 => Assert.eq(Vector#{0, 1}, v)
+            case 2 => Assert.eq(Vector#{0, 1, 2}, v)
+            case 3 => Assert.eq(Vector#{0, 3}, v)
+            case 4 => Assert.eq(Vector#{0, 3, 4}, v)
+            case 5 =>
+                let shortestPathFound = v == Vector#{0, 1, 5} or v == Vector#{0, 3, 5};
+                Assert.eq(true, shortestPathFound)
+            case 6 =>
+                let shortestPathFound = v == Vector#{0, 1, 2, 5} or v == Vector#{0, 1, 5, 6} or v == Vector#{0, 3, 5, 6};
+                Assert.eq(true, shortestPathFound)
+            case _ => unreachable!()
+        })
 }


### PR DESCRIPTION
The tests were hard-coded to use the paths the old engine found.

They have here been generalized to accept any shortest paths that exist in the graphs.

The usage of `Assert.eq(true, shortestPathFound)` is unfortunate, as errors are hard to track, but I am unaware of a better way to assert this.