### PR TITLE
feat: add unimplemented `runSolverWithProvenance` to Datalog solver and match `SolveMode` in `Lowering`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -46,6 +46,7 @@ object Lowering {
     val version: String = ""
     lazy val Box: Symbol.DefnSym = Symbol.mkDefnSym(s"Fixpoint${version}.Boxable.box")
     lazy val Solve: Symbol.DefnSym = Symbol.mkDefnSym(s"Fixpoint${version}.Solver.runSolver")
+    lazy val SolveWithProvenance: Symbol.DefnSym = Symbol.mkDefnSym(s"Fixpoint${version}.Solver.runSolverWithProvenance")
     lazy val Merge: Symbol.DefnSym = Symbol.mkDefnSym(s"Fixpoint${version}.Solver.union")
     lazy val Filter: Symbol.DefnSym = Symbol.mkDefnSym(s"Fixpoint${version}.Solver.projectSym")
     lazy val Rename: Symbol.DefnSym = Symbol.mkDefnSym(s"Fixpoint${version}.Solver.rename")
@@ -75,7 +76,7 @@ object Lowering {
     lazy val Datalog: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.Datalog")
     lazy val Constraint: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.Constraint")
 
-    lazy val SolveMode: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.SolveMode")
+    lazy val SolveMode: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint3.Ast.Datalog.SolveMode")
 
     lazy val HeadPredicate: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.HeadPredicate")
     lazy val BodyPredicate: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.BodyPredicate")
@@ -789,7 +790,11 @@ object Lowering {
       LoweredAst.Expr.ApplyDef(defn.sym, argExps, Types.MergeType, resultType, eff, loc)
 
     case TypedAst.Expr.FixpointSolve(exp, _, eff, loc) =>
-      val defn = Defs.lookup(Defs.Solve)
+      val solveMode: SolveMode = SolveMode.Default
+      val defn = solveMode match {
+        case SolveMode.Default => Defs.lookup(Defs.Solve)
+        case SolveMode.WithProvenance => Defs.lookup(Defs.SolveWithProvenance)
+      }
       val argExps = visitExp(exp) :: Nil
       val resultType = Types.Datalog
       LoweredAst.Expr.ApplyDef(defn.sym, argExps, Types.SolveType, resultType, eff, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -786,8 +786,8 @@ object Lowering {
       LoweredAst.Expr.ApplyDef(defn.sym, argExps, Types.MergeType, resultType, eff, loc)
 
     case TypedAst.Expr.FixpointSolve(exp, _, eff, loc) =>
-      val solveMode: SolveMode = SolveMode.Default
-      val defn = solveMode match {
+      val mode: SolveMode = SolveMode.Default
+      val defn = mode match {
         case SolveMode.Default => Defs.lookup(Defs.Solve)
         case SolveMode.WithProvenance => Defs.lookup(Defs.SolveWithProvenance)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -76,8 +76,6 @@ object Lowering {
     lazy val Datalog: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.Datalog")
     lazy val Constraint: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.Constraint")
 
-    lazy val SolveMode: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint3.Ast.Datalog.SolveMode")
-
     lazy val HeadPredicate: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.HeadPredicate")
     lazy val BodyPredicate: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.BodyPredicate")
 
@@ -127,8 +125,6 @@ object Lowering {
     lazy val ChannelMpmc: Type = Type.Cst(TypeConstructor.Enum(Enums.ChannelMpmc, Kind.Star ->: Kind.Eff ->: Kind.Star), SourceLocation.Unknown)
 
     lazy val ConcurrentReentrantLock: Type = Type.mkEnum(Enums.ConcurrentReentrantLock, Nil, SourceLocation.Unknown)
-
-    lazy val SolveMode: Type = Type.mkEnum(Enums.SolveMode, Nil, SourceLocation.Unknown)
 
     def mkList(t: Type, loc: SourceLocation): Type = Type.mkEnum(Enums.FList, List(t), loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -75,6 +75,8 @@ object Lowering {
     lazy val Datalog: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.Datalog")
     lazy val Constraint: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.Constraint")
 
+    lazy val SolveMode: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.SolveMode")
+
     lazy val HeadPredicate: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.HeadPredicate")
     lazy val BodyPredicate: Symbol.EnumSym = Symbol.mkEnumSym(s"Fixpoint${Defs.version}.Ast.Datalog.BodyPredicate")
 
@@ -124,6 +126,8 @@ object Lowering {
     lazy val ChannelMpmc: Type = Type.Cst(TypeConstructor.Enum(Enums.ChannelMpmc, Kind.Star ->: Kind.Eff ->: Kind.Star), SourceLocation.Unknown)
 
     lazy val ConcurrentReentrantLock: Type = Type.mkEnum(Enums.ConcurrentReentrantLock, Nil, SourceLocation.Unknown)
+
+    lazy val SolveMode: Type = Type.mkEnum(Enums.SolveMode, Nil, SourceLocation.Unknown)
 
     def mkList(t: Type, loc: SourceLocation): Type = Type.mkEnum(Enums.FList, List(t), loc)
 

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -41,6 +41,13 @@ mod Fixpoint.Solver {
         Fixpoint.Phase.Stratifier.stratify(d) |> runWithStratification(d)
 
     ///
+    /// Returns a provenance model of the given Datalog program `d`.
+    /// The provenance model can later be used for provenance queries.
+    ///
+    @Internal
+    pub def runSolverWithProvenance(d: Datalog): Datalog = ???
+
+    ///
     /// Returns the minimal model of the given Datalog program `d`.
     /// The minimal model is given by the model semantics for Datalog programs with stratified negation.
     /// A stratification of `d` is given by `stf`.

--- a/main/src/library/Fixpoint3/Ast/Datalog.flix
+++ b/main/src/library/Fixpoint3/Ast/Datalog.flix
@@ -326,14 +326,4 @@ mod Fixpoint3.Ast.Datalog {
         case Negative
     }
 
-    /////////////////////////////////////////////////////////////////////////////
-    // SolveMode                                                               //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Internal
-    pub enum SolveMode {
-        case Default,
-        case WithProvenance
-    }
-
 }

--- a/main/src/library/Fixpoint3/Ast/Datalog.flix
+++ b/main/src/library/Fixpoint3/Ast/Datalog.flix
@@ -37,7 +37,7 @@ mod Fixpoint3.Ast.Datalog {
     /// `Datalog(facts, rules)` is a Datalog program where `facts` and `rules` are the
     /// facts and rules of the program, respectively.
     ///
-    /// `Model(factsMap)` is a 
+    /// `Model(factsMap)` is a model containing the facts given by `factsMap`.
     ///
     /// `Join(p1, p2)` is the combination of Datalog programs `p1` and `p2`.
     ///
@@ -79,7 +79,7 @@ mod Fixpoint3.Ast.Datalog {
         pub def toString(cs: Datalog): String = match cs {
             case Datalog.Datalog(facts, rules) => region rc {
                 if(not Fixpoint3.Options.enableDebugPrintFacts()) {
-                    "Printing facts disabled ${String.lineSeparator()}" + 
+                    "Printing facts disabled ${String.lineSeparator()}" +
                     Vector.iterator(rc, rules)
                         |> Iterator.join(String.lineSeparator())
                 } else {
@@ -112,7 +112,7 @@ mod Fixpoint3.Ast.Datalog {
             }
         }
     }
-    
+
     /////////////////////////////////////////////////////////////////////////////
     // Constraint                                                              //
     /////////////////////////////////////////////////////////////////////////////
@@ -324,6 +324,16 @@ mod Fixpoint3.Ast.Datalog {
     pub enum Polarity {
         case Positive,
         case Negative
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // SolveMode                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Internal
+    pub enum SolveMode {
+        case Default,
+        case WithProvenance
     }
 
 }

--- a/main/src/library/Fixpoint3/Solver.flix
+++ b/main/src/library/Fixpoint3/Solver.flix
@@ -16,6 +16,13 @@ mod Fixpoint3.Solver {
     pub def runSolver(d: Datalog): Datalog = ???
 
     ///
+    /// Returns a provenance model of the given Datalog program `d`.
+    /// The provenance model can later be used for provenance queries.
+    ///
+    @Internal
+    pub def runSolverWithProvenance(d: Datalog): Datalog = ???
+
+    ///
     /// Returns the pairwise union of `d1` and `d2`.
     /// I.e. the facts of the union is the union of the facts and likewise for rules.
     /// A fact or rule may occur twice in the Datalog program. This has no effect on its semantics.


### PR DESCRIPTION
This allows `Lowering` to handle the `solveMode` in the pattern-match in `visitExp` for when https://github.com/flix/flix/pull/11035 is merged.

See https://github.com/flix/flix/issues/11022.
