### PR TITLE
feat: Add "Go to definition" for stdlib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,19 @@ task testIDECompletion(dependsOn: ['testClasses'], type: JavaExec) {
 
 test.dependsOn testAll
 
-task vscode(type: Copy, dependsOn: [clean, jar]) {
+task extractStdlibSources(type: Copy) {
+    description = 'Extracts Flix standard library source files'
+
+    from 'main'
+    include '**/*.flix'
+    into project.findProperty('flix.stdlib.output') ?: 'build/stdlib-sources'
+
+    doLast {
+        println "Flix stdlib sources extracted to: ${destinationDir}"
+    }
+}
+
+task vscode(type: Copy, dependsOn: [clean, jar, extractStdlibSources]) {
     from 'build/libs/flix.jar'
     into providers.gradleProperty('dev.flix.vscode.project')
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -36,7 +36,95 @@ object GotoProvider {
 
     gotoRight
       .orElse(gotoLeft)
-      .filter(_.targetUri.startsWith("file://")) // We do not support goto for non-file URIs, which is the case for the standard library.
+      .map(convertToValidUri)
+  }
+
+  /**
+   * Converts non-file URIs to file URIs by searching for the corresponding source file.
+   * If the URI is already a file URI, returns it unchanged.
+   * If the URI points to a standard library file that cannot be found as a regular file,
+   * attempts to locate it in the standard library sources directory.
+   */
+  private def convertToValidUri(link: LocationLink): LocationLink = {
+    if (link.targetUri.startsWith("file://")) {
+      link
+    } else {
+      // Try to find corresponding source file for non-file URIs (e.g., stdlib references)
+      findSourceFile(link.targetUri) match {
+        case Some(sourceUri) => link.copy(targetUri = sourceUri)
+        case None =>
+          link
+      }
+    }
+  }
+
+  /**
+   * Attempts to find a source file for the given URI by searching in configured source directories.
+   * This is primarily used for standard library files that are not directly accessible as regular files.
+   */
+  private def findSourceFile(originalUri: String): Option[String] = {
+    val fileName = extractFileName(originalUri)
+
+    if (fileName.endsWith(".flix")) {
+      getSourceDirectories().view
+        .map(new java.io.File(_))
+        .filter(_.exists())
+        .flatMap(findFileRecursively(_, fileName))
+        .headOption
+        .map(file => s"file://${file.getAbsolutePath}")
+    } else {
+      None
+    }
+  }
+
+  /**
+   * Extracts the filename from a URI path.
+   */
+  private def extractFileName(uri: String): String = {
+    uri.split("[/\\\\]").lastOption.getOrElse("")
+  }
+
+  /**
+   * Returns a list of directories to search for source files.
+   * Directories are searched in order of priority.
+   */
+  private def getSourceDirectories(): List[String] = {
+    val customDirs = Option(System.getProperty("flix.stdlib.sources"))
+      .map(_.split("[;:]").toList)
+      .getOrElse(Nil)
+
+    val defaultDirs = List(
+      "stdlib-sources",
+      "src/library",
+      "../stdlib-sources",
+      "main/src/library"
+    )
+
+    customDirs ++ defaultDirs
+  }
+
+  /**
+   * Recursively searches for a file with the given name in the specified directory.
+   */
+  private def findFileRecursively(dir: java.io.File, fileName: String): Option[java.io.File] = {
+    if (!dir.exists() || !dir.isDirectory()) {
+      return None
+    }
+
+    // First, try to find the file directly in this directory
+    Option(dir.listFiles())
+      .getOrElse(Array.empty)
+      .find(file => file.isFile && file.getName == fileName) match {
+      case Some(file) => Some(file)
+      case None =>
+        // If not found, search subdirectories
+        Option(dir.listFiles())
+          .getOrElse(Array.empty)
+          .filter(_.isDirectory)
+          .view
+          .flatMap(findFileRecursively(_, fileName))
+          .headOption
+    }
   }
 
   /**


### PR DESCRIPTION
Adds the "Go to definition" functionality in the LSP for stdlib code. 
This is done via extracting the sources to a given location with a gradle task and pointing to respective files in the sources.

Pasting the message with more details from gitter:

> On this one, I checked how Scala Metals [does it](https://github.com/scalameta/metals/blob/c9f074fac10084f2e04dc814f72255796c8013ae/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala#L1647), looks like when you click on Go To Defintion in a stdlib construct they open it in the sources (that also means sources should be readily available), e.g
`file:/Users/myuser/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.16/scala-library-2.13.16-sources.jar!/scala/Predef.scala`
> For Flix that path would look different, but the approach should work as well. 
I tried adjusting Flix's LSP code and the gradle task to extract sources and look them up for stdlib files, see PR here:
> We will also need to change [this glob](https://github.com/flix/vscode-flix/blob/465e587ec00fdf9f786f814cc9dc4cee3859fb7d/client/src/extension.ts#L37C1-L40C2) in the VSCode extension to add a new directory where we extract the sources to, something like /.flix or /.flix-stdlib .
> Currently going to definition works in my PR but it refuses to e.g syntax highlight in the stdlib source files because of this rule in the extension code. 