### PR TITLE
fix: bug in MutDisjointSet

### DIFF
--- a/main/src/library/MutDisjointSets.flix
+++ b/main/src/library/MutDisjointSets.flix
@@ -140,7 +140,7 @@ mod MutDisjointSets {
                 union(x, y, s)
             }
             case (None, Some(_)) => {
-                makeSet(y, s);
+                makeSet(x, s);
                 union(x, y, s)
             }
             case (None, None)     => {

--- a/main/test/ca/uwaterloo/flix/library/TestMutDisjointSets.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutDisjointSets.flix
@@ -318,6 +318,22 @@ mod TestMutDisjointSets {
         Assert.eq(true, MutDisjointSets.memberOf(21, s))
     }
 
+    @Test
+    def union18(): Bool = region rc {
+        let s = MutDisjointSets.empty(rc);
+        MutDisjointSets.makeSet(0, s);
+        MutDisjointSets.union(1, 0, s);
+        Assert.eq(true, MutDisjointSets.equivalent(1, 0, s))
+    }
+
+    @Test
+    def union19(): Bool = region rc {
+        let s = MutDisjointSets.empty(rc);
+        MutDisjointSets.makeSet(0, s);
+        MutDisjointSets.union(0, 1, s);
+        Assert.eq(true, MutDisjointSets.equivalent(1, 0, s))
+    }
+
     /////////////////////////////////////////////////////////////////////////////
     // equivalent                                                              //
     /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The following function would loop forever.
```
def func(): Bool = region rc {
    let s = MutDisjointSets.empty(rc);
    MutDisjointSets.makeSet(0, s);
    MutDisjointSets.union(1, 0, s);
    Assert.eq(true, MutDisjointSets.equivalent(1, 0, s))
}
```