### PR TITLE
feat: add support for `pquery` in `Parser2` and `Weeder2`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -222,9 +222,9 @@ object SyntaxTree {
 
       case object FixpointInject extends Expr
 
-      case object FixpointPQuery extends Expr
-
       case object FixpointQuery extends Expr
+
+      case object FixpointQueryWithProvenance extends Expr
 
       case object FixpointSelect extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -234,6 +234,8 @@ object SyntaxTree {
 
       case object FixpointWhere extends Expr
 
+      case object FixpointWith extends Expr
+
       case object ForApplicative extends Expr
 
       case object Foreach extends Expr

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -761,8 +761,6 @@ sealed trait TokenKind {
     * and still discover `Legumes`, because isRecoverDecl return true for TokenKind.KeywordEnum.
     */
 
-  def isPredicateName: Boolean = this == TokenKind.NameUpperCase
-
   /**
     * Checks if kind is a TokenKind that warrants breaking a declaration parsing loop.
     * This is used to skip tokens until the start of a declaration is found,

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -761,6 +761,8 @@ sealed trait TokenKind {
     * and still discover `Legumes`, because isRecoverDecl return true for TokenKind.KeywordEnum.
     */
 
+  def isPredicateName: Boolean = this == TokenKind.NameUpperCase
+
   /**
     * Checks if kind is a TokenKind that warrants breaking a declaration parsing loop.
     * This is used to skip tokens until the start of a declaration is found,

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2947,7 +2947,7 @@ object Parser2 {
         case TokenKind.CurlyL => zeroOrMore(
           namedTokenSet = NamedTokenSet.FromKinds(NAME_PREDICATE),
           getItem = () => nameUnqualified(NAME_PREDICATE),
-          checkForItem = _.isPredicateName,
+          checkForItem = NAME_PREDICATE.contains,
           breakWhen = _.isRecoverExpr,
           delimiterL = TokenKind.CurlyL,
           delimiterR = TokenKind.CurlyR

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1679,6 +1679,7 @@ object Parser2 {
         case TokenKind.KeywordPSolve => fixpointSolveExpr(isPSolve = true)
         case TokenKind.HashCurlyL => fixpointConstraintSetExpr()
         case TokenKind.HashParenL => fixpointLambdaExpr()
+        case TokenKind.KeywordPQuery => fixpointPQueryExpr()
         case TokenKind.KeywordSolve => fixpointSolveExpr(isPSolve = false)
         case TokenKind.KeywordInject => fixpointInjectExpr()
         case TokenKind.KeywordQuery => fixpointQueryExpr()
@@ -2912,6 +2913,54 @@ object Parser2 {
         predicateAndArity()
       }
       close(mark, TreeKind.Expr.FixpointInject)
+    }
+
+    private def fixpointPQueryExpr()(implicit s: State): Mark.Closed = {
+      implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr
+      assert(at(TokenKind.KeywordPQuery))
+      val mark = open()
+      expect(TokenKind.KeywordPQuery)
+      expression()
+      while (eat(TokenKind.Comma) && !eof()) {
+        expression()
+      }
+      fixpointPQuerySelect()
+      fixpointPQueryWith()
+      close(mark, TreeKind.Expr.FixpointQueryWithProvenance)
+    }
+
+    private def fixpointPQuerySelect()(implicit s: State): Mark.Closed = {
+      implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr
+      assert(at(TokenKind.KeywordSelect))
+      val mark = open()
+      expect(TokenKind.KeywordSelect)
+      Predicate.head()
+      close(mark, TreeKind.Expr.FixpointSelect)
+    }
+
+    private def fixpointPQueryWith()(implicit s: State): Mark.Closed = {
+      implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr
+      assert(at(TokenKind.KeywordWith))
+      val mark = open()
+      expect(TokenKind.KeywordWith)
+      nth(0) match {
+        case TokenKind.CurlyL => zeroOrMore(
+          namedTokenSet = NamedTokenSet.FromKinds(NAME_PREDICATE),
+          getItem = () => nameUnqualified(NAME_PREDICATE),
+          checkForItem = _.isPredicateName,
+          breakWhen = _.isRecoverExpr,
+          delimiterL = TokenKind.CurlyL,
+          delimiterR = TokenKind.CurlyR
+        )
+        case t => UnexpectedToken(
+          expected = NamedTokenSet.FromKinds(Set(TokenKind.CurlyL)),
+          actual = Some(t),
+          sctx,
+          hint = Some("provide a list of predicates"),
+          loc = currentSourceLocation()
+        )
+      }
+      close(mark, TreeKind.Expr.FixpointWith)
     }
 
     private def fixpointQueryExpr()(implicit s: State): Mark.Closed = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -915,6 +915,7 @@ object Weeder2 {
         case TreeKind.Expr.FixpointSolveWithProvenance => visitFixpointSolveExpr(tree, isPSolve = true)
         case TreeKind.Expr.FixpointSolveWithProject => visitFixpointSolveExpr(tree, isPSolve = false)
         case TreeKind.Expr.FixpointQuery => visitFixpointQueryExpr(tree)
+        case TreeKind.Expr.FixpointQueryWithProvenance => visitFixpointQueryWithProvenanceExpr(tree)
         case TreeKind.Expr.Debug => visitDebugExpr(tree)
         case TreeKind.Expr.ExtMatch => visitExtMatch(tree)
         case TreeKind.Expr.ExtTag => visitExtTag(tree)
@@ -2133,6 +2134,21 @@ object Weeder2 {
         (expressions, selects, froms, where) =>
           val whereList = where.map(w => List(w)).getOrElse(List.empty)
           Expr.FixpointQueryWithSelect(expressions, selects, froms, whereList, tree.loc)
+      }
+    }
+
+    private def visitFixpointQueryWithProvenanceExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
+      expect(tree, TreeKind.Expr.FixpointQueryWithProvenance)
+      val expressions = traverse(pickAll(TreeKind.Expr.Expr, tree))(visitExpr)
+      val select = flatMapN(pick(TreeKind.Expr.FixpointSelect, tree))(Predicates.pickHead)
+      val withh = flatMapN(pick(TreeKind.Expr.FixpointWith, tree))(
+        withTree => traverse(pickAll(TreeKind.Ident, withTree))(
+          identTree => pickNameIdent(identTree)
+        )
+      )
+      mapN(expressions, select, withh) {
+        (expressions, select, withh) =>
+          Expr.FixpointQueryWithProvenance(expressions, select, withh.map(Name.mkPred), tree.loc)
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -2141,10 +2141,8 @@ object Weeder2 {
       expect(tree, TreeKind.Expr.FixpointQueryWithProvenance)
       val expressions = traverse(pickAll(TreeKind.Expr.Expr, tree))(visitExpr)
       val select = flatMapN(pick(TreeKind.Expr.FixpointSelect, tree))(Predicates.pickHead)
-      val withh = flatMapN(pick(TreeKind.Expr.FixpointWith, tree))(
-        withTree => traverse(pickAll(TreeKind.Ident, withTree))(
-          identTree => pickNameIdent(identTree)
-        )
+      val withh = mapN(pick(TreeKind.Expr.FixpointWith, tree))(
+        withTree => pickAll(TreeKind.Ident, withTree).map(tokenToIdent)
       )
       mapN(expressions, select, withh) {
         (expressions, select, withh) =>


### PR DESCRIPTION
Related to https://github.com/flix/flix/issues/11023.

I tested `pquery` in a program by adding it to the lexer, and it mostly works fine but causes a lot of crashing when it's not written out fully.  There is also an issue with the predicate symbols in the `with { ... }` part; it will accept anything but an `Ident` and I can't figure out why. 