### PR TITLE
fix: parse `pquery` expressions without crashing

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2931,7 +2931,6 @@ object Parser2 {
 
     private def fixpointPQuerySelect()(implicit s: State): Mark.Closed = {
       implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr
-      assert(at(TokenKind.KeywordSelect))
       val mark = open()
       expect(TokenKind.KeywordSelect)
       Predicate.head()
@@ -2940,7 +2939,6 @@ object Parser2 {
 
     private def fixpointPQueryWith()(implicit s: State): Mark.Closed = {
       implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr
-      assert(at(TokenKind.KeywordWith))
       val mark = open()
       expect(TokenKind.KeywordWith)
       nth(0) match {


### PR DESCRIPTION
Remove unnecessary asserts causing crashes