### PR TITLE
chore: remove join-profiler leftover

### DIFF
--- a/main/src/library/Fixpoint3/Ast/ExecutableRam.flix
+++ b/main/src/library/Fixpoint3/Ast/ExecutableRam.flix
@@ -102,12 +102,6 @@ mod Fixpoint3.Ast.ExecutableRam {
     ///
     /// `Comment(string)` is a comment for debugging.
     ///
-    /// `EstimateJoinSize(indexPosition, savePosition, search)` estimates the size of the
-    /// index at `indexPosition` as described by `search` and save the result to
-    /// `savePosition`. `EstimateJoinSize` statements only exist during the
-    /// join profiling stage during join optimization. For more details see 
-    /// `JoinOptimizer.flix`. 
-    ///
     @Internal
     pub enum RamStmt {
         case Insert(RelOp)
@@ -118,7 +112,6 @@ mod Fixpoint3.Ast.ExecutableRam {
         case Par(Vector[RamStmt])
         case Until(Vector[BoolExp], RamStmt)
         case Comment(String)
-        case EstimateJoinSize(Int32, Int32, Vector[Int32])
     }
 
     instance ToString[RamStmt] {
@@ -135,8 +128,6 @@ mod Fixpoint3.Ast.ExecutableRam {
                     "Until(${tst}) do${nl}${String.indent(4, "${body}")}end"
                 case RamStmt.Comment(comment) => "/* ${comment} */"
                 case RamStmt.Par(xs) => Vector.join("|${nl}", xs)
-                case RamStmt.EstimateJoinSize(index, writeTo, attr) => 
-                    "EstimateJoinSize(<optimized out>, {${Vector.join(", ", attr)}}) @ ${index}, ${writeTo}"
             }
     }
 

--- a/main/src/library/Fixpoint3/Ast/Ram.flix
+++ b/main/src/library/Fixpoint3/Ast/Ram.flix
@@ -43,7 +43,7 @@ mod Fixpoint3.Ast.Ram {
     pub type alias Predicates = (Int64, Set[RelSym])
 
     ///
-    /// The EDB of a program.
+    /// The extensible database (EDB) of a program.
     ///
     @Internal
     pub type alias Facts = Map[RelSym, Vector[Vector[Boxed]]]
@@ -110,10 +110,6 @@ mod Fixpoint3.Ast.Ram {
     ///
     /// `Comment(string)` is a comment for debugging.
     ///
-    /// `EstimateJoinSize(relSym, indexUsed, savePosition, search)` estimates the size
-    /// relation `relSym` based on index `indexUsed` as described by `search` and saves
-    /// the result to `savePosition`. For details see JoinOptimizer.
-    ///
     @Internal
     pub enum RamStmt {
         case Insert(RelOp)
@@ -124,7 +120,6 @@ mod Fixpoint3.Ast.Ram {
         case Par(Vector[RamStmt])
         case Until(Vector[BoolExp], RamStmt)
         case Comment(String)
-        case EstimateJoinSize(RelSym, Int32, Int32, Search)
     }
 
     instance ToString[RamStmt] {
@@ -136,13 +131,11 @@ mod Fixpoint3.Ast.Ram {
                 case RamStmt.Swap(lhs, rhs) => "Swap ${lhs} and ${rhs}"
                 case RamStmt.Purge(relSym) => "Purge ${relSym}"
                 case RamStmt.Seq(xs) => Vector.join(";${nl}", xs)
+                case RamStmt.Par(xs) => Vector.join("|${nl}", xs)
                 case RamStmt.Until(test, body) =>
                     let tst = test |> Vector.join(" && ");
                     "until(${tst}) do${nl}${String.indent(4, "${body}")}end"
                 case RamStmt.Comment(comment) => "/* ${comment} */"
-                case RamStmt.Par(xs) => Vector.join("|${nl}", xs)
-                case RamStmt.EstimateJoinSize(relSym, _, _, attr) =>
-                    "EstimateJoinSize(${relSym}, {${Vector.join(", ", attr)}})"
             }
     }
 
@@ -258,7 +251,7 @@ mod Fixpoint3.Ast.Ram {
     /////////////////////////////////////////////////////////////////////////////
 
     ///
-    /// Represents a RAM term.
+    /// Represents a Relational Algebra Machine (RAM) term.
     ///
     /// Enums with a `RamId` can be referred to by the `RamId`.
     ///

--- a/main/src/library/Fixpoint3/Boxing.flix
+++ b/main/src/library/Fixpoint3/Boxing.flix
@@ -435,7 +435,6 @@ mod Fixpoint3.Boxing {
                 unifyRamIdsStmt(predicates, set, withProv, body);
                 Vector.forEach(unifyRamIdsBool(set), bools)
             case RamStmt.Comment(_) => ()
-            case RamStmt.EstimateJoinSize(_, _, _, _) => ()
         }
 
         ///
@@ -596,7 +595,6 @@ mod Fixpoint3.Boxing {
                 computeMappingStmt(disjoint, map, counter, withProv, body);
                 Vector.forEach(computeMappingBool(disjoint, map, counter), bools)
             case RamStmt.Comment(_) => ()
-            case RamStmt.EstimateJoinSize(_, _, _, _) => ()
         }
 
         ///

--- a/main/src/library/Fixpoint3/Interpreter.flix
+++ b/main/src/library/Fixpoint3/Interpreter.flix
@@ -274,8 +274,6 @@ mod Fixpoint3.Interpreter {
                 ()
             } as _ \ rc2)) // The `IO` effect is undesirable, so we cast it back to an `r` effect
         }
-        case RamStmt.EstimateJoinSize(indexPos, writeTo, attr) =>
-            ???
     }
 
     ///

--- a/main/src/library/Fixpoint3/Phase/Hoisting.flix
+++ b/main/src/library/Fixpoint3/Phase/Hoisting.flix
@@ -191,7 +191,6 @@ mod Fixpoint3.Phase.Hoisting {
                 case None => None
                 case Some(v) => Some(RamStmt.Until(test, v))
             }
-        case RamStmt.EstimateJoinSize(_, _, _, _) => Some(stmt)
         case RamStmt.Comment(_) => Some(stmt)
     }
 
@@ -616,7 +615,7 @@ mod Fixpoint3.Phase.Hoisting {
     ///
     /// Returns `true` if `term` is ground with respect to `termMap` and `equalitySets`.
     ///
-    /// A `RowLoad` is ground if it represents `(rv, index)` with respect to `equalitySets`
+    /// A `RowLoad` is ground if its representing `(rv, index)` with respect to `equalitySets`
     /// is in `termMap`.
     ///
     def isTermGround(
@@ -663,7 +662,6 @@ mod Fixpoint3.Phase.Hoisting {
         case RamStmt.Swap(_, _) => ()
         case RamStmt.Purge(_) => ()
         case RamStmt.Comment(_) => ()
-        case RamStmt.EstimateJoinSize(_, _, _, _) => ()
     }
 
     ///

--- a/main/src/library/Fixpoint3/Phase/IndexSelection.flix
+++ b/main/src/library/Fixpoint3/Phase/IndexSelection.flix
@@ -146,9 +146,6 @@ mod Fixpoint3.Phase.IndexSelection {
         case RamStmt.Seq(xs) => RamStmt.Seq(Vector.map(x -> indexStmt(x, constructedIndexes, indexState), xs))
         case RamStmt.Par(xs) => RamStmt.Par(Vector.map(x -> indexStmt(x, constructedIndexes, indexState), xs))
         case RamStmt.Until(boolExps, body) => RamStmt.Until(boolExps, indexStmt(body, constructedIndexes, indexState))
-        case RamStmt.EstimateJoinSize(relSym, _, writeTo, search) =>
-            let absoluteIndex = UniqueInts.getIndex((relSym, lookupIndex(relSym, search, constructedIndexes)), indexState);
-            RamStmt.EstimateJoinSize(relSym, absoluteIndex, writeTo, search)
         case RamStmt.Comment(_) => stmt
     }
 
@@ -231,9 +228,6 @@ mod Fixpoint3.Phase.IndexSelection {
         case RamStmt.Par(xs) => RamStmt.Par(Vector.map(collectSearchesStmt(indexes, rc), xs))
         case RamStmt.Until(boolExps, body) =>
             RamStmt.Until(boolExps, collectSearchesStmt(indexes, rc, body))
-        case RamStmt.EstimateJoinSize(relSym, _, _, search) =>
-            collectSearch(relSym, search, indexes);
-            stmt
         case RamStmt.Comment(_) => stmt
     }
 

--- a/main/src/library/Fixpoint3/Phase/Lowering.flix
+++ b/main/src/library/Fixpoint3/Phase/Lowering.flix
@@ -100,6 +100,7 @@ mod Fixpoint3.Phase.Lowering {
     use Fixpoint3.Ast.Ram
     use Fixpoint3.Ast.Ram.{arityOf, arityOfNonLat, getTermRamId, IndexInformation, RamId, RelSym, RowVar, Search, toDenotation}
     use Fixpoint3.Ast.Shared.{Denotation, PredSym}
+    use Fixpoint3.Boxed
     use Fixpoint3.Boxing
     use Fixpoint3.BoxingType.{Boxing, RamIdToPos};
     use Fixpoint3.UniqueInts
@@ -262,8 +263,6 @@ mod Fixpoint3.Phase.Lowering {
                     Vector.filterMap(lowerBool(idToIndex, boxingInfo, indexInfo, (Nil, MutDisjointSets.empty(rc))));
                 let newBody = lowerStmtRec(body);
                 ExecutableRam.RamStmt.Until(newTests, newBody)
-            case Ram.RamStmt.EstimateJoinSize(_, relIndex, estWriteTo, attr) =>
-                ExecutableRam.RamStmt.EstimateJoinSize(relIndex, estWriteTo, attr)
             case Ram.RamStmt.Comment(s) => ExecutableRam.RamStmt.Comment(s)
     }
 
@@ -607,7 +606,6 @@ mod Fixpoint3.Phase.Lowering {
         case Ram.RamStmt.Par(stmts) => Vector.foldLeft(acc -> x -> List.append(collectRowVarRelSymStmt(x), acc), Nil, stmts)
         case Ram.RamStmt.Until(_, rest) => collectRowVarRelSymStmt(rest)
         case Ram.RamStmt.Comment(_) => Nil
-        case Ram.RamStmt.EstimateJoinSize(_, _, _, _) => Nil
     }
 
     ///

--- a/main/src/library/Fixpoint3/Phase/Simplifier.flix
+++ b/main/src/library/Fixpoint3/Phase/Simplifier.flix
@@ -101,7 +101,6 @@ mod Fixpoint3.Phase.Simplifier {
                         Some(RamStmt.Until(test, simplifiedBody))
                     }
             }
-        case RamStmt.EstimateJoinSize(_, _, _, _) => Some(stmt)
         case RamStmt.Comment(_) => Some(stmt)
     }
 
@@ -187,7 +186,6 @@ mod Fixpoint3.Phase.Simplifier {
         case RamStmt.Seq(xs) => Vector.forAll(isOnlyMergeSwapPurge, xs)
         case RamStmt.Par(xs) => Vector.forAll(isOnlyMergeSwapPurge, xs)
         case RamStmt.Until(_, _) => false
-        case RamStmt.EstimateJoinSize(_, _, _, _) => false
         case RamStmt.Comment(_) => true
     }
 

--- a/main/src/library/Fixpoint3/Util.flix
+++ b/main/src/library/Fixpoint3/Util.flix
@@ -16,7 +16,6 @@
  */
 
 mod Fixpoint3.Util {
-    use Fixpoint3.Boxed
 
     ///
     /// Unwraps an option.


### PR DESCRIPTION
Primarily remove `RamStmt.EstimateJoinSize`.