### PR TITLE
chore: use `Vector` in `injectIntoX` and `factsOf` and exclude tuples with lattice element bot

### DIFF
--- a/main/src/library/Fixpoint3/Solver.flix
+++ b/main/src/library/Fixpoint3/Solver.flix
@@ -19,6 +19,7 @@
 mod Fixpoint3.Solver {
     import dev.flix.runtime.Global
 
+    use Fixpoint3.{Boxed, Debugging, Interpreter, Options, Phase, Predicate, PredSymsOf, SubstitutePredSym }
     use Fixpoint3.Ast.Datalog.{Datalog, Constraint, HeadTerm}
     use Fixpoint3.Ast.Datalog.Datalog.{Datalog, Model, Join}
     use Fixpoint3.Ast.Datalog.Constraint.Constraint
@@ -31,16 +32,8 @@ mod Fixpoint3.Solver {
     use Fixpoint3.Ast.Shared.PredSym
     use Fixpoint3.Ast.Shared.PredSym.PredSym
     use Fixpoint3.Boxable.{box, unbox}
-    use Fixpoint3.Boxed
     use Fixpoint3.BoxingType.Boxing
-    use Fixpoint3.Debugging
-    use Fixpoint3.Interpreter
     use Fixpoint3.Interpreter.Database
-    use Fixpoint3.Options
-    use Fixpoint3.Phase
-    use Fixpoint3.Predicate
-    use Fixpoint3.PredSymsOf
-    use Fixpoint3.SubstitutePredSym
     use Fixpoint3.Util.getOrCrash
 
     ///
@@ -76,17 +69,17 @@ mod Fixpoint3.Solver {
         };
         let model = match d {
             case Datalog(_, r) =>
-                compiler(d, Map.empty()) |>  
+                compiler(d, Map.empty()) |>
                 Debugging.notifyPreInterpret |>
-                Interpreter.interpret(rc, withProv) |> 
+                Interpreter.interpret(rc, withProv) |>
                 toModelOnlyFull(withProv, r)
-            case Model(_) => 
+            case Model(_) =>
                 d
-            case Join(Model(m), Datalog(f, r)) => 
+            case Join(Model(m), Datalog(f, r)) =>
                 let cs = Datalog(f, r);
-                compiler(cs, m) |> 
+                compiler(cs, m) |>
                 Debugging.notifyPreInterpret |>
-                Interpreter.interpret(rc, withProv) |> 
+                Interpreter.interpret(rc, withProv) |>
                 toModelOnlyFull(withProv, r)
             case _ => bug!("Datalog Boxing bug")
         };
@@ -175,9 +168,9 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto1(p: PredSym, ts: f[t1]):
         Datalog \ Foldable.Aef[f] with Order[t1], Foldable[f] =
-        injectIntoX(match (v1) ->
-            box(v1) ::
-            Nil
+        injectIntoX(match (v1) -> Vector#{
+            box(v1)
+        }
         , p, ts)
 
     ///
@@ -189,10 +182,10 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto2(p: PredSym, ts: f[(t1, t2)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Foldable[f] =
-        injectIntoX(match (v1, v2) ->
-            box(v1) ::
-            box(v2) ::
-            Nil
+        injectIntoX(match (v1, v2) -> Vector#{
+            box(v1),
+            box(v2)
+        }
         , p, ts)
 
     ///
@@ -204,11 +197,11 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto3(p: PredSym, ts: f[(t1, t2, t3)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Foldable[f] =
-        injectIntoX(match (v1, v2, v3) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            Nil
+        injectIntoX(match (v1, v2, v3) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3)
+        }
         , p, ts)
 
     ///
@@ -221,12 +214,12 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto4(p: PredSym, ts: f[(t1, t2, t3, t4)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4)
+        }
         , p, ts)
 
     ///
@@ -239,13 +232,13 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto5(p: PredSym, ts: f[(t1, t2, t3, t4, t5)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5)
+        }
         , p, ts)
 
     ///
@@ -258,14 +251,14 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto6(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6)
+        }
         , p, ts)
 
     ///
@@ -278,15 +271,15 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto7(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            box(v7) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6),
+            box(v7)
+        }
         , p, ts)
 
     ///
@@ -300,16 +293,16 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto8(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            box(v7) ::
-            box(v8) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6),
+            box(v7),
+            box(v8)
+        }
         , p, ts)
 
     ///
@@ -323,17 +316,17 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto9(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            box(v7) ::
-            box(v8) ::
-            box(v9) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6),
+            box(v7),
+            box(v8),
+            box(v9)
+        }
         , p, ts)
 
     ///
@@ -349,18 +342,18 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto10(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            box(v7) ::
-            box(v8) ::
-            box(v9) ::
-            box(v10) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6),
+            box(v7),
+            box(v8),
+            box(v9),
+            box(v10)
+        }
         , p, ts)
 
     ///
@@ -376,19 +369,19 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto11(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            box(v7) ::
-            box(v8) ::
-            box(v9) ::
-            box(v10) ::
-            box(v11) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6),
+            box(v7),
+            box(v8),
+            box(v9),
+            box(v10),
+            box(v11)
+        }
         , p, ts)
 
     ///
@@ -404,20 +397,20 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto12(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11], Order[t12], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            box(v7) ::
-            box(v8) ::
-            box(v9) ::
-            box(v10) ::
-            box(v11) ::
-            box(v12) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6),
+            box(v7),
+            box(v8),
+            box(v9),
+            box(v10),
+            box(v11),
+            box(v12)
+        }
         , p, ts)
 
     ///
@@ -433,21 +426,21 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto13(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11], Order[t12], Order[t13], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            box(v7) ::
-            box(v8) ::
-            box(v9) ::
-            box(v10) ::
-            box(v11) ::
-            box(v12) ::
-            box(v13) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6),
+            box(v7),
+            box(v8),
+            box(v9),
+            box(v10),
+            box(v11),
+            box(v12),
+            box(v13)
+        }
         , p, ts)
 
     ///
@@ -463,22 +456,22 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto14(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11], Order[t12], Order[t13], Order[t14], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            box(v7) ::
-            box(v8) ::
-            box(v9) ::
-            box(v10) ::
-            box(v11) ::
-            box(v12) ::
-            box(v13) ::
-            box(v14) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6),
+            box(v7),
+            box(v8),
+            box(v9),
+            box(v10),
+            box(v11),
+            box(v12),
+            box(v13),
+            box(v14)
+        }
         , p, ts)
 
     ///
@@ -494,34 +487,34 @@ mod Fixpoint3.Solver {
     @Internal
     pub def injectInto15(p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)]):
         Datalog \ Foldable.Aef[f] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11], Order[t12], Order[t13], Order[t14], Order[t15], Foldable[f] =
-        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) ->
-            box(v1) ::
-            box(v2) ::
-            box(v3) ::
-            box(v4) ::
-            box(v5) ::
-            box(v6) ::
-            box(v7) ::
-            box(v8) ::
-            box(v9) ::
-            box(v10) ::
-            box(v11) ::
-            box(v12) ::
-            box(v13) ::
-            box(v14) ::
-            box(v15) ::
-            Nil
+        injectIntoX(match (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) -> Vector#{
+            box(v1),
+            box(v2),
+            box(v3),
+            box(v4),
+            box(v5),
+            box(v6),
+            box(v7),
+            box(v8),
+            box(v9),
+            box(v10),
+            box(v11),
+            box(v12),
+            box(v13),
+            box(v14),
+            box(v15)
+        }
         , p, ts)
 
-    def injectIntoX(f: t -> List[Boxed] \ ef, p: PredSym, ts: f[t]): Datalog \ (ef + Foldable.Aef[f]) with Foldable[f] =
+    def injectIntoX(f: t -> Vector[Boxed] \ ef, p: PredSym, ts: f[t]): Datalog \ (ef + Foldable.Aef[f]) with Foldable[f] =
         region rc {
             let db = MutMap.empty(rc);
             Foldable.foldLeft(() -> t -> {
                 let vs = f(t);
-                let arity = List.length(vs);
+                let arity = Vector.length(vs);
                 let ramSym = RelSym.Symbol(p, arity, Relational);
                 let rel = MutMap.getOrElsePut(ramSym, MutMap.empty(rc), db);
-                MutMap.put(List.toVector(vs), Reflect.default(), rel)
+                MutMap.put(vs, Reflect.default(), rel)
             }, (), ts);
             toModel(db)
         }
@@ -539,23 +532,20 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts1(p: PredSym, d: Datalog): Vector[t] with Order[t] =
-        let f = terms -> match terms {
-            case hd :: _ =>
-                unbox(hd)
-            case _ => unreachable!()
-        };
-       factsOf(f, p, d)
+        let f = terms -> (
+            unbox(Vector.get(0, terms))
+        );
+        factsOf(f, p, d)
 
     ///
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
     pub def facts2(p: PredSym, d: Datalog): Vector[(t1, t2)] with Order[t1], Order[t2] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: _ =>
-                (unbox(v0), unbox(v1))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -563,11 +553,11 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts3(p: PredSym, d: Datalog): Vector[(t1, t2, t3)] with Order[t1], Order[t2], Order[t3] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -575,11 +565,12 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts4(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4)] with Order[t1], Order[t2], Order[t3], Order[t4] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -587,11 +578,13 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts5(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -599,11 +592,14 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts6(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -611,11 +607,15 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts7(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6, t7)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: v6 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5), unbox(v6))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms)),
+            unbox(Vector.get(6, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -623,11 +623,16 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts8(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6, t7, t8)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: v6 :: v7 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5), unbox(v6), unbox(v7))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms)),
+            unbox(Vector.get(6, terms)),
+            unbox(Vector.get(7, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -635,11 +640,17 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts9(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6, t7, t8, t9)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: v6 :: v7 :: v8 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5), unbox(v6), unbox(v7), unbox(v8))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms)),
+            unbox(Vector.get(6, terms)),
+            unbox(Vector.get(7, terms)),
+            unbox(Vector.get(8, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -647,11 +658,18 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts10(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: v6 :: v7 :: v8 :: v9 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5), unbox(v6), unbox(v7), unbox(v8), unbox(v9))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms)),
+            unbox(Vector.get(6, terms)),
+            unbox(Vector.get(7, terms)),
+            unbox(Vector.get(8, terms)),
+            unbox(Vector.get(9, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -659,11 +677,19 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts11(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: v6 :: v7 :: v8 :: v9 :: v10 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5), unbox(v6), unbox(v7), unbox(v8), unbox(v9), unbox(v10))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms)),
+            unbox(Vector.get(6, terms)),
+            unbox(Vector.get(7, terms)),
+            unbox(Vector.get(8, terms)),
+            unbox(Vector.get(9, terms)),
+            unbox(Vector.get(10, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -671,11 +697,20 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts12(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11], Order[t12] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: v6 :: v7 :: v8 :: v9 :: v10 :: v11 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5), unbox(v6), unbox(v7), unbox(v8), unbox(v9), unbox(v10), unbox(v11))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms)),
+            unbox(Vector.get(6, terms)),
+            unbox(Vector.get(7, terms)),
+            unbox(Vector.get(8, terms)),
+            unbox(Vector.get(9, terms)),
+            unbox(Vector.get(10, terms)),
+            unbox(Vector.get(11, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -683,11 +718,21 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts13(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11], Order[t12], Order[t13] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: v6 :: v7 :: v8 :: v9 :: v10 :: v11 :: v12 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5), unbox(v6), unbox(v7), unbox(v8), unbox(v9), unbox(v10), unbox(v11), unbox(v12))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms)),
+            unbox(Vector.get(6, terms)),
+            unbox(Vector.get(7, terms)),
+            unbox(Vector.get(8, terms)),
+            unbox(Vector.get(9, terms)),
+            unbox(Vector.get(10, terms)),
+            unbox(Vector.get(11, terms)),
+            unbox(Vector.get(12, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -695,11 +740,22 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts14(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11], Order[t12], Order[t13], Order[t14] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: v6 :: v7 :: v8 :: v9 :: v10 :: v11 :: v12 :: v13 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5), unbox(v6), unbox(v7), unbox(v8), unbox(v9), unbox(v10), unbox(v11), unbox(v12), unbox(v13))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms)),
+            unbox(Vector.get(6, terms)),
+            unbox(Vector.get(7, terms)),
+            unbox(Vector.get(8, terms)),
+            unbox(Vector.get(9, terms)),
+            unbox(Vector.get(10, terms)),
+            unbox(Vector.get(11, terms)),
+            unbox(Vector.get(12, terms)),
+            unbox(Vector.get(13, terms))
+        );
         factsOf(f, p, d)
 
     ///
@@ -707,24 +763,36 @@ mod Fixpoint3.Solver {
     ///
     @Internal
     pub def facts15(p: PredSym, d: Datalog): Vector[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)] with Order[t1], Order[t2], Order[t3], Order[t4], Order[t5], Order[t6], Order[t7], Order[t8], Order[t9], Order[t10], Order[t11], Order[t12], Order[t13], Order[t14], Order[t15] =
-        let f = terms -> match terms {
-            case v0 :: v1 :: v2 :: v3 :: v4 :: v5 :: v6 :: v7 :: v8 :: v9 :: v10 :: v11 :: v12 :: v13 :: v14 :: _ =>
-                (unbox(v0), unbox(v1), unbox(v2), unbox(v3), unbox(v4), unbox(v5), unbox(v6), unbox(v7), unbox(v8), unbox(v9), unbox(v10), unbox(v11), unbox(v12), unbox(v13), unbox(v14))
-            case _ => unreachable!()
-        };
+        let f = terms -> (
+            unbox(Vector.get(0, terms)),
+            unbox(Vector.get(1, terms)),
+            unbox(Vector.get(2, terms)),
+            unbox(Vector.get(3, terms)),
+            unbox(Vector.get(4, terms)),
+            unbox(Vector.get(5, terms)),
+            unbox(Vector.get(6, terms)),
+            unbox(Vector.get(7, terms)),
+            unbox(Vector.get(8, terms)),
+            unbox(Vector.get(9, terms)),
+            unbox(Vector.get(10, terms)),
+            unbox(Vector.get(11, terms)),
+            unbox(Vector.get(12, terms)),
+            unbox(Vector.get(13, terms)),
+            unbox(Vector.get(14, terms))
+        );
         factsOf(f, p, d)
 
     ///
     /// Returns an array of facts associated with the given predicate symbol `p` in the given Datalog program `d`.
     ///
-    def factsOf(f: List[Boxed] -> t \ ef, p: PredSym, d: Datalog): Vector[t] \ ef = match d {
+    def factsOf(f: Vector[Boxed] -> t \ ef, p: PredSym, d: Datalog): Vector[t] \ ef = match d {
         case Datalog(_, cs) => region rc {
             let pFacts = MutList.empty(rc);
             Vector.forEach(c -> match c {
                 case Constraint(HeadAtom(headPred, _, terms), body) =>
                     if (headPred == p and Vector.isEmpty(body))
                         let vs = Vector.map(headTermValue, terms);
-                        MutList.push(f(Vector.toList(vs)), pFacts)
+                        MutList.push(f(vs), pFacts)
                     else ()
                 case _ => ()
             }, cs);
@@ -741,17 +809,20 @@ mod Fixpoint3.Solver {
             };
             Map.rangeQueryWith(qquery, ramSym -> rel -> match toDenotation(ramSym) {
                 case Relational =>
-                    Map.forEach((tuple, _) -> MutList.push(f(Vector.toList(tuple)), pFacts), rel)
-                case Latticenal(_, _, _, _) =>
+                    Map.forEach((tuple, _) -> MutList.push(f(tuple), pFacts), rel)
+                case Latticenal(bot, leq, _, _) =>
                     Map.forEach((tuple, lat) -> {
-                        let it = Iterator.range(rc, 0, Vector.length(tuple) + 1);
-                        let vs = it |> Iterator.map(i -> {
-                            if (i < Vector.length(tuple))
-                                Vector.get(i, tuple)
-                            else
-                                lat
-                        }) |> Iterator.toList;
-                        MutList.push(f(vs), pFacts)
+                        if (not leq(lat, bot)) {
+                            let arity = Vector.length(tuple);
+                            let it = Iterator.range(rc, 0, arity + 1);
+                            let vs = it |> Iterator.map(i -> {
+                                if (i < arity)
+                                    Vector.get(i, tuple)
+                                else
+                                    lat
+                            }) |> Iterator.toVector;
+                            MutList.push(f(vs), pFacts)
+                        } else ()
                     }, rel)
             }, db);
             pFacts |> MutList.toVector


### PR DESCRIPTION
Store tuples as `Vector` rather than first as a list followed by a `List.toVector`. Also exclude latticenal tuples mapping to bottom.