### PR TITLE
feat: allow keyword escape in new java defs

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2742,7 +2742,11 @@ object Parser2 {
       assert(at(TokenKind.KeywordDef))
       val mark = open()
       expect(TokenKind.KeywordDef)
-      nameUnqualified(NAME_JAVA)
+      if (eat(TokenKind.InfixFunction)) {
+        ()
+      } else {
+        nameUnqualified(NAME_JAVA)
+      }
       Decl.parameters()
       expect(TokenKind.Colon)
       Type.typeAndEffect()

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -33,6 +33,7 @@ mod Test.Exp.Jvm.NewObject {
     import java.io.Serializable
     import java.lang.Object
     import java.lang.Class
+    import java.lang.Runnable
     import java.util.Comparator
 
     def implementSerializable(): Serializable \ IO =
@@ -306,4 +307,8 @@ mod Test.Exp.Jvm.NewObject {
     @test
     def testClassWithProtectedConstructor01(): TestClassWithProtectedConstructor \ IO =
         new TestClassWithProtectedConstructor {}
+
+    @test
+    def testKeywordMethod01(): Runnable \ IO =
+        new Runnable { def `run`(_this: Runnable): Unit = () }
 }


### PR DESCRIPTION
allows
```
new Runnable {
    def `run`(_this: Runnable): Unit \ IO = println("Cool!")
}
```