### PR TITLE
feat: add Extensible `DisplayType`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
@@ -159,6 +159,35 @@ object DisplayType {
     */
   case class SchemaRowExtend(fields: List[PredicateFieldType], rest: DisplayType) extends DisplayType
 
+  //////////////////////////////
+  // Extensible Variants Schemas
+  //////////////////////////////
+
+  /**
+    * A schema constructor. `arg` should be a variable or a Hole.
+    */
+  case class ExtSchemaConstructor(arg: DisplayType) extends DisplayType
+
+  /**
+    * An unextended schema.
+    */
+  case class ExtSchema(fields: List[PredicateFieldType]) extends DisplayType
+
+  /**
+    * An extended schema. `arg` should be a variable or a Hole.
+    */
+  case class ExtSchemaExtend(fields: List[PredicateFieldType], rest: DisplayType) extends DisplayType
+
+  /**
+    * An unextended schema row.
+    */
+  case class ExtSchemaRow(fields: List[PredicateFieldType]) extends DisplayType
+
+  /**
+    * An extended schema row. `arg` should be a variable or a Hole.
+    */
+  case class ExtSchemaRowExtend(fields: List[PredicateFieldType], rest: DisplayType) extends DisplayType
+
   ////////////////////
   // Boolean Operators
   ////////////////////
@@ -443,12 +472,12 @@ object DisplayType {
           val args = t.typeArguments.map(visit)
           args match {
             // Case 1: No args. { ? }
-            case Nil => SchemaConstructor(Hole)
+            case Nil => ExtSchemaConstructor(Hole)
             // Case 2: One row argument. Extract its values.
             case tpe :: Nil => tpe match {
-              case SchemaRow(fields) => Schema(fields)
-              case SchemaRowExtend(fields, rest) => SchemaExtend(fields, rest)
-              case nonSchema => SchemaConstructor(nonSchema)
+              case SchemaRow(fields) => ExtSchema(fields)
+              case SchemaRowExtend(fields, rest) => ExtSchemaExtend(fields, rest)
+              case nonSchema => ExtSchemaConstructor(nonSchema)
             }
             // Case 3: Too many args. Error.
             case _ :: _ :: _ => throw new OverAppliedType(t.loc)

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -197,6 +197,11 @@ object FormatType {
       case DisplayType.SchemaExtend(_, _) => true
       case DisplayType.SchemaRow(_) => true
       case DisplayType.SchemaRowExtend(_, _) => true
+      case DisplayType.ExtSchemaConstructor(_) => true
+      case DisplayType.ExtSchema(_) => true
+      case DisplayType.ExtSchemaExtend(_, _) => true
+      case DisplayType.ExtSchemaRow(_) => true
+      case DisplayType.ExtSchemaRowExtend(_, _) => true
       case DisplayType.RelationConstructor => true
       case DisplayType.Relation(_) => true
       case DisplayType.LatticeConstructor => true
@@ -297,6 +302,21 @@ object FormatType {
         val restString = visit(rest, Mode.Type)
         s"#( $fieldString | $restString )"
       case DisplayType.SchemaConstructor(arg) => s"#{ ${visit(arg, Mode.Type)} }"
+      case DisplayType.ExtSchema(fields) =>
+        val fieldString = fields.map(visitSchemaFieldType).mkString(", ")
+        s"#|{ $fieldString }|"
+      case DisplayType.ExtSchemaExtend(fields, rest) =>
+        val fieldString = fields.map(visitSchemaFieldType).mkString(", ")
+        val restString = visit(rest, Mode.Type)
+        s"#|{ $fieldString | $restString }|"
+      case DisplayType.ExtSchemaRow(fields) =>
+        val fieldString = fields.map(visitSchemaFieldType).mkString(", ")
+        s"#|( $fieldString )|"
+      case DisplayType.ExtSchemaRowExtend(fields, rest) =>
+        val fieldString = fields.map(visitSchemaFieldType).mkString(", ")
+        val restString = visit(rest, Mode.Type)
+        s"#|( $fieldString | $restString )|"
+      case DisplayType.ExtSchemaConstructor(arg) => s"#|{ ${visit(arg, Mode.Type)} }|"
       case DisplayType.Not(tpe) => s"not ${delimit(tpe, mode)}"
       case DisplayType.And(tpes) =>
         val strings = tpes.map(delimit(_, mode))


### PR DESCRIPTION
Formats extensible types as `#|{ ... }|`. Notice the vertial bars `|`.

Closes https://github.com/flix/flix/issues/11075