### PR TITLE
chore: fix spacing in standard library

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -220,7 +220,7 @@ mod Array {
     ///
     /// Returns `a` as a MutDeque.
     ///
-    pub def toMutDeque(rc1: Region[r1], a: Array[a, r2]): MutDeque[a, r1] \ { r2, r1 }  =
+    pub def toMutDeque(rc1: Region[r1], a: Array[a, r2]): MutDeque[a, r1] \ { r2, r1 } =
         let d = MutDeque.empty(rc1);
         forEach(x -> MutDeque.pushBack(x, d), a);
         d
@@ -403,7 +403,7 @@ mod Array {
     ///
     /// Accumulates the result of applying `f` to `arr` going left to right.
     ///
-    /// That is, the result is of the form: `[s , f(s, x1), f(f(s, x1), x2),  ...]`.
+    /// That is, the result is of the form: `[s , f(s, x1), f(f(s, x1), x2), ...]`.
     ///
     pub def scanLeft(rc: Region[r], f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, r } =
         let len = length(arr) + 1;
@@ -815,7 +815,7 @@ mod Array {
     /// That is, the result is of the form: `f(a[0], ...f(a[n-1], f(a[n], z))...)`.
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ {ef,  r}) -> b \ {ef, r}, z: b, arr: Array[a, r]): b \ { ef, r } =
+    pub def foldRightWithCont(f: (a, Unit -> b \ {ef, r}) -> b \ {ef, r}, z: b, arr: Array[a, r]): b \ { ef, r } =
         def loop(i) = {
             if (i == length(arr))
                 z
@@ -831,11 +831,11 @@ mod Array {
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), arr)
 
     ///
-    /// Applies `f` to all elements in `a` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `a` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def reduceLeft(f: (a, a) ->  a \ ef, a: Array[a, r]): Option[a] \ { ef, r } =
+    pub def reduceLeft(f: (a, a) -> a \ ef, a: Array[a, r]): Option[a] \ { ef, r } =
         let len = length(a);
         def loop(i, acc) = {
             if (i >= len)
@@ -849,7 +849,7 @@ mod Array {
             Some(loop(1, get(0, a)))
 
     ///
-    /// Applies `f` to all elements in `arr` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `arr` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// Returns `None` if `arr` is empty.
     ///
@@ -1204,7 +1204,7 @@ mod Array {
     /// Accumulates the result of applying `f` pairwise to the elements of `a` and `b`
     /// starting with the initial value `c` and going from left to right.
     ///
-    pub def foldLeft2(f: (c, a, b) ->  c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, r1, r2 } =
+    pub def foldLeft2(f: (c, a, b) -> c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, r1, r2 } =
         let lena = length(a);
         let lenb = length(b);
         def loop(i, acc) = {

--- a/main/src/library/BPlusTree.flix
+++ b/main/src/library/BPlusTree.flix
@@ -634,7 +634,7 @@ mod BPlusTree {
         ///
         def applyPredicate(v: Vector[k], f: k -> k -> Bool \ r): Bool \ r =
             let zipped = Vector.map(x -> (x, true), v);
-            let reduced =  Vector.reduceLeft(old -> cur ->
+            let reduced = Vector.reduceLeft(old -> cur ->
                 let (oldNum, oldBool) = old;
                 let (curNum, _) = cur;
                 (curNum, oldBool and f(oldNum, curNum))
@@ -802,7 +802,7 @@ mod BPlusTree {
                     case false => 
                         if(n->size == 0) {
                             count
-                        }  else {
+                        } else {
                             loop(count + 1, Array.get(0, n->children))
                         }
                 }
@@ -1401,8 +1401,8 @@ mod BPlusTree {
                     let values = Array.copyOfRange(rc, 0, node->size, node->values);
                     let keys = Array.copyOfRange(rc, 0, node->size, node->keys);
                     let keysStrings = Array.mapWithIndex(rc, i -> key -> "${key}: ${Array.get(i, values)}", keys);
-                    let keysString = Array.join(",\n${indentString}  ", keysStrings);
-                    "${indentString}Leaf(\n${indentString}  ${keysString}\n${indentString})\n"
+                    let keysString = Array.join(",\n${indentString} ", keysStrings);
+                    "${indentString}Leaf(\n${indentString} ${keysString}\n${indentString})\n"
             }
 
         ///

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -275,7 +275,7 @@ mod Chain {
         def loop(cc, acc, k) = match cc {
             case Empty       => k(ViewRight.NoneRight)
             case One(x)      => k(ViewRight.SomeRight(acc, x))
-            case Chain(l, r) => loop(r, append(acc, l),  k)
+            case Chain(l, r) => loop(r, append(acc, l), k)
         };
         loop(c, Empty, identity)
 
@@ -356,7 +356,7 @@ mod Chain {
     ///
     /// Accumulates the result of applying `f` to `c` going left to right.
     ///
-    /// That is, the result is of the form: `s :: f(s, x1) :: f(f(s, x1), x2)  ...`.
+    /// That is, the result is of the form: `s :: f(s, x1) :: f(f(s, x1), x2) ...`.
     ///
     pub def scanLeft(f: (b, a) -> b \ ef, s: b, c: Chain[a]): Chain[b] \ ef =
         def loop(a, cc, acc) = match viewLeft(cc) {

--- a/main/src/library/Char.flix
+++ b/main/src/library/Char.flix
@@ -27,7 +27,7 @@ mod Char {
     import java.lang.Character
 
     ///
-    ///  Returns `true` if the given char `c` is an ascii character.
+    /// Returns `true` if the given char `c` is an ascii character.
     ///
     pub def isAscii(c: Char): Bool =
         c <= '\u0080'

--- a/main/src/library/CodePoint.flix
+++ b/main/src/library/CodePoint.flix
@@ -38,10 +38,10 @@ mod CodePoint {
     pub def maxValue(): Int32 = unsafe Character.MAX_CODE_POINT
 
     ///
-    ///  Returns `true` if the given char `c` is an ascii character.
+    /// Returns `true` if the given char `c` is an ascii character.
     ///
     pub def isAscii(cp: Int32): Bool =
-        0x0000 <= cp  and cp <= 0x0080
+        0x0000 <= cp and cp <= 0x0080
 
     ///
     /// Returns `true` if the given code point `cp` represents a letter character.

--- a/main/src/library/Collectable.flix
+++ b/main/src/library/Collectable.flix
@@ -31,6 +31,6 @@ pub trait Collectable[t: Type] {
     ///
     /// Run an Iterator collecting the results.
     ///
-    pub def collect(iter: Iterator[Collectable.Elm[t], ef, r]): t \ (ef + Collectable.Aef[t] +  r)
+    pub def collect(iter: Iterator[Collectable.Elm[t], ef, r]): t \ (ef + Collectable.Aef[t] + r)
 
 }

--- a/main/src/library/Debug.flix
+++ b/main/src/library/Debug.flix
@@ -45,7 +45,7 @@ mod Debug {
     pub def stringify(x: a): String = {
         typematch x {
             case _: Unit => "()"
-            case b: Bool =>  if (b) "true" else "false"
+            case b: Bool => if (b) "true" else "false"
             case c: Char => "\'" + escape("${(c: Char)}") + "\'"
             case y: Float32 =>
                 Float.toString(y) + "f32"

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -55,7 +55,7 @@ instance Order[DelayList[a]] with Order[a] {
             if (cmp == Comparison.EqualTo) xs <=> (force ys) else cmp
         case (DelayList.LCons(x, xs), DelayList.ECons(y, ys)) =>
             let cmp = x <=> y;
-            if (cmp == Comparison.EqualTo) (force xs) <=> ys  else cmp
+            if (cmp == Comparison.EqualTo) (force xs) <=> ys else cmp
         case (DelayList.LCons(x, xs), DelayList.LCons(y, ys)) =>
             let cmp = x <=> y;
             if (cmp == Comparison.EqualTo) (force xs) <=> (force ys) else cmp
@@ -670,7 +670,7 @@ mod DelayList {
     }
 
     ///
-    /// Applies `f` to all elements in `l` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `l` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(x1, x2), x3)..., xn))`
     ///
@@ -687,7 +687,7 @@ mod DelayList {
     }
 
     ///
-    /// Applies `f` to all elements in `l` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `l` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(x1, ...f(xn-2, f(xn-1, xn))...))`
     ///

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -627,7 +627,7 @@ mod DelayMap {
         RedBlackTree.foldRightWithCont(f1, s, t)
 
     ///
-    /// Applies `f` to all values in `m` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all values in `m` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(v1, v2), v3)..., vn))`
     ///
@@ -638,7 +638,7 @@ mod DelayMap {
         reduceLeftWithKey((k, v1, _, v2) -> (k, f(v1, v2)), m) |> Option.map(snd)
 
     ///
-    /// Applies `f` to all mappings in `m` going from left to right until a single mapping `(k, v)` is obtained.  Returns `Some((k, v))`.
+    /// Applies `f` to all mappings in `m` going from left to right until a single mapping `(k, v)` is obtained. Returns `Some((k, v))`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(k1, v1, k2, v2), k3, v3)..., kn, vn))`
     ///
@@ -658,7 +658,7 @@ mod DelayMap {
         }
 
     ///
-    /// Applies `f` to all values in `m` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all values in `m` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(v1, ...f(vn-2, f(vn-1, vn))...))`
     ///
@@ -669,7 +669,7 @@ mod DelayMap {
         reduceRightWithKey((k, v1, _, v2) -> (k, f(v1, v2)), m) |> Option.map(snd)
 
     ///
-    /// Applies `f` to all mappings in `m` going from right to left until a single mapping `(k, v)` is obtained.  Returns `Some((k, v))`.
+    /// Applies `f` to all mappings in `m` going from right to left until a single mapping `(k, v)` is obtained. Returns `Some((k, v))`.
     ///
     /// That is, the result is of the form: `Some(f(k1, v1, ...f(kn-2, vn-2, f(kn-1, vn-1, kn, vn))...))`
     ///

--- a/main/src/library/Environment.flix
+++ b/main/src/library/Environment.flix
@@ -41,17 +41,17 @@ eff Environment {
     def getOsName(): Option[String]
 
     ///
-    ///  Returns the operating system architecture
+    /// Returns the operating system architecture
     ///
     def getOsArch(): Option[String]
 
     ///
-    ///  Returns the operating system version
+    /// Returns the operating system version
     ///
     def getOsVersion(): Option[String]
 
     ///
-    ///  Returns the file separator
+    /// Returns the file separator
     ///
     def getFileSeparator(): String
 

--- a/main/src/library/Exit.flix
+++ b/main/src/library/Exit.flix
@@ -51,6 +51,6 @@ mod Exit {
     ///
     /// Note: This function can still return normally if `exit` is never called by `f`.
     ///
-    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Exit) + {Sys, IO}  = handle(f)()
+    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Exit) + {Sys, IO} = handle(f)()
 
 }

--- a/main/src/library/GetOpt.flix
+++ b/main/src/library/GetOpt.flix
@@ -217,8 +217,8 @@ mod GetOpt {
     /// "--" has been parsed
     /// `xstr` is the rest of the current token
     def longOpt(xstr: String, optDescrs: List[OptionDescr[a]], tokens: List[String]): (OptionKind[a], List[String]) =
-        let (optname, arg)  = String.breakOnLeft({substr = "="}, xstr);
-        let optStr      = "--${optname}";
+        let (optname, arg) = String.breakOnLeft({substr = "="}, xstr);
+        let optStr         = "--${optname}";
         match findOptionByName(optname, optDescrs) {
             case Ok(opt) => match (opt#argDescriptor, deconsLeft(arg), tokens) {
                 case (ArgDescr.NoArg(a),     None,               rest)          => (OptionKind.Opt(a), rest)
@@ -251,9 +251,9 @@ mod GetOpt {
     /// `xstr` is the rest of the current token
     /// Never see "=" for a short arg
     def shortOpt(xc: Char, xstr: String, optDescrs: List[OptionDescr[a]], tokens: List[String]): (OptionKind[a], List[String]) =
-        let optStr  = "-${xc}";
+        let optStr = "-${xc}";
         match findOptionById(xc, optDescrs) {
-            case Ok(opt) => match (opt#argDescriptor, xstr, tokens)  {
+            case Ok(opt) => match (opt#argDescriptor, xstr, tokens) {
                 case (ArgDescr.NoArg(a), "", rest)           => (OptionKind.Opt(a), rest)
                 case (ArgDescr.NoArg(a), str, rest)          => (OptionKind.Opt(a), "-${str}" :: rest)
                 case (ArgDescr.ReqArg(_, d), "", Nil)        => (errReq(d, optStr), Nil)
@@ -408,8 +408,8 @@ mod GetOpt {
     def groupWhenQuotedHelperInner(quoteOpen: String, quoteClose: String, tokens: List[String], acc: String, k: List[String] -> List[String] \ ef): List[String] \ ef =
         match tokens {
             case Nil => k(acc :: Nil)
-            case x :: rest if String.contains({substr = quoteClose}, x) => groupWhenQuotedHelper(quoteOpen, quoteClose, rest, ks -> k((acc + " " +  x) :: ks))
-            case x :: rest => groupWhenQuotedHelperInner(quoteOpen, quoteClose, rest, (acc + " " +  x), k)
+            case x :: rest if String.contains({substr = quoteClose}, x) => groupWhenQuotedHelper(quoteOpen, quoteClose, rest, ks -> k((acc + " " + x) :: ks))
+            case x :: rest => groupWhenQuotedHelperInner(quoteOpen, quoteClose, rest, (acc + " " + x), k)
         }
 
     ///

--- a/main/src/library/Http.flix
+++ b/main/src/library/Http.flix
@@ -142,7 +142,7 @@ mod Http {
                     }))
                 } catch {
                     case ex: IllegalArgumentException => Err(IoError(ErrorKind.InvalidInput, ex.getMessage()))
-                    case ex: ConnectException          => Err(IoError(ErrorKind.ConnectionFailed, ex.getMessage()))
+                    case ex: ConnectException         => Err(IoError(ErrorKind.ConnectionFailed, ex.getMessage()))
                     case ex: InterruptedException     => Err(IoError(ErrorKind.Interrupted, ex.getMessage()))
                     case ex: UncheckedIOException     => Err(IoError(ErrorKind.Other, ex.getMessage()))
                     case ex: IOException              => Err(IoError(ErrorKind.Other, ex.getMessage()))

--- a/main/src/library/Identity.flix
+++ b/main/src/library/Identity.flix
@@ -107,21 +107,21 @@ instance Add[Identity[a]] with Add[a] {
         Identity.Identity(Add.add(x1, y1))
 }
 
-instance Sub[Identity[a]] with Sub[a]  {
+instance Sub[Identity[a]] with Sub[a] {
     pub def sub(x: Identity[a], y: Identity[a]): Identity[a] =
         let Identity.Identity(x1) = x;
         let Identity.Identity(y1) = y;
         Identity.Identity(Sub.sub(x1, y1))
 }
 
-instance Mul[Identity[a]] with Mul[a]  {
+instance Mul[Identity[a]] with Mul[a] {
     pub def mul(x: Identity[a], y: Identity[a]): Identity[a] =
         let Identity.Identity(x1) = x;
         let Identity.Identity(y1) = y;
         Identity.Identity(Mul.mul(x1, y1))
 }
 
-instance Div[Identity[a]] with Div[a]  {
+instance Div[Identity[a]] with Div[a] {
     pub def div(x: Identity[a], y: Identity[a]): Identity[a] =
         let Identity.Identity(x1) = x;
         let Identity.Identity(y1) = y;

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -91,8 +91,8 @@ mod Int16 {
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
     pub def dist(x: Int16, y: Int16): Int16 = {
-        if      (x >= 0i16 and y >= 0i16)                abs(x - y)
-        else if (x < 0i16 and y < 0i16)                  abs(x - y)
+        if      (x >= 0i16 and y >= 0i16)               abs(x - y)
+        else if (x < 0i16 and y < 0i16)                 abs(x - y)
         else if (x == minValue() or y == minValue())    -1i16
         else if (minValue() + abs(x) + abs(y) >= 0i16)  -1i16
         else                                            abs(x - y)

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -91,8 +91,8 @@ mod Int32 {
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
     pub def dist(x: Int32, y: Int32): Int32 = {
-        if      (x >= 0 and y >= 0)                      abs(x - y)
-        else if (x < 0 and y < 0)                        abs(x - y)
+        if      (x >= 0 and y >= 0)                     abs(x - y)
+        else if (x < 0 and y < 0)                       abs(x - y)
         else if (x == minValue() or y == minValue())    -1
         else if (minValue() + abs(x) + abs(y) >= 0)     -1
         else                                            abs(x - y)

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -91,8 +91,8 @@ mod Int64 {
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
     pub def dist(x: Int64, y: Int64): Int64 = {
-        if (x >= 0i64 and y >= 0i64)                     abs(x - y)
-        else if (x < 0i64 and y < 0i64)                  abs(x - y)
+        if (x >= 0i64 and y >= 0i64)                    abs(x - y)
+        else if (x < 0i64 and y < 0i64)                 abs(x - y)
         else if (x == minValue() or y == minValue())    -1i64
         else if (minValue() + abs(x) + abs(y) >= 0i64)  -1i64
         else                                            abs(x - y)

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -91,8 +91,8 @@ mod Int8 {
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
     pub def dist(x: Int8, y: Int8): Int8 = {
-        if      (x >= 0i8 and y >= 0i8)                  abs(x - y)
-        else if (x < 0i8 and y < 0i8)                    abs(x - y)
+        if      (x >= 0i8 and y >= 0i8)                 abs(x - y)
+        else if (x < 0i8 and y < 0i8)                   abs(x - y)
         else if (x == minValue() or y == minValue())    -1i8
         else if (minValue() + abs(x) + abs(y) >= 0i8)   -1i8
         else                                            abs(x - y)

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -53,7 +53,7 @@ mod Iterator {
     /// Returns an empty iterator.
     ///
     pub def empty(rc: Region[r]): Iterator[a, r, r] =
-        let f = _ ->  checked_ecast(Done);
+        let f = _ -> checked_ecast(Done);
         Iterator(rc, f)
 
     ///
@@ -462,7 +462,7 @@ mod Iterator {
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), iter)
 
     ///
-    /// Applies `f` to all elements in `iter` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `iter` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(x1, x2), x3)..., xn))`
     ///
@@ -745,7 +745,7 @@ mod Iterator {
     pub def cons(x: a, iter: Iterator[a, ef, r]): Iterator[a, ef, r] \ r =
         let Iterator(rc, iterF) = iter;
         let first = Ref.fresh(rc, true);
-        let f = () ->  {
+        let f = () -> {
             if (Ref.get(first)) {
                 Ref.put(false, first);
                 Ans(x)

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -320,7 +320,7 @@ mod List {
     ///
     /// Accumulates the result of applying `f` to `l` going left to right.
     ///
-    /// That is, the result is of the form: `s :: f(s, x1) :: f(f(s, x1), x2)  ...`.
+    /// That is, the result is of the form: `s :: f(s, x1) :: f(f(s, x1), x2) ...`.
     ///
     pub def scanLeft(f: (b, a) -> b \ ef, s: b, l: List[a]): List[b] \ ef =
         def loop(ll, k, acc) = match ll {
@@ -679,7 +679,7 @@ mod List {
     }
 
     ///
-    /// Applies `f` to all elements in `l` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `l` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(x1, x2), x3)..., xn))`
     ///
@@ -691,7 +691,7 @@ mod List {
     }
 
     ///
-    /// Applies `f` to all elements in `l` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `l` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(x1, ...f(xn-2, f(xn-1, xn))...))`
     ///
@@ -1245,7 +1245,7 @@ mod List {
     ///
     pub def unfold(f: s -> Option[(a, s)] \ ef, st: s): List[a] \ ef =
         def loop(sst, k) = match f(sst) {
-            case None         => k(Nil)
+            case None           => k(Nil)
             case Some((a, st1)) => loop(st1, ks -> k(a :: ks))
         };
         loop(st, identity)
@@ -1269,7 +1269,7 @@ mod List {
     /// Build a list by applying the function `next` to `()`. `next` is expected to encapsulate
     /// a stateful resource such as a file handle that can be iterated.
     ///
-    /// `next` should return `Ok(Some(a)` to signal a new list element `Ok(a)`.
+    /// `next` should return `Ok(Some(a))` to signal a new list element `Ok(a)`.
     ///
     /// `next` should return `Ok(None)` to signal the end of building the list.
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -546,7 +546,7 @@ mod Map {
         foldMapWithKey(_ -> f, m)
 
     ///
-    /// Applies `f` to all values in `m` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all values in `m` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(v1, v2), v3)..., vn))`
     ///
@@ -556,7 +556,7 @@ mod Map {
         reduceLeftWithKey((k, v1, _, v2) -> (k, f(v1, v2)), m) |> Option.map(snd)
 
     ///
-    /// Applies `f` to all mappings in `m` going from left to right until a single mapping `(k, v)` is obtained.  Returns `Some((k, v))`.
+    /// Applies `f` to all mappings in `m` going from left to right until a single mapping `(k, v)` is obtained. Returns `Some((k, v))`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(k1, v1, k2, v2), k3, v3)..., kn, vn))`
     ///
@@ -567,7 +567,7 @@ mod Map {
         RedBlackTree.reduceLeft(f, t)
 
     ///
-    /// Applies `f` to all values in `m` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all values in `m` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(v1, ...f(vn-2, f(vn-1, vn))...))`
     ///
@@ -577,7 +577,7 @@ mod Map {
         reduceRightWithKey((k, v1, _, v2) -> (k, f(v1, v2)), m) |> Option.map(snd)
 
     ///
-    /// Applies `f` to all mappings in `m` going from right to left until a single mapping `(k, v)` is obtained.  Returns `Some((k, v))`.
+    /// Applies `f` to all mappings in `m` going from right to left until a single mapping `(k, v)` is obtained. Returns `Some((k, v))`.
     ///
     /// That is, the result is of the form: `Some(f(k1, v1, ...f(kn-2, vn-2, f(kn-1, vn-1, kn, vn))...))`
     ///
@@ -872,7 +872,7 @@ mod Map {
     ///
     pub def unfoldWithIter(next: Unit -> Option[(k, v)] \ ef): Map[k, v] \ ef with Order[k] =
         def loop(m) = match next() {
-            case None       => m
+            case None         => m
             case Some((k, v)) => loop(insert(k, v, m))
         };
         loop(empty())

--- a/main/src/library/MultiMap.flix
+++ b/main/src/library/MultiMap.flix
@@ -213,7 +213,7 @@ mod MultiMap {
         MultiMap(Map.remove(k, m1))
 
     ///
-    /// Removes the mapping of `(k, v)`  from the MultiMap `m` it it exists.
+    /// Removes the mapping of `(k, v)` from the MultiMap `m` it it exists.
     ///
     pub def removeWithValue(k: k, v: v, m: MultiMap[k, v]): MultiMap[k, v] with Order[k], Order[v] =
         let MultiMap(m1) = m;
@@ -358,7 +358,7 @@ mod MultiMap {
         foldMapWithKey(_ -> f, m)
 
     ///
-    /// Applies `f` to all values in `m` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all values in `m` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(v1, v2), v3)..., vn))`
     ///
@@ -368,7 +368,7 @@ mod MultiMap {
         reduceLeftWithKey((k, v1, _, v2) -> (k, f(v1, v2)), m) |> Option.map(snd)
 
     ///
-    /// Applies `f` to all mappings in `m` going from left to right until a single mapping `(k, v)` is obtained.  Returns `Some((k, v))`.
+    /// Applies `f` to all mappings in `m` going from left to right until a single mapping `(k, v)` is obtained. Returns `Some((k, v))`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(k1, v1, k2, v2), k3, v3)..., kn, vn))`
     ///
@@ -384,7 +384,7 @@ mod MultiMap {
         Map.foldLeftWithKey(outer, None, m1)
 
     ///
-    /// Applies `f` to all values in `m` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all values in `m` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(v1, ...f(vn-2, f(vn-1, vn))...))`
     ///
@@ -394,7 +394,7 @@ mod MultiMap {
         reduceRightWithKey((k, v1, _, v2) -> (k, f(v1, v2)), m) |> Option.map(snd)
 
     ///
-    /// Applies `f` to all mappings in `m` going from right to left until a single mapping `(k, v)` is obtained.  Returns `Some((k, v))`.
+    /// Applies `f` to all mappings in `m` going from right to left until a single mapping `(k, v)` is obtained. Returns `Some((k, v))`.
     ///
     /// That is, the result is of the form: `Some(f(k1, v1, ...f(kn-2, vn-2, f(kn-1, vn-1, kn, vn))...))`
     ///

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -356,7 +356,7 @@ mod MutDeque {
         let j = d->back;
         if (i == j)
             Array#{} @ rc1
-        else if (i  < j)
+        else if (i < j)
             Array.copyOfRange(rc1, i, j, d->values)
         else
             Array.append(rc1, Array.copyOfRange(rc1, i, len, d->values), Array.copyOfRange(rc1, 0, j, d->values))

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -752,7 +752,7 @@ mod MutList {
     ///
     /// Returns `v` as a MutDeque.
     ///
-    pub def toMutDeque(rc1: Region[r1], v: MutList[a, r2]): MutDeque[a, r1] \ { r2, r1 }  =
+    pub def toMutDeque(rc1: Region[r1], v: MutList[a, r2]): MutDeque[a, r1] \ { r2, r1 } =
         let d = MutDeque.empty(rc1);
         forEach(x -> MutDeque.pushBack(x, d), v);
         d

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -384,7 +384,7 @@ mod MutMap {
     ///
     /// Alias for `foldLeftWithKey`.
     ///
-    pub def foldWithKey(f: (b, k, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, r }  =
+    pub def foldWithKey(f: (b, k, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, r } =
         foldLeftWithKey(f, i, m)
 
     ///

--- a/main/src/library/MutPriorityQueue.flix
+++ b/main/src/library/MutPriorityQueue.flix
@@ -166,7 +166,7 @@ mod MutPriorityQueue {
     def heapifyUp(idx: Int32, mq: MutPriorityQueue[a, r]): Unit \ r with Order[a] =
         if (idx != 0) {
             let parentIdx = (idx - 1) / 2;
-            let cur  = Array.get(idx, mq->values);
+            let cur = Array.get(idx, mq->values);
             let parent = Array.get(parentIdx, mq->values);
             if (cur > parent) {
                 Array.put(parent, idx, mq->values);
@@ -221,7 +221,7 @@ mod MutPriorityQueue {
         let oldCapacity = Array.length(mq->values);
         if (oldCapacity == mq->size) {
             let newCapacity = 2 + (oldCapacity * 2);
-            let newArr  = Array.empty(mq->r, newCapacity);
+            let newArr = Array.empty(mq->r, newCapacity);
             Array.forEachWithIndex((idx, x) -> Array.put(x, idx, newArr), mq->values);
             mq->values = newArr
         }

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -270,7 +270,7 @@ mod MutSet {
         Set.reduceLeft(f, Ref.get(ms))
 
     ///
-    /// Applies `f` to all elements in the mutable set `s` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in the mutable set `s` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(x1, ...f(xn-2, f(xn-1, xn))...))`
     ///

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -258,7 +258,7 @@ mod Nec {
             case (NecOne(x), None)      => k(ViewLeft.OneLeft(x))
             case (NecOne(x), Some(rs1)) => k(ViewLeft.SomeLeft(x, rs1))
             case (Nec(l, r), None)      => loop(l, Some(r),  k)
-            case (Nec(l, r), Some(rs1)) => loop(l, Some(append(r, rs1)),  k)
+            case (Nec(l, r), Some(rs1)) => loop(l, Some(append(r, rs1)), k)
         };
         loop(c, None, x -> x)
 
@@ -275,8 +275,8 @@ mod Nec {
         def loop(c1: Nec[a], rs: Option[Nec[a]], k: ViewRight[a] -> ViewRight[a]) = match (c1, rs) {
             case (NecOne(x), None)      => k(ViewRight.OneRight(x))
             case (NecOne(x), Some(rs1)) => k(ViewRight.SomeRight(rs1, x))
-            case (Nec(l, r), None)      => loop(r, Some(l),  k)
-            case (Nec(l, r), Some(rs1)) => loop(r, Some(append(rs1, l)),  k)
+            case (Nec(l, r), None)      => loop(r, Some(l), k)
+            case (Nec(l, r), Some(rs1)) => loop(r, Some(append(rs1, l)), k)
         };
         loop(c, None, x -> x)
 
@@ -751,7 +751,7 @@ mod Nec {
     ///
     /// Returns `c` as a MutDeque.
     ///
-    pub def toMutDeque(rc: Region[r], c: Nec[a]): MutDeque[a, r] \ r  =
+    pub def toMutDeque(rc: Region[r], c: Nec[a]): MutDeque[a, r] \ r =
         let d = MutDeque.empty(rc);
         forEach(x -> MutDeque.pushBack(x, d), c);
         d

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -165,7 +165,7 @@ mod Nel {
     ///
     pub def init(l: Nel[a]): List[a] = match l {
         case Nel(_, Nil) => Nil
-        case Nel(x, xs)   => match List.reverse(xs) {
+        case Nel(x, xs)  => match List.reverse(xs) {
             case Nil     => x :: Nil
             case _ :: ys => x :: List.reverse(ys)
         }

--- a/main/src/library/PingWithResult.flix
+++ b/main/src/library/PingWithResult.flix
@@ -58,7 +58,7 @@ mod PingWithResult {
     ///
     /// In other words, re-interprets the `PingWithResult` effect using the `IO` effect.
     ///
-    pub def runWithIO(f: Unit -> a \ ef):  a \ ef - PingWithResult + {Net, IO} = handle(f)()
+    pub def runWithIO(f: Unit -> a \ ef): a \ ef - PingWithResult + {Net, IO} = handle(f)()
 
 }
 

--- a/main/src/library/Process.flix
+++ b/main/src/library/Process.flix
@@ -33,7 +33,7 @@ eff Process {
     def exitValue(ph: ProcessHandle): Option[Int32]
 
     ///
-    ///  Returns status of the process, if it alive or not.
+    /// Returns status of the process, if it alive or not.
     ///
     def isAlive(ph: ProcessHandle): Bool
 

--- a/main/src/library/ProcessWithResult.flix
+++ b/main/src/library/ProcessWithResult.flix
@@ -30,7 +30,7 @@ eff ProcessWithResult {
     def exitValue(ph: ProcessHandle): Result[IoError, Int32]
 
     ///
-    ///  Returns status of the process, if it alive or not.
+    /// Returns status of the process, if it alive or not.
     ///
     def isAlive(ph: ProcessHandle): Result[IoError, Bool]
 

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -113,7 +113,7 @@ pub trait Reducible[t: Type -> Type] {
     /// Returns the tail of `t` as a list.
     ///
     pub def tail(t: t[a]): List[a] =
-        Reducible.reduceLeftTo((k, a) -> ks -> k(a :: ks),  _ -> identity, t)(Nil) // NB: Builds a continuation function without the first
+        Reducible.reduceLeftTo((k, a) -> ks -> k(a :: ks), _ -> identity, t)(Nil) // NB: Builds a continuation function without the first
                                                                                    // element that is immediately invoked to avoid `foldRight`.
     ///
     /// Returns the reverse of `t` as a list.

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -328,7 +328,7 @@ mod Set {
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), s)
 
     ///
-    /// Applies `f` to all elements in `s` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `s` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     /// That is, the result is of the form: `Some(f(...f(f(x1, x2), x3)..., xn))`
     /// Returns `None` if `s` is the empty set.
     ///
@@ -337,7 +337,7 @@ mod Set {
         RedBlackTree.reduceLeft((x, _, y, _) -> (f(x, y), ()), t) |> Option.map(fst)
 
     ///
-    /// Applies `f` to all elements in `s` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `s` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
     /// That is, the result is of the form: `Some(f(x1, ...f(xn-2, f(xn-1, xn))...))`
     /// Returns `None` if `s` is the empty set.
     ///
@@ -578,7 +578,7 @@ mod Set {
     ///
     pub def unfold(f: s -> Option[(a, s)] \ ef, st: s): Set[a] \ ef with Order[a] =
         def loop(sst, s) = match f(sst) {
-            case None         => s
+            case None           => s
             case Some((a, st1)) => loop(st1, insert(a, s))
         };
         loop(st, empty())

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -631,7 +631,7 @@ mod String {
         def loop(a) = {
             let a1 = f(a);
             match a1 {
-                case None         => StringBuilder.toString(sb)
+                case None           => StringBuilder.toString(sb)
                 case Some((c, st1)) => {
                     StringBuilder.append(c, sb);
                     loop(st1)
@@ -673,7 +673,7 @@ mod String {
         def loop(a) = {
             let a1 = f(a);
             match a1 {
-                case None         => StringBuilder.toString(sb)
+                case None             => StringBuilder.toString(sb)
                 case Some(((s, st1))) => {
                     StringBuilder.appendString(s, sb);
                     loop(st1)
@@ -1131,7 +1131,7 @@ mod String {
     /// Helper function for `levenshteinDistance`.
     ///
     def arraySwap(a: Array[Int32, r1], b : Array[Int32, r2]): Unit \ { r2, r1 } =
-        forIndex(0, Array.length(a) - 1, {i ->  Array.put(Array.get(i, b), i, a) })
+        forIndex(0, Array.length(a) - 1, {i -> Array.put(Array.get(i, b), i, a) })
 
     ///
     /// Returns an array where the element at index `i` is `(x, y)` where
@@ -1247,7 +1247,7 @@ mod String {
         let sublen = length(substr#substr);
         match indexOfRight({substr = substr#substr}, s) {
             case None    => (s, "")
-            case Some(i) => (sliceLeft(end  = i + sublen, s), sliceRight(start = i + sublen, s))
+            case Some(i) => (sliceLeft(end = i + sublen, s), sliceRight(start = i + sublen, s))
         }
 
     ///
@@ -1334,7 +1334,7 @@ mod String {
     pub def wrap(w: Int32, s: String): String =
         if (w <= 0) ""
         else {
-            let lines = List.flatMap(l -> wrapLine(w, l),  lines(s));
+            let lines = List.flatMap(l -> wrapLine(w, l), lines(s));
             intercalate(lineSeparator(), lines)
         }
 

--- a/main/src/library/TcpBindWithResult.flix
+++ b/main/src/library/TcpBindWithResult.flix
@@ -58,6 +58,6 @@ mod TcpBindWithResult {
     ///
     /// In other words, re-interprets the `TcpBindWithResult` effect using the `Net` and `IO` effects.
     ///
-    pub def runWithIO(f: Unit -> a \ ef):  a \ ef - TcpBindWithResult + {Net, IO} = handle(f)()
+    pub def runWithIO(f: Unit -> a \ ef): a \ ef - TcpBindWithResult + {Net, IO} = handle(f)()
 
 }

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -169,7 +169,7 @@ mod Vector {
     /// Version of `Array.updateSequence` where sub is a vector rather than an array,
     /// so a extra copy of `sub` is avoided.
     ///
-    def arrayUpdateSeqV(i: Int32, sub: Vector[a], arr: Array[a, r]): Unit \ r  =
+    def arrayUpdateSeqV(i: Int32, sub: Vector[a], arr: Array[a, r]): Unit \ r =
         let end = Array.length(arr);
         let subLen = length(sub);
         def loop(ri, wi) = {
@@ -295,7 +295,7 @@ mod Vector {
     ///
     /// Returns `v` as a MutDeque.
     ///
-    pub def toMutDeque(rc: Region[r], v: Vector[a]): MutDeque[a, r] \ r   =
+    pub def toMutDeque(rc: Region[r], v: Vector[a]): MutDeque[a, r] \ r =
         let d = MutDeque.empty(rc);
         forEach(x -> MutDeque.pushBack(x, d), v);
         d
@@ -459,7 +459,7 @@ mod Vector {
     ///
     /// Accumulates the result of applying `f` to `v` going left to right.
     ///
-    /// That is, the result is of the form: `[s , f(s, x1), f(f(s, x1), x2),  ...]`.
+    /// That is, the result is of the form: `[s , f(s, x1), f(f(s, x1), x2), ...]`.
     ///
     pub def scanLeft(f: (b, a) -> b \ ef, s: b, v: Vector[a]): Vector[b] \ ef = region rc {
         let arr = Array.empty(rc, length(v) + 1);
@@ -676,9 +676,9 @@ mod Vector {
         let len1 = length(v);
         let len2 = len1 + len1 - 1;
         let f = ix -> match ix {
-            case 0                         => get(0, v)
+            case 0                               => get(0, v)
             case n if Int32.remainder(n, 2) != 0 => sep
-            case n                         => {let i = n / 2; get(i, v)}
+            case n                               => {let i = n / 2; get(i, v)}
         };
         init(f, len2)
 
@@ -881,11 +881,11 @@ mod Vector {
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), v)
 
     ///
-    /// Applies `f` to all elements in `v` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `v` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// Returns `None` if `v` is empty.
     ///
-    pub def reduceLeft(f: (a, a) ->  a \ ef, v: Vector[a]): Option[a] \ ef =
+    pub def reduceLeft(f: (a, a) -> a \ ef, v: Vector[a]): Option[a] \ ef =
         let len = length(v);
         def loop(i, acc) = {
             if (i >= len)
@@ -899,7 +899,7 @@ mod Vector {
             Some(loop(1, get(0, v)))
 
     ///
-    /// Applies `f` to all elements in `v` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
+    /// Applies `f` to all elements in `v` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// Returns `None` if `v` is empty.
     ///
@@ -1242,7 +1242,7 @@ mod Vector {
     /// Accumulates the result of applying `f` pairwise to the elements of `a` and `b`
     /// starting with the initial value `c` and going from left to right.
     ///
-    pub def foldLeft2(f: (c, a, b) ->  c \ ef, c: c, a: Vector[a], b: Vector[b]): c \ ef =
+    pub def foldLeft2(f: (c, a, b) -> c \ ef, c: c, a: Vector[a], b: Vector[b]): c \ ef =
         let lena = length(a);
         let lenb = length(b);
         def loop(i, acc) = {


### PR DESCRIPTION
This is mostly just removing double spacing where it is not used for typesetting.