### PR TITLE
chore: improve performance of tuple comparison

### DIFF
--- a/main/src/library/Order.flix
+++ b/main/src/library/Order.flix
@@ -374,11 +374,12 @@ instance Order[(a1, a2)] with Order[a1], Order[a2] {
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2), t2: (a1, a2)): Comparison =
-        use Order.thenCompare;
         let (x1, x2) = t1;
         let (y1, y2) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => x2 <=> y2
+            case res => res
+        }
 
 }
 
@@ -388,12 +389,15 @@ instance Order[(a1, a2, a3)] with Order[a1], Order[a2], Order[a3] {
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3), t2: (a1, a2, a3)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3) = t1;
         let (y1, y2, y3) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => x3 <=> y3
+                case res => res
+            }
+            case res => res
+        }
 
 }
 
@@ -403,13 +407,18 @@ instance Order[(a1, a2, a3, a4)] with Order[a1], Order[a2], Order[a3], Order[a4]
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4), t2: (a1, a2, a3, a4)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4) = t1;
         let (y1, y2, y3, y4) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => x4 <=> y4
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
 
 }
 
@@ -419,14 +428,21 @@ instance Order[(a1, a2, a3, a4, a5)] with Order[a1], Order[a2], Order[a3], Order
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5), t2: (a1, a2, a3, a4, a5)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5) = t1;
         let (y1, y2, y3, y4, y5) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => x5 <=> y5
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
 
 }
 
@@ -436,15 +452,24 @@ instance Order[(a1, a2, a3, a4, a5, a6)] with Order[a1], Order[a2], Order[a3], O
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6), t2: (a1, a2, a3, a4, a5, a6)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6) = t1;
         let (y1, y2, y3, y4, y5, y6) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => x6 <=> y6
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
 
 }
 
@@ -454,16 +479,27 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7)] with Order[a1], Order[a2], Order[a3
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7), t2: (a1, a2, a3, a4, a5, a6, a7)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6, x7) = t1;
         let (y1, y2, y3, y4, y5, y6, y7) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6) `thenCompare`
-        lazy (x7 <=> y7)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => match x6 <=> y6 {
+                                case Comparison.EqualTo => x7 <=> y7
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
 
 }
 
@@ -473,17 +509,30 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8)] with Order[a1], Order[a2], Orde
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8), t2: (a1, a2, a3, a4, a5, a6, a7, a8)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6, x7, x8) = t1;
         let (y1, y2, y3, y4, y5, y6, y7, y8) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6) `thenCompare`
-        lazy (x7 <=> y7) `thenCompare`
-        lazy (x8 <=> y8)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => match x6 <=> y6 {
+                                case Comparison.EqualTo => match x7 <=> y7 {
+                                    case Comparison.EqualTo => x8 <=> y8
+                                    case res => res
+                                }
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
 
 }
 
@@ -493,18 +542,33 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with Order[a1], Order[a2], 
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6, x7, x8, x9) = t1;
         let (y1, y2, y3, y4, y5, y6, y7, y8, y9) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6) `thenCompare`
-        lazy (x7 <=> y7) `thenCompare`
-        lazy (x8 <=> y8) `thenCompare`
-        lazy (x9 <=> y9)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => match x6 <=> y6 {
+                                case Comparison.EqualTo => match x7 <=> y7 {
+                                    case Comparison.EqualTo => match x8 <=> y8 {
+                                        case Comparison.EqualTo => x9 <=> y9
+                                        case res => res
+                                    }
+                                    case res => res
+                                }
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
 
 }
 
@@ -514,19 +578,36 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Order[a1], Order[
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) = t1;
         let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6) `thenCompare`
-        lazy (x7 <=> y7) `thenCompare`
-        lazy (x8 <=> y8) `thenCompare`
-        lazy (x9 <=> y9) `thenCompare`
-        lazy (x10 <=> y10)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => match x6 <=> y6 {
+                                case Comparison.EqualTo => match x7 <=> y7 {
+                                    case Comparison.EqualTo => match x8 <=> y8 {
+                                        case Comparison.EqualTo => match x9 <=> y9 {
+                                            case Comparison.EqualTo => x10 <=> y10
+                                            case res => res
+                                        }
+                                        case res => res
+                                    }
+                                    case res => res
+                                }
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
 
 }
 
@@ -536,20 +617,40 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)] with Order[a1], O
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) = t1;
         let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6) `thenCompare`
-        lazy (x7 <=> y7) `thenCompare`
-        lazy (x8 <=> y8) `thenCompare`
-        lazy (x9 <=> y9) `thenCompare`
-        lazy (x10 <=> y10) `thenCompare`
-        lazy (x11 <=> y11)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => match x6 <=> y6 {
+                                case Comparison.EqualTo => match x7 <=> y7 {
+                                    case Comparison.EqualTo => match x8 <=> y8 {
+                                        case Comparison.EqualTo => match x9 <=> y9 {
+                                            case Comparison.EqualTo => match x10 <=> y10 {
+                                                case Comparison.EqualTo => x11 <=> y11
+                                                case res => res
+                                            }
+                                            case res => res
+                                        }
+                                        case res => res
+                                    }
+                                    case res => res
+                                }
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
+
 }
 
 instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12] {
@@ -558,21 +659,43 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with Order[a
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) = t1;
         let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6) `thenCompare`
-        lazy (x7 <=> y7) `thenCompare`
-        lazy (x8 <=> y8) `thenCompare`
-        lazy (x9 <=> y9) `thenCompare`
-        lazy (x10 <=> y10) `thenCompare`
-        lazy (x11 <=> y11) `thenCompare`
-        lazy (x12 <=> y12)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => match x6 <=> y6 {
+                                case Comparison.EqualTo => match x7 <=> y7 {
+                                    case Comparison.EqualTo => match x8 <=> y8 {
+                                        case Comparison.EqualTo => match x9 <=> y9 {
+                                            case Comparison.EqualTo => match x10 <=> y10 {
+                                                case Comparison.EqualTo => match x11 <=> y11 {
+                                                    case Comparison.EqualTo => x12 <=> y12
+                                                    case res => res
+                                                }
+                                                case res => res
+                                            }
+                                            case res => res
+                                        }
+                                        case res => res
+                                    }
+                                    case res => res
+                                }
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
+
 }
 
 instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13] {
@@ -581,22 +704,46 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with Or
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) = t1;
         let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6) `thenCompare`
-        lazy (x7 <=> y7) `thenCompare`
-        lazy (x8 <=> y8) `thenCompare`
-        lazy (x9 <=> y9) `thenCompare`
-        lazy (x10 <=> y10) `thenCompare`
-        lazy (x11 <=> y11) `thenCompare`
-        lazy (x12 <=> y12) `thenCompare`
-        lazy (x13 <=> y13)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => match x6 <=> y6 {
+                                case Comparison.EqualTo => match x7 <=> y7 {
+                                    case Comparison.EqualTo => match x8 <=> y8 {
+                                        case Comparison.EqualTo => match x9 <=> y9 {
+                                            case Comparison.EqualTo => match x10 <=> y10 {
+                                                case Comparison.EqualTo => match x11 <=> y11 {
+                                                    case Comparison.EqualTo => match x12 <=> y12 {
+                                                        case Comparison.EqualTo => x13 <=> y13
+                                                        case res => res
+                                                    }
+                                                    case res => res
+                                                }
+                                                case res => res
+                                            }
+                                            case res => res
+                                        }
+                                        case res => res
+                                    }
+                                    case res => res
+                                }
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
+
 }
 
 instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13], Order[a14] {
@@ -605,23 +752,48 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] wi
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) = t1;
         let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6) `thenCompare`
-        lazy (x7 <=> y7) `thenCompare`
-        lazy (x8 <=> y8) `thenCompare`
-        lazy (x9 <=> y9) `thenCompare`
-        lazy (x10 <=> y10) `thenCompare`
-        lazy (x11 <=> y11) `thenCompare`
-        lazy (x12 <=> y12) `thenCompare`
-        lazy (x13 <=> y13) `thenCompare`
-        lazy (x14 <=> y14)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => match x6 <=> y6 {
+                                case Comparison.EqualTo => match x7 <=> y7 {
+                                    case Comparison.EqualTo => match x8 <=> y8 {
+                                        case Comparison.EqualTo => match x9 <=> y9 {
+                                            case Comparison.EqualTo => match x10 <=> y10 {
+                                                case Comparison.EqualTo => match x11 <=> y11 {
+                                                    case Comparison.EqualTo => match x12 <=> y12 {
+                                                        case Comparison.EqualTo => match x13 <=> y13 {
+                                                            case Comparison.EqualTo => x14 <=> y14
+                                                            case res => res
+                                                        }
+                                                        case res => res
+                                                    }
+                                                    case res => res
+                                                }
+                                                case res => res
+                                            }
+                                            case res => res
+                                        }
+                                        case res => res
+                                    }
+                                    case res => res
+                                }
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
 
 }
 
@@ -631,23 +803,50 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15
     /// Compares `t1` and `t2` lexicographically.
     ///
     pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)): Comparison =
-        use Order.thenCompare;
         let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) = t1;
         let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15) = t2;
-             (x1 <=> y1) `thenCompare`
-        lazy (x2 <=> y2) `thenCompare`
-        lazy (x3 <=> y3) `thenCompare`
-        lazy (x4 <=> y4) `thenCompare`
-        lazy (x5 <=> y5) `thenCompare`
-        lazy (x6 <=> y6) `thenCompare`
-        lazy (x7 <=> y7) `thenCompare`
-        lazy (x8 <=> y8) `thenCompare`
-        lazy (x9 <=> y9) `thenCompare`
-        lazy (x10 <=> y10) `thenCompare`
-        lazy (x11 <=> y11) `thenCompare`
-        lazy (x12 <=> y12) `thenCompare`
-        lazy (x13 <=> y13) `thenCompare`
-        lazy (x14 <=> y14) `thenCompare`
-        lazy (x15 <=> y15)
+        match x1 <=> y1 {
+            case Comparison.EqualTo => match x2 <=> y2 {
+                case Comparison.EqualTo => match x3 <=> y3 {
+                    case Comparison.EqualTo => match x4 <=> y4 {
+                        case Comparison.EqualTo => match x5 <=> y5 {
+                            case Comparison.EqualTo => match x6 <=> y6 {
+                                case Comparison.EqualTo => match x7 <=> y7 {
+                                    case Comparison.EqualTo => match x8 <=> y8 {
+                                        case Comparison.EqualTo => match x9 <=> y9 {
+                                            case Comparison.EqualTo => match x10 <=> y10 {
+                                                case Comparison.EqualTo => match x11 <=> y11 {
+                                                    case Comparison.EqualTo => match x12 <=> y12 {
+                                                        case Comparison.EqualTo => match x13 <=> y13 {
+                                                            case Comparison.EqualTo => match x14 <=> y14 {
+                                                                case Comparison.EqualTo => x15 <=> y15
+                                                                case res => res
+                                                            }
+                                                            case res => res
+                                                        }
+                                                        case res => res
+                                                    }
+                                                    case res => res
+                                                }
+                                                case res => res
+                                            }
+                                            case res => res
+                                        }
+                                        case res => res
+                                    }
+                                    case res => res
+                                }
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+            case res => res
+        }
 
 }


### PR DESCRIPTION
Removed `lazy` and `thenCompare` from tuple comparison.

The following very unscientific program was used to evaluate the performance (it prints every 5000000 comparison):
```
mod TupleOrder {
    pub def compare(t1: (a1, a2), t2: (a1, a2)): Comparison with Order[a1], Order[a2] =
        let (x1, x2) = t1;
        let (y1, y2) = t2;
        match x1 <=> y1 {
            case Comparison.EqualTo => x2 <=> y2
            case res => res
        }

    pub def compare2(t1: (a1, a2), t2: (a1, a2)): Comparison with Order[a1], Order[a2] =
        let (x1, x2) = t1;
        let (y1, y2) = t2;
        let cmp1 = x1 <=> y1;
        if (cmp1 != Comparison.EqualTo) cmp1
        else x2 <=> y2

}

def mainBTreeExperiment(): Unit \ IO = region rc {
    let t1 = (1, 2);
    let t2 = (1, 2);
    // let t1 = (1, 2);
    // let t2 = (3, 2);
    spawn runForeverOld(0i64, t1, t2) @ rc;
    spawn runForeverNew(0i64, t1, t2) @ rc;
    spawn runForeverNew2(0i64, t1, t2) @ rc;
    ()
}

def runForeverOld(i: Int64, t1: (a, b), t2: (a, b)): Unit \ IO with Order[a], Order[b] = 
    if(Int64.modulo(i, 5000000i64) == 0i64) {
        println("Old: ${i}")
    } else {
        ()
    };
    if (t1 <=> t2 == Comparison.EqualTo) {
        runForeverOld(i + 1i64, t1, t2)
    } else {
        runForeverOld(i + 1i64, t1, t2)
    }

def runForeverNew(i: Int64, t1: (a, b), t2: (a, b)): Unit \ IO with Order[a], Order[b] = 
    if(Int64.modulo(i, 5000000i64) == 0i64) {
        println("New: ${i}")
    } else {
        ()
    };
    if (TupleOrder.compare(t1, t2) == Comparison.EqualTo) {
        runForeverNew(i + 1i64, t1, t2)
    } else {
        runForeverNew(i + 1i64, t1, t2)
    }


def runForeverNew2(i: Int64, t1: (a, b), t2: (a, b)): Unit \ IO with Order[a], Order[b] = 
    if(Int64.modulo(i, 5000000i64) == 0i64) {
        println("New2: ${i}")
    } else {
        ()
    };
    if (TupleOrder.compare2(t1, t2) == Comparison.EqualTo) {
        runForeverNew2(i + 1i64, t1, t2)
    } else {
        runForeverNew2(i + 1i64, t1, t2)
    }
```