### PR TITLE
W3c validator

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -854,7 +854,7 @@ object HtmlDocumentor {
        |<link href='https://fonts.googleapis.com/css?family=Inter&display=swap' rel='stylesheet'>
        |<link href='styles.css' rel='stylesheet'>
        |<link href='favicon.png' rel='icon'>
-       |<script defer type='module' src='./index.js'></script>
+       |<script type='module' src='./index.js'></script>
        |<title>Flix | ${esc(name)}</title>
        |</head>
     """.stripMargin

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -847,7 +847,7 @@ object HtmlDocumentor {
        |<meta name='viewport' content='width=device-width,initial-scale=1'>
        |<meta name='description' content='API documentation for ${esc(name)}| The Flix Programming Language'>
        |<meta name='keywords' content='Flix, Programming, Language, API, Documentation, ${esc(name)}'>
-       |<base href='${fileName}'></base>
+       |<base href='${fileName}'>
        |<link href='https://fonts.googleapis.com/css?family=Fira+Code&display=swap' rel='stylesheet'>
        |<link href='https://fonts.googleapis.com/css?family=Oswald&display=swap' rel='stylesheet'>
        |<link href='https://fonts.googleapis.com/css?family=Noto+Sans&display=swap' rel='stylesheet'>


### PR DESCRIPTION
This fixes the issues reported by the W3C validator (https://validator.w3.org/nu/?doc=https%3A%2F%2Fapi.flix.dev%2F):

```
Error: Stray end tag base.

From line 7, column 25; to line 7, column 31

dex.html'></base>↩<link
```

A `base` element must have a start tag and must not have an end tag. See e.g. https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/base. Note that removing the end tag may break IE6 compatibility, see https://stackoverflow.com/questions/25526017/which-versions-of-ie-require-the-base-tag-close-bugfix, but I think this is not a concern.

```
Error: A script element with a defer attribute must not have a type attribute with the value module.

From line 14, column 1; to line 14, column 45

l='icon'>↩<script defer type='module' src='./index.js'></scri
```

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script:

> The defer attribute has no effect on [module scripts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) — they defer by default.

The `type='module'` attribute was added in #9314 and probably the author didn't remove the now redundant `defer` attribute by omission.