### PR TITLE
chore: rename sym: XSymUse to symUse: XSymUse

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Consumer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Consumer.scala
@@ -56,7 +56,7 @@ trait Consumer {
 
   def consumeCase(cse: Case): Unit = ()
 
-  def consumeCaseSymUse(sym: CaseSymUse): Unit = ()
+  def consumeCaseSymUse(symUse: CaseSymUse): Unit = ()
 
   def consumeCatchRule(rule: CatchRule): Unit = ()
 
@@ -66,7 +66,7 @@ trait Consumer {
 
   def consumeDef(defn: Def): Unit = ()
 
-  def consumeDefSymUse(sym: DefSymUse): Unit = ()
+  def consumeDefSymUse(symUse: DefSymUse): Unit = ()
 
   def consumeDerivation(derive: Derivation): Unit = ()
 
@@ -98,7 +98,7 @@ trait Consumer {
 
   def consumeOp(op: Op): Unit = ()
 
-  def consumeOpSymUse(sym: OpSymUse): Unit = ()
+  def consumeOpSymUse(symUse: OpSymUse): Unit = ()
 
   def consumePattern(pat: Pattern): Unit = ()
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
@@ -157,11 +157,11 @@ object LocationLink {
   /**
     * Returns a reference to the instance node `instance`.
     */
-  def fromInstanceTraitSymUse(trt: TraitSymUse, originLoc: SourceLocation): LocationLink = {
+  def fromInstanceTraitSymUse(symUse: TraitSymUse, originLoc: SourceLocation): LocationLink = {
     val originSelectionRange = Range.from(originLoc)
-    val targetUri = trt.loc.source.name
-    val targetRange = Range.from(trt.loc)
-    val targetSelectionRange = Range.from(trt.loc)
+    val targetUri = symUse.loc.source.name
+    val targetRange = Range.from(symUse.loc)
+    val targetSelectionRange = Range.from(symUse.loc)
     LocationLink(originSelectionRange, targetUri, targetRange, targetSelectionRange)
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -505,9 +505,9 @@ object Visitor {
         visitType(runEff)
         visitExpr(exp)
 
-      case Expr.Without(exp, sym, _, _, _) =>
+      case Expr.Without(exp, symUse, _, _, _) =>
         visitExpr(exp)
-        visitEffSymUse(sym)
+        visitEffSymUse(symUse)
 
       case Expr.TryCatch(exp, rules, _, _, _) =>
         visitExpr(exp)
@@ -516,8 +516,8 @@ object Visitor {
       case Expr.Throw(exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.Handler(sym, rules, _, _, _, _, _) =>
-        visitEffSymUse(sym)
+      case Expr.Handler(symUse, rules, _, _, _, _, _) =>
+        visitEffSymUse(symUse)
         rules.foreach(visitHandlerRule)
 
       case Expr.RunWith(exp1, exp2, _, _, _) =>
@@ -865,8 +865,8 @@ object Visitor {
       case Wild(_, _) => ()
       case Var(bnd, _, _) => visitBinder(bnd)
       case Cst(_, _, _) => ()
-      case Tag(sym, pats, _, _) =>
-        visitCaseSymUse(sym)
+      case Tag(symUse, pats, _, _) =>
+        visitCaseSymUse(symUse)
         pats.foreach(visitPattern)
       case Tuple(pats, _, _) =>
         pats.foreach(visitPattern)

--- a/main/src/ca/uwaterloo/flix/api/lsp/consumers/StackConsumer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/consumers/StackConsumer.scala
@@ -52,7 +52,7 @@ case class StackConsumer() extends Consumer {
 
   override def consumeCase(cse: Case): Unit = push(cse)
 
-  override def consumeCaseSymUse(sym: CaseSymUse): Unit = push(sym)
+  override def consumeCaseSymUse(symUse: CaseSymUse): Unit = push(symUse)
 
   override def consumeCatchRule(rule: CatchRule): Unit = push(rule)
 
@@ -62,7 +62,7 @@ case class StackConsumer() extends Consumer {
 
   override def consumeDef(defn: Def): Unit = push(defn)
 
-  override def consumeDefSymUse(sym: DefSymUse): Unit = push(sym)
+  override def consumeDefSymUse(symUse: DefSymUse): Unit = push(symUse)
 
   override def consumeDerivation(derive: Derivation): Unit = push(derive)
 
@@ -94,7 +94,7 @@ case class StackConsumer() extends Consumer {
 
   override def consumeOp(op: Op): Unit = push(op)
 
-  override def consumeOpSymUse(sym: OpSymUse): Unit = push(sym)
+  override def consumeOpSymUse(symUse: OpSymUse): Unit = push(symUse)
 
   override def consumePattern(pat: Pattern): Unit = push(pat)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -264,7 +264,7 @@ object FindReferencesProvider {
     }
 
     object CaseSymConsumer extends Consumer {
-      override def consumeCaseSymUse(sym: SymUse.CaseSymUse): Unit = consider(sym.sym, sym.loc)
+      override def consumeCaseSymUse(symUse: SymUse.CaseSymUse): Unit = consider(symUse.sym, symUse.loc)
     }
 
     Visitor.visitRoot(root, CaseSymConsumer, AllAcceptor)
@@ -282,7 +282,7 @@ object FindReferencesProvider {
     }
 
     object DefnSymConsumer extends Consumer {
-      override def consumeDefSymUse(sym: SymUse.DefSymUse): Unit = consider(sym.sym, sym.loc)
+      override def consumeDefSymUse(symUse: SymUse.DefSymUse): Unit = consider(symUse.sym, symUse.loc)
     }
 
     Visitor.visitRoot(root, DefnSymConsumer, AllAcceptor)
@@ -344,7 +344,7 @@ object FindReferencesProvider {
     }
 
     object OpSymConsumer extends Consumer {
-      override def consumeOpSymUse(sym: SymUse.OpSymUse): Unit = consider(sym.sym, sym.loc)
+      override def consumeOpSymUse(symUse: SymUse.OpSymUse): Unit = consider(symUse.sym, symUse.loc)
     }
 
     Visitor.visitRoot(root, OpSymConsumer, AllAcceptor)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
@@ -358,7 +358,7 @@ object HighlightProvider {
     object DefnSymConsumer extends Consumer {
       override def consumeDef(defn: TypedAst.Def): Unit = considerWrite(defn.sym, defn.sym.loc)
 
-      override def consumeDefSymUse(sym: SymUse.DefSymUse): Unit = considerRead(sym.sym, sym.loc)
+      override def consumeDefSymUse(symUse: SymUse.DefSymUse): Unit = considerRead(symUse.sym, symUse.loc)
     }
 
     Visitor.visitRoot(root, DefnSymConsumer, acceptor)
@@ -452,7 +452,7 @@ object HighlightProvider {
     object CaseSymConsumer extends Consumer {
       override def consumeCase(cse: TypedAst.Case): Unit = considerWrite(cse.sym, cse.sym.loc)
 
-      override def consumeCaseSymUse(sym: CaseSymUse): Unit = considerRead(sym.sym, sym.loc)
+      override def consumeCaseSymUse(symUse: CaseSymUse): Unit = considerRead(symUse.sym, symUse.loc)
     }
 
     Visitor.visitRoot(root, CaseSymConsumer, acceptor)
@@ -479,7 +479,7 @@ object HighlightProvider {
     object OpSymConsumer extends Consumer {
       override def consumeOp(op: TypedAst.Op): Unit = considerWrite(op.sym, op.sym.loc)
 
-      override def consumeOpSymUse(sym: SymUse.OpSymUse): Unit = considerRead(sym.sym, sym.loc)
+      override def consumeOpSymUse(symUse: SymUse.OpSymUse): Unit = considerRead(symUse.sym, symUse.loc)
     }
 
     Visitor.visitRoot(root, OpSymConsumer, acceptor)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -330,8 +330,8 @@ object SemanticTokensProvider {
     * Returns all semantic tokens in the given associated type definition `assoc`.
     */
   private def visitAssocTypeDef(assoc: TypedAst.AssocTypeDef): Iterator[SemanticToken] = assoc match {
-    case TypedAst.AssocTypeDef(_, _, sym, arg, tpe, _) =>
-      val t = SemanticToken(SemanticTokenType.Type, Nil, sym.loc)
+    case TypedAst.AssocTypeDef(_, _, symUse, arg, tpe, _) =>
+      val t = SemanticToken(SemanticTokenType.Type, Nil, symUse.loc)
       IteratorOps.all(
         Iterator(t),
         visitType(arg),
@@ -600,8 +600,8 @@ object SemanticTokensProvider {
     case Expr.Unsafe(exp, runEff, _, _, _) =>
       visitType(runEff) ++ visitExp(exp)
 
-    case Expr.Without(exp, sym, _, _, _) =>
-      val t = SemanticToken(SemanticTokenType.Type, Nil, sym.qname.loc)
+    case Expr.Without(exp, symUse, _, _, _) =>
+      val t = SemanticToken(SemanticTokenType.Type, Nil, symUse.qname.loc)
       Iterator(t) ++ visitExp(exp)
 
     case Expr.TryCatch(exp1, rules, _, _, _) =>
@@ -614,8 +614,8 @@ object SemanticTokensProvider {
     case Expr.Throw(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Handler(sym, rules, _, _, _, _, _) =>
-      val t = SemanticToken(SemanticTokenType.Type, Nil, sym.qname.loc)
+    case Expr.Handler(symUse, rules, _, _, _, _, _) =>
+      val t = SemanticToken(SemanticTokenType.Type, Nil, symUse.qname.loc)
       val st1 = Iterator(t)
       val st2 = rules.foldLeft(Iterator.empty[SemanticToken]) {
         case (acc, HandlerRule(op, fparams, exp, _)) =>
@@ -897,9 +897,9 @@ object SemanticTokensProvider {
   }
 
   /**
-    * Returns all semantic tokens in the given type constraint head `head0`.
+    * Returns all semantic tokens in the given trait sym use `symUse`.
     */
-  private def visitTraitSymUse(head0: TraitSymUse): Iterator[SemanticToken] = head0 match {
+  private def visitTraitSymUse(symUse: TraitSymUse): Iterator[SemanticToken] = symUse match {
     case TraitSymUse(_, loc) =>
       val o = SemanticTokenType.Class
       val t = SemanticToken(o, Nil, loc)

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -99,7 +99,7 @@ object LiftedAst {
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr)
 
-  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
+  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr)
 
   case class FormalParam(sym: Symbol.VarSym, mod: Modifiers, tpe: SimpleType, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -59,7 +59,7 @@ object LoweredAst {
   case class AssocTypeSig(doc: Doc, mod: Modifiers, sym: Symbol.AssocTypeSym, tparam: TypedAst.TypeParam, kind: Kind, loc: SourceLocation)
 
   // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
-  case class AssocTypeDef(doc: Doc, mod: Modifiers, sym: AssocTypeSymUse, arg: Type, tpe: Type, loc: SourceLocation)
+  case class AssocTypeDef(doc: Doc, mod: Modifiers, symUse: AssocTypeSymUse, arg: Type, tpe: Type, loc: SourceLocation)
 
   case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EffSym, ops: List[Op], loc: SourceLocation)
 
@@ -155,7 +155,7 @@ object LoweredAst {
 
     case class Cst(cst: Constant, tpe: Type, loc: SourceLocation) extends Pattern
 
-    case class Tag(sym: CaseSymUse, pats: List[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
+    case class Tag(symUse: CaseSymUse, pats: List[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
 
     case class Tuple(pats: Nel[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
 
@@ -206,7 +206,7 @@ object LoweredAst {
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr)
 
-  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
+  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr)
 
   case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -129,7 +129,7 @@ object MonoAst {
 
     case class Cst(cst: Constant, tpe: Type, loc: SourceLocation) extends Pattern
 
-    case class Tag(sym: CaseSymUse, pats: List[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
+    case class Tag(symUse: CaseSymUse, pats: List[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
 
     case class Tuple(pats: Nel[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -78,7 +78,7 @@ object TypedAst {
   case class AssocTypeSig(doc: Doc, mod: Modifiers, sym: Symbol.AssocTypeSym, tparam: TypeParam, kind: Kind, tpe: Option[Type], loc: SourceLocation)
 
   // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
-  case class AssocTypeDef(doc: Doc, mod: Modifiers, sym: AssocTypeSymUse, arg: Type, tpe: Type, loc: SourceLocation)
+  case class AssocTypeDef(doc: Doc, mod: Modifiers, symUse: AssocTypeSymUse, arg: Type, tpe: Type, loc: SourceLocation)
 
   case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EffSym, tparams: List[TypeParam], ops: List[Op], loc: SourceLocation) extends Decl
 
@@ -160,9 +160,9 @@ object TypedAst {
 
     case class ExtensibleMatch(label: Name.Label, exp1: Expr, bnd1: Binder, exp2: Expr, bnd2: Binder, exp3: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class Tag(sym: CaseSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Tag(symUse: CaseSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class RestrictableTag(sym: RestrictableCaseSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class ExtensibleTag(label: Name.Label, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
@@ -190,9 +190,9 @@ object TypedAst {
 
     case class StructNew(sym: Symbol.StructSym, fields: List[(StructFieldSymUse, Expr)], region: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class StructGet(exp: Expr, sym: StructFieldSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class StructGet(exp: Expr, symUse: StructFieldSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class StructPut(exp1: Expr, sym: StructFieldSymUse, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class StructPut(exp1: Expr, symUse: StructFieldSymUse, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class VectorLit(exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
@@ -218,13 +218,13 @@ object TypedAst {
 
     case class Unsafe(exp: Expr, runEff: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class Without(exp: Expr, sym: EffSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Without(exp: Expr, symUse: EffSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class Throw(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class Handler(sym: EffSymUse, rules: List[HandlerRule], bodyType: Type, bodyEff: Type, handledEff: Type, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Handler(symUse: EffSymUse, rules: List[HandlerRule], bodyType: Type, bodyEff: Type, handledEff: Type, tpe: Type, loc: SourceLocation) extends Expr {
       override def eff: Type = Type.Pure
     }
 
@@ -302,7 +302,7 @@ object TypedAst {
 
     case class Cst(cst: Constant, tpe: Type, loc: SourceLocation) extends Pattern
 
-    case class Tag(sym: CaseSymUse, pats: List[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
+    case class Tag(symUse: CaseSymUse, pats: List[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
 
     case class Tuple(pats: Nel[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
 
@@ -325,7 +325,7 @@ object TypedAst {
 
     case class Var(bnd: Binder, tpe: Type, loc: SourceLocation) extends VarOrWild
 
-    case class Tag(sym: RestrictableCaseSymUse, pat: List[VarOrWild], tpe: Type, loc: SourceLocation) extends RestrictableChoosePattern
+    case class Tag(symUse: RestrictableCaseSymUse, pat: List[VarOrWild], tpe: Type, loc: SourceLocation) extends RestrictableChoosePattern
 
     case class Error(tpe: Type, loc: SourceLocation) extends VarOrWild with RestrictableChoosePattern
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -62,8 +62,8 @@ object LiftedAstPrinter {
       case LiftedAst.CatchRule(sym, clazz, rexp) => (sym, clazz, print(rexp))
     })
     case RunWith(exp, effUse, rules, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map {
-      case LiftedAst.HandlerRule(op, fparams, body) =>
-        (op.sym, fparams.map(printFormalParam), print(body))
+      case LiftedAst.HandlerRule(symUse, fparams, body) =>
+        (symUse.sym, fparams.map(printFormalParam), print(body))
     })
     case NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expr.NewObject(name, clazz, SimpleTypePrinter.print(tpe), methods.map {
       case LiftedAst.JvmMethod(ident, fparams, clo, retTpe, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -102,11 +102,11 @@ object LoweredAstPrinter {
         case LoweredAst.CatchRule(sym, clazz, body) => (sym, clazz, print(body))
       }
       DocAst.Expr.TryCatch(expD, rulesD)
-    case Expr.RunWith(exp, effUse, rules, _, _, _) =>
+    case Expr.RunWith(exp, effSymUse, rules, _, _, _) =>
       val expD = print(exp)
-      val effD = effUse.sym
+      val effD = effSymUse.sym
       val rulesD = rules.map {
-        case LoweredAst.HandlerRule(op, fparams, body) => (op.sym, fparams.map(printFormalParam), print(body))
+        case LoweredAst.HandlerRule(opSymUse, fparams, body) => (opSymUse.sym, fparams.map(printFormalParam), print(body))
       }
       DocAst.Expr.RunWithHandler(expD, effD, rulesD)
     case Expr.NewObject(name, clazz, tpe, _, methods, _) =>
@@ -123,7 +123,7 @@ object LoweredAstPrinter {
     case Pattern.Wild(_, _) => DocAst.Expr.Wild
     case Pattern.Var(sym, _, _) => DocAst.Expr.Var(sym)
     case Pattern.Cst(cst, _, _) => DocAst.Expr.Cst(cst)
-    case Pattern.Tag(sym, pats, _, _) => DocAst.Expr.Tag(sym.sym, pats.map(printPattern))
+    case Pattern.Tag(symUse, pats, _, _) => DocAst.Expr.Tag(symUse.sym, pats.map(printPattern))
     case Pattern.Tuple(elms, _, _) => DocAst.Expr.Tuple(elms.map(printPattern).toList)
     case Pattern.Record(pats, rest, _, _) => printRecordPattern(pats, rest)
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -75,7 +75,7 @@ object MonoAstPrinter {
     case Pattern.Wild(_, _) => DocAst.Expr.Wild
     case Pattern.Var(sym, _, _, _) => printVar(sym)
     case Pattern.Cst(cst, _, _) => ConstantPrinter.print(cst)
-    case Pattern.Tag(sym, pats, _, _) => DocAst.Expr.Tag(sym.sym, pats.map(printPattern))
+    case Pattern.Tag(symUse, pats, _, _) => DocAst.Expr.Tag(symUse.sym, pats.map(printPattern))
     case Pattern.Tuple(elms, _, _) => DocAst.Expr.Tuple(elms.map(printPattern).toList)
     case Pattern.Record(pats, pat, _, _) => printRecordPattern(pats, pat)
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -52,7 +52,7 @@ object TypedAstPrinter {
     case Expr.TypeMatch(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.RestrictableChoose(_, _, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.ExtensibleMatch(_, _, _, _, _, _, _, _, _) => DocAst.Expr.Unknown // TODO: Ext-Variants
-    case Expr.Tag(sym, exps, _, _, _) => DocAst.Expr.Tag(sym.sym, exps.map(print))
+    case Expr.Tag(symUse, exps, _, _, _) => DocAst.Expr.Tag(symUse.sym, exps.map(print))
     case Expr.RestrictableTag(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.ExtensibleTag(_, _, _, _, _) => DocAst.Expr.Unknown // TODO: Ext-Variants
     case Expr.Tuple(elms, _, _, _) => DocAst.Expr.Tuple(elms.map(print))
@@ -78,7 +78,7 @@ object TypedAstPrinter {
     case Expr.Without(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule))
     case Expr.Throw(exp, _, _, _) => DocAst.Expr.Throw(print(exp))
-    case Expr.Handler(sym, rules, _, _, _, _, _) => DocAst.Expr.Handler(sym.sym, rules.map(printHandlerRule))
+    case Expr.Handler(symUse, rules, _, _, _, _, _) => DocAst.Expr.Handler(symUse.sym, rules.map(printHandlerRule))
     case Expr.RunWith(exp1, exp2, _, _, _) => DocAst.Expr.RunWith(print(exp1), print(exp2))
     case Expr.InvokeConstructor(constructor, exps, _, _, _) => DocAst.Expr.JavaInvokeConstructor(constructor, exps.map(print))
     case Expr.InvokeMethod(method, exp, exps, _, _, _) => DocAst.Expr.JavaInvokeMethod(method, print(exp), exps.map(print))
@@ -143,7 +143,7 @@ object TypedAstPrinter {
     case Pattern.Wild(_, _) => DocAst.Expr.Wild
     case Pattern.Var(TypedAst.Binder(sym, _), _, _) => printVar(sym)
     case Pattern.Cst(cst, _, _) => ConstantPrinter.print(cst)
-    case Pattern.Tag(sym, pats, _, _) => DocAst.Expr.Tag(sym.sym, pats.map(printPattern))
+    case Pattern.Tag(symUse, pats, _, _) => DocAst.Expr.Tag(symUse.sym, pats.map(printPattern))
     case Pattern.Tuple(elms, _, _) => DocAst.Expr.Tuple(elms.map(printPattern).toList)
     case Pattern.Record(pats, pat, _, _) => printRecordPattern(pats, pat)
     case Pattern.Error(_, _) => DocAst.Expr.Error

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -250,14 +250,14 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Tag(sym, exps, tpe, eff, _) =>
-      visitSymUse(sym)
+    case Expr.Tag(symUse, exps, tpe, eff, _) =>
+      visitSymUse(symUse)
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.RestrictableTag(sym, exps, tpe, eff, _) =>
-      visitSymUse(sym)
+    case Expr.RestrictableTag(symUse, exps, tpe, eff, _) =>
+      visitSymUse(symUse)
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
@@ -326,15 +326,15 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.StructGet(exp, sym, tpe, eff, _) =>
+    case Expr.StructGet(exp, symUse, tpe, eff, _) =>
       visitExp(exp)
-      visitSymUse(sym)
+      visitSymUse(symUse)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.StructPut(exp1, sym, exp2, tpe, eff, _) =>
+    case Expr.StructPut(exp1, symUse, exp2, tpe, eff, _) =>
       visitExp(exp1)
-      visitSymUse(sym)
+      visitSymUse(symUse)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
@@ -379,9 +379,9 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Without(exp, sym, tpe, eff, _) =>
+    case Expr.Without(exp, symUse, tpe, eff, _) =>
       visitExp(exp)
-      visitSymUse(sym)
+      visitSymUse(symUse)
       visitType(tpe)
       visitType(eff)
 
@@ -396,8 +396,8 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Handler(sym, rules, bodyType, bodyEff, handledEff, tpe, _) =>
-      visitSymUse(sym)
+    case Expr.Handler(symUse, rules, bodyType, bodyEff, handledEff, tpe, _) =>
+      visitSymUse(symUse)
       rules.foreach(visitHandlerRule)
       visitType(bodyType)
       visitType(bodyEff)
@@ -558,7 +558,7 @@ object Dependencies {
     case Type.Var(_, _) => ()
   }
 
-  private def visitSymUse(use: SymUse)(implicit sctx: SharedContext): Unit = use match {
+  private def visitSymUse(symUse: SymUse)(implicit sctx: SharedContext): Unit = symUse match {
     case SymUse.AssocTypeSymUse(sym, loc) => addDependency(sym.loc, loc)
     case SymUse.CaseSymUse(sym, loc) => addDependency(sym.loc, loc)
     case SymUse.DefSymUse(sym, loc) => addDependency(sym.loc, loc)
@@ -614,8 +614,8 @@ object Dependencies {
     case Pattern.Var(bnd, tpe, _) =>
       visitBinder(bnd)
       visitType(tpe)
-    case Pattern.Tag(sym, pats, tpe, _) =>
-      visitSymUse(sym)
+    case Pattern.Tag(symUse, pats, tpe, _) =>
+      visitSymUse(symUse)
       pats.foreach(visitPattern)
       visitType(tpe)
     case Pattern.Tuple(pats, tpe, _) =>
@@ -646,8 +646,8 @@ object Dependencies {
   }
 
   private def visitRestrictableChoosePattern(pattern: TypedAst.RestrictableChoosePattern)(implicit sctx: SharedContext): Unit = pattern match {
-    case RestrictableChoosePattern.Tag(sym, pats, tpe, _) =>
-      visitSymUse(sym)
+    case RestrictableChoosePattern.Tag(symUse, pats, tpe, _) =>
+      visitSymUse(symUse)
       pats.foreach(visitVarOrWild)
       visitType(tpe)
     case RestrictableChoosePattern.Error(tpe, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -205,10 +205,10 @@ object EffectBinder {
     case LiftedAst.Expr.RunWith(exp, effUse, rules, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val rules1 = rules.map {
-        case LiftedAst.HandlerRule(op, fparams0, body) =>
+        case LiftedAst.HandlerRule(symUse, fparams0, body) =>
           val fparams = fparams0.map(visitParam)
           val b = visitExpr(body)
-          ReducedAst.HandlerRule(op, fparams, b)
+          ReducedAst.HandlerRule(symUse, fparams, b)
       }
       ReducedAst.Expr.RunWith(e, effUse, rules1, ExpPosition.NonTail, tpe, purity, loc)
 
@@ -300,10 +300,10 @@ object EffectBinder {
     case LiftedAst.Expr.RunWith(exp, effUse, rules, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val rs = rules.map {
-        case LiftedAst.HandlerRule(op, fparams0, body) =>
+        case LiftedAst.HandlerRule(symUse, fparams0, body) =>
           val fparams = fparams0.map(visitParam)
           val b = visitExpr(body)
-          ReducedAst.HandlerRule(op, fparams, b)
+          ReducedAst.HandlerRule(symUse, fparams, b)
       }
       ReducedAst.Expr.RunWith(e, effUse, rs, ExpPosition.NonTail, tpe, purity, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -220,10 +220,10 @@ object LambdaLift {
     case SimplifiedAst.Expr.RunWith(exp, effUse, rules, tpe, purity, loc) =>
       val e = visitExp(exp)
       val rs = rules map {
-        case SimplifiedAst.HandlerRule(sym, fparams, body) =>
+        case SimplifiedAst.HandlerRule(symUse, fparams, body) =>
           val fps = fparams.map(visitFormalParam)
           val b = visitExp(body)
-          LiftedAst.HandlerRule(sym, fps, b)
+          LiftedAst.HandlerRule(symUse, fps, b)
       }
       LiftedAst.Expr.RunWith(e, effUse, rs, tpe, purity, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -192,7 +192,7 @@ object Lowering {
       val tconstrs = tconstrs0.map(visitTraitConstraint)
       val econstrs = econstrs0.map(visitEqConstraint)
       val assocs = assocs0.map {
-        case TypedAst.AssocTypeDef(defDoc, defMod, defSym, args, defTpe, defLoc) => LoweredAst.AssocTypeDef(defDoc, defMod, defSym, args, defTpe, defLoc)
+        case TypedAst.AssocTypeDef(defDoc, defMod, defSymUse, args, defTpe, defLoc) => LoweredAst.AssocTypeDef(defDoc, defMod, defSymUse, args, defTpe, defLoc)
       }
       val defs = defs0.map(visitDef)
       LoweredAst.Instance(doc, ann, mod, sym, tpe, tconstrs, econstrs, assocs, defs, ns, loc)
@@ -257,8 +257,8 @@ object Lowering {
   /**
     * Lowers `sym` from a restrictable case sym use into a regular case sym use.
     */
-  private def visitRestrictableCaseSymUse(sym: RestrictableCaseSymUse): CaseSymUse = {
-    CaseSymUse(visitRestrictableCaseSym(sym.sym), sym.sym.loc)
+  private def visitRestrictableCaseSymUse(symUse: RestrictableCaseSymUse): CaseSymUse = {
+    CaseSymUse(visitRestrictableCaseSym(symUse.sym), symUse.sym.loc)
   }
 
   /**
@@ -486,14 +486,14 @@ object Lowering {
       val t = visitType(tpe)
       LoweredAst.Expr.ExtensibleMatch(label, e1, sym1, e2, sym2, e3, t, eff, loc)
 
-    case TypedAst.Expr.Tag(sym, exps, tpe, eff, loc) =>
+    case TypedAst.Expr.Tag(symUse, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Tag(sym.sym), es, t, eff, loc)
+      LoweredAst.Expr.ApplyAtomic(AtomicOp.Tag(symUse.sym), es, t, eff, loc)
 
-    case TypedAst.Expr.RestrictableTag(sym0, exps, tpe, eff, loc) =>
+    case TypedAst.Expr.RestrictableTag(symUse, exps, tpe, eff, loc) =>
       // Lower a restrictable tag into a normal tag.
-      val caseSym = visitRestrictableCaseSym(sym0.sym)
+      val caseSym = visitRestrictableCaseSym(symUse.sym)
       val es = exps.map(visitExp)
       val t = visitType(tpe)
       LoweredAst.Expr.ApplyAtomic(AtomicOp.Tag(caseSym), es, t, eff, loc)
@@ -624,7 +624,7 @@ object Lowering {
       val t = visitType(tpe)
       LoweredAst.Expr.ApplyAtomic(AtomicOp.Throw, List(e), t, eff, loc)
 
-    case TypedAst.Expr.Handler(sym, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
+    case TypedAst.Expr.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
       // handler sym { rules }
       // is lowered to
       // handlerBody -> try handlerBody() with sym { rules }
@@ -635,7 +635,7 @@ object Lowering {
       val bodyThunkType = Type.mkArrowWithEffect(Type.Unit, bodyEff, bt, loc.asSynthetic)
       val bodyVar = LoweredAst.Expr.Var(bodySym, bodyThunkType, loc.asSynthetic)
       val body = LoweredAst.Expr.ApplyClo(bodyVar, LoweredAst.Expr.Cst(Constant.Unit, Type.Unit, loc.asSynthetic), bt, bodyEff, loc.asSynthetic)
-      val RunWith = LoweredAst.Expr.RunWith(body, sym, rs, bt, handledEff, loc)
+      val RunWith = LoweredAst.Expr.RunWith(body, symUse, rs, bt, handledEff, loc)
       val param = LoweredAst.FormalParam(bodySym, Modifiers.Empty, bodyThunkType, loc.asSynthetic)
       LoweredAst.Expr.Lambda(param, RunWith, t, loc)
 
@@ -876,10 +876,10 @@ object Lowering {
     case TypedAst.Pattern.Cst(cst, tpe, loc) =>
       LoweredAst.Pattern.Cst(cst, tpe, loc)
 
-    case TypedAst.Pattern.Tag(sym, pats, tpe, loc) =>
+    case TypedAst.Pattern.Tag(symUse, pats, tpe, loc) =>
       val ps = pats.map(visitPat)
       val t = visitType(tpe)
-      LoweredAst.Pattern.Tag(sym, ps, t, loc)
+      LoweredAst.Pattern.Tag(symUse, ps, t, loc)
 
     case TypedAst.Pattern.Tuple(elms, tpe, loc) =>
       val es = elms.map(visitPat)
@@ -985,14 +985,14 @@ object Lowering {
     case TypedAst.RestrictableChooseRule(pat, exp) =>
       val e = visitExp(exp)
       pat match {
-        case TypedAst.RestrictableChoosePattern.Tag(sym, pat0, tpe, loc) =>
+        case TypedAst.RestrictableChoosePattern.Tag(symUse, pat0, tpe, loc) =>
           val termPatterns = pat0.map {
             case TypedAst.RestrictableChoosePattern.Var(TypedAst.Binder(varSym, _), varTpe, varLoc) => LoweredAst.Pattern.Var(varSym, varTpe, varLoc)
             case TypedAst.RestrictableChoosePattern.Wild(wildTpe, wildLoc) => LoweredAst.Pattern.Wild(wildTpe, wildLoc)
             case TypedAst.RestrictableChoosePattern.Error(_, errLoc) => throw InternalCompilerException("unexpected restrictable choose variable", errLoc)
           }
-          val tagSym = visitRestrictableCaseSymUse(sym)
-          val p = LoweredAst.Pattern.Tag(tagSym, termPatterns, tpe, loc)
+          val tagSymUse = visitRestrictableCaseSymUse(symUse)
+          val p = LoweredAst.Pattern.Tag(tagSymUse, termPatterns, tpe, loc)
           LoweredAst.MatchRule(p, None, e)
         case TypedAst.RestrictableChoosePattern.Error(_, loc) => throw InternalCompilerException("unexpected error restrictable choose pattern", loc)
       }
@@ -1011,10 +1011,10 @@ object Lowering {
     * Lowers the given handler rule `rule0`.
     */
   private def visitHandlerRule(rule0: TypedAst.HandlerRule)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.HandlerRule = rule0 match {
-    case TypedAst.HandlerRule(sym, fparams0, exp, _) =>
+    case TypedAst.HandlerRule(symUse, fparams0, exp, _) =>
       val fparams = fparams0.map(visitFormalParam)
       val e = visitExp(exp)
-      LoweredAst.HandlerRule(sym, fparams, e)
+      LoweredAst.HandlerRule(symUse, fparams, e)
   }
 
   /**
@@ -1929,15 +1929,15 @@ object Lowering {
 
     case LoweredAst.Expr.TryCatch(_, _, _, _, _) => ??? // TODO
 
-    case LoweredAst.Expr.RunWith(exp, sym, rules, tpe, eff, loc) =>
+    case LoweredAst.Expr.RunWith(exp, effSymUse, rules, tpe, eff, loc) =>
       val e = substExp(exp, subst)
       val rs = rules.map {
-        case LoweredAst.HandlerRule(op, fparams, hexp) =>
+        case LoweredAst.HandlerRule(opSymUse, fparams, hexp) =>
           val fps = fparams.map(substFormalParam(_, subst))
           val he = substExp(hexp, subst)
-          LoweredAst.HandlerRule(op, fps, he)
+          LoweredAst.HandlerRule(opSymUse, fps, he)
       }
-      LoweredAst.Expr.RunWith(e, sym, rs, tpe, eff, loc)
+      LoweredAst.Expr.RunWith(e, effSymUse, rs, tpe, eff, loc)
 
     case LoweredAst.Expr.NewObject(_, _, _, _, _, _) => exp0
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
@@ -607,16 +607,16 @@ object Monomorpher {
       }
       MonoAst.Expr.TryCatch(e, rs, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.RunWith(exp, effect, rules, tpe, eff, loc) =>
+    case LoweredAst.Expr.RunWith(exp, effSymUse, rules, tpe, eff, loc) =>
       val e = specializeExp(exp, env0, subst)
       val rs = rules map {
-        case LoweredAst.HandlerRule(op, fparams0, body0) =>
+        case LoweredAst.HandlerRule(opSymUse, fparams0, body0) =>
           val (fparams, fparamEnv) = specializeFormalParams(fparams0, subst)
           val env1 = env0 ++ fparamEnv
           val body = specializeExp(body0, env1, subst)
-          MonoAst.HandlerRule(op, fparams, body)
+          MonoAst.HandlerRule(opSymUse, fparams, body)
       }
-      MonoAst.Expr.RunWith(e, effect, rs, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.RunWith(e, effSymUse, rs, subst(tpe), subst(eff), loc)
 
     case LoweredAst.Expr.NewObject(name, clazz, tpe, eff, methods0, loc) =>
       val methods = methods0.map(specializeJvmMethod(_, env0, subst))
@@ -707,9 +707,9 @@ object Monomorpher {
       val freshSym = Symbol.freshVarSym(sym)
       (MonoAst.Pattern.Var(freshSym, subst(tpe), Occur.Unknown, loc), Map(sym -> freshSym))
     case LoweredAst.Pattern.Cst(cst, tpe, loc) => (MonoAst.Pattern.Cst(cst, subst(tpe), loc), Map.empty)
-    case LoweredAst.Pattern.Tag(sym, pats, tpe, loc) =>
+    case LoweredAst.Pattern.Tag(symUse, pats, tpe, loc) =>
       val (ps, envs) = pats.map(specializePat(_, subst)).unzip
-      (MonoAst.Pattern.Tag(sym, ps, subst(tpe), loc), combineEnvs(envs))
+      (MonoAst.Pattern.Tag(symUse, ps, subst(tpe), loc), combineEnvs(envs))
     case LoweredAst.Pattern.Tuple(elms, tpe, loc) =>
       val (ps, envs) = elms.map(specializePat(_, subst)).unzip
       (MonoAst.Pattern.Tuple(ps, subst(tpe), loc), combineEnvs(envs))

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -696,8 +696,8 @@ object Redundancy {
         case _ => visitExp(exp, env0, rc)
       }
 
-    case Expr.Without(exp, sym, _, _, _) =>
-      sctx.effSyms.put(sym.sym, ())
+    case Expr.Without(exp, symUse, _, _, _) =>
+      sctx.effSyms.put(symUse.sym, ())
       visitExp(exp, env0, rc)
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
@@ -715,8 +715,8 @@ object Redundancy {
     case Expr.Throw(exp, _, _, _) =>
       visitExp(exp, env0, rc)
 
-    case Expr.Handler(sym, rules, _, _, _, _, _) =>
-      sctx.effSyms.put(sym.sym, ())
+    case Expr.Handler(symUse, rules, _, _, _, _, _) =>
+      sctx.effSyms.put(symUse.sym, ())
       rules.foldLeft(Used.empty) {
         case (acc, HandlerRule(_, fparams, body, _)) =>
           val syms = fparams.map(_.bnd.sym)

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -266,10 +266,10 @@ object Safety {
       visitExp(exp)
       checkThrow(exp)
 
-    case Expr.Handler(sym, rules, _, _, _, _, _) =>
+    case Expr.Handler(symUse, rules, _, _, _, _, _) =>
       // Check for [[PrimitiveEffectInRunWith]]
-      if (Symbol.isPrimitiveEff(sym.sym)) {
-        sctx.errors.add(PrimitiveEffectInRunWith(sym.sym, sym.qname.loc))
+      if (Symbol.isPrimitiveEff(symUse.sym)) {
+        sctx.errors.add(PrimitiveEffectInRunWith(symUse.sym, symUse.qname.loc))
       }
       rules.foreach(rule => visitExp(rule.exp))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -204,13 +204,13 @@ object Stratifier {
       val e3 = visitExp(exp3)
       Expr.ExtensibleMatch(label, e1, bnd1, e2, bnd2, e3, tpe, eff, loc)
 
-    case Expr.Tag(sym, exps, tpe, eff, loc) =>
+    case Expr.Tag(symUse, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.Tag(sym, es, tpe, eff, loc)
+      Expr.Tag(symUse, es, tpe, eff, loc)
 
-    case Expr.RestrictableTag(sym, exps, tpe, eff, loc) =>
+    case Expr.RestrictableTag(symUse, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.RestrictableTag(sym, es, tpe, eff, loc)
+      Expr.RestrictableTag(symUse, es, tpe, eff, loc)
 
     case Expr.ExtensibleTag(label, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
@@ -308,9 +308,9 @@ object Stratifier {
       val e = visitExp(exp)
       Expr.Unsafe(e, runEff, tpe, eff, loc)
 
-    case Expr.Without(exp, sym, tpe, eff, loc) =>
+    case Expr.Without(exp, symUse, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Without(e, sym, tpe, eff, loc)
+      Expr.Without(e, symUse, tpe, eff, loc)
 
     case Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
@@ -321,9 +321,9 @@ object Stratifier {
       val e = visitExp(exp)
       Expr.Throw(e, tpe, eff, loc)
 
-    case Expr.Handler(sym, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
+    case Expr.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
       val rs = rules.map(visitRunWithRule)
-      Expr.Handler(sym, rs, bodyTpe, bodyEff, handledEff, tpe, loc)
+      Expr.Handler(symUse, rs, bodyTpe, bodyEff, handledEff, tpe, loc)
 
     case Expr.RunWith(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -122,9 +122,9 @@ object CodeHinter {
     var traitOccurs: List[TraitSymUse] = Nil
 
     object OccurConsumer extends Consumer {
-      override def consumeCaseSymUse(sym: SymUse.CaseSymUse): Unit = enumOccurs = (sym.sym.enumSym, sym.loc) :: enumOccurs
+      override def consumeCaseSymUse(symUse: SymUse.CaseSymUse): Unit = enumOccurs = (symUse.sym.enumSym, symUse.loc) :: enumOccurs
 
-      override def consumeDefSymUse(sym: DefSymUse): Unit = defOccurs = sym :: defOccurs
+      override def consumeDefSymUse(symUse: DefSymUse): Unit = defOccurs = symUse :: defOccurs
 
       override def consumeExpr(exp: Expr): Unit = exp match {
         case TypedAst.Expr.ApplyDef(symUse, exps, _, _, _, _) => applyDefOccurs = (symUse.sym, exps) :: applyDefOccurs

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -401,10 +401,10 @@ object Inliner {
     case Pattern.Cst(cst, tpe, loc) =>
       (Pattern.Cst(cst, tpe, loc), Map.empty)
 
-    case Pattern.Tag(sym, pats, tpe, loc) =>
+    case Pattern.Tag(symUse, pats, tpe, loc) =>
       val (ps, varSubsts) = pats.map(visitPattern).unzip
       val varSubst = varSubsts.foldLeft(Map.empty[Symbol.VarSym, Symbol.VarSym])(_ ++ _)
-      (Pattern.Tag(sym, ps, tpe, loc), varSubst)
+      (Pattern.Tag(symUse, ps, tpe, loc), varSubst)
 
     case Pattern.Tuple(pats, tpe, loc) =>
       val (ps, varSubsts) = pats.map(visitPattern).unzip

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -338,13 +338,13 @@ object OccurrenceAnalyzer {
     case MonoAst.Pattern.Cst(_, _, _) =>
       (pat0, Set.empty) // Always reuse pat0.
 
-    case MonoAst.Pattern.Tag(sym, pats, tpe, loc) =>
+    case MonoAst.Pattern.Tag(symUse, pats, tpe, loc) =>
       val (ps, listOfSyms) = pats.map(visitPattern(_, ctx)).unzip
       val syms = listOfSyms.flatten.toSet
       if (pats.zip(ps).forall { case (p1, p2) => p1 eq p2 }) {
         (pat0, syms) // Reuse pat0.
       } else {
-        (MonoAst.Pattern.Tag(sym, ps, tpe, loc), syms)
+        (MonoAst.Pattern.Tag(symUse, ps, tpe, loc), syms)
       }
 
     case MonoAst.Pattern.Tuple(pats, tpe, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -638,9 +638,9 @@ object ConstraintGen {
         val (fieldTpes, fieldEffs) = visitedFields.unzip
         c.unifyType(tvar, structTpe, loc)
         for {
-          ((fieldSym, expr), fieldTpe1) <- fields.zip(fieldTpes)
+          ((fieldSymUse, expr), fieldTpe1) <- fields.zip(fieldTpes)
         } {
-          instantiatedFieldTpes.get(fieldSym.sym) match {
+          instantiatedFieldTpes.get(fieldSymUse.sym) match {
             case None => () // if not an actual field, there is nothing to unify
             case Some((_, fieldTpe2)) => c.unifyType(fieldTpe1, fieldTpe2, expr.loc)
           }

--- a/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
@@ -177,12 +177,12 @@ object EffectVerifier {
       expectType(expected, actual, loc)
     case Expr.ExtensibleMatch(label, exp1, bnd1, exp2, bnd2, exp3, tpe, eff, loc) =>
       () // TODO: Ext-Variants
-    case Expr.Tag(sym, exps, tpe, eff, loc) =>
+    case Expr.Tag(symUse, exps, tpe, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(exps.map(_.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.RestrictableTag(sym, exps, tpe, eff, loc) =>
+    case Expr.RestrictableTag(symUse, exps, tpe, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(exps.map(_.eff), loc)
       val actual = eff
@@ -278,7 +278,7 @@ object EffectVerifier {
       val expected = Type.mkDifference(exp.eff, runEff, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Without(exp, sym, tpe, eff, loc) =>
+    case Expr.Without(exp, symUse, tpe, eff, loc) =>
       visitExp(exp)
       val expected = exp.eff
       val actual = eff
@@ -292,7 +292,7 @@ object EffectVerifier {
     case Expr.Throw(exp, _, eff, loc) =>
       visitExp(exp)
       expectType(eff, Type.mkUnion(exp.eff, Type.IO, loc), loc)
-    case Expr.Handler(sym, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
+    case Expr.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
       rules.foreach { r => visitExp(r.exp) }
       // TODO effect stuff
       ()


### PR DESCRIPTION
Fixes #9650

I searched for the regexes:

```regex
sym:\s*\S*SymUse                      # sym: XyzSymUse
[Ss]ym\.sym                           # sym.sym or Sym.sym
(?<!Use):\s*(SymUse\.)?\w*SymUse\b    # x: XyzSymUse where x is not "Use"
```