### PR TITLE
fix: use zeroOrMore for parsing NewObject body

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2707,7 +2707,7 @@ object Parser2 {
         close(mark, TreeKind.Expr.NewStruct)
       } else if (at(TokenKind.CurlyL)) {
         // `new Type { ... }`.
-        oneOrMore(
+        zeroOrMore(
           namedTokenSet = NamedTokenSet.FromKinds(Set(TokenKind.KeywordDef)),
           checkForItem = t => t.isComment || t == TokenKind.KeywordDef,
           getItem = jvmMethod,


### PR DESCRIPTION
Related to #11130.

This doesn't actually change any behavior since the return value of `oneOrMore` was ignored before.