### PR TITLE
fix: use zeroOrMore for parsing 'without' expressions

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1487,17 +1487,14 @@ object Parser2 {
       if (eat(TokenKind.KeywordWithout)) {
         val mark = open()
         if (at(TokenKind.CurlyL)) {
-          oneOrMore(
+          zeroOrMore(
             namedTokenSet = NamedTokenSet.Effect,
             getItem = () => nameAllowQualified(NAME_EFFECT),
             checkForItem = NAME_EFFECT.contains,
             breakWhen = _.isRecoverExpr,
             delimiterL = TokenKind.CurlyL,
             delimiterR = TokenKind.CurlyR
-          ) match {
-            case Some(error) => closeWithError(open(), error)
-            case _ =>
-          }
+          )
         } else if (NAME_EFFECT.contains(nth(0))) {
           nameAllowQualified(NAME_EFFECT)
         } else {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1546,4 +1546,15 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[ParseError.NeedAtleastOne](result)
   }
+
+  test("MissingWithout.01") {
+    val input =
+      """
+        |def foo(): String = {
+        |  "hi" without {}
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError.NeedAtleastOne](result)
+  }
 }


### PR DESCRIPTION
related to #11130 

This also improves recovery by using the nested expression directly instead of creating an error.