### PR TITLE
fix: removed redundant parentheticals in effects

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
@@ -624,8 +624,16 @@ object DisplayType {
           }
 
         case TypeConstructor.SymmetricDiff =>
-          val args = t.typeArguments.map(visit)
-          SymmetricDiff(args)
+          t.typeArguments.map(visit).map(splitSymmetricDiff) match {
+            // Case 1: No args. ? ⊕ ?
+            case Nil => SymmetricDiff(Hole :: Hole :: Nil)
+            // Case 2: One arg. Take the left and put a hole at the end: tpe1 ⊕ tpe2 ⊕ ?
+            case args :: Nil => SymmetricDiff(args :+ Hole)
+            // Case 3: Multiple args. Concatenate them: tpe1 ⊕ tpe2 ⊕ tpe3 ⊕ tpe4
+            case args1 :: args2 :: Nil => SymmetricDiff(args1 ++ args2)
+            // Case 4: Too many args. Error.
+            case _ :: _ :: _ :: _ => throw new OverAppliedType(t.loc)
+          }
 
         case TypeConstructor.CaseSet(syms, _) =>
           val names = syms.toList.map(sym => DisplayType.Name(sym.name))


### PR DESCRIPTION
Made it so that terms aren't shown like this `(((((((((((((e1 ⊕ e2) ⊕ e3) ⊕ e0) ⊕ (e1 & e3)) ⊕ (e0 & e2)) ⊕ (e0 & e3)) ⊕ (e0 & e1)) ⊕ (e2 & e3)) ⊕ (e1 & e2)) ⊕ (e1 & e2 & e3)) ⊕ (e0 & e1 & e3)) ⊕ (e0 & e1 & e2)) ⊕ (e0 & e2 & e3)) ⊕ (e0 & e1 & e3 & e2)` and instead are shown like `e1 ⊕ e2 ⊕ e3 ⊕ e0 ⊕ (e1 & e3) ⊕ (e0 & e2) ⊕ (e0 & e3) ⊕ (e0 & e1) ⊕ (e2 & e3) ⊕ (e1 & e2) ⊕ (e1 & e2 & e3) ⊕ (e0 & e1 & e3) ⊕ (e0 & e1 & e2) ⊕ (e0 & e2 & e3) ⊕ (e0 & e1 & e3 & e2)`