### PR TITLE
chore: remove dead code from Lowering

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1427,16 +1427,6 @@ object Lowering {
       throw InternalCompilerException("Cannot lift functions with more than 5 free variables.", loc)
     }
 
-    // Special case: No free variables.
-    if (fvs.isEmpty) {
-      val sym = Symbol.freshVarSym("_unit", BoundBy.FormalParam, loc)
-      // Construct a lambda that takes the unit argument.
-      val fparam = LoweredAst.FormalParam(sym, Modifiers.Empty, Type.Unit, loc)
-      val tpe = Type.mkPureArrow(Type.Unit, exp.tpe, loc)
-      val lambdaExp = LoweredAst.Expr.Lambda(fparam, exp, tpe, loc)
-      return mkTag(Enums.HeadTerm, s"App0", List(lambdaExp), Types.HeadTerm, loc)
-    }
-
     // Introduce a fresh variable for each free variable.
     val freshVars = fvs.foldLeft(Map.empty[Symbol.VarSym, Symbol.VarSym]) {
       case (acc, (oldSym, _)) => acc + (oldSym -> Symbol.freshVarSym(oldSym))


### PR DESCRIPTION
The function, `mkAppTerm`, is only called once. This call is from `visitHeadTerm`:
```
if (quantifiedFreeVars.isEmpty) {
    // Case 2: No quantified variables. The expression can be reduced to a value.
    mkHeadTermLit(box(visitExp(exp0)))
    } else {
    // Case 3: Quantified variables. The expression is translated to an application term.
    mkAppTerm(quantifiedFreeVars, visitExp(exp0), exp0.loc)
}
```
So `fvs` cannot be empty.

This will allow us to remove `App0` from `Fixpoint/Ast/Datalog/HeadTerm`.