### PR TITLE
chore: re-add `runSolverWithProvenance` and `provenanceOf`

### DIFF
--- a/main/src/library/Fixpoint3/Solver.flix
+++ b/main/src/library/Fixpoint3/Solver.flix
@@ -144,7 +144,7 @@ mod Fixpoint3.Solver {
     /// Returns the provenance of fact `f` of relation `p` given Datalog program `d`.
     ///
     @Internal
-    pub def provenanceOf(f: Vector[Boxed], p: PredSym, d: Datalog, mapping: PredSym -> Vector[Boxed] -> t): Vector[t] = ???
+    pub def provenanceOf(f: Vector[Boxed], p: PredSym, d: Datalog, mkExtVar: PredSym -> Vector[Boxed] -> t): Vector[t] = ???
 
     ///
     /// Returns the `Provenance` program `d` as a `Model`.


### PR DESCRIPTION
These were deleted by https://github.com/flix/flix/pull/11145 