### PR TITLE
fix: arity of `$Result` determined by tuple in `query` expression

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -598,7 +598,7 @@ object Visitor {
       case Expr.FixpointInject(exp, _, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.FixpointProject(_, exp, _, _, _) =>
+      case Expr.FixpointProject(_, _, exp, _, _, _) =>
         visitExpr(exp)
 
       case Expr.Error(_, _, _) => ()

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -712,7 +712,7 @@ object SemanticTokensProvider {
     case Expr.FixpointInject(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.FixpointProject(_, exp, _, _, _) =>
+    case Expr.FixpointProject(_, _, exp, _, _, _) =>
       visitExp(exp)
 
     case Expr.Error(_, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -280,7 +280,7 @@ object TypedAst {
 
     case class FixpointInject(exp: Expr, pred: Name.Pred, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class FixpointProject(pred: Name.Pred, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class FixpointProject(pred: Name.Pred, arity: Int, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class Error(m: CompilationMessage, tpe: Type, eff: Type) extends Expr {
       override def loc: SourceLocation = m.loc

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -114,7 +114,7 @@ object TypedAstOps {
     case Expr.FixpointSolve(exp, _, _, _, _) => sigSymsOf(exp)
     case Expr.FixpointFilter(_, exp, _, _, _) => sigSymsOf(exp)
     case Expr.FixpointInject(exp, _, _, _, _) => sigSymsOf(exp)
-    case Expr.FixpointProject(_, exp, _, _, _) => sigSymsOf(exp)
+    case Expr.FixpointProject(_, _, exp, _, _, _) => sigSymsOf(exp)
     case Expr.Error(_, _, _) => Set.empty
   }
 
@@ -413,7 +413,7 @@ object TypedAstOps {
     case Expr.FixpointInject(exp, _, _, _, _) =>
       freeVars(exp)
 
-    case Expr.FixpointProject(_, exp, _, _, _) =>
+    case Expr.FixpointProject(_, _, exp, _, _, _) =>
       freeVars(exp)
 
     case Expr.Error(_, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -103,7 +103,7 @@ object TypedAstPrinter {
     case Expr.FixpointSolve(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointFilter(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointInject(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointProject(_, _, _, _, _) => DocAst.Expr.Unknown
+    case Expr.FixpointProject(_, _, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.Error(_, _, _) => DocAst.Expr.Error
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -523,7 +523,7 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.FixpointProject(_, exp, tpe, eff, _) =>
+    case Expr.FixpointProject(_, _, exp, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -834,7 +834,7 @@ object Lowering {
       val argExps = mkPredSym(pred) :: visitExp(exp) :: Nil
       LoweredAst.Expr.ApplyDef(sym, argExps, targ :: targs, defTpe, Types.Datalog, eff, loc)
 
-    case TypedAst.Expr.FixpointProject(pred, exp, tpe, eff, loc) =>
+    case TypedAst.Expr.FixpointProject(pred, arity, exp, tpe, eff, loc) =>
       // Compute the arity of the predicate symbol.
       // The type is either of the form `Array[(a, b, c)]` or `Array[a]`.
       val (_, targs) = Type.eraseAliases(tpe) match {
@@ -847,7 +847,7 @@ object Lowering {
       }
 
       // Compute the symbol of the function.
-      val sym = Defs.Facts(targs.length)
+      val sym = Defs.Facts(arity)
 
       // The type of the function.
       val defTpe = Type.mkPureUncurriedArrow(List(Types.PredSym, Types.Datalog), tpe, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -339,7 +339,7 @@ object PatMatch {
 
       case Expr.FixpointInject(exp, _, _, _, _) => visitExp(exp)
 
-      case Expr.FixpointProject(_, exp, _, _, _) => visitExp(exp)
+      case Expr.FixpointProject(_, _, exp, _, _, _) => visitExp(exp)
 
       case Expr.Error(_, _, _) => ()
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -353,7 +353,7 @@ object PredDeps {
     case Expr.FixpointInject(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.FixpointProject(_, exp, _, _, _) =>
+    case Expr.FixpointProject(_, _, exp, _, _, _) =>
       visitExp(exp)
 
     case Expr.Error(_, _, _) => ()

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -880,7 +880,7 @@ object Redundancy {
     case Expr.FixpointInject(exp, _, _, _, _) =>
       visitExp(exp, env0, rc)
 
-    case Expr.FixpointProject(_, exp, _, _, _) =>
+    case Expr.FixpointProject(_, _, exp, _, _, _) =>
       visitExp(exp, env0, rc)
 
     case Expr.Error(_, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -365,7 +365,7 @@ object Safety {
     case Expr.FixpointInject(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.FixpointProject(_, exp, _, _, _) =>
+    case Expr.FixpointProject(_, _, exp, _, _, _) =>
       visitExp(exp)
 
     case Expr.Error(_, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -435,9 +435,9 @@ object Stratifier {
       val e = visitExp(exp)
       Expr.FixpointInject(e, pred, tpe, eff, loc)
 
-    case Expr.FixpointProject(pred, exp, tpe, eff, loc) =>
+    case Expr.FixpointProject(pred, arity, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.FixpointProject(pred, e, tpe, eff, loc)
+      Expr.FixpointProject(pred, arity, e, tpe, eff, loc)
 
     case Expr.Error(m, tpe, eff) =>
       Expr.Error(m, tpe, eff)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -619,7 +619,7 @@ object TypeReconstruction {
       val e = visitExp(exp)
       TypedAst.Expr.FixpointInject(e, pred, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.FixpointProject(pred, _, exp1, exp2, tvar, loc) =>
+    case KindedAst.Expr.FixpointProject(pred, arity, exp1, exp2, tvar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val tpe = subst(tvar)
@@ -630,7 +630,7 @@ object TypeReconstruction {
       // See Weeder for more details.
       val mergeExp = TypedAst.Expr.FixpointMerge(e1, e2, e1.tpe, eff, loc)
       val solveExp = TypedAst.Expr.FixpointSolve(mergeExp, e1.tpe, eff, SolveMode.Default, loc)
-      TypedAst.Expr.FixpointProject(pred, solveExp, tpe, eff, loc)
+      TypedAst.Expr.FixpointProject(pred, arity, solveExp, tpe, eff, loc)
 
     case KindedAst.Expr.Error(m, tvar, evar) =>
       val tpe = subst(tvar)

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -291,7 +291,7 @@ object Summary {
     case Expr.FixpointSolve(exp, _, _, _, _) => countCheckedEcasts(exp)
     case Expr.FixpointFilter(_, exp, _, _, _) => countCheckedEcasts(exp)
     case Expr.FixpointInject(exp, _, _, _, _) => countCheckedEcasts(exp)
-    case Expr.FixpointProject(_, exp, _, _, _) => countCheckedEcasts(exp)
+    case Expr.FixpointProject(_, _, exp, _, _, _) => countCheckedEcasts(exp)
     case Expr.Error(_, _, _) => 0
   }
 

--- a/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
@@ -402,7 +402,7 @@ object EffectVerifier {
       visitExp(exp)
       // TODO ?
       ()
-    case Expr.FixpointProject(pred, exp, tpe, eff, loc) =>
+    case Expr.FixpointProject(pred, _, exp, tpe, eff, loc) =>
       visitExp(exp)
       // TODO ?
       ()


### PR DESCRIPTION
This should fix #11222.

I have added `arity` to `TypedAst.Expr.FixpointProject`. This is then used in Lowering when deciding what the arity of `$Result` is. Previously the return type was used in this way, but that is unsafe when the elements that are returned is a tuple.