### PR TITLE
chore: remove unnecessary ascription from desugared foreach

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -1131,7 +1131,7 @@ object Desugar {
   private def desugarForEach(frags0: List[WeededAst.ForFragment], exp0: WeededAst.Expr, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
     val fqnForEach = "ForEach.forEach"
 
-    val foreachExp = frags0.foldRight(visitExp(exp0)) {
+    frags0.foldRight(visitExp(exp0)) {
       case (WeededAst.ForFragment.Generator(pat1, exp1, loc1), acc) =>
         val p1 = visitPattern(pat1)
         val e1 = visitExp(exp1)
@@ -1150,9 +1150,6 @@ object Desugar {
         val matchRule = DesugaredAst.MatchRule(p1, None, acc, loc1.asSynthetic)
         DesugaredAst.Expr.Match(e1, List(matchRule), loc1.asSynthetic)
     }
-
-    // We add an ascription to Unit because inference across region boundaries is limited.
-    DesugaredAst.Expr.Ascribe(foreachExp, Some(DesugaredAst.Type.Unit(loc0.asSynthetic)), None, loc0.asSynthetic)
   }
 
   /**


### PR DESCRIPTION
This is a follow up from https://github.com/flix/flix/pull/11209#discussion_r2250942848

The region boundary in question no longer exists because we are no longer using iterators. So it maybe makes sense to remove this in the interest of minimizing cruft.

That being said, i don't fully understand the problem that motivated this ascription in the first place, so maybe this is a chesterson fence and it's safer to leave it be. Bringing it up to the team to consider, i don't have strong feelings about it