### PR TITLE
feat: add support for `pquery` in Datalog3 engine

### DIFF
--- a/main/src/library/Fixpoint3/Interpreter.flix
+++ b/main/src/library/Fixpoint3/Interpreter.flix
@@ -689,7 +689,7 @@ mod Fixpoint3.Interpreter {
                 // and `indexInTuple` described at which of the entries in the fact is the depth.
                 let (_, _, tupleEnv, _) = env;
                 vec
-                    |> Vector.map(match (tupleIndex, indexInTuple) -> Vector.get(indexInTuple, Array.get(tupleIndex, tupleEnv)))
+                    |> Vector.map(match (tupleIndex, indexInTuple) -> 1i64 + Vector.get(indexInTuple, Array.get(tupleIndex, tupleEnv)))
                     |> Vector.maximum
                     |> Option.getWithDefault(1i64)
             case RamTerm.Meet(cap, lhs, rhs, i) =>

--- a/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
+++ b/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
@@ -99,9 +99,10 @@ mod Fixpoint3.Phase.RenamePredSyms {
         case Provenance(rules, model) => {
             let transformer = mapBack(fixing);
             let newRules = remapConstraints(rules, transformer);
-            Map.foldLeftWithKey(newMap -> relSym -> v -> match relSym {
-                case RelSym.Symbol(p, arity, den) => Map.insert(RelSym.Symbol(transformer(p), arity, den), v, newMap)
-            } , Map#{}, model)
+            (Map#{}, model)
+                ||> Map.foldLeftWithKey(newMap -> relSym -> v -> match relSym {
+                    case RelSym.Symbol(p, arity, den) => Map.insert(RelSym.Symbol(transformer(p), arity, den), v, newMap)
+                })
                 |> Provenance(newRules)
         }
         case Join(_, _) => bug!("Bad argument of type 'Join' in PredSym renaming")

--- a/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
+++ b/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
@@ -28,7 +28,7 @@
 ///
 mod Fixpoint3.Phase.RenamePredSyms {
     use Fixpoint3.Ast.Datalog.{Datalog, Constraint, BodyPredicate, BodyTerm, HeadTerm, Polarity, VarSym}
-    use Fixpoint3.Ast.Datalog.Datalog.{Datalog, Model, Join}
+    use Fixpoint3.Ast.Datalog.Datalog.{Datalog, Model, Join, Provenance}
     use Fixpoint3.Ast.Datalog.Constraint.Constraint
     use Fixpoint3.Ast.Datalog.HeadPredicate
     use Fixpoint3.Ast.Datalog.HeadPredicate.HeadAtom
@@ -62,11 +62,21 @@ mod Fixpoint3.Phase.RenamePredSyms {
             let transformer = mapForward(mapping);
             Datalog(remapConstraints(facts, transformer), remapConstraints(rules, transformer))
         case Model(facts) =>
-            Model(Map.foldLeftWithKey(acc -> k -> v -> match k {
-                case RelSym.Symbol(predSym, arity, den) =>
-                    let newSym = RelSym.Symbol(mapForward(mapping, predSym), arity, den);
-                    Map.insert(newSym, v, acc)
-            }, Map#{}, facts))
+            (Map#{}, facts)
+                ||> Map.foldLeftWithKey(acc -> k -> v -> match k {
+                    case RelSym.Symbol(predSym, arity, den) =>
+                        let newSym = RelSym.Symbol(mapForward(mapping, predSym), arity, den);
+                        Map.insert(newSym, v, acc)
+                })
+                |> Model
+        case Provenance(rules, facts) =>
+            (Map#{}, facts)
+                ||> Map.foldLeftWithKey(acc -> k -> v -> match k {
+                    case RelSym.Symbol(predSym, arity, den) =>
+                        let newSym = RelSym.Symbol(mapForward(mapping, predSym), arity, den);
+                        Map.insert(newSym, v, acc)
+                })
+                |> Provenance(rules)
         case Join(d1, d2) =>
             Join(fixPredSymsInternal(d1, mapping), fixPredSymsInternal(d2, mapping))
         case _ => bug!("PredSym error")
@@ -86,7 +96,15 @@ mod Fixpoint3.Phase.RenamePredSyms {
                 case RelSym.Symbol(p, arity, den) => Map.insert(RelSym.Symbol(transformer(p), arity, den), v, newMap)
             }, Map#{}, map) |>
                 Model
-        case _ => bug!("Bad argument of type 'Join' in PredSym renaming")
+        case Provenance(rules, model) => {
+            let transformer = mapBack(fixing);
+            let newRules = remapConstraints(rules, transformer);
+            Map.foldLeftWithKey(newMap -> relSym -> v -> match relSym {
+                case RelSym.Symbol(p, arity, den) => Map.insert(RelSym.Symbol(transformer(p), arity, den), v, newMap)
+            } , Map#{}, model)
+                |> Provenance(newRules)
+        }
+        case Join(_, _) => bug!("Bad argument of type 'Join' in PredSym renaming")
     }
 
     ///

--- a/main/src/library/Fixpoint3/Solver.flix
+++ b/main/src/library/Fixpoint3/Solver.flix
@@ -41,10 +41,19 @@ mod Fixpoint3.Solver {
     /// The stratification is computed automatically by the solver.
     ///
     @Internal
-    pub def runSolver(d: Datalog): Datalog = region rc {
+    pub def runSolver(d: Datalog): Datalog = runSolverInternal(false, d)
+
+    ///
+    /// Returns a provenance model of the given Datalog program `d`.
+    /// The provenance model can later be used for provenance queries.
+    ///
+    @Internal
+    pub def runSolverWithProvenance(d: Datalog): Datalog = runSolverInternal(true, d)
+
+    def runSolverInternal(withProv: Bool, d: Datalog): Datalog = region rc {
         let (fixed, fixInfo) = Phase.RenamePredSyms.assignUniqueIdentifiersToPredSyms(rc, d);
         let strat = Phase.Stratifier.stratify(fixed);
-        Phase.RenamePredSyms.renamePredSyms(runWithStratification(fixed, strat, false), fixInfo)
+        Phase.RenamePredSyms.renamePredSyms(runWithStratification(fixed, strat, withProv), fixInfo)
     }
 
     ///
@@ -98,13 +107,6 @@ mod Fixpoint3.Solver {
     }
 
     ///
-    /// Returns a provenance model of the given Datalog program `d`.
-    /// The provenance model can later be used for provenance queries.
-    ///
-    @Internal
-    pub def runSolverWithProvenance(d: Datalog): Datalog = ???
-
-    ///
     /// Returns the pairwise union of `d1` and `d2`.
     /// I.e. the facts of the union is the union of the facts and likewise for rules.
     /// A fact or rule may occur twice in the Datalog program. This has no effect on its semantics.
@@ -144,8 +146,31 @@ mod Fixpoint3.Solver {
     /// Returns the provenance of fact `f` of relation `p` given Datalog program `d`.
     ///
     @Internal
-    pub def provenanceOf(f: Vector[Boxed], p: PredSym, _d: Datalog, mkExtVar: PredSym -> Vector[Boxed] -> t): Vector[t] =
-        Vector#{mkExtVar(p, f)}
+    pub def provenanceOf(f: Vector[Boxed], p: PredSym, d: Datalog, mkExtVar: PredSym -> Vector[Boxed] -> t): Vector[t] = match d {
+        case Datalog(_, _) => provenanceOf(f, p, runSolverWithProvenance(d), mkExtVar)
+        case Model(db) => unsafely IO run {
+            // This is a dirty hack based on the implementation of Order on RelSym (it only depends on PredSym).
+            let fakeRelSym = Ram.makeFakeRelSym(p);
+            match Map.get(fakeRelSym, db) {
+                case None => // Temporary
+                    let termsStr = Vector.join(", ", f);
+                    bug!("${p}(${termsStr}) is not a fact")
+                case Some(facts) => match BPlusTree.memberOf(f, facts) {
+                    case false => // Temporary
+                        let termsStr = Vector.join(", ", f);
+                        bug!("${p}(${termsStr}) is not a fact")
+                    case true => Vector#{mkExtVar(p, f)}
+                }
+            }
+        }
+        case Provenance(_, _) => match Fixpoint3.Provenance.provQuery(p, f, d) {
+            case None =>
+                let termsStr = Vector.join(", ", f);
+                bug!("${p}(${termsStr}) is not a fact")
+            case Some(v) => Vector.map(match (pred, fact) -> mkExtVar(pred, fact), v)
+        }
+        case Join(_, _) => provenanceOf(f, p, runSolverWithProvenance(d), mkExtVar)
+    }
 
     ///
     /// Returns the `Provenance` program `d` as a `Model`.


### PR DESCRIPTION
Related to https://github.com/flix/flix/issues/11023.

It does currently not filter the facts according to the `with` part. This will be fixed in a separate PR.