### PR TITLE
fix: refine type of `pquery` expression

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
@@ -86,17 +86,19 @@ object SchemaConstraintGen {
     e match {
       case KindedAst.Expr.FixpointQueryWithProvenance(exps, select, withh, tvar, loc1) =>
         val (tpes, effs) = exps.map(visitExp).unzip
-        val selectSchemaRow = select match {
-          case KindedAst.Predicate.Head.Atom(_, Denotation.Relational, _, _, _) =>
-            visitHeadPredicate(select)
+        val selectRow = select match {
+          case KindedAst.Predicate.Head.Atom(_, Denotation.Relational, _, _, _) => visitHeadPredicate(select)
           case _ => throw InternalCompilerException("Provenance for lattice relations is not supported", loc1)
         }
-        val withSchemaRow = withh.foldRight(mkAnySchemaRowType(loc1)) {
-          (pred, acc) => Type.mkSchemaRowExtend(pred, Type.freshVar(Kind.Predicate, loc1), acc, loc1)
+        val (openRow, resultRow) = withh.foldRight((mkAnySchemaRowType(loc1), Type.mkSchemaRowEmpty(loc1))) {
+          case (pred, (acc1, acc2)) =>
+            val relType = Type.freshVar(Kind.Predicate, loc1)
+            val openRow = Type.mkSchemaRowExtend(pred, relType, acc1, loc1)
+            val closedRow = Type.mkSchemaRowExtend(pred, relType, acc2, loc1)
+            (openRow, closedRow)
         }
-        val fresh = Type.freshVar(Kind.SchemaRow, loc1)
-        c.unifyAllTypes(Type.mkSchema(fresh, loc1) :: Type.mkSchema(withSchemaRow, loc1) :: Type.mkSchema(selectSchemaRow, loc1) :: tpes, loc1)
-        val resTpe = Type.mkVector(Type.mkExtensible(fresh, loc1), loc1)
+        c.unifyAllTypes(Type.mkSchema(openRow, loc1) :: Type.mkSchema(selectRow, loc1) :: tpes, loc1)
+        val resTpe = Type.mkVector(Type.mkExtensible(resultRow, loc1), loc1)
         val resEff = Type.mkUnion(effs, loc1)
         c.unifyType(tvar, resTpe, loc1)
         (resTpe, resEff)


### PR DESCRIPTION
Refines row types in `pquery` according to predicates appearing in `with`.

Example: In the program below, `db1` has type `#{ Edge(Int32, Int32), Path(Int32, Int32) | t }` and `p` has type `Vector[#| Edge(Int32, Int32) |#]`, since we only include the `Edge` relation.
```
def main2(): Unit \ IO = 
    let db1 = #{ 
        Edge(1, 2). 
        Edge(2, 3).
        Path(x, y) :- Edge(x, y).
        Path(x, z) :- Path(x, y), Edge(y, z). 
    };
    let p = pquery db1 select Path(1, 2) with { Edge };
    ematch Vector.get(0, p) {
        case Edge(x, y) => println("${x} -> ${y}")
    }
```
You would previously have to include `Path` in the `ematch` to pass typechecking even though `p` only contains `Edge` facts, i.e.
```
   ematch Vector.get(0, p) {
        case Edge(x, y) => println("${x} -> ${y}")
        case Path(x, y) => ()
    }
```
This PR allows us to exclude the `Path` case in the `ematch`.

A separate PR will fix the `MatchError` crash, which is due to not yet passing predicates appearing in the `with` part to the Datalog engine.