### PR TITLE
fix: flatten provenance tree in a left to right order

### DIFF
--- a/main/src/library/Fixpoint3/Provenance.flix
+++ b/main/src/library/Fixpoint3/Provenance.flix
@@ -164,7 +164,7 @@ mod Fixpoint3.Provenance {
             case ProofTree.IDB(pred, fact, subTrees) :: tail => {
                 if (filter(pred)) MutList.push((pred, fact), res)
                 else ();
-                let furtherWork = (tail, subTrees) ||> Vector.foldLeft(acc -> cur -> cur :: acc);
+                let furtherWork = (tail, subTrees) ||> Vector.foldRight(cur -> acc -> cur :: acc);
                 recurse(furtherWork)
         }};
         recurse(p :: Nil);


### PR DESCRIPTION
```
def main(): Unit \ IO = 
    let db = #{
        Edge("Aarhus", "Kolding").
        Edge("Kolding", "Odense").
        Edge("Odense", "Copenhagen").
        Path(x, y) :- Edge(x, y).
        Path(x, z) :- Path(x, y), Edge(y, z).
    };
    let r = pquery db select Path("Aarhus", "Copenhagen") with {Edge, Path};
    Vector.forEach(v -> ematch v {
        case Edge(src, dst) => println("${src} -> ${dst}")
        case Path(_src, _dst) => ()
    }, r)
```
now prints
```
Aarhus -> Kolding
Kolding -> Odense
Odense -> Copenhagen
```