### PR TITLE
chore: use `foreach` keyword

### DIFF
--- a/main/src/library/Fixpoint3/Ast/Datalog.flix
+++ b/main/src/library/Fixpoint3/Ast/Datalog.flix
@@ -110,13 +110,13 @@ mod Fixpoint3.Ast.Datalog {
                    unsafely IO run {
                         let builder = StringBuilder.empty(rc);
                         foreach ((relSym, innerMap) <- db) {
-                            innerMap |> BPlusTree.forEach(tuple -> lat -> {
+                            foreach ((tuple, lat) <- innerMap) {
                                 let tupleString = tuple |> Vector.map(Debug.stringify) |> Vector.join(", ");
                                 match toDenotation(relSym) {
                                     case Relational => StringBuilder.append("${relSym}(${tupleString}).${String.lineSeparator()}", builder)
                                     case Latticenal(_, _, _, _) => StringBuilder.append("${relSym}(${tupleString}; %{lat}).${String.lineSeparator()}", builder)
                                 }
-                            })
+                            }
                         };
                         StringBuilder.toString(builder)
                     }
@@ -131,10 +131,9 @@ mod Fixpoint3.Ast.Datalog {
                     let indent = String.repeat(4, " ");
                     Map.joinWith(predSym -> facts -> {
                         let builder = StringBuilder.empty(rc);
-                        facts |>
-                            BPlusTree.forEach(fact -> annotation -> {
-                                StringBuilder.append("${indent}${fact} @ ${annotation},{String.lineSeparator()}${indent}", builder)
-                            });
+                        foreach ((fact, annotation) <- facts) {
+                            StringBuilder.append("${indent}${fact} @ ${annotation},{String.lineSeparator()}${indent}", builder)
+                        };
                         let textOverflow = String.length("$,{String.lineSeparator()}${indent}");
                         let rawFactString = StringBuilder.toString(builder);
                         let factsString = String.sliceLeft(end = String.length(rawFactString)- textOverflow, rawFactString);

--- a/main/src/library/Fixpoint3/Boxing.flix
+++ b/main/src/library/Fixpoint3/Boxing.flix
@@ -361,7 +361,7 @@ mod Fixpoint3.Boxing {
             case BoolExp.Not(bexp) => unifyRamIdsBool(set, bexp)
             case BoolExp.IsEmpty(_) => ()
             case BoolExp.NotMemberOf(terms, RelSym.Symbol(PredSym.PredSym(_, id), _, _)) =>
-                Vector.forEach(term -> unifyRamIdsTerm(set, term), terms);
+                Vector.forEach(unifyRamIdsTerm(set), terms);
                 foreach ((i, term) <- ForEach.withIndex(terms)) {
                     MutDisjointSets.union(Ram.getTermRamId(term), RamId.RelPos(id, i), set)
                 }

--- a/main/src/library/Fixpoint3/Interpreter.flix
+++ b/main/src/library/Fixpoint3/Interpreter.flix
@@ -124,7 +124,7 @@ mod Fixpoint3.Interpreter {
             if (BPlusTree.isEmpty(tuples))
                 index
             else {
-                BPlusTree.forEach(match nonLat -> lat -> {
+                BPlusTree.forEach(nonLat -> lat -> {
                     match toDenotation(relSym) {
                         case Relational =>
                             BPlusTree.put(nonLat, lat, index)
@@ -151,13 +151,13 @@ mod Fixpoint3.Interpreter {
         let indexes = Array.empty(rc, indexNum);
         foreach ((relSym, searches) <- indexMap) {
             let tuples = Map.getWithDefault(relSym, BPlusTree.empty(rc), facts);
-            searches |> Vector.forEachWithIndex(num -> search -> {
+            foreach ((num, search) <- ForEach.withIndex(searches)) {
                 let pos = match Map.get((relSym, num), posMap) {
                     case Some(v) => v
                     case None => bug!("In Fixpoint.Interpreter.interpretWithInput: ${relSym} has no index!")
                 };
                 storeIndex(mkIndex(rc, relSym, search, tuples), pos, indexes)
-            })
+            }
         };
         interpretWithDatabase(rc, indexes, boxing, withProv, program)
 

--- a/main/src/library/Fixpoint3/Phase/Compiler.flix
+++ b/main/src/library/Fixpoint3/Phase/Compiler.flix
@@ -158,7 +158,7 @@ mod Fixpoint3.Phase.Compiler {
 
         // Construct the inserts for step 1.
         let inserts = MutList.empty(rc);
-        foreach ((rule, ruleNum) <- List.zip(stratum, rulesWithId)) {
+        foreach ((rule, ruleNum) <- ForEach.withZip(stratum, rulesWithId)) {
             compileRule(inserts, rule, ruleNum, predicates, counter)
         };
         let optPar =
@@ -178,7 +178,7 @@ mod Fixpoint3.Phase.Compiler {
                 let loopBody = MutList.empty(rc);
 
                 let loopInserts = MutList.empty(rc);
-                foreach ((rule, ruleNum) <- List.zip(stratum, rulesWithId)) {
+                foreach ((rule, ruleNum) <- ForEach.withZip(stratum, rulesWithId)) {
                     compileRuleIncr(loopInserts, rule, ruleNum, idbIds, predicates, counter)
                 };
                 let loopParOpt =

--- a/main/src/library/Fixpoint3/Provenance.flix
+++ b/main/src/library/Fixpoint3/Provenance.flix
@@ -93,13 +93,12 @@ mod Fixpoint3.Provenance {
                         let extractSearchPart = k -> Vector.init(i -> Vector.get(Vector.get(i, search), k), Vector.length(search));
                         let nonSearch = Vector.range(0, arity) |> Vector.filter(v -> not Vector.memberOf(v, search));
                         let extractNonSearchPart = k -> Vector.init(i -> Vector.get(Vector.get(i, nonSearch), k), Vector.length(nonSearch));
-                        fullTree |>
-                            BPlusTree.forEach(k -> match (depth, rule) -> {
-                                let searchPart = extractSearchPart(k);
-                                let nonSearchPart = extractNonSearchPart(k);
-                                let newVal = (nonSearchPart, depth, rule);
-                                BPlusTree.putWith(_ -> old -> newVal :: old, searchPart, newVal :: Nil, tree)
-                            });
+                        foreach ((k, (depth, rule)) <- fullTree) {
+                            let searchPart = extractSearchPart(k);
+                            let nonSearchPart = extractNonSearchPart(k);
+                            let newVal = (nonSearchPart, depth, rule);
+                            BPlusTree.putWith(_ -> old -> newVal :: old, searchPart, newVal :: Nil, tree)
+                        };
                         BPlusTree.put(search, tree, innerMap);
                         BPlusTree.get(vals, tree)
                 }

--- a/main/src/library/Fixpoint3/Solver.flix
+++ b/main/src/library/Fixpoint3/Solver.flix
@@ -926,7 +926,7 @@ mod Fixpoint3.Solver {
             case None => Vector#{}
             case Some(facts) => region rc {
                 let acc = MutList.empty(rc);
-                facts |> BPlusTree.forEach(k -> _ -> MutList.push(f(k), acc));
+                BPlusTree.forEach(k -> _ -> MutList.push(f(k), acc), facts);
                 unchecked_cast((MutList.toArray(rc, acc): Array[t, rc]) as Vector[t])
             }
         }
@@ -966,11 +966,10 @@ mod Fixpoint3.Solver {
             ||> Map.foldLeftWithKey(acc -> relSym -> facts -> {
                 let len = Vector.length(fst(getOrCrash(BPlusTree.minimumKey(facts))));
                 let newTree = BPlusTree.empty(Static);
-                facts |>
-                    BPlusTree.forEach(fact -> _ -> {
-                        let (rawFact, annotation) = Vector.splitAt(len - 2, fact);
-                        newTree |> BPlusTree.put(rawFact, (unbox(Vector.get(0, annotation)), getOrCrash(Int64.tryToInt32(unbox(Vector.get(1, annotation))))))
-                    });
+                foreach ((fact, _) <- facts) {
+                    let (rawFact, annotation) = Vector.splitAt(len - 2, fact);
+                    newTree |> BPlusTree.put(rawFact, (unbox(Vector.get(0, annotation)), getOrCrash(Int64.tryToInt32(unbox(Vector.get(1, annotation))))))
+                };
                 Map.insert(relSym, newTree, acc)
             })
             |> Provenance(rules)


### PR DESCRIPTION
See #11066.

There are 3 cases where the new `foreach` keyword is not used.

1. Partial application. Example: `Vector.forEach(unifyRamIdsTerm(set), terms)`
2. One liner. Example: `Vector.forEach(i -> insert(RamId.RelPos(predSym, i)), Vector.range(0, arity))`
3. Performance critical `BPlusTree.forEach`. This is mainly in the interpreter, as the implementation of `foreach` for `BPlusTree` allocates a new tuple per entry.

If any of the cases should be converted to `foreach` loops please say so, otherwise I will consider this more or less done.