### PR TITLE
refactor: only transform predicates to list once

### DIFF
--- a/main/src/library/Fixpoint3/Ast/Ram.flix
+++ b/main/src/library/Fixpoint3/Ast/Ram.flix
@@ -36,11 +36,11 @@ mod Fixpoint3.Ast.Ram {
     }
 
     ///
-    /// Contains a set of `RelSym` representing the names of the relations in the program
-    /// and 1 + the maximal identifier of the `RelSym`s.
+    /// Contains a list of `RelSym` representing the names of the relations in the program,
+    /// a list of Full `RelSym` and 1 + the maximal identifier of the Full `RelSym`s.
     ///
     @Internal
-    pub type alias Predicates = (Int64, Set[RelSym])
+    pub type alias Predicates = (List[RelSym], List[RelSym], Int64)
 
     ///
     /// The extensible database (EDB) of a program.

--- a/main/src/library/Fixpoint3/Boxing.flix
+++ b/main/src/library/Fixpoint3/Boxing.flix
@@ -263,7 +263,7 @@ mod Fixpoint3.Boxing {
         use Fixpoint3.BoxingType.RamIdToPos
         use Fixpoint3.Counter
         use Fixpoint3.Util.getOrCrash
-        use Fixpoint3.Predicate.{PredType, idToFullPredId, fullRelSymToType, relSymFromPredType, relSymsOfProgram}
+        use Fixpoint3.Predicate.{PredType, fullRelSymToType, relSymFromPredType, relSymsOfProgram}
 
         ///
         /// Returns a map from `RamId` to `UnifiedTypePos` constructed from `program`.

--- a/main/src/library/Fixpoint3/Predicate.flix
+++ b/main/src/library/Fixpoint3/Predicate.flix
@@ -67,21 +67,28 @@ mod Fixpoint3.Predicate {
     }
 
     ///
+    /// Returns 1 plus the maximum full predicate in `predicates`.
+    ///
+    def getMax(predicates: Predicates): Int64 = {
+        let (_, _, res) = predicates;
+        res
+    }
+
+    ///
     /// Returns a list of all full `RelSym` in `predInfo`.
     ///
     @Internal
     pub def allFullRelSyms(predInfo: Predicates): List[RelSym] =
-        Set.foldLeft(acc -> relSym -> relSym :: acc , Nil, snd(predInfo))
+        let (_, full, _) = predInfo;
+        full
 
     ///
     /// Returns a list of all `RelSym` in `predInfo`.
     ///
     @Internal
     pub def allRelSyms(predInfo: Predicates): List[RelSym] =
-        let full = allFullRelSyms(predInfo);
-        full |>
-        List.append(List.map(x -> fullRelSymToType(x, PredType.Delta, predInfo), full)) |>
-        List.append(List.map(x -> fullRelSymToType(x, PredType.New, predInfo), full))
+        let (relSyms, _, _) = predInfo;
+        relSyms
 
     ///
     /// Returns the full `RelSym` associated with the `PredSym` in `body` according to `predInfo`.
@@ -94,9 +101,7 @@ mod Fixpoint3.Predicate {
     ///
     /// Returns the identifier of `wantedType` of `id` according to `predInfo`
     ///
-    @Internal
-    pub def fullIdtoPredType(id: Int64, wantedType: PredType, predInfo: Predicates): Int64 =
-        let (max, _) = predInfo;
+    def fullIdtoPredType(id: Int64, wantedType: PredType, max: Int64): Int64 =
         match wantedType {
             case PredType.Full => id
             case PredType.Delta => id + max
@@ -108,23 +113,28 @@ mod Fixpoint3.Predicate {
     /// a full `RelSym`.
     ///
     @Internal
-    pub def fullRelSymToType(relSym: RelSym, wantedType: PredType, predInfo: Predicates): RelSym = match relSym {
-        case RelSym.Symbol(PredSym.PredSym(name, id), arity, den) => RelSym.Symbol(PredSym.PredSym(name, fullIdtoPredType(id, wantedType, predInfo)), arity, den)
+    pub def fullRelSymToType(relSym: RelSym, wantedType: PredType, predInfo: Predicates): RelSym = 
+        fullRelSymToTypeInternal(relSym, wantedType, getMax(predInfo))
+
+    ///
+    /// Returns a `RelSym` of type `wantedType` given the `RelSym` `relSym`, which must be
+    /// a full `RelSym`.
+    ///
+    def fullRelSymToTypeInternal(relSym: RelSym, wantedType: PredType, max: Int64): RelSym = match relSym {
+        case RelSym.Symbol(PredSym.PredSym(name, id), arity, den) => RelSym.Symbol(PredSym.PredSym(name, fullIdtoPredType(id, wantedType, max)), arity, den)
     }
 
     ///
     /// Returns the identifier of type `wantedType` from `id` according to `predInfo`.
     ///
-    @Internal
-    pub def getIdAsType(id: Int64, wantedType: PredType, predInfo: Predicates): Int64 =
+    def getIdAsType(id: Int64, wantedType: PredType, predInfo: Predicates): Int64 =
         let fullId = idToFullPredId(id, predInfo);
-        fullIdtoPredType(fullId, wantedType, predInfo)
+        fullIdtoPredType(fullId, wantedType, getMax(predInfo))
 
     ///
     /// Returns the `PredSym` of type `wantedType` from `predSym` according to `predInfo`.
     ///
-    @Internal
-    pub def getPredSymAsType(predSym: PredSym, wantedType: PredType, predInfo: Predicates): PredSym = match predSym {
+    def getPredSymAsType(predSym: PredSym, wantedType: PredType, predInfo: Predicates): PredSym = match predSym {
         case PredSym.PredSym(name, id) => PredSym.PredSym(name, getIdAsType(id, wantedType, predInfo))
     }
 
@@ -148,9 +158,8 @@ mod Fixpoint3.Predicate {
     /// Returns the identifier of the full `PredSym` associated with the identifier `id`
     /// according to `predInfo`.
     ///
-    @Internal
-    pub def idToFullPredId(id: Int64, predInfo: Predicates): Int64 =
-        let (max, _) = predInfo;
+    def idToFullPredId(id: Int64, predInfo: Predicates): Int64 =
+        let max = getMax(predInfo);
         if (id <= max) {
             id
         } else if (id <= max * 2i64) {
@@ -162,9 +171,8 @@ mod Fixpoint3.Predicate {
     ///
     /// Returns the type of a `PredSym` with identifier `id` according to `predInfo`.
     ///
-    @Internal
-    pub def idToPredType(id: Int64, predInfo: Predicates): PredType =
-        let (max, _) = predInfo;
+    def idToPredType(id: Int64, predInfo: Predicates): PredType =
+        let max = getMax(predInfo);
         if (id <= max) {
             PredType.Full
         } else if (id <= max * 2i64) {
@@ -193,7 +201,7 @@ mod Fixpoint3.Predicate {
     @Internal
     pub def relSymFromPredType(relSym: RelSym, wantedType: PredType, predInfo: Predicates): RelSym = match relSym {
         case RelSym.Symbol(PredSym.PredSym(name, id), arity, den) =>
-            RelSym.Symbol(PredSym.PredSym(name, fullIdtoPredType(idToFullPredId(id, predInfo), wantedType, predInfo)), arity, den)
+            RelSym.Symbol(PredSym.PredSym(name, fullIdtoPredType(idToFullPredId(id, predInfo), wantedType, getMax(predInfo))), arity, den)
     }
 
     ///
@@ -215,18 +223,23 @@ mod Fixpoint3.Predicate {
     ///
     /// Returns a set of all full `RelSym` created from `PredSym`s in `program` and `db` and the maximal identifier+1.
     ///
-    def collectPreds(program: Datalog, db: Map[RelSym, BPlusTree[Vector[Boxed], Boxed, Static]]): (Int64, Set[RelSym]) = match program {
+    def collectPreds(program: Datalog, db: Map[RelSym, BPlusTree[Vector[Boxed], Boxed, Static]]): Predicates = match program {
         case Datalog(facts, rules) =>
             let set1 = collectPredicates(rules);
             let set2 = collectPredicates(facts);
             let set3 = collectDbPredicates(db);
             let set = (set1 `Set.union` set2) `Set.union` set3;
-            let optMax = set |>
-                Set.maximumBy(match RelSym.Symbol(PredSym.PredSym(_, id1), _, _) -> match RelSym.Symbol(PredSym.PredSym(_, id2), _, _) -> id1 <=> id2);
-            match optMax {
-                case None => (-1i64, set)
-                case Some(max) => (toId(max) + 1i64, set)
-            }
+            let fullRels = Set.toList(set);
+            let optMax = fullRels |>
+                List.maximumBy(match RelSym.Symbol(PredSym.PredSym(_, id1), _, _) -> match RelSym.Symbol(PredSym.PredSym(_, id2), _, _) -> id1 <=> id2);
+            let max = match optMax {
+                case None => 0i64
+                case Some(max) => toId(max) + 1i64
+            };
+            let deltaRels = List.map(x -> fullRelSymToTypeInternal(x, PredType.Delta, max), fullRels);
+            let newRels = List.map(x -> fullRelSymToTypeInternal(x, PredType.New, max), fullRels);
+            let allRels = fullRels ::: deltaRels ::: newRels;
+            (allRels, fullRels, max)
         case _ => bug!("Datalog Boxing bug")
     }
 


### PR DESCRIPTION
This started as a simple transformation of `Predicates` from `(Int64, Set[RelSym])` to `(List[RelSym], List[RelSym], Int64)`.

It ended up also removing a few `@Internal pub` from functions and in minor refactoring of the module `Predicate`.