### PR TITLE
chore: improve built in `Order` performance

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -264,7 +264,10 @@ object Deriver {
     *     match (x, y) {
     *       case (C0, C0) => Comparison.EqualTo
     *       case (C1(x0), C1(y0)) => Order.compare(x0, y0)
-    *       case (C2(x0, x1), C2(y0, y1)) => Order.compare(x0, y0) `Order.thenCompare` lazy Order.compare(x1, y1)
+    *       case (C2(x0, x1), C2(y0, y1)) => match Order.compare(x0, y0) {
+    *         case Comparison.EqualTo => Order.compare(x1, y1)
+    *         case z                  => z
+    *       }
     *       case _ => Order.compare(indexOf(x), indexOf(y))
     *     }
     *   }
@@ -418,7 +421,6 @@ object Deriver {
     case KindedAst.Case(sym, tpes, _, _) =>
       val equalToSym = PredefinedTraits.lookupCaseSym("Comparison", "EqualTo", root)
       val compareSigSym = PredefinedTraits.lookupSigSym("Order", "compare", root)
-//      val thenCompareDefSym = PredefinedTraits.lookupDefSym(List("Order"), "thenCompare", root)
       val comparisonEquals = PredefinedTraits.lookupCaseSym("Comparison", "EqualTo", root)
 
       // Match on the tuple
@@ -447,7 +449,7 @@ object Deriver {
       }
 
       /**
-        * Joins the two expressions via `Compare.thenCompare`, making the second expression lazy.
+        * Joins the two expressions via nested match rules.
         * (Cannot be inlined due to issues with Scala's type inference.
         */
       def thenCompare(exp1: KindedAst.Expr, exp2: KindedAst.Expr): KindedAst.Expr = {
@@ -456,9 +458,9 @@ object Deriver {
           List(
             KindedAst.MatchRule(
               KindedAst.Pattern.Tag(
-                // Don't know what the type should be.
                 CaseSymUse(comparisonEquals, loc), Nil, Type.freshVar(Kind.Star, loc), loc
-              ), None, exp2, loc
+              ),
+              None, exp2, loc
             ),
             KindedAst.MatchRule(
               mkVarPattern(matchVarSym, loc),


### PR DESCRIPTION
Basically a follow up of #11129.

Improves performance for small test. Still gets destroyed by the third set of inputs.

Test program:
```
use Standard.Case1;
use Standard.Case2
enum Standard {
    case Case1(String, Int32)
    case Case2(Int32, String)
}

instance Eq[Standard] {
    pub def eq(s1: Standard, s2: Standard): Bool =
    match (s1, s2) {
        case (Case1(str1, int1), Case1(str2, int2)) => str1 == str2 and int1 == int2
        case (Case2(int1, str1), Case2(int2, str2)) => int1 == int2 and str1 == str2
        case _ => false
    }
}
instance Order[Standard] {
    pub def compare(s1: Standard, s2: Standard): Comparison =
    match (s1, s2) {
        case (Case1(str1, int1), Case1(str2, int2)) => match str1 <=> str2 {
            case Comparison.EqualTo => int1 <=> int2
            case y => y
        }
        case (Case2(int1, str1), Case2(int2, str2)) => match int1 <=> int2 {
            case Comparison.EqualTo => str1 <=> str2
            case y => y
        }
        case (Case1(_, _), _) => Comparison.GreaterThan
        case (Case2(_, _), _) => Comparison.LessThan
    }
}

enum Standard2 with Eq, Order {
    case Case1(String, Int32)
    case Case2(Int32, String)
}


def main(): Unit \ IO = region rc {
    let t1 = Standard.Case1("str", 1);
    let t2 = Standard.Case1("str", 1);
    let t3 = Standard2.Case1("str", 1);
    let t4 = Standard2.Case1("str", 1);

    // let t1 = Standard.Case2(1, "str");
    // let t2 = Standard.Case2(1, "str");
    // let t3 = Standard2.Case2(1, "str");
    // let t4 = Standard2.Case2(1, "str");

    // let t1 = Standard.Case1("str", 1);
    // let t2 = Standard.Case2(1, "str");
    // let t3 = Standard2.Case1("str", 1);
    // let t4 = Standard2.Case2(1, "str");

    // let t1 = Standard.Case1("str1", 1);
    // let t2 = Standard.Case1("str", 1);
    // let t3 = Standard2.Case1("str1", 1);
    // let t4 = Standard2.Case1("str", 1);

    spawn runForeverOld(0i64, t1, t2) @ rc;
    spawn runForeverNew(0i64, t3, t4) @ rc;
    ()
}

def runForeverOld(i: Int64, t1: a, t2: a): Unit \ IO with Order[a] = 
    if(Int64.modulo(i, 5000000i64) == 0i64) {
        println("Self: ${i}")
    } else {
        ()
    };
    if (t1 <=> t2 == Comparison.EqualTo) {
        runForeverOld(i + 1i64, t1, t2)
    } else {
        runForeverOld(i + 1i64, t1, t2)
    }

def runForeverNew(i: Int64, t1: a, t2: a): Unit \ IO with Order[a] = 
    if(Int64.modulo(i, 5000000i64) == 0i64) {
        println("Flix: ${i}")
    } else {
        ()
    };
    if (t1 <=> t2 == Comparison.EqualTo) {
        runForeverNew(i + 1i64, t1, t2)
    } else {
        runForeverNew(i + 1i64, t1, t2)
    }
```