### PR TITLE
chore: add error in Weeder2 for illegal lattice provenance

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -235,7 +235,6 @@ object WeederError {
     override def explain(formatter: Formatter): Option[String] = Some("Annotations are not allowed on local functions.")
   }
 
-
   /**
     * An error raised to indicate that a lowercase name was expected.
     *
@@ -455,6 +454,24 @@ object WeederError {
       s""">> Unexpected type ascription. Type ascriptions are not permitted on effect handler cases.
          |
          |${code(loc, "unexpected type ascription")}
+         |
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * An error raised to indicate that a provenance query was executed on a lattice relation, which is not supported.
+    *
+    * @param loc the location of the illegal latticenal atom.
+    */
+  case class IllegalLatticeProvenance(loc: SourceLocation) extends WeederError {
+    override def summary: String = "Illegal lattice relation in provenance query."
+
+    override def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Illegal lattice relation in provenance query. Provenance on lattice relations is not supported.
+         |
+         |${code(loc, "illegal lattice relation")}
          |
          |""".stripMargin
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -2149,6 +2149,10 @@ object Weeder2 {
       )
       mapN(expressions, select, withh) {
         (expressions, select, withh) =>
+          if (select.den == Denotation.Latticenal) {
+              val error = IllegalLatticeProvenance(select.loc)
+              sctx.errors.add(error)
+          }
           Expr.FixpointQueryWithProvenance(expressions, select, withh.map(Name.mkPred), tree.loc)
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
@@ -86,10 +86,7 @@ object SchemaConstraintGen {
     e match {
       case KindedAst.Expr.FixpointQueryWithProvenance(exps, select, withh, tvar, loc1) =>
         val (tpes, effs) = exps.map(visitExp).unzip
-        val selectRow = select match {
-          case KindedAst.Predicate.Head.Atom(_, Denotation.Relational, _, _, _) => visitHeadPredicate(select)
-          case _ => throw InternalCompilerException("Provenance for lattice relations is not supported", loc1)
-        }
+        val selectRow = visitHeadPredicate(select)
         val (withRow, resultRow) = withh.foldRight((mkAnySchemaRowType(loc1), mkAnySchemaRowType(loc1))) {
           case (pred, (acc1, acc2)) =>
             val relType = Type.freshVar(Kind.Predicate, loc1)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -570,6 +570,46 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalFormalParamAscription](result)
   }
 
+  test("IllegalLatticeProvenance.01") {
+    val input =
+      """
+        |def main(): Unit  =
+        |    let p = #{
+        |        A(x; y) :- B(x, y).
+        |    };
+        |    let _ = pquery p select A(1; 2) with { B };
+        |    ()
+        |""".stripMargin
+    val result = compile(input, Options.Default)
+    expectError[WeederError.IllegalLatticeProvenance](result)
+  }
+
+  test("IllegalLatticeProvenance.02") {
+    val input =
+      """
+        |def main(): Unit  =
+        |    let p = #{
+        |        A(x; y) :- B(x, y).
+        |    };
+        |    let _ = pquery p select A("hello"; 2) with { B };
+        |    ()
+        |""".stripMargin
+    val result = compile(input, Options.Default)
+    expectError[WeederError.IllegalLatticeProvenance](result)
+  }
+
+  test("IllegalLatticeProvenance.03") {
+    val input =
+      """
+        |def main(): Unit  =
+        |    let p = #{ };
+        |    let _ = pquery p select A("hello"; 2) with { B };
+        |    ()
+        |""".stripMargin
+    val result = compile(input, Options.Default)
+    expectError[WeederError.IllegalLatticeProvenance](result)
+  }
+
   test("IllegalModifier.01") {
     val input =
       """


### PR DESCRIPTION
Fixes https://github.com/flix/flix/issues/11272.

The error is only for the `select` atom and not potential lattice relations appearing in `with`.