### PR TITLE
fix: only close `psolve` once in Parser2

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2885,7 +2885,8 @@ object Parser2 {
 
       if (isPSolve) {
         return close(mark, TreeKind.Expr.FixpointSolveWithProvenance)
-      } else if (eat(TokenKind.KeywordProject)) {
+      }
+      if (eat(TokenKind.KeywordProject)) {
         nameUnqualified(NAME_PREDICATE)
         while (eat(TokenKind.Comma) && !eof()) {
           nameUnqualified(NAME_PREDICATE)


### PR DESCRIPTION
Fixes #11279