### PR TITLE
fix: issue error when `with` misses `{}`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2946,13 +2946,13 @@ object Parser2 {
           delimiterL = TokenKind.CurlyL,
           delimiterR = TokenKind.CurlyR
         )
-        case t => UnexpectedToken(
+        case t => closeWithError(open(), UnexpectedToken(
           expected = NamedTokenSet.FromKinds(Set(TokenKind.CurlyL)),
           actual = Some(t),
           sctx,
           hint = Some("provide a list of predicates"),
           loc = currentSourceLocation()
-        )
+        ))
       }
       close(mark, TreeKind.Expr.FixpointWith)
     }


### PR DESCRIPTION
Fixes #11280.

The error can be kind of hard to see in the editor. Closing the with-mark causes another error which makes it hard to see the problem.