### PR TITLE
fix: renamePredSyms failing to rename rules in `Provenance` enum

### DIFF
--- a/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
+++ b/main/src/library/Fixpoint3/Phase/RenamePredSyms.flix
@@ -69,12 +69,14 @@ mod Fixpoint3.Phase.RenamePredSyms {
                 })
                 |> Model
         case Provenance(rules, facts) =>
+            let transformer = mapForward(mapping);
+            let newRules = remapConstraints(rules, transformer);
             (Map#{}, facts)
                 ||> Map.foldLeftWithKey(acc -> match RelSym.Symbol(predSym, arity, den) -> v ->
                     let newSym = RelSym.Symbol(mapForward(mapping, predSym), arity, den);
                     Map.insert(newSym, v, acc)
                 )
-                |> Provenance(rules)
+                |> Provenance(newRules)
         case Join(d1, d2) =>
             Join(fixPredSymsInternal(d1, mapping), fixPredSymsInternal(d2, mapping))
         case _ => bug!("PredSym error")


### PR DESCRIPTION
Should fix #11321

In the current implementation successive calls to `solve` and `psolve` should be idempotent. Is this what we want? As in do we want that
```psolve (psolve X) == solve (psolve X)```
I would not say it is a guaranteed property, just a consequence of the current `Solver.runWithStratification` being lazy.

An argument against this property being allowed would be that it allows people to confuse the semantics and could lead to people depending on it.