### PR TITLE
fix: remove race condition in `BPlusTree`

### DIFF
--- a/main/src/library/BPlusTree.flix
+++ b/main/src/library/BPlusTree.flix
@@ -1361,7 +1361,9 @@ mod BPlusTree {
                 splitInternalToRightChild(rc, insertedChild, insertionPoint, newKey, mid, arity, rightSize, leftNode)
             };
             let rightNode = mkInternal(rc, rightKeys, rightChildren, rightSize, leftNode->parent);
-            // You do not have a lock on the rightNode?
+            // Lock `rightNode` before updating child-pointers.
+            // This prevents threads working on children from grabbing the lock of our
+            // parent pointer before we lock it.
             let rightNodeStamp = Lock.writeLock(rightNode->lock);
             let parentStamp = lockParent(leftNode, tree);
             rightNode->parent = leftNode->parent;


### PR DESCRIPTION
I believe this fixes #11309.

The `BPlusTree` has so far passed its tests 1325 times.

I also believe that the change for `lockParent` is unnecessary with the current use, but this should prevent future failures if the tree is extended with new methods.