### PR TITLE
fix: allow unused variables in functional predicates

### DIFF
--- a/main/src/library/Fixpoint3/Boxing.flix
+++ b/main/src/library/Fixpoint3/Boxing.flix
@@ -336,11 +336,15 @@ mod Fixpoint3.Boxing {
                 };
                 Vector.forEach(unifyRamIdsBool(set), bools);
                 unifyRamIdsOp(predicates, set, withProv, body)
-            case RelOp.Functional(RowVar.Named(id), _, inputTerms, body, _) =>
+            case RelOp.Functional(rv, _, inputTerms, body, arity) =>
+                let RowVar.Named(id) = rv;
                 foreach ((i, curTerm) <- ForEach.withIndex(inputTerms)) {
                     let termID = Ram.getTermRamId(curTerm);
                     MutDisjointSets.union(RamId.InId(id, i), termID, set);
                     unifyRamIdsTerm(set, curTerm)
+                };
+                foreach (i <- Vector.range(0, arity)) {
+                    MutDisjointSets.makeSet(RamId.TuplePos(rv, i), set)
                 };
                 unifyRamIdsOp(predicates, set, withProv, body)
             case RelOp.Project(terms, RelSym.Symbol(PredSym.PredSym(_, predSym), _, _), _) =>

--- a/main/test/flix/Test.Exp.Fixpoint.Functional.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.Functional.flix
@@ -180,7 +180,7 @@ mod Test.Exp.Fixpoint.Functional {
     }
 
     @Test
-    def testFunctionalIgnoreRes01(): Bool = {
+    def testFunctionalUnusedVar01(): Bool = {
         let db = #{
             A(1). A(3). A(5).
         };
@@ -191,7 +191,7 @@ mod Test.Exp.Fixpoint.Functional {
     }
 
     @Test
-    def testFunctionalIgnoreRes02(): Bool = {
+    def testFunctionalUnusedVar02(): Bool = {
         let db = #{
             A(1). A(3). A(5).
         };
@@ -202,7 +202,7 @@ mod Test.Exp.Fixpoint.Functional {
     }
 
     @Test
-    def testFunctionalIgnoreRes03(): Bool = {
+    def testFunctionalUnusedVar03(): Bool = {
         let db = #{
             A(1). A(3). A(5).
         };

--- a/main/test/flix/Test.Exp.Fixpoint.Functional.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.Functional.flix
@@ -179,6 +179,39 @@ mod Test.Exp.Fixpoint.Functional {
         Vector#{1f64} `Assert.eq` query p select (x) from NonEmpty(x)
     }
 
+    @Test
+    def testFunctionalIgnoreRes01(): Bool = {
+        let db = #{
+            A(1). A(3). A(5).
+        };
+        let pr = #{
+            R(x) :- A(x), let y = Vector#{3}, if (y + x > 5 and x + y < 7).
+        };
+        Vector#{3} `Assert.eq` query db, pr select x from R(x)
+    }
+
+    @Test
+    def testFunctionalIgnoreRes02(): Bool = {
+        let db = #{
+            A(1). A(3). A(5).
+        };
+        let pr = #{
+            R(x) :- A(x), let y = Vector#{3}.
+        };
+        Vector#{1, 3, 5} `Assert.eq` query db, pr select x from R(x)
+    }
+
+    @Test
+    def testFunctionalIgnoreRes03(): Bool = {
+        let db = #{
+            A(1). A(3). A(5).
+        };
+        let pr = #{
+            R(10) :- A(x), let y = Vector#{x}.
+        };
+        Vector#{10} `Assert.eq` query db, pr select x from R(x)
+    }
+
     /////////////////////////////////////////////////////////////////////////////
     // Tests with lattice values                                               //
     /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When this has been merged I will make a PR for #11304.