### PR TITLE
fix: support arbitrary size provenance paths

### DIFF
--- a/main/src/library/Fixpoint3/Provenance.flix
+++ b/main/src/library/Fixpoint3/Provenance.flix
@@ -117,15 +117,15 @@ mod Fixpoint3.Provenance {
     /// respect to `ProvIDB`, and it is not a ground atom. Furthermore `subproofs`
     /// contains the proofs/facts of the body which (could have) derived `P(tuple)`.
     ///
-    enum ProofTree {
+    enum ProofTree[r: Region] {
         case EDB(PredSym, Vector[Boxed])
         case Negative(PredSym, Vector[Boxed])
-        case IDB(PredSym, Vector[Boxed], Vector[ProofTree])
+        case IDB(PredSym, Vector[Boxed], Array[ProofTree[r], r])
     }
 
     mod ProofTree {
         @Internal
-        pub def toString(p: ProofTree, indentChild: Int32): String = match p {
+        pub def toString(p: ProofTree[r], indentChild: Int32): String \ r = match p {
             case EDB(pred, fact) =>
                 let indentCur = String.repeat(indentChild, " ");
                 let factString = Vector.join(", ", fact);
@@ -137,13 +137,9 @@ mod Fixpoint3.Provenance {
             case IDB(pred, fact, subs) =>
                 let factString = Vector.join(", ", fact);
                 let indentCur = String.repeat(indentChild, " ");
-                let subProofs = Vector.joinWith(sub -> toString(sub, indentChild + 4), "${String.lineSeparator()}", subs);
+                let subProofs = Array.joinWith(sub -> toString(sub, indentChild + 4), "${String.lineSeparator()}", subs);
                 "${indentCur}${pred}(${factString}). Proof:${String.lineSeparator()}${subProofs}"
         }
-    }
-
-    instance ToString[ProofTree] {
-        pub def toString(p: ProofTree): String = ProofTree.toString(p, 0)
     }
 
     ///
@@ -151,9 +147,9 @@ mod Fixpoint3.Provenance {
     ///
     /// The tree is traversed in a pre-order fashion meaning that for `IDB` atoms the atom is listed before the children.
     ///
-    def filterAndFlattenProof(p: ProofTree, filter: PredSym -> Bool): Vector[(PredSym, Vector[Boxed])] = region rc {
+    def filterAndFlattenProof(p: ProofTree[r], filter: PredSym -> Bool): Vector[(PredSym, Vector[Boxed])] \ r = region rc {
         let res = MutList.empty(rc);
-        def recurse(workList: List[ProofTree]) = match workList {
+        def recurse(workList: List[ProofTree[r]]) = match workList {
             case Nil                               => ()
             case ProofTree.EDB(pred, fact) :: tail =>
                 if (filter(pred)) MutList.push((pred, fact), res)
@@ -163,7 +159,7 @@ mod Fixpoint3.Provenance {
             case ProofTree.IDB(pred, fact, subTrees) :: tail => {
                 if (filter(pred)) MutList.push((pred, fact), res)
                 else ();
-                let furtherWork = Vector.foldRight(cur -> acc -> cur :: acc, tail, subTrees);
+                let furtherWork = Array.foldRight(cur -> acc -> cur :: acc, tail, subTrees);
                 recurse(furtherWork)
         }};
         recurse(p :: Nil);
@@ -213,34 +209,52 @@ mod Fixpoint3.Provenance {
     }
 
     ///
-    /// Builds the provenance tree for `predSym(fact)` where `fact` was derived with
-    /// depth `depth` using `rules[ruleUsed]`.
+    /// Builds the provenance tree for `topPredSym(topFact)` where `topFact` was derived with
+    /// depth `topDepth` using `rules[topRuleUsed]`.
     ///
-    /// `ruleUsed == -1` means that `predSym(fact)` is an `EDB` atom. `ruleUsed == -2`
-    /// means that `predSym(fact)` is a negative fact/not a fact in the model.
+    /// `topRuleUsed == -1` means that `topPredSym(topFact)` is an `EDB` atom. `topRuleUsed == -2`
+    /// means that `topPredSym(topFact)` is a negative fact/not a fact in the model.
     ///
-    def buildProof(predSym: PredSym, fact: Vector[Boxed], depth: Int64, ruleUsed: Int32, rules: Vector[Constraint], provIdb: ProvIDB, lookupStruct: ProvLookupStruct[r], rc: Region[r]): ProofTree \ r + IO = {
-        if (ruleUsed == -1) {
-            ProofTree.EDB(predSym, fact)
-        } else if (ruleUsed == -2) {
-            ProofTree.Negative(predSym, fact)
-        } else {
-            let rule = Vector.get(ruleUsed, rules);
-            let bodyAtoms = getMatchingBody(fact, depth, rc, provIdb, lookupStruct, rule);
-            let Constraint.Constraint(_, bodyPreds) = rule;
-            let relevantPreds = bodyPreds |>
-                Vector.filter(bodyAtom -> match bodyAtom {
-                    case BodyPredicate.BodyAtom(_, _, _, _, _) => true
-                    case _ => false
-                });
-            let childProofs = Vector.zip(relevantPreds, bodyAtoms) |>
-                Vector.map(match (bodyP, (bodyFact, bodyDepth, bodyRule)) -> match bodyP {
-                    case BodyPredicate.BodyAtom(p, _, _, _, _) =>
-                        buildProof(p, bodyFact, bodyDepth, bodyRule, rules, provIdb, lookupStruct, rc)
-                    case _ => unreachable!()
-                });
-            ProofTree.IDB(predSym, fact, childProofs)
-        }
+    def buildProof(
+        topPredSym: PredSym,
+        topFact: Vector[Boxed],
+        topDepth: Int64,
+        topRuleUsed: Int32,
+        rules: Vector[Constraint],
+        provIdb: ProvIDB,
+        lookupStruct: ProvLookupStruct[r],
+        rc: Region[r]
+    ): ProofTree[r] \ r + IO = {
+        let resultArr = Array.empty(rc, 1);
+        def buildProofInternal(workList: List[(Int32, Array[ProofTree[r], r], PredSym, (Vector[Boxed], Int64, Int32))]) = match workList {
+            case Nil => Array.get(0, resultArr)
+            case (savePos, saveArr, predSym, (fact, depth, ruleUsed)) :: tail => match ruleUsed {
+                case -1 =>
+                    Array.put(ProofTree.EDB(predSym, fact), savePos, saveArr);
+                    buildProofInternal(tail)
+                case -2 =>
+                    Array.put(ProofTree.Negative(predSym, fact), savePos, saveArr);
+                    buildProofInternal(tail)
+                case _ =>
+                    let rule = Vector.get(ruleUsed, rules);
+                    let bodyAtoms = getMatchingBody(fact, depth, rc, provIdb, lookupStruct, rule);
+                    let Constraint.Constraint(_, bodyPreds) = rule;
+                    let relevantPreds = bodyPreds |>
+                        Vector.filterMap(bodyAtom -> match bodyAtom {
+                            case BodyPredicate.BodyAtom(pred, _, _, _, _) => Some(pred)
+                            case _ => None
+                        });
+                    let ref = Ref.fresh(rc, tail);
+                    let childProofs = Array.empty(rc, Array.length(bodyAtoms));
+                    foreach((i, atom) <- ForEach.withIndex(relevantPreds)) {
+                        let pred = Array.get(i, bodyAtoms);
+                        Ref.put((i, childProofs, atom, pred) :: Ref.get(ref), ref)
+                    };
+                    Array.put(ProofTree.IDB(predSym, fact, childProofs), savePos, saveArr);
+                    buildProofInternal(Ref.get(ref))
+            }
+        };
+        buildProofInternal((0, resultArr, topPredSym, (topFact, topDepth, topRuleUsed)) :: Nil)
     }
 
     ///
@@ -260,7 +274,7 @@ mod Fixpoint3.Provenance {
         provIdb: ProvIDB,
         lookupStruct: ProvLookupStruct[r],
         rule: Constraint
-    ): Vector[(Vector[Boxed], Int64, Int32)] \ r + IO = {
+    ): Array[(Vector[Boxed], Int64, Int32), r] \ r + IO = {
         let Constraint.Constraint(HeadPredicate.HeadAtom(_, _, headTerms), bodyPreds) = rule;
         // Array which contains the current assignment of body atoms.
         // Not all body predicates will be atoms. After termination of `loop` a
@@ -448,7 +462,7 @@ mod Fixpoint3.Provenance {
             }
         };
         loop(0, MutMap.toMap(varSymToVal));
-        bodyValues |> Array.filterMap(rc, identity) |> Array.toVector
+        bodyValues |> Array.filterMap(rc, identity)
     }
 
     ///


### PR DESCRIPTION
Fix for #11343

Should we add some tests for this? They will be somewhat slow as they will need >2000 iterations of fixpoint computations to show it works? The simplest (performant) test I can imagine is:
```
@Test
def testPQueryLargePath01(): Bool =
    let db = inject Vector.range(0, 5000) |> Vector.map(x -> (x, x + 1)) into R/2;
    let pr = #{
        A(0).
        A(y) :- A(x), R(x, y).
    };
    let result = pquery db, pr select A(5000) with {R};
    Assert.eq(5000, Vector.length(result))
```