### PR TITLE
refactor: grab lock before calling `Node.insertIntoLeafPropagate`

### DIFF
--- a/main/src/library/BPlusTree.flix
+++ b/main/src/library/BPlusTree.flix
@@ -976,50 +976,55 @@ mod BPlusTree {
         ): Option[(Node[k, v, r], Int64)] \ r with Order[k] = {
             let search = BPlusTree.search(tree);
             let index = binarySearch(key, search, node);
-            insertIntoLeafPropagate(key, val, index, node, stamp, tree)
+            let writeStamp = Lock.tryConvertToWrite(stamp, node->lock);
+            if(not Lock.valid(writeStamp, node->lock)) {
+                // Restart
+                Lock.yieldBasedOn(node->lock);
+                BPlusTree.putInternal(key, val, tree)
+            } else {
+                insertIntoLeafPropagate(key, val, index, node, writeStamp, tree)
+            }
         }
 
+        ///
+        /// Inserts the mapping `key => val` into the leaf `node`, potentially causing a
+        /// split and returning a new root.
+        ///
+        /// Lock invariants:
+        ///
+        /// - On invocation, `writeStamp` is a write stamp on `node->lock`.
+        ///
+        /// - On return, the thread has no lock on the tree if the returned value is None.
+        ///   Otherwise it has a write-lock on `tree->rootLock` and `p` where `Some(p)` is returned
+        ///
         def insertIntoLeafPropagate(
             key: k,
             val: v,
             index: Int32,
             node: Node[k, v, r],
-            stamp: Int64,
+            writeStamp: Int64,
             tree: BPlusTree[k, v, r]
         ): Option[(Node[k, v, r], Int64)] \ r with Order[k] = {
             let arity = BPlusTree.arity(tree);
             let size = node->size;
             if (index >= 0) {
-                let writeStamp = Lock.tryConvertToWrite(stamp, node->lock);
-                if(not Lock.valid(writeStamp, node->lock)) {
-                    // Restart
-                    Lock.yieldBasedOn(node->lock);
-                    BPlusTree.putInternal(key, val, tree)
-                } else {
-                    // We now have a write lock and can insert before releasing lock
-                    Array.put(val, index, node->values);
+                // We now have a write lock and can insert before releasing lock
+                Array.put(val, index, node->values);
+                Lock.unlockWrite(writeStamp, node->lock);
+                None
+            } else {
+                BPlusTree.incrementSize(tree);
+                // We now have a write lock and can insert and propagate.
+                let insertionPoint = toInsertionPoint(index);
+                if (size < arity) {
+                    // Just insert and after which we are done, so release lock.
+                    actualInsertLeaf(key, val, insertionPoint, node);
                     Lock.unlockWrite(writeStamp, node->lock);
                     None
-                }
-            } else {
-                let writeStamp = Lock.tryConvertToWrite(stamp, node->lock);
-                if(not Lock.valid(writeStamp, node->lock)) {
-                    // Restart
-                    Lock.yieldBasedOn(node->lock);
-                    BPlusTree.putInternal(key, val, tree)
                 } else {
-                    BPlusTree.incrementSize(tree);
-                    // We now have a write lock and can insert and propagate.
-                    let insertionPoint = toInsertionPoint(index);
-                    if (size < arity) {
-                        // Just insert and after which we are done, so release lock.
-                        actualInsertLeaf(key, val, insertionPoint, node);
-                        Lock.unlockWrite(writeStamp, node->lock);
-                        None
-                    } else {
-                        // We need to insert and split, locking up through the tree.
-                        splitLeaf(node, writeStamp, key, val, insertionPoint, tree)
-                    }}
+                    // We need to insert and split, locking up through the tree.
+                    splitLeaf(node, writeStamp, key, val, insertionPoint, tree)
+                }
             }
         }
 


### PR DESCRIPTION
Refactor before #11362