### PR TITLE
refactor: move typing from `Fixpoint/Phase/Lowering` to `Fixpoint/Phase/`Compiler`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -288,6 +288,7 @@ class Flix {
     "Fixpoint3/ReadWriteLock.flix" -> LocalResource.get("/src/library/Fixpoint3/ReadWriteLock.flix"),
     "Fixpoint3/Solver.flix" -> LocalResource.get("/src/library/Fixpoint3/Solver.flix"),
     "Fixpoint3/SubstitutePredSym.flix" -> LocalResource.get("/src/library/Fixpoint3/SubstitutePredSym.flix"),
+    "Fixpoint3/TypeInfo.flix" -> LocalResource.get("/src/library/Fixpoint3/TypeInfo.flix"),
     "Fixpoint3/UniqueInts.flix" -> LocalResource.get("/src/library/Fixpoint3/UniqueInts.flix"),
     "Fixpoint3/Util.flix" -> LocalResource.get("/src/library/Fixpoint3/Util.flix"),
 

--- a/main/src/library/Fixpoint3/Ast/ExecutableRam.flix
+++ b/main/src/library/Fixpoint3/Ast/ExecutableRam.flix
@@ -22,8 +22,9 @@
 mod Fixpoint3.Ast.ExecutableRam {
     use Fixpoint3.Ast.Ram.{Predicates, RelSym, IndexInformation}
     use Fixpoint3.Ast.Shared.{BoxedDenotation => Denotation}
-    use Fixpoint3.Boxed;
-    use Fixpoint3.BoxingType.{UnifiedTypePos, RamIdToPos};
+    use Fixpoint3.Boxed
+    use Fixpoint3.BoxingType.UnifiedTypePos
+    use Fixpoint3.TypeInfo.TypeInformation
 
     /////////////////////////////////////////////////////////////////////////////
     // RamProgram                                                              //
@@ -34,7 +35,7 @@ mod Fixpoint3.Ast.ExecutableRam {
     /// by the interpreter.
     ///
     pub enum RamProgram[r: Region] {
-        case Program(RamStmt, Facts[r], Predicates, IndexInformation, (Arities, ConstWrites), RamIdToPos)
+        case Program(RamStmt, Facts[r], Predicates, IndexInformation, (Arities, ConstWrites), TypeInformation)
     }
     ///
     /// The extensible database (EDB) of a program.

--- a/main/src/library/Fixpoint3/Ast/Ram.flix
+++ b/main/src/library/Fixpoint3/Ast/Ram.flix
@@ -22,6 +22,7 @@ mod Fixpoint3.Ast.Ram {
     use Fixpoint3.Boxed
     use Fixpoint3.PredSymsOf
     use Fixpoint3.SubstitutePredSym
+    use Fixpoint3.TypeInfo.{provType, RelType, Type, TypeInformation}
 
     /////////////////////////////////////////////////////////////////////////////
     // RamProgram                                                              //
@@ -32,7 +33,7 @@ mod Fixpoint3.Ast.Ram {
     ///
     @Internal
     pub enum RamProgram {
-        case Program(RamStmt, FactTuple, Predicates, IndexInformation)
+        case Program(RamStmt, FactTuple, Predicates, IndexInformation, TypeInformation)
     }
 
     ///
@@ -133,16 +134,16 @@ mod Fixpoint3.Ast.Ram {
         pub def toString(stmt: RamStmt): String =
             let nl = String.lineSeparator();
             match stmt {
-                case RamStmt.Insert(op) => ToString.toString(op)
+                case RamStmt.Insert(op)          => ToString.toString(op)
                 case RamStmt.MergeInto(src, dst) => "Merge ${src} into ${dst}"
-                case RamStmt.Swap(lhs, rhs) => "Swap ${lhs} and ${rhs}"
-                case RamStmt.Purge(relSym) => "Purge ${relSym}"
-                case RamStmt.Seq(xs) => Vector.join(";${nl}", xs)
-                case RamStmt.Par(xs) => Vector.join("|${nl}", xs)
-                case RamStmt.Until(test, body) =>
+                case RamStmt.Swap(lhs, rhs)      => "Swap ${lhs} and ${rhs}"
+                case RamStmt.Purge(relSym)       => "Purge ${relSym}"
+                case RamStmt.Seq(xs)             => Vector.join(";${nl}", xs)
+                case RamStmt.Par(xs)             => Vector.join("|${nl}", xs)
+                case RamStmt.Until(test, body)   =>
                     let tst = test |> Vector.join(" && ");
                     "until(${tst}) do${nl}${String.indent(4, "${body}")}end"
-                case RamStmt.Comment(comment) => "/* ${comment} */"
+                case RamStmt.Comment(comment)    => "/* ${comment} */"
             }
     }
 
@@ -151,14 +152,14 @@ mod Fixpoint3.Ast.Ram {
     /////////////////////////////////////////////////////////////////////////////
 
     ///
-    /// `Search(rv, relSym, body)` iterates through the facts in relation `relSym`, saving
-    /// them as RowVar `rv` and executes `body`.
+    /// `Search(rv, relSym, relType, body)` iterates through the facts in relation
+    /// `relSym`, saving them as RowVar `rv` and executes `body`.
     ///
-    /// `Query(rv, relSym, bools, indexPos, body)` iterates through the facts in relation
+    /// `Query(rv, relSym, bools, indexPos, relType, body)` iterates through the facts in relation
     /// `relSym`, saving them as `rv` and executes `body` if `bools` is
     /// true. The index saved at `indexPos` will be used.
     ///
-    /// `Functional(rv, f, input, body, arity)` evaluates `f(input)`, for each result,
+    /// `Functional(rv, f, input, body, arity, relType)` evaluates `f(input)`, for each result,
     /// saves it as `rv` and executes `body`. `arity` is the arity of the output tuples.
     ///
     /// `Project(terms, relSym, ruleNum)` constructs a tuple from `terms` and inserts it as a fact
@@ -169,9 +170,9 @@ mod Fixpoint3.Ast.Ram {
     ///
     @Internal
     pub enum RelOp {
-        case Search(RowVar, RelSym, RelOp)
-        case Query(RowVar, RelSym, Vector[BoolExp], Int32, RelOp)
-        case Functional(RowVar, Vector[Boxed] -> Vector[Vector[Boxed]], Vector[RamTerm], RelOp, Int32)
+        case Search(RowVar, RelSym, RelType, RelOp)
+        case Query(RowVar, RelSym, Vector[BoolExp], Int32, RelType, RelOp)
+        case Functional(RowVar, Vector[Boxed] -> Vector[Vector[Boxed]], Vector[RamTerm], RelOp, Int32, RelType)
         case Project(Vector[RamTerm], RelSym, Int32)
         case If(Vector[BoolExp], RelOp)
     }
@@ -180,14 +181,14 @@ mod Fixpoint3.Ast.Ram {
         pub def toString(op: RelOp): String =
             let nl = String.lineSeparator();
             match op {
-                case RelOp.Search(var, relSym, body) =>
+                case RelOp.Search(var, relSym, _types, body) =>
                     "search ${var} ∈ ${relSym} do${nl}${String.indent(4, "${body}")}end"
-                case RelOp.Query(var, relSym, prefixQuery, _, body) =>
+                case RelOp.Query(var, relSym, prefixQuery, _, _types, body) =>
                     let qry = Vector.joinWith(match term -> {
                         ToString.toString(term)
                     }, " ∧ ", prefixQuery);
                     "query {${var} ∈ ${relSym} | ${qry}} do${nl}${String.indent(4, "${body}")}end"
-                case RelOp.Functional(RowVar.Named(id), _, terms, body, _) =>
+                case RelOp.Functional(RowVar.Named(id), _, terms, body, _, _) =>
                     "loop(x${id} <- f(${terms |> Vector.join(", ")})) do${nl}${String.indent(4, "${body}")}end"
                 case RelOp.Project(terms, relSym, _) =>
                     "project (${terms |> Vector.join(", ")}) into ${relSym}"
@@ -240,16 +241,16 @@ mod Fixpoint3.Ast.Ram {
     instance ToString[BoolExp] {
         pub def toString(exp: BoolExp): String =
             match exp {
-                case BoolExp.Not(boolExp) => "not (${boolExp})"
-                case BoolExp.IsEmpty(relSym) => "${relSym} = ∅"
-                case BoolExp.NotMemberOf(terms, relSym) => "(${terms |> Vector.join(", ")}) ∉ ${relSym}"
-                case BoolExp.NotBot(term, _, _) => "(${term}) ≠ ⊥"
-                case BoolExp.Leq(elem, _, term) => "${elem} ≤ (${term})"
-                case BoolExp.Eq(lhs, rhs) => "${lhs} = ${rhs}"
-                case BoolExp.Guard1(_, v) => "<clo>(${v})"
-                case BoolExp.Guard2(_, v1, v2) => "<clo>(${v1}, ${v2})"
-                case BoolExp.Guard3(_, v1, v2, v3) => "<clo>(${v1}, ${v2}, ${v3})"
-                case BoolExp.Guard4(_, v1, v2, v3, v4) => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
+                case BoolExp.Not(boolExp)                  => "not (${boolExp})"
+                case BoolExp.IsEmpty(relSym)               => "${relSym} = ∅"
+                case BoolExp.NotMemberOf(terms, relSym)    => "(${terms |> Vector.join(", ")}) ∉ ${relSym}"
+                case BoolExp.NotBot(term, _, _)            => "(${term}) ≠ ⊥"
+                case BoolExp.Leq(elem, _, term)            => "${elem} ≤ (${term})"
+                case BoolExp.Eq(lhs, rhs)                  => "${lhs} = ${rhs}"
+                case BoolExp.Guard1(_, v)                  => "<clo>(${v})"
+                case BoolExp.Guard2(_, v1, v2)             => "<clo>(${v1}, ${v2})"
+                case BoolExp.Guard3(_, v1, v2, v3)         => "<clo>(${v1}, ${v2}, ${v3})"
+                case BoolExp.Guard4(_, v1, v2, v3, v4)     => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
                 case BoolExp.Guard5(_, v1, v2, v3, v4, v5) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
             }
     }
@@ -260,8 +261,6 @@ mod Fixpoint3.Ast.Ram {
 
     ///
     /// Represents a Relational Algebra Machine (RAM) term.
-    ///
-    /// Enums with a `RamId` can be referred to by the `RamId`.
     ///
     /// `Lit(val, id)` represents the literal `val`.
     ///
@@ -287,53 +286,45 @@ mod Fixpoint3.Ast.Ram {
     ///
     @Internal
     pub enum RamTerm {
-        case Lit(Boxed, RamId)
+        case Lit(Boxed, Type)
         case ProvMax(Vector[(RowVar, Int32)])
-        case RowLoad(RowVar, Int32, RelSym)
-        case Meet(Boxed -> Boxed -> Boxed, RamTerm, (RowVar, RelSym), RamId)
-        case App1(Boxed -> Boxed, RamTerm, RamId)
-        case App2(Boxed -> Boxed -> Boxed, RamTerm, RamTerm, RamId)
-        case App3(Boxed -> Boxed -> Boxed -> Boxed, RamTerm, RamTerm, RamTerm, RamId)
-        case App4(Boxed -> Boxed -> Boxed -> Boxed -> Boxed, RamTerm, RamTerm, RamTerm, RamTerm, RamId)
-        case App5(Boxed -> Boxed -> Boxed -> Boxed -> Boxed -> Boxed, RamTerm, RamTerm, RamTerm, RamTerm, RamTerm, RamId)
+        case RowLoad(RowVar, Int32, Type, RelSym)
+        case Meet(Boxed -> Boxed -> Boxed, RamTerm, (RowVar, RelSym), Type)
+        case App1(Boxed -> Boxed, RamTerm, Type)
+        case App2(Boxed -> Boxed -> Boxed, RamTerm, RamTerm, Type)
+        case App3(Boxed -> Boxed -> Boxed -> Boxed, RamTerm, RamTerm, RamTerm, Type)
+        case App4(Boxed -> Boxed -> Boxed -> Boxed -> Boxed, RamTerm, RamTerm, RamTerm, RamTerm, Type)
+        case App5(Boxed -> Boxed -> Boxed -> Boxed -> Boxed -> Boxed, RamTerm, RamTerm, RamTerm, RamTerm, RamTerm, Type)
     }
 
     ///
-    /// Returns the `RamId` of `t`.
+    /// Returns the type of `t`.
     ///
     @Internal
-    pub def getTermRamId(t: RamTerm): RamId = match t {
-        case RamTerm.Lit(_, id) => id
-        case RamTerm.ProvMax(_) => RamId.Id(-1)
-        case RamTerm.RowLoad(rv, index, _) => RamId.TuplePos(rv, index)
-        case RamTerm.Meet(_, _, _, id) => id
-        case RamTerm.App1(_ , _, id) => id
-        case RamTerm.App2(_, _, _, id) => id
-        case RamTerm.App3(_, _, _, _, id) => id
-        case RamTerm.App4(_, _, _, _, _, id) => id
-        case RamTerm.App5(_, _, _, _, _, _, id) => id
+    pub def getType(t: RamTerm): Type = match t {
+        case RamTerm.Lit(_, ty)                 => ty
+        case RamTerm.ProvMax(_)                 => provType()
+        case RamTerm.RowLoad(_, _, ty, _)       => ty
+        case RamTerm.Meet(_, _, _, ty)          => ty
+        case RamTerm.App1(_ , _, ty)            => ty
+        case RamTerm.App2(_, _, _, ty)          => ty
+        case RamTerm.App3(_, _, _, _, ty)       => ty
+        case RamTerm.App4(_, _, _, _, _, ty)    => ty
+        case RamTerm.App5(_, _, _, _, _, _, ty) => ty
     }
-
-    ///
-    /// Returns the `RamId` of the lattice-element of `rv`.
-    ///
-    @Internal
-    pub def getLatVarRamId(rv: RowVar, relSym: RelSym): RamId =
-        let arity = arityOfNonLat(relSym);
-        RamId.TuplePos(rv, arity)
 
     instance ToString[RamTerm] {
         pub def toString(term: RamTerm): String = match term {
-            case RamTerm.Lit(v, _) => "%{v}"
-            case RamTerm.ProvMax(loads) =>
+            case RamTerm.Lit(v, _)                      => "%{v}"
+            case RamTerm.ProvMax(loads)                 =>
                 let loadsStr = Vector.joinWith(match (rv, i) -> "${rv}[${i}]", ", ", loads);
                 "max(${loadsStr})"
-            case RamTerm.RowLoad(var, index, _) => "${var}[${index}]"
-            case RamTerm.Meet(_, lhs, rhs, _) => "(${lhs} ⊓ ${rhs})"
-            case RamTerm.App1(_, v, _) => "<clo>(${v})"
-            case RamTerm.App2(_, v1, v2, _) => "<clo>(${v1}, ${v2})"
-            case RamTerm.App3(_, v1, v2, v3, _) => "<clo>(${v1}, ${v2}, ${v3})"
-            case RamTerm.App4(_, v1, v2, v3, v4, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
+            case RamTerm.RowLoad(var, index, _, _)      => "${var}[${index}]"
+            case RamTerm.Meet(_, lhs, rhs, _)           => "(${lhs} ⊓ ${rhs})"
+            case RamTerm.App1(_, v, _)                  => "<clo>(${v})"
+            case RamTerm.App2(_, v1, v2, _)             => "<clo>(${v1}, ${v2})"
+            case RamTerm.App3(_, v1, v2, v3, _)         => "<clo>(${v1}, ${v2}, ${v3})"
+            case RamTerm.App4(_, v1, v2, v3, v4, _)     => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
             case RamTerm.App5(_, v1, v2, v3, v4, v5, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
         }
     }
@@ -409,7 +400,7 @@ mod Fixpoint3.Ast.Ram {
     pub def arityOfNonLat(relSym: RelSym): Int32 = match relSym {
         case RelSym.Symbol(_, arity, den) => match den {
             case Relational => arity
-            case _ => arity - 1
+            case _          => arity - 1
         }
     }
 
@@ -461,72 +452,4 @@ mod Fixpoint3.Ast.Ram {
         }
     }
 
-    /////////////////////////////////////////////////////////////////////////////
-    // RamId                                                                   //
-    /////////////////////////////////////////////////////////////////////////////
-
-    ///
-    /// `RamId` represents a unique identifier for literals, positions in relations,
-    /// positions in tuples or input to a function.
-    ///
-    /// The uniqueness is broken by provenance for convenience of implementation.
-    /// Literals describing rules also use `Id(-1)`.
-    ///
-    /// `Id(id)` represents the id `id`. If `Id(id)` exists `RowVar.Named(id)` does not.
-    ///
-    /// `InId(id, i)` represents the `i`'th input of the term represented by `id`.
-    ///
-    /// `TuplePos(rv, i)` represents `rv[i]`.
-    ///
-    /// `RelPos(predId, i)` represents `i`'th index of the `RelSym` with PredSym-id `predId`.
-    ///
-    @Internal
-    pub enum RamId {
-        case Id(Int32)
-        case InId(Int32, Int32)
-        case TuplePos(RowVar, Int32)
-        case RelPos(Int64, Int32)
-    }
-
-    instance ToString[RamId] {
-        pub def toString(x: RamId): String = match x {
-            case (RamId.Id(i1)) => "Id[${i1}]"
-            case (RamId.InId(i0, i1)) => "InId[${i0}, ${i1}]"
-            case (RamId.TuplePos(i0, i1)) => "TuplePos[${i0}, ${i1}]"
-            case (RamId.RelPos(i0, i1)) => "RelPos[${i0}, ${i1}]"
-        }
-    }
-
-    instance Eq[RamId] {
-        pub def eq(a: RamId, b: RamId): Bool = match (a, b) {
-            case (RamId.Id(i1), RamId.Id(i2)) => i1 == i2
-            case (RamId.InId(id1, index1), RamId.InId(id2, index2)) => id1 == id2 and index1 == index2
-            case (RamId.TuplePos(i0, i1), RamId.TuplePos(j0, j1)) => i0 == j0 and i1 == j1
-            case (RamId.RelPos(i0, i1), RamId.RelPos(j0, j1)) => i0 == j0 and i1 == j1
-            case _ => false
-        }
-    }
-
-    instance Order[RamId] {
-        pub def compare(a: RamId, b: RamId): Comparison = match (a, b) {
-            case (RamId.Id(i1), RamId.Id(i2)) => i1 <=> i2
-            case (RamId.TuplePos(i0, i1), RamId.TuplePos(j0, j1)) =>
-                let firstComp = i0 <=> j0;
-                if (firstComp != Comparison.EqualTo) firstComp else i1 <=> j1
-            case (RamId.RelPos(i0, i1), RamId.RelPos(j0, j1)) =>
-                let firstComp = i0 <=> j0;
-                if (firstComp != Comparison.EqualTo) firstComp else i1 <=> j1
-            case (RamId.InId(i0, i1), RamId.InId(j0, j1)) =>
-                let firstComp = i0 <=> j0;
-                if (firstComp != Comparison.EqualTo) firstComp else i1 <=> j1
-            case (RamId.TuplePos(_, _), _) => Comparison.LessThan
-            case (_, RamId.TuplePos(_, _)) => Comparison.GreaterThan
-            case (RamId.RelPos(_, _), _) => Comparison.LessThan
-            case (_, RamId.RelPos(_, _)) => Comparison.GreaterThan
-            case (RamId.Id(_), _) => Comparison.LessThan
-            case (_, RamId.Id(_)) => Comparison.GreaterThan
-            case (RamId.InId(_, _), _) => Comparison.LessThan
-            case (_, RamId.InId(_, _)) => Comparison.GreaterThan
-        }
-    }
 }

--- a/main/src/library/Fixpoint3/Boxing.flix
+++ b/main/src/library/Fixpoint3/Boxing.flix
@@ -47,49 +47,51 @@ mod Fixpoint3.Boxing {
     use Fixpoint3.Ast.Datalog.Datalog
     use Fixpoint3.Ast.ExecutableRam.{Facts => EFacts}
     use Fixpoint3.Ast.Ram
-    use Fixpoint3.Ast.Ram.{arityOf, BoolExp, RamId, RamProgram, RamStmt, RelSym, RamTerm, RelOp, toDenotation}
+    use Fixpoint3.Ast.Ram.{arityOf, BoolExp, RamProgram, RamStmt, RelSym, RamTerm, RelOp, toDenotation}
     use Fixpoint3.Ast.Shared.{PredSym, isRelational, Denotation}
     use Fixpoint3.Boxable
     use Fixpoint3.Boxed
     use Fixpoint3.Boxed.{BoxedBool, BoxedChar, BoxedFloat32, BoxedFloat64, BoxedInt8, BoxedInt16, BoxedInt32, BoxedInt64, BoxedObject}
-    use Fixpoint3.BoxingType.{Boxing, getType, RamIdToPos, setType, Types, TypeInfo, UnifiedTypePos}
+    use Fixpoint3.BoxingType.{Boxing, getType, setType, Types, TypeInfo, UnifiedTypePos}
     use Fixpoint3.Options.usedArity
-    use Fixpoint3.Predicate.relSymsOfProgram
+    use Fixpoint3.Predicate.{fullRelSymsOfProgram, relSymsOfProgram}
     use Fixpoint3.ReadWriteLock
+    use Fixpoint3.TypeInfo
     use Fixpoint3.Util.getOrCrash
 
     ///
     /// Returns a `(boxing, facts, idToBoxing)` where `Boxing` is information as described above,
-    /// `facts` are the EDB of `program` as `Int64`, with respect to `boxing` and `idToBoxing`
-    /// described where the boxing information associated with a specific `RamId` is placed,
-    /// aka the `UnifiedTypePos`.
+    /// `facts` are the EDB of `program` as `Int64`, with respect to `boxing`.
     ///
     @Internal
-    pub def initialize(rc: Region[r], withProv: Bool, program: RamProgram): (Boxing[r], EFacts[r], RamIdToPos) \ r =
-        let mapping = Equality.computeMapping(program, withProv);
-        let boxingInfo = initializeInternal(rc, program, mapping, withProv);
-        let facts = unsafely IO run initializeFacts(rc, program, boxingInfo, mapping, withProv);
-        (boxingInfo, facts, mapping)
+    pub def initialize(rc: Region[r], withProv: Bool, program: RamProgram): (Boxing[r], EFacts[r]) \ r =
+        let boxingInfo = initializeInternal(rc, program, withProv);
+        let facts = unsafely IO run initializeFacts(rc, program, boxingInfo, withProv);
+        (boxingInfo, facts)
 
     ///
     /// Returns `(facts, boxing)` where `facts` consists of the `Int64` representatives of
     /// the facts in `program`, with respect to `boxing`. Note that the old `boxingInfo` is
     /// invalid for the returned `facts`.
     ///
-    def initializeFacts(rc1: Region[r], program: RamProgram, boxingInfo: Boxing[r], mapping: RamIdToPos, withProv: Bool): EFacts[r] \ r + IO =
-        let RamProgram.Program(_, facts, _, (indexes, _)) = program;
+    def initializeFacts(rc1: Region[r], program: RamProgram, boxingInfo: Boxing[r], withProv: Bool): EFacts[r] \ r + IO =
+        let RamProgram.Program(_, facts, _, (indexes, _), typeInfo) = program;
         let (f1, f2) = facts;
         let newFacts = MutMap.empty(rc1);
         foreach ((relSym, relFacts) <- f1) {
+            let RelSym.Symbol(PredSym.PredSym(_, id), _, _) = relSym;
             // Get some search. This means that we have to create one less index in the interpreter.
             let search = getOrCrash(Map.get(relSym, indexes)) |> Vector.get(0);
             let newTree = BPlusTree.emptyWithArityAndSearch(rc1, usedArity(), search);
-            mapAllFacts(relSym, relFacts, boxingInfo, mapping, withProv, newTree);
+            // `id` will always be a full `id`.
+            mapAllFacts(relSym, relFacts, boxingInfo, TypeInfo.getTypeOf(id, typeInfo), withProv, newTree);
             MutMap.put(relSym, newTree, newFacts)
         };
         foreach ((relSym, relFacts) <- f2) {
+            let RelSym.Symbol(PredSym.PredSym(_, id), _, _) = relSym;
             let newTree = MutMap.getOrElsePut(relSym, BPlusTree.empty(rc1), newFacts);
-            mapAllFacts(relSym, relFacts, boxingInfo, mapping, withProv, newTree)
+            // `id` will always be a full `id`.
+            mapAllFacts(relSym, relFacts, boxingInfo, TypeInfo.getTypeOf(id, typeInfo), withProv, newTree)
         };
         newFacts |> MutMap.toMap
 
@@ -97,17 +99,17 @@ mod Fixpoint3.Boxing {
         relSym: RelSym,
         facts: BPlusTree[Vector[Boxed], Boxed, Static],
         boxingInfo: Boxing[r],
-        mapping: RamIdToPos,
+        mapping: Vector[Int32],
         withProv: Bool,
         newTree: BPlusTree[Vector[Int64], Boxed, r]
     ): Unit \ r + IO = unchecked_cast({
-        let relSymId = Ram.toId(relSym);
         let nonExtendedPositions = Vector.range(0, arityOf(relSym)) |>
-            Vector.map(i -> getOrCrash(Map.get(RamId.RelPos(relSymId, i), mapping)));
+            Vector.map(i -> Vector.get(i, mapping));
         let positions = if (not withProv) {
             nonExtendedPositions
         } else {
-            nonExtendedPositions ++ Vector#{getOrCrash(Map.get(RamId.Id(-1), mapping)), getOrCrash(Map.get(RamId.Id(-1), mapping))}
+            // Both can use this type. It does not really matter.
+            nonExtendedPositions ++ Vector#{TypeInfo.provType(), TypeInfo.provType()}
         };
         facts |>
             BPlusTree.parForEach(tuple -> lat -> {
@@ -125,18 +127,19 @@ mod Fixpoint3.Boxing {
     } as _ \ IO + r)
 
     ///
-    /// Construct a `Boxing` from `program` given a map from `RamId` to `UnifiedTypePos`.
+    /// Construct a `Boxing` from `program`.
     ///
-    def initializeInternal(rc: Region[r], program: RamProgram, map: RamIdToPos, withProv: Bool): Boxing[r] \ r =
-        let max = 1 + snd(Option.getWithDefault((RamId.Id(-1), -1), Map.maximumValue(map)));
+    def initializeInternal(rc: Region[r], program: RamProgram, withProv: Bool): Boxing[r] \ r =
+        let RamProgram.Program(_, _, _, _, typeInfo) = program;
+        let max = 1 + Vector.map(v -> Option.getWithDefault(0, Vector.maximum(v)), typeInfo) |> Vector.maximum |> Option.getWithDefault(-1);
         let intToBox = Vector.init(_ -> MutList.empty(rc), max);
         let boxToInt = Vector.init(_ -> BPlusTree.empty(rc), max);
         let locks = Vector.init(_ -> ReadWriteLock.mkLock(rc), max);
-        let posToIndex = Array.init(rc, _ -> Types.TyUnknown, max);
+        let posToIndex = Array.repeat(rc, max, Types.TyUnknown);
         let info = (intToBox, boxToInt, posToIndex, locks);
-        let relSyms = relSymsOfProgram(program);
+        let relSyms = fullRelSymsOfProgram(program);
         if (withProv) {
-            setType(Types.TyInt64, getOrCrash(Map.get(RamId.Id(-1), map)), posToIndex)
+            setType(Types.TyInt64, TypeInfo.provType(), posToIndex)
         } else {
             ()
         };
@@ -144,7 +147,7 @@ mod Fixpoint3.Boxing {
         foreach (x <- relSyms) {
             match x {
                 case RelSym.Symbol(PredSym.PredSym(_, index), arity, Denotation.Latticenal(bot, _, _, _)) =>
-                    unboxWith(bot, getOrCrash(Map.get(RamId.RelPos(index, arity - 1), map)), info); ()
+                    unboxWith(bot, TypeInfo.getType(index, arity - 1, typeInfo), info); ()
                 case _ => ()
             }
         };
@@ -248,431 +251,5 @@ mod Fixpoint3.Boxing {
             case Types.TyObject    => deMarshalObject(v, index, info)
             case Types.TyUnknown   => bug!("Unormalizing value, which has never been normalized")
         }
-
-    ///
-    /// Construct a map from `RamId` to `UnifiedTypePos`.
-    ///
-    /// See the description of the Boxing module.
-    ///
-    mod Equality {
-        use Fixpoint3.Ast.Ram.getTermRamId
-        use Fixpoint3.Ast.Ram
-        use Fixpoint3.Ast.Ram.{RamId, Predicates, RamStmt, RelOp, RamTerm, BoolExp, RamProgram, RowVar}
-        use Fixpoint3.Ast.Ram.{RelSym, RamProgram}
-        use Fixpoint3.Ast.Shared.PredSym
-        use Fixpoint3.BoxingType.RamIdToPos
-        use Fixpoint3.Counter
-        use Fixpoint3.Util.getOrCrash
-        use Fixpoint3.Predicate.{PredType, fullRelSymToType, relSymFromPredType, relSymsOfProgram}
-
-        ///
-        /// Returns a map from `RamId` to `UnifiedTypePos` constructed from `program`.
-        ///
-        @Internal
-        pub def computeMapping(program: RamProgram, withProv: Bool): RamIdToPos = region rc {
-            // First compute the equivalence relation for `RamId`s in program
-            // and afterwards use this to assign unique ints to each
-            // equivalence relation.
-            let disjointSet = MutDisjointSets.empty(rc);
-            let RamProgram.Program(stmt, _, _, _) = program;
-            unifyRamIds(program, disjointSet, withProv);
-            let relSyms = relSymsOfProgram(program);
-            let mutMap = MutMap.empty(rc);
-            let counter = Counter.fresh(rc);
-            foreach (RelSym.Symbol(PredSym.PredSym(_, id), arity, _) <- relSyms) {
-                foreach (i <- Vector.range(0, getProvSafeIdArity(arity, withProv))) {
-                    registerRamId(disjointSet, mutMap, counter, RamId.RelPos(id, i))
-                }
-            };
-            // Given the equivalence relation just computed assign unique positions for each
-            // equivalence relation.
-            computeMappingStmt(disjointSet, mutMap, counter, withProv, stmt);
-            if (withProv) {
-                registerRamId(disjointSet, mutMap, counter, RamId.Id(-1))
-            } else ();
-            MutMap.toMap(mutMap)
-        }
-
-        ///
-        /// Unify all `RamId`s in `program` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIds(program: RamProgram, set: MutDisjointSets[RamId, r], withProv: Bool): Unit \ r = match program {
-            case RamProgram.Program(stmt, _, predicates, _) =>
-                let relSyms = relSymsOfProgram(program);
-                List.forEach(unifyPredTypes(predicates, set, withProv), relSyms);
-                unifyRamIdsStmt(predicates, set, withProv, stmt)
-        }
-
-        ///
-        /// Unify all `RamId`s in `stmt` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIdsStmt(predicates: Predicates, set: MutDisjointSets[RamId, r], withProv: Bool, stmt: RamStmt): Unit \ r = match stmt {
-            case RamStmt.Insert(body)          => unifyRamIdsOp(predicates, set, withProv, body)
-            case RamStmt.MergeInto(rel1, rel2) => unifyRelSyms(rel1, rel2, set, withProv)
-            case RamStmt.Swap(rel1, rel2)      => unifyRelSyms(rel1, rel2, set, withProv)
-            case RamStmt.Purge(_)              => ()
-            case RamStmt.Seq(stmts)            => Vector.forEach(unifyRamIdsStmt(predicates, set, withProv), stmts)
-            case RamStmt.Par(stmts)            => Vector.forEach(unifyRamIdsStmt(predicates, set, withProv), stmts)
-            case RamStmt.Until(bools, body) =>
-                unifyRamIdsStmt(predicates, set, withProv, body);
-                Vector.forEach(unifyRamIdsBool(set), bools)
-            case RamStmt.Comment(_) => ()
-        }
-
-        ///
-        /// Unify all `RamId`s in `op` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIdsOp(predicates: Predicates, set: MutDisjointSets[RamId, r], withProv: Bool, op: RelOp): Unit \ r = match op {
-            case RelOp.Search(rv, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _), body) =>
-                let usedArity = getProvSafeIdArity(arity, withProv);
-                foreach (i <- Vector.range(0, usedArity)) {
-                    MutDisjointSets.union(RamId.TuplePos(rv, i), RamId.RelPos(predSym, i), set)
-                };
-                unifyRamIdsOp(predicates, set, withProv, body)
-            case RelOp.Query(rv, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _), bools, _, body) =>
-                let usedArity = getProvSafeIdArity(arity, withProv);
-                foreach (i <- Vector.range(0, usedArity)) {
-                    MutDisjointSets.union(RamId.TuplePos(rv, i), RamId.RelPos(predSym, i), set)
-                };
-                Vector.forEach(unifyRamIdsBool(set), bools);
-                unifyRamIdsOp(predicates, set, withProv, body)
-            case RelOp.Functional(rv, _, inputTerms, body, arity) =>
-                let RowVar.Named(id) = rv;
-                foreach ((i, curTerm) <- ForEach.withIndex(inputTerms)) {
-                    let termID = Ram.getTermRamId(curTerm);
-                    MutDisjointSets.union(RamId.InId(id, i), termID, set);
-                    unifyRamIdsTerm(set, curTerm)
-                };
-                foreach (i <- Vector.range(0, arity)) {
-                    MutDisjointSets.makeSet(RamId.TuplePos(rv, i), set)
-                };
-                unifyRamIdsOp(predicates, set, withProv, body)
-            case RelOp.Project(terms, RelSym.Symbol(PredSym.PredSym(_, predSym), _, _), _) =>
-                foreach ((i, term) <- ForEach.withIndex(terms)) {
-                    unifyRamIdsTerm(set, term);
-                    let termID = Ram.getTermRamId(term);
-                    MutDisjointSets.union(RamId.RelPos(predSym, i), termID, set)
-                }
-            case RelOp.If(bools, body) =>
-                Vector.forEach(unifyRamIdsBool(set), bools);
-                unifyRamIdsOp(predicates, set, withProv, body)
-        }
-
-        ///
-        /// Unify all `RamId`s in `boolExp` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIdsBool(set: MutDisjointSets[RamId, r], boolExp: BoolExp): Unit \ r = match boolExp {
-            case BoolExp.Not(bexp) => unifyRamIdsBool(set, bexp)
-            case BoolExp.IsEmpty(_) => ()
-            case BoolExp.NotMemberOf(terms, RelSym.Symbol(PredSym.PredSym(_, id), _, _)) =>
-                Vector.forEach(unifyRamIdsTerm(set), terms);
-                foreach ((i, term) <- ForEach.withIndex(terms)) {
-                    MutDisjointSets.union(Ram.getTermRamId(term), RamId.RelPos(id, i), set)
-                }
-            case BoolExp.NotBot(term, _, _) => unifyRamIdsTerm(set, term)
-            case BoolExp.Leq(_, _, _) => ()
-            case BoolExp.Eq(term1, term2) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2);
-                MutDisjointSets.union(Ram.getTermRamId(term1), Ram.getTermRamId(term2), set)
-            case BoolExp.Guard1(_, term1) =>
-                unifyRamIdsTerm(set, term1)
-            case BoolExp.Guard2(_, term1, term2) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2)
-            case BoolExp.Guard3(_, term1, term2, term3) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2);
-                unifyRamIdsTerm(set, term3)
-            case BoolExp.Guard4(_, term1, term2, term3, term4) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2);
-                unifyRamIdsTerm(set, term3);
-                unifyRamIdsTerm(set, term4)
-            case BoolExp.Guard5(_, term1, term2, term3, term4, term5) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2);
-                unifyRamIdsTerm(set, term3);
-                unifyRamIdsTerm(set, term4);
-                unifyRamIdsTerm(set, term5)
-        }
-
-        ///
-        /// Unify all `RamId`s in `term` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIdsTerm(set: MutDisjointSets[RamId, r], term: RamTerm): Unit \ r = match term {
-            case RamTerm.Lit(_, _) => ()
-            case RamTerm.RowLoad(_, _, _) => ()
-            case RamTerm.ProvMax(vec) =>
-                let id = Ram.getTermRamId(term);
-                foreach ((rv, index) <- vec) {
-                    MutDisjointSets.union(RamId.TuplePos(rv, index), id, set)
-                }
-            case RamTerm.Meet(_, t1, (rv, relSym), id) =>
-                unifyRamIdsTerm(set, t1);
-                let id1 = Ram.getTermRamId(t1);
-                let id2 = Ram.getLatVarRamId(rv, relSym);
-                MutDisjointSets.union(id1, id, set);
-                MutDisjointSets.union(id1, id2, set)
-            case RamTerm.App1(_, t1, RamId.Id(id)) =>
-                unifyAppTerms(Vector#{t1}, id, set)
-            case RamTerm.App2(_, t1, t2, RamId.Id(id)) =>
-                unifyAppTerms(Vector#{t1, t2}, id, set)
-            case RamTerm.App3(_, t1, t2, t3, RamId.Id(id)) =>
-                unifyAppTerms(Vector#{t1, t2, t3}, id, set)
-            case RamTerm.App4(_, t1, t2, t3, t4, RamId.Id(id)) =>
-                unifyAppTerms(Vector#{t1, t2, t3, t4}, id, set)
-            case RamTerm.App5(_, t1, t2, t3, t4, t5, RamId.Id(id)) =>
-                unifyAppTerms(Vector#{t1, t2, t3, t4, t4, t5}, id, set)
-            case _ => unreachable!()
-        }
-
-        ///
-        /// Unify all `RamId`s that can be associated with `relSym1` and `relSym2`.
-        ///
-        /// Concretely, unify `RamId.RelPos(id1, i)` and `RamId.RelPos(id2, i)` for `0 <= i < arity`
-        /// for symbols `RelSym(id1, arity, _)` and `RelSym(id2, arity, _)`.
-        ///
-        def unifyRelSyms(relSym1: RelSym, relSym2: RelSym, set: MutDisjointSets[RamId, r], withProv: Bool): Unit \ r =
-            let arity = Ram.arityOf(relSym1);
-            let usedArity = getProvSafeIdArity(arity, withProv);
-            let id1 = Ram.toId(relSym1);
-            let id2 = Ram.toId(relSym2);
-            foreach (i <- Vector.range(0, usedArity)) {
-                MutDisjointSets.union(RamId.RelPos(id1, i), RamId.RelPos(id2, i), set)
-            }
-
-        ///
-        /// For `predSym = 'P'` unify all indexes for `(P, ΔP, ΔP')`.
-        ///
-        def unifyPredTypes(predicates: Predicates, set: MutDisjointSets[RamId, r], withProv: Bool, relSym: RelSym): Unit \ r =
-            let fullSymbol = relSymFromPredType(relSym, PredType.Full, predicates);
-            let deltaSymbol = fullRelSymToType(fullSymbol, PredType.Delta, predicates);
-            let newSymbol = fullRelSymToType(fullSymbol, PredType.New, predicates);
-            unifyRelSyms(fullSymbol, deltaSymbol, set, withProv);
-            unifyRelSyms(fullSymbol, newSymbol, set, withProv);
-            let arity = Ram.arityOf(fullSymbol);
-            let id1 = Ram.toId(fullSymbol);
-            if (withProv) {
-                MutDisjointSets.union(RamId.RelPos(id1, arity), RamId.Id(-1), set);
-                MutDisjointSets.union(RamId.RelPos(id1, arity + 1), RamId.Id(-1), set)
-            } else ()
-
-        ///
-        /// Unify the `i`'th `RamTerm` in `terms` with `RamId.InId(id, i)`.
-        ///
-        /// This should be understood as 'register that term `i` will be input to
-        /// the function at position `i`'.
-        ///
-        def unifyAppTerms(terms: Vector[RamTerm], id: Int32, set: MutDisjointSets[RamId, r]): Unit \ r =
-            foreach ((i, t) <- ForEach.withIndex(terms)) {
-                unifyRamIdsTerm(set, t);
-                let id1 = Ram.getTermRamId(t);
-                MutDisjointSets.union(id1, RamId.InId(id, i), set)
-            }
-
-        ///
-        /// Based on the equivalence `disjoint` assign all unique `RamId`'s a `Boxing` position.
-        ///
-        def computeMappingStmt(disjoint: MutDisjointSets[RamId, r], map: MutMap[RamId, Int32, r], counter: Counter[r], withProv: Bool, stmt: RamStmt): Unit \ r = match stmt {
-            case RamStmt.Insert(rest) => computeMappingOp(disjoint, map, counter, withProv, rest)
-            case RamStmt.MergeInto(rel1, rel2) =>
-                insertIndexRelSym(rel1, disjoint, map, counter, withProv);
-                insertIndexRelSym(rel2, disjoint, map, counter, withProv)
-            case RamStmt.Swap(rel1, rel2) =>
-                insertIndexRelSym(rel1, disjoint, map, counter, withProv);
-                insertIndexRelSym(rel2, disjoint, map, counter, withProv)
-            case RamStmt.Purge(_) => ()
-            case RamStmt.Seq(stmts) => Vector.forEach(computeMappingStmt(disjoint, map, counter, withProv), stmts)
-            case RamStmt.Par(stmts) => Vector.forEach(computeMappingStmt(disjoint, map, counter, withProv), stmts)
-            case RamStmt.Until(bools, body) =>
-                computeMappingStmt(disjoint, map, counter, withProv, body);
-                Vector.forEach(computeMappingBool(disjoint, map, counter), bools)
-            case RamStmt.Comment(_) => ()
-        }
-
-        ///
-        /// Based on the equivalence `disjoint` assign all unique `RamId`'s a `Boxing` position.
-        ///
-        def computeMappingOp(set: MutDisjointSets[RamId, r], map: MutMap[RamId, Int32, r], counter: Counter[r], withProv: Bool, op: RelOp): Unit \ r =
-            let recurse = computeMappingOp(set, map, counter, withProv);
-            let insert = registerRamId(set, map, counter);
-            match op {
-                case RelOp.Search(rv, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _), body) =>
-                    let usedArity = getProvSafeIdArity(arity, withProv);
-                    foreach (i <- Vector.range(0, usedArity)) {
-                        insert(RamId.TuplePos(rv, i));
-                        insert(RamId.RelPos(predSym, i))
-                    };
-                    recurse(body)
-                case RelOp.Query(rv, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _), bools, _, body) =>
-                    let usedArity = getProvSafeIdArity(arity, withProv);
-                    foreach (i <- Vector.range(0, usedArity)) {
-                        insert(RamId.TuplePos(rv, i));
-                        insert(RamId.RelPos(predSym, i))
-                    };
-                    Vector.forEach(computeMappingBool(set, map, counter), bools);
-                    recurse(body)
-                case RelOp.Functional(RowVar.Named(id), _, inputTerms, body, arity) => // equality on the input should be handled elsewhere.
-                    Vector.forEach(i -> insert(RamId.TuplePos(RowVar.Named(id), i)), Vector.range(0, arity));
-                    Vector.forEach(i -> insert(RamId.InId(id, i)), Vector.range(0, Vector.length(inputTerms)));
-                    Vector.forEach(computeMappingTerm(set, map, counter), inputTerms);
-                    recurse(body)
-                case RelOp.Project(terms, RelSym.Symbol(PredSym.PredSym(_, predSym), _, _), _) =>
-                    terms |> Vector.forEachWithIndex(i -> _ -> insert(RamId.RelPos(predSym, i)));
-                    terms |> Vector.forEach(computeMappingTerm(set, map, counter))
-                case RelOp.If(bools, body) =>
-                    recurse(body);
-                    Vector.forEach(computeMappingBool(set, map, counter), bools)
-            }
-
-        ///
-        /// Assign all `RamId`s in `boolExp` `UnifiedTypePos`.
-        ///
-        def computeMappingBool(
-            set: MutDisjointSets[RamId, r],
-            map: MutMap[RamId, Int32, r],
-            counter: Counter[r],
-            boolExp: BoolExp
-        ): Unit \ r =
-            let insert = registerRamId(set, map, counter);
-            let computeMappingTermRec = computeMappingTerm(set, map, counter);
-            match boolExp {
-                case BoolExp.Not(bexp) => computeMappingBool(set, map, counter, bexp)
-                case BoolExp.IsEmpty(_) => ()
-                case BoolExp.NotMemberOf(terms, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _)) =>
-                    Vector.forEach(computeMappingTermRec, terms);
-                    Vector.forEach(i -> insert(RamId.RelPos(predSym, i)), Vector.range(0, arity))
-                case BoolExp.Eq(t1, t2) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2)
-                case BoolExp.NotBot(t1, _, _) =>
-                    computeMappingTermRec(t1)
-                case BoolExp.Leq(_, _, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _)) =>
-                    insert(RamId.RelPos(predSym, arity - 1))
-                case BoolExp.Guard1(_, t1) =>
-                    computeMappingTermRec(t1)
-                case BoolExp.Guard2(_, t1, t2) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2)
-                case BoolExp.Guard3(_, t1, t2, t3) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2);
-                    computeMappingTermRec(t3)
-                case BoolExp.Guard4(_, t1, t2, t3, t4) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2);
-                    computeMappingTermRec(t3);
-                    computeMappingTermRec(t4)
-                case BoolExp.Guard5(_, t1, t2, t3, t4, t5) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2);
-                    computeMappingTermRec(t3);
-                    computeMappingTermRec(t4);
-                    computeMappingTermRec(t5)
-            }
-
-        ///
-        /// Assign all `RamId`s in `term` `UnifiedTypePos`.
-        ///
-        def computeMappingTerm(
-            set: MutDisjointSets[RamId, r],
-            map: MutMap[RamId, Int32, r],
-            counter: Counter[r],
-            term: RamTerm
-        ): Unit \ r =
-            let registerRamIdRec = registerRamId(set, map, counter);
-            let computeMappingTermRec = computeMappingTerm(set, map, counter);
-            let computeMappingTermAppRec = computeMappingTermApp(computeMappingTermRec, registerRamIdRec, getTermRamId(term));
-            match term {
-                case RamTerm.Lit(_, id) => registerRamIdRec(id)
-                case RamTerm.RowLoad(_, _, _) => registerRamIdRec(getTermRamId(term))
-                case RamTerm.Meet(_, t1, (rv, relSym), RamId.Id(id)) =>
-                    computeMappingTermRec(t1);
-                    registerRamIdRec(Ram.getLatVarRamId(rv, relSym));
-                    registerRamIdRec(RamId.Id(id))
-                case RamTerm.App1(_, t1, _) =>
-                    Vector#{t1} |> computeMappingTermAppRec
-                case RamTerm.App2(_, t1, t2, _) =>
-                    Vector#{t1, t2} |> computeMappingTermAppRec
-                case RamTerm.App3(_, t1, t2, t3, _) =>
-                    Vector#{t1, t2, t3} |> computeMappingTermAppRec
-                case RamTerm.App4(_, t1, t2, t3, t4, _) =>
-                    Vector#{t1, t2, t3, t4} |> computeMappingTermAppRec
-                case RamTerm.App5(_, t1, t2, t3, t4, t5, _) =>
-                    Vector#{t1, t2, t3, t4, t5} |> computeMappingTermAppRec
-                case RamTerm.ProvMax(loads) =>
-                    loads |> Vector.forEach(match (rv, index) -> registerRamIdRec(RamId.TuplePos(rv, index)))
-                case RamTerm.Meet(_, _, _, _) => unreachable!()
-            }
-
-        ///
-        /// Based on the equivalence `disjoint` assign all unique `RamId`'s a `Boxing` position.
-        ///
-        def computeMappingTermApp(
-            computeMappingTermRec: RamTerm -> Unit \ r,
-            registerRamIdRec: RamId -> Unit \ r,
-            id: RamId,
-            terms: Vector[RamTerm]
-        ): Unit \ r =
-            registerRamIdRec(id);
-            let id1 = match id {
-                case RamId.Id(i) => i
-                case _ => unreachable!()
-            };
-            foreach ((i, t) <- ForEach.withIndex(terms)) {
-                computeMappingTermRec(t);
-                registerRamIdRec(RamId.InId(id1, i))
-            }
-
-        ///
-        /// If `withProv` is true return `arity + 2`. Otherwise return `arity`.
-        ///
-        def getProvSafeIdArity(arity: Int32, withProv: Bool): Int32 =
-            if (withProv) arity + 2
-            else arity
-
-        ///
-        /// Add all `RamId`'s associated with `relSym` to `map`.
-        ///
-        /// Concretely, add `RamId.RelPos(id, i)` where `0 <= i <= arity` for `RelSym(id, arity, _)`.
-        ///
-        def insertIndexRelSym(
-            relSym: RelSym,
-            disjoint: MutDisjointSets[RamId, r],
-            map: MutMap[RamId, Int32, r],
-            counter: Counter[r],
-            withProv: Bool
-        ): Unit \ r =
-            let arity = Ram.arityOf(relSym);
-            let id = Ram.toId(relSym);
-            let usedArity = getProvSafeIdArity(arity, withProv);
-            foreach (i <- Vector.range(0, usedArity)) {
-                registerRamId(disjoint, map, counter, RamId.RelPos(id, i))
-            }
-
-        ///
-        /// Add `id` to `map` pointing to the `Int32` representing its boxing-information.
-        ///
-        /// Concretely, lookup `id` in `disjoint` to get `rep`. If `map[rep] => v` add
-        /// [id => v]. Otherwise add `[id => newID]` and `[rep => newID]`.
-        ///
-        /// `counter` is used to generate new identifiers.
-        ///
-        def registerRamId(
-            disjoint: MutDisjointSets[RamId, r],
-            ramIdToBoxingPos: MutMap[RamId, Int32, r],
-            counter: Counter[r],
-            ramID: RamId
-        ): Unit \ r =
-            let repID = getOrCrash(MutDisjointSets.find(ramID, disjoint));
-            match MutMap.get(repID, ramIdToBoxingPos) {
-                case Some(v) => MutMap.put(ramID, v, ramIdToBoxingPos)
-                case None =>
-                    let newID = Counter.getAndIncrement(counter);
-                    MutMap.put(ramID, newID, ramIdToBoxingPos);
-                    MutMap.put(repID, newID, ramIdToBoxingPos)
-            }
-    }
 
 }

--- a/main/src/library/Fixpoint3/Boxing.flix
+++ b/main/src/library/Fixpoint3/Boxing.flix
@@ -66,7 +66,7 @@ mod Fixpoint3.Boxing {
     @Internal
     pub def initialize(rc: Region[r], withProv: Bool, program: RamProgram): (Boxing[r], EFacts[r]) \ r =
         let boxingInfo = initializeInternal(rc, program, withProv);
-        let facts = unsafely IO run initializeFacts(rc, program, boxingInfo, withProv);
+        let facts = unsafely IO run initializeFacts(rc, program, boxingInfo);
         (boxingInfo, facts)
 
     ///
@@ -74,7 +74,7 @@ mod Fixpoint3.Boxing {
     /// the facts in `program`, with respect to `boxing`. Note that the old `boxingInfo` is
     /// invalid for the returned `facts`.
     ///
-    def initializeFacts(rc1: Region[r], program: RamProgram, boxingInfo: Boxing[r], withProv: Bool): EFacts[r] \ r + IO =
+    def initializeFacts(rc1: Region[r], program: RamProgram, boxingInfo: Boxing[r]): EFacts[r] \ r + IO =
         let RamProgram.Program(_, facts, _, (indexes, _), typeInfo) = program;
         let (f1, f2) = facts;
         let newFacts = MutMap.empty(rc1);
@@ -84,40 +84,30 @@ mod Fixpoint3.Boxing {
             let search = getOrCrash(Map.get(relSym, indexes)) |> Vector.get(0);
             let newTree = BPlusTree.emptyWithArityAndSearch(rc1, usedArity(), search);
             // `id` will always be a full `id`.
-            mapAllFacts(relSym, relFacts, boxingInfo, TypeInfo.getTypeOf(id, typeInfo), withProv, newTree);
+            mapAllFacts(relFacts, boxingInfo, TypeInfo.getTypeOf(id, typeInfo), newTree);
             MutMap.put(relSym, newTree, newFacts)
         };
         foreach ((relSym, relFacts) <- f2) {
             let RelSym.Symbol(PredSym.PredSym(_, id), _, _) = relSym;
             let newTree = MutMap.getOrElsePut(relSym, BPlusTree.empty(rc1), newFacts);
             // `id` will always be a full `id`.
-            mapAllFacts(relSym, relFacts, boxingInfo, TypeInfo.getTypeOf(id, typeInfo), withProv, newTree)
+            mapAllFacts(relFacts, boxingInfo, TypeInfo.getTypeOf(id, typeInfo), newTree)
         };
         newFacts |> MutMap.toMap
 
     def mapAllFacts(
-        relSym: RelSym,
         facts: BPlusTree[Vector[Boxed], Boxed, Static],
         boxingInfo: Boxing[r],
         mapping: Vector[Int32],
-        withProv: Bool,
         newTree: BPlusTree[Vector[Int64], Boxed, r]
     ): Unit \ r + IO = unchecked_cast({
-        let nonExtendedPositions = Vector.range(0, arityOf(relSym)) |>
-            Vector.map(i -> Vector.get(i, mapping));
-        let positions = if (not withProv) {
-            nonExtendedPositions
-        } else {
-            // Both can use this type. It does not really matter.
-            nonExtendedPositions ++ Vector#{TypeInfo.provType(), TypeInfo.provType()}
-        };
         facts |>
-            BPlusTree.parForEach(tuple -> lat -> {
+            BPlusTree.forEach(tuple -> lat -> {
                 // `facts` and `newTree` must have same the same region. Cast to achieve this.
                 unchecked_cast(({
                     let savedVec = tuple |>
                         Vector.mapWithIndex(index -> boxedVal ->
-                            let unifiedPos = Vector.get(index, positions);
+                            let unifiedPos = Vector.get(index, mapping);
                             unboxWith(boxedVal, unifiedPos, boxingInfo)
                         );
                     BPlusTree.put(savedVec, lat, newTree)

--- a/main/src/library/Fixpoint3/BoxingType.flix
+++ b/main/src/library/Fixpoint3/BoxingType.flix
@@ -52,7 +52,6 @@
 mod Fixpoint3.BoxingType {
     use Fixpoint3.ReadWriteLock
     use Fixpoint3.Boxed
-    use Fixpoint3.Ast.Ram.RamId
 
     ///
     /// `Types` represent the different types a program can contain.
@@ -81,13 +80,6 @@ mod Fixpoint3.BoxingType {
     ///
     @Internal
     pub type alias UnifiedTypePos = Int32
-
-    ///
-    /// Maps `RamId`'s to the `UnifiedTypePos`. It facilitates getting the type
-    /// information of a `RamTerm`.
-    ///
-    @Internal
-    pub type alias RamIdToPos = Map[RamId, UnifiedTypePos]
 
     ///
     /// Describes the type of values. The `UnifiedTypePos` describes where in `TypeInfo`

--- a/main/src/library/Fixpoint3/Debugging.flix
+++ b/main/src/library/Fixpoint3/Debugging.flix
@@ -94,7 +94,7 @@ mod Fixpoint3.Debugging {
     ///
     @Internal
     pub def notifyPreLowering(phase: String, program: Ram.RamProgram): Ram.RamProgram = match program {
-        case Ram.RamProgram.Program(stmt, _, _, _) => unsafely IO run {
+        case Ram.RamProgram.Program(stmt, _, _, _, _) => unsafely IO run {
             if (Options.enableDebugging()) region rc {
                 let strings = MutList.empty(rc);
                 let psh = s -> MutList.push(s, strings);

--- a/main/src/library/Fixpoint3/Interpreter.flix
+++ b/main/src/library/Fixpoint3/Interpreter.flix
@@ -142,7 +142,7 @@ mod Fixpoint3.Interpreter {
     /// Executes the `RamProgram` in `fst(input)` using the `Boxing` in `snd(input)`.
     ///
     @Internal
-    pub def interpret(rc: Region[r], withProv: Bool, input: (RamProgram[r], Boxing[r])): (Database[r], Predicates) \ r =
+    pub def interpret(rc: Region[r], input: (RamProgram[r], Boxing[r])): (Database[r], Predicates) \ r =
         let (program, boxing) = input;
         // Create `Indexes` from `program`.
         let RamProgram.Program(_, facts, _, (indexMap, posMap), _, _) = program;
@@ -161,7 +161,7 @@ mod Fixpoint3.Interpreter {
                 storeIndex(mkIndex(rc, relSym, search, tuples), pos, indexes)
             }
         };
-        interpretWithDatabase(rc, indexes, boxing, withProv, program)
+        interpretWithDatabase(rc, indexes, boxing, program)
 
     ///
     /// Executes `program` using `boxing` as `Boxing` information and `db` as initial
@@ -171,7 +171,6 @@ mod Fixpoint3.Interpreter {
         rc: Region[r],
         db: Indexes[r],
         boxing: Boxing[r],
-        withProv: Bool,
         program: RamProgram[r]
     ): (Database[r], Predicates) \ r = match program {
         case RamProgram.Program(stmt, _, predState, (_, indexPos), (arities, constWrites), typeInfo) =>
@@ -187,7 +186,7 @@ mod Fixpoint3.Interpreter {
             let ctx = (db, env, boxing);
             evalStmt(rc, ctx, parLevel(), stmt);
             // Remove the `IO` effect from dealing with static.
-            let boxedFacts = unsafely IO run marshallDb(rc, db, boxing, indexPos, predState, typeInfo, withProv);
+            let boxedFacts = unsafely IO run marshallDb(rc, db, boxing, indexPos, predState, typeInfo);
             (boxedFacts, predState)
     }
 
@@ -203,14 +202,12 @@ mod Fixpoint3.Interpreter {
         boxing: Boxing[r],
         indexPos: Map[(RelSym, Int32), Int32],
         predTrack: Predicates,
-        typeInfo: TypeInformation,
-        _withProv: Bool
+        typeInfo: TypeInformation
     ): Database[r] \ r + IO =
         let res = MutMap.empty(rc);
         foreach (relSym <- allFullRelSyms(predTrack)) {
             let innerMap = BPlusTree.empty(Static);
-            let fullId = toId(getRelSymAsType(relSym, Full, predTrack));
-            let curBoxingInfo = getTypeOf(fullId, typeInfo);
+            let curBoxingInfo = getTypeOf(toId(relSym), typeInfo);
             Array.get(getOrCrash(Map.get((relSym, 0), indexPos)), db) |>
                 BPlusTree.forEach(vec -> latticeElem -> {
                     let boxedVec = vec |>

--- a/main/src/library/Fixpoint3/Interpreter.flix
+++ b/main/src/library/Fixpoint3/Interpreter.flix
@@ -18,15 +18,17 @@
 
 mod Fixpoint3.Interpreter {
     use Fixpoint3.Ast.ExecutableRam.{BoolExp, RamProgram, RamStmt, RamTerm, RelOp, WriteTuple}
-    use Fixpoint3.Ast.Ram.{arityOfNonLat, Predicates, RamId, RelSym, Search, toDenotation, toId}
+    use Fixpoint3.Ast.Ram.{arityOfNonLat, Predicates, RelSym, Search, toDenotation, toId}
     use Fixpoint3.Ast.Shared.{BoxedDenotation => Denotation}
     use Fixpoint3.Ast.Shared.Denotation.{Latticenal, Relational}
     use Fixpoint3.Boxed
     use Fixpoint3.Boxing.{boxWith, unboxWith}
-    use Fixpoint3.BoxingType.{Boxing, RamIdToPos}
+    use Fixpoint3.BoxingType.Boxing
     use Fixpoint3.Counter
     use Fixpoint3.Options.{usedArity, parLevel}
-    use Fixpoint3.Predicate.allFullRelSyms
+    use Fixpoint3.Predicate.{allFullRelSyms, getRelSymAsType}
+    use Fixpoint3.Predicate.PredType.Full
+    use Fixpoint3.TypeInfo.{TypeInformation, getTypeOf}
     use Fixpoint3.Util.getOrCrash
 
     ///
@@ -172,7 +174,7 @@ mod Fixpoint3.Interpreter {
         withProv: Bool,
         program: RamProgram[r]
     ): (Database[r], Predicates) \ r = match program {
-        case RamProgram.Program(stmt, _, predState, (_, indexPos), (arities, constWrites), marshallIndexes) =>
+        case RamProgram.Program(stmt, _, predState, (_, indexPos), (arities, constWrites), typeInfo) =>
             let minEnv = arities |> Vector.map(x -> Array.repeat(rc, x, Int64.minValue()));
             let maxEnv = arities |> Vector.map(x -> Array.repeat(rc, x, Int64.maxValue()));
             foreach ((id1, id2, val) <- constWrites) {
@@ -185,7 +187,7 @@ mod Fixpoint3.Interpreter {
             let ctx = (db, env, boxing);
             evalStmt(rc, ctx, parLevel(), stmt);
             // Remove the `IO` effect from dealing with static.
-            let boxedFacts = unsafely IO run marshallDb(rc, db, boxing, indexPos, predState, marshallIndexes, withProv);
+            let boxedFacts = unsafely IO run marshallDb(rc, db, boxing, indexPos, predState, typeInfo, withProv);
             (boxedFacts, predState)
     }
 
@@ -201,21 +203,14 @@ mod Fixpoint3.Interpreter {
         boxing: Boxing[r],
         indexPos: Map[(RelSym, Int32), Int32],
         predTrack: Predicates,
-        boxingIndexes: RamIdToPos,
-        withProv: Bool
+        typeInfo: TypeInformation,
+        _withProv: Bool
     ): Database[r] \ r + IO =
         let res = MutMap.empty(rc);
         foreach (relSym <- allFullRelSyms(predTrack)) {
             let innerMap = BPlusTree.empty(Static);
-            // If we are doing provenance computations we need to also rebox the annotations.
-            // Since there are 2 annotations we add 2 in this case.
-            let usedArity =
-                if (withProv) arityOfNonLat(relSym) + 2
-                else arityOfNonLat(relSym);
-            let curBoxingInfo = Vector.range(0, usedArity) |>
-                Vector.map(i ->
-                    getOrCrash(Map.get(RamId.RelPos(toId(relSym), i), boxingIndexes))
-                );
+            let fullId = toId(getRelSymAsType(relSym, Full, predTrack));
+            let curBoxingInfo = getTypeOf(fullId, typeInfo);
             Array.get(getOrCrash(Map.get((relSym, 0), indexPos)), db) |>
                 BPlusTree.forEach(vec -> latticeElem -> {
                     let boxedVec = vec |>

--- a/main/src/library/Fixpoint3/Phase/Compiler.flix
+++ b/main/src/library/Fixpoint3/Phase/Compiler.flix
@@ -17,7 +17,7 @@
  */
 
 mod Fixpoint3.Phase.Compiler {
-    use Fixpoint3.Ast.Ram.{arityOfNonLat, BoolExp, Facts, Predicates, RamId, RamProgram, RamStmt, RamTerm, RelOp, RelSym, RowVar}
+    use Fixpoint3.Ast.Ram.{arityOfNonLat, BoolExp, Facts, Predicates, RamProgram, RamStmt, RamTerm, RelOp, RelSym, RowVar}
     use Fixpoint3.Ast.Datalog.{BodyPredicate, BodyTerm, Constraint, Datalog, Fixity, HeadTerm, Polarity, VarSym}
     use Fixpoint3.Ast.Datalog.Datalog.{Datalog}
     use Fixpoint3.Ast.Datalog.Constraint.Constraint
@@ -33,6 +33,7 @@ mod Fixpoint3.Phase.Compiler {
     use Fixpoint3.Util.getOrCrash
     use Fixpoint3.Predicate
     use Fixpoint3.Predicate.PredType.{Full, Delta, New}
+    use Fixpoint3.TypeInfo.{getType, getTypeOf, Type, typeDatalog, TypeInformation}
 
     ///
     /// Compile the given Datalog program `d` to RAM.
@@ -42,7 +43,7 @@ mod Fixpoint3.Phase.Compiler {
     /// A rule belongs to the same stratum as its head predicate.
     ///
     @Internal
-    pub def compile(d: Datalog, db: Map[RelSym, BPlusTree[Vector[Boxed], Boxed, Static]], strat: Map[PredSym, (Int32, Int32)]): RamProgram = match d {
+    pub def compile(d: Datalog, db: Map[RelSym, BPlusTree[Vector[Boxed], Boxed, Static]], strat: Map[PredSym, (Int32, Int32)], withProv: Bool): RamProgram = match d {
         case Datalog(facts, _) => region rc {
             let predicates = Predicate.initialize(d, db);
             let stmts = MutList.empty(rc);
@@ -59,12 +60,15 @@ mod Fixpoint3.Phase.Compiler {
                         MutMap.putWith(List.append, stratum, (num, rule) :: Nil, pseudoMap)
                 }
             };
+            let typeInfo = typeDatalog(d, pseudoStratums, predicates, withProv);
+            let functionalCounter = Counter.fresh(rc);
+            Counter.set(getOrCrash(Int64.tryToInt32(Predicate.getMax(predicates))), functionalCounter);
             foreach ((_, pseudStrat) <- pseudoStratums) {
                     let runInParallel = (Nil, pseudStrat) ||>
                         MutMap.foldLeft(acc -> enumeratedRules -> {
                             let stmtsForPseudo = MutList.empty(rc);
                             let (stratarulesWithId, strataRules) = List.unzip(enumeratedRules);
-                            compileStratum(stmtsForPseudo, strataRules, stratarulesWithId, predicates, counter);
+                            compileStratum(stmtsForPseudo, strataRules, stratarulesWithId, predicates, counter, functionalCounter, typeInfo);
                             RamStmt.Seq(MutList.toVector(stmtsForPseudo)) :: acc
                         });
                     if (List.size(runInParallel) > 1) {
@@ -76,7 +80,7 @@ mod Fixpoint3.Phase.Compiler {
                     }
             };
             let stmt = RamStmt.Seq(MutList.toVector(stmts));
-            RamProgram.Program(stmt, compiledFacts, predicates, (Map#{}, Map#{}))
+            RamProgram.Program(stmt, compiledFacts, predicates, (Map#{}, Map#{}), typeInfo)
         }
         case _ => bug!("Datalog normalization bug")
     }
@@ -146,7 +150,8 @@ mod Fixpoint3.Phase.Compiler {
     /// Note that Eval-Rule is the code emitted by `compileRule`
     /// and Eval-Rule-Incr is the code emitted by `compileRuleIncr`.
     ///
-    def compileStratum(stmts: MutList[RamStmt, r1], stratum: List[Constraint], rulesWithId: List[Int32], predicates: Predicates, counter: Counter[r2]): Unit \ r1 + r2 = region rc {
+    def compileStratum(stmts: MutList[RamStmt, r1], stratum: List[Constraint], rulesWithId: List[Int32], predicates: Predicates, counter: Counter[r2], functionalCounter: Counter[r2], typeInfo: TypeInformation): Unit \ r1 + r2 = region rc {
+        let functionalCountBackUp = Counter.get(functionalCounter);
         let idb = (Set#{}, stratum) ||>
             List.foldRight(match Constraint(head, _) -> {
                 Set.insert(Predicate.headAtomToRelSym(head, Full, predicates))
@@ -159,7 +164,7 @@ mod Fixpoint3.Phase.Compiler {
         // Construct the inserts for step 1.
         let inserts = MutList.empty(rc);
         foreach ((rule, ruleNum) <- ForEach.withZip(stratum, rulesWithId)) {
-            compileRule(inserts, rule, ruleNum, predicates, counter)
+            compileRule(inserts, rule, ruleNum, predicates, counter, functionalCounter, typeInfo)
         };
         let optPar =
             if (MutList.size(inserts) > 1) {
@@ -178,9 +183,13 @@ mod Fixpoint3.Phase.Compiler {
                 let loopBody = MutList.empty(rc);
 
                 let loopInserts = MutList.empty(rc);
+
+                let finalFunctionalCounter =  Counter.get(functionalCounter);
+                Counter.set(functionalCountBackUp, functionalCounter);
                 foreach ((rule, ruleNum) <- ForEach.withZip(stratum, rulesWithId)) {
-                    compileRuleIncr(loopInserts, rule, ruleNum, idbIds, predicates, counter)
+                    compileRuleIncr(loopInserts, rule, ruleNum, idbIds, predicates, counter, functionalCounter, typeInfo)
                 };
+                Counter.set(finalFunctionalCounter, functionalCounter);
                 let loopParOpt =
                     if (MutList.size(loopInserts) > 1) {
                         Some(RamStmt.Par(MutList.toVector(loopInserts)))
@@ -260,24 +269,25 @@ mod Fixpoint3.Phase.Compiler {
     ///         end
     ///     end
     ///
-    def compileRule(stmts: MutList[RamStmt, r1], rule: Constraint, ruleNum: Int32, predicates: Predicates, counter: Counter[r2]): Unit \ r1 + r2 = match rule {
+    def compileRule(stmts: MutList[RamStmt, r1], rule: Constraint, ruleNum: Int32, predicates: Predicates, counter: Counter[r2], functionalCounter: Counter[r2], typeInfo: TypeInformation): Unit \ r1 + r2 = match rule {
         case Constraint(headAtom, body) =>
-            let HeadAtom(_, _, headTerms) = headAtom;
+            let HeadAtom(PredSym(_, headId), _, headTerms) = headAtom;
             let augBody = augmentBody(body, counter);
-            let env = unifyVars(predicates, counter, augBody);
-            let ramTerms = Vector.map(compileHeadTerm(env, counter), headTerms);
+            let env = unifyVars(predicates, augBody, functionalCounter, typeInfo);
+            let ramTerms = Vector.mapWithIndex(i -> atom -> compileHeadTerm(env, getType(headId, i, typeInfo), atom), headTerms);
             let projection = RelOp.Project(ramTerms, Predicate.headAtomToRelSym(headAtom, New, predicates), ruleNum);
-            match compileBody(env, augBody, predicates, counter) {
+            match compileBody(env, augBody, predicates, typeInfo) {
                 case None       => ()
                 case Some(join) =>
                     let loopBody = RelOp.If(join, projection);
                     let insert = (loopBody, augBody)
                         ||> Vector.foldRight(match (atom, rowVar) -> acc -> match atom {
-                            case BodyAtom(_, _, Polarity.Positive, _, _) =>
-                                RelOp.Search(rowVar, Predicate.bodyAtomToRelSym(atom, Full, predicates), acc)
+                            case BodyAtom(PredSym(_, id), _, Polarity.Positive, _, _) =>
+                                RelOp.Search(rowVar, Predicate.bodyAtomToRelSym(atom, Full, predicates), getTypeOf(id, typeInfo), acc)
                             case Functional(boundVars, f, freeVars) =>
                                 let terms = Vector.map(v -> getOrCrash(Map.get(v, env)), freeVars);
-                                RelOp.Functional(rowVar, f, terms, acc, Vector.length(boundVars))
+                                let t = getTypeOf(Int32.toInt64(Counter.getAndIncrement(functionalCounter)), typeInfo);
+                                RelOp.Functional(rowVar, f, terms, acc, Vector.length(boundVars), t)
                             case _ => acc
                         })
                         |> RamStmt.Insert;
@@ -321,16 +331,16 @@ mod Fixpoint3.Phase.Compiler {
     ///
     /// `ruleNum` is the rules assigned number and `counter` is used to create unique `RowVar`s.
     ///
-    def compileRuleIncr(stmts: MutList[RamStmt, r1], rule: Constraint, ruleNum: Int32, idbSet: Set[Int64], predicates: Predicates, counter: Counter[r2]): Unit \ r1 + r2 = match rule {
+    def compileRuleIncr(stmts: MutList[RamStmt, r1], rule: Constraint, ruleNum: Int32, idbSet: Set[Int64], predicates: Predicates, counter: Counter[r2], functionalCounter: Counter[r2], typeInfo: TypeInformation): Unit \ r1 + r2 = match rule {
         case Constraint(headAtom, body) =>
-            let HeadAtom(_, _, headTerms) = headAtom;
+            let HeadAtom(PredSym(_, headId), _, headTerms) = headAtom;
             let compileSomething = deltaIndex -> { // `delta` designates the focused atom.
                 let augBody = augmentBody(body, counter);
                 let delta = snd(Vector.get(deltaIndex, augBody));
-                let env = unifyVars(predicates, counter, augBody);
-                let ramTerms = Vector.map(compileHeadTerm(env, counter), headTerms);
+                let env = unifyVars(predicates, augBody, functionalCounter, typeInfo);
+                let ramTerms = Vector.mapWithIndex(i -> atom -> compileHeadTerm(env, getType(headId, i, typeInfo), atom), headTerms);
                 let projection = RelOp.Project(ramTerms, Predicate.headAtomToRelSym(headAtom, New, predicates), ruleNum);
-                match compileBody(env, augBody, predicates, counter) {
+                match compileBody(env, augBody, predicates, typeInfo) {
                     case None       => ()
                     case Some(join) =>
                         let relSym = Predicate.headAtomToRelSym(headAtom, Full, predicates);
@@ -340,16 +350,17 @@ mod Fixpoint3.Phase.Compiler {
                         );
                         let insert = (loopBody, augBody)
                             ||> Vector.foldRight(match (atom, rowVar) -> acc -> match atom {
-                                case BodyAtom(_, den, Polarity.Positive, _, _) =>
+                                case BodyAtom(PredSym(_, id), den, Polarity.Positive, _, _) =>
                                     let ramSym = if (rowVar == delta and isRelational(den)) {
                                         Predicate.bodyAtomToRelSym(atom, Delta, predicates)
                                     } else {
                                         Predicate.bodyAtomToRelSym(atom, Full, predicates)
                                     };
-                                    RelOp.Search(rowVar, ramSym, acc)
+                                    RelOp.Search(rowVar, ramSym, getTypeOf(id, typeInfo), acc)
                                 case Functional(boundVars, f, freeVars) =>
                                     let terms = Vector.map(v -> getOrCrash(Map.get(v, env)), freeVars);
-                                    RelOp.Functional(rowVar, f, terms, acc, Vector.length(boundVars))
+                                    let t = getTypeOf(Int32.toInt64(Counter.getAndIncrement(functionalCounter)), typeInfo);
+                                    RelOp.Functional(rowVar, f, terms, acc, Vector.length(boundVars), t)
                                 case _ => acc
                             })
                             |> RamStmt.Insert;
@@ -369,46 +380,47 @@ mod Fixpoint3.Phase.Compiler {
                 })
                 |> Vector.filter(i -> i != -1);
 
+            let count = Counter.get(functionalCounter);
             if (Fixpoint3.Options.enableDebugging()) {
                 let comment = RamStmt.Comment(ToString.toString(rule));
                 MutList.push(comment, stmts);
-                Vector.forEach(compileSomething, positiveIDBAtoms)
+                Vector.forEach(i -> {Counter.set(count, functionalCounter); compileSomething(i)}, positiveIDBAtoms)
             } else {
-                Vector.forEach(compileSomething, positiveIDBAtoms)
+                Vector.forEach(i -> {Counter.set(count, functionalCounter); compileSomething(i)}, positiveIDBAtoms)
             }
     }
 
     ///
     /// Substitute Datalog head term `term` for a RAM term according to the given substitution `env`.
     ///
-    def compileHeadTerm(env: Map[VarSym, RamTerm], counter: Counter[r], term: HeadTerm): RamTerm \ r = match term {
+    def compileHeadTerm(env: Map[VarSym, RamTerm], ty: Type, term: HeadTerm): RamTerm = match term {
         case HeadTerm.Var(var)   => getOrCrash(Map.get(var, env))
-        case HeadTerm.Lit(v)     => RamTerm.Lit(v, RamId.Id(Counter.getAndIncrement(counter)))
+        case HeadTerm.Lit(v)     => RamTerm.Lit(v, ty)
         case HeadTerm.App1(f, v) =>
             let t = getOrCrash(Map.get(v, env));
-            RamTerm.App1(f, t, RamId.Id(Counter.getAndIncrement(counter)))
+            RamTerm.App1(f, t, ty)
         case HeadTerm.App2(f, v1, v2) =>
             let t1 = getOrCrash(Map.get(v1, env));
             let t2 = getOrCrash(Map.get(v2, env));
-            RamTerm.App2(f, t1, t2, RamId.Id(Counter.getAndIncrement(counter)))
+            RamTerm.App2(f, t1, t2, ty)
         case HeadTerm.App3(f, v1, v2, v3) =>
             let t1 = getOrCrash(Map.get(v1, env));
             let t2 = getOrCrash(Map.get(v2, env));
             let t3 = getOrCrash(Map.get(v3, env));
-            RamTerm.App3(f, t1, t2, t3, RamId.Id(Counter.getAndIncrement(counter)))
+            RamTerm.App3(f, t1, t2, t3, ty)
         case HeadTerm.App4(f, v1, v2, v3, v4) =>
             let t1 = getOrCrash(Map.get(v1, env));
             let t2 = getOrCrash(Map.get(v2, env));
             let t3 = getOrCrash(Map.get(v3, env));
             let t4 = getOrCrash(Map.get(v4, env));
-            RamTerm.App4(f, t1, t2, t3, t4, RamId.Id(Counter.getAndIncrement(counter)))
+            RamTerm.App4(f, t1, t2, t3, t4, ty)
         case HeadTerm.App5(f, v1, v2, v3, v4, v5) =>
             let t1 = getOrCrash(Map.get(v1, env));
             let t2 = getOrCrash(Map.get(v2, env));
             let t3 = getOrCrash(Map.get(v3, env));
             let t4 = getOrCrash(Map.get(v4, env));
             let t5 = getOrCrash(Map.get(v5, env));
-            RamTerm.App5(f, t1, t2, t3, t4, t5, RamId.Id(Counter.getAndIncrement(counter)))
+            RamTerm.App5(f, t1, t2, t3, t4, t5, ty)
     }
 
     ///
@@ -431,36 +443,41 @@ mod Fixpoint3.Phase.Compiler {
     /// `x` is mapped to B$1[0] because `x` occurs positively in the second atom.
     /// `s` is mapped to the glb of all its positive occurences because it is latticenal.
     ///
-    def unifyVars(predicates: Predicates, counter: Counter[r], body: Vector[(BodyPredicate, RowVar)]): Map[VarSym, RamTerm] \ r =
+    /// Does not change `functionalCounter`
+    ///
+    def unifyVars(predicates: Predicates, body: Vector[(BodyPredicate, RowVar)], functionalCounter: Counter[r], typeInfo: TypeInformation): Map[VarSym, RamTerm] \ r =
+        let functionalCountBackUp = Counter.get(functionalCounter);
         let toFullSym = bodyAtom -> (Predicate.bodyAtomToRelSym(bodyAtom, Full, predicates));
         let innerFunc = {
             acc -> atomVar ->
             let (atom, rowVar) = atomVar;
             match atom {
-            case BodyAtom(_, denotation, Polarity.Positive, _, terms) =>
+            case BodyAtom(PredSym(_, id), denotation, Polarity.Positive, _, terms) =>
                 let termsWithIndexes = Vector.mapWithIndex(i -> term -> (term, i), terms);
                 (acc, termsWithIndexes) ||>
                     Vector.foldRight(termI -> acc1 ->
                         let (term, i) = termI;
+                        let sType = getType(id, i, typeInfo);
                         match term {
                             case BodyTerm.Var(var) => match denotation {
                                 case Relational =>
-                                    Map.insertWith(_ -> t -> t, var, RamTerm.RowLoad(rowVar, i, toFullSym(atom)), acc1)
+                                    Map.insertWith(_ -> t -> t, var, RamTerm.RowLoad(rowVar, i, sType, toFullSym(atom)), acc1)
                                 case Latticenal(_, _, _, glb) =>
                                     if (i < Vector.length(terms) - 1)
-                                        Map.insertWith(_ -> t -> t, var, RamTerm.RowLoad(rowVar, i, toFullSym(atom)), acc1)
+                                        Map.insertWith(_ -> t -> t, var, RamTerm.RowLoad(rowVar, i, sType, toFullSym(atom)), acc1)
                                     else
-                                        let f = _ -> t2 -> RamTerm.Meet(glb, t2, (rowVar, toFullSym(atom)), RamId.Id(Counter.getAndIncrement(counter)));
-                                        Map.insertWith(f, var, RamTerm.RowLoad(rowVar, i, toFullSym(atom)), acc1)
+                                        let f = _ -> t2 -> RamTerm.Meet(glb, t2, (rowVar, toFullSym(atom)), getType(id, i, typeInfo));
+                                        Map.insertWith(f, var, RamTerm.RowLoad(rowVar, i, sType, toFullSym(atom)), acc1)
                             }
                             case _ => acc1
                     })
             case BodyAtom(_, _, Polarity.Negative, _, _) => acc
             case Functional(boundVars, _, freeVars) =>
+                let typeId = Int32.toInt64(Counter.getAndIncrement(functionalCounter));
                 let funcRelSym = functionalRelSym(Vector.length(freeVars));
                 let varsWithIndexes = Vector.mapWithIndex(i -> var -> (var, i), boundVars);
                 (acc, varsWithIndexes) ||>
-                    Vector.foldRight(match (var, i) -> Map.insertWith(_ -> old -> old, var, RamTerm.RowLoad(rowVar, i, funcRelSym)))
+                    Vector.foldRight(match (var, i) -> Map.insertWith(_ -> old -> old, var, RamTerm.RowLoad(rowVar, i, getType(typeId, i, typeInfo), funcRelSym)))
             case Guard0(_)                => acc
             case Guard1(_, _)             => acc
             case Guard2(_, _, _)          => acc
@@ -469,7 +486,9 @@ mod Fixpoint3.Phase.Compiler {
             case Guard5(_, _, _, _, _, _) => acc
             case _                        => acc
         }};
-        Vector.foldLeft(innerFunc, Map#{}, body)
+        let res = Vector.foldLeft(innerFunc, Map#{}, body);
+        Counter.set(functionalCountBackUp, functionalCounter);
+        res
 
     ///
     /// Equates every term in a positive body atom with a RAM term corresponding to an attribute
@@ -487,9 +506,9 @@ mod Fixpoint3.Phase.Compiler {
     /// (2) comes from the negative atom `not A(x)`.
     /// (3) is a function call that computes the expression `x > 0`.
     ///
-    def compileBody(env: Map[VarSym, RamTerm], body: Vector[(BodyPredicate, RowVar)], predicates: Predicates, counter: Counter[r]): Option[Vector[BoolExp]] \ r =
+    def compileBody(env: Map[VarSym, RamTerm], body: Vector[(BodyPredicate, RowVar)], predicates: Predicates, typeInfo: TypeInformation): Option[Vector[BoolExp]] =
         if (isImpossible(body)) None
-        else Some(compileBodyWithoutGuard0(env, body, predicates, counter))
+        else Some(compileBodyWithoutGuard0(env, body, predicates, typeInfo))
 
     ///
     /// Returns true if a rule is impossible to satisfy. Used for removing `Guard0()` from the AST.
@@ -514,30 +533,32 @@ mod Fixpoint3.Phase.Compiler {
     ///
     /// Compiles `body` under substitution `env`, assuming any `Guard0` is true.
     ///
-    def compileBodyWithoutGuard0(env: Map[VarSym, RamTerm], body: Vector[(BodyPredicate, RowVar)], predicates: Predicates, counter: Counter[r]): Vector[BoolExp] \ r =
+    def compileBodyWithoutGuard0(env: Map[VarSym, RamTerm], body: Vector[(BodyPredicate, RowVar)], predicates: Predicates, typeInfo: TypeInformation): Vector[BoolExp] =
         let toFullSym = bodyAtom -> (Predicate.bodyAtomToRelSym(bodyAtom, Full, predicates));
         body |>
             Vector.flatMap(match (atom, rowVar) ->
-                let compileBodyTerm = j -> term -> match term {
-                    case BodyTerm.Wild      => RamTerm.RowLoad(rowVar, j, toFullSym(atom))
+                let compileBodyTerm = id -> j -> term -> match term {
+                    case BodyTerm.Wild      =>
+                        RamTerm.RowLoad(rowVar, j, getType(id, j, typeInfo), toFullSym(atom))
                     case BodyTerm.Var(var)  => getOrCrash(Map.get(var, env))
-                    case BodyTerm.Lit(v)    => RamTerm.Lit(v, RamId.Id(Counter.getAndIncrement(counter)))
+                    case BodyTerm.Lit(v)    => RamTerm.Lit(v, getType(id, j, typeInfo))
                 };
                 match atom {
-                    case BodyAtom(_, denotation, Polarity.Positive, _, terms) =>
-                        Vector.mapWithIndex(compileBodyTerm, terms)
+                    case BodyAtom(PredSym(_, id), denotation, Polarity.Positive, _, terms) =>
+                        let full = toFullSym(atom);
+                        Vector.mapWithIndex(compileBodyTerm(id), terms)
                             |> Vector.zip(Vector.range(0, Vector.length(terms)))
                             |> Vector.map(match (i, t) -> match denotation {
                                 case Relational =>
-                                    BoolExp.Eq(RamTerm.RowLoad(rowVar, i, toFullSym(atom)), t)
+                                    BoolExp.Eq(RamTerm.RowLoad(rowVar, i, getType(id, i, typeInfo), full), t)
                                 case Latticenal(bot, leq, _, _) =>
                                     if (i < Vector.length(terms) - 1)
-                                        BoolExp.Eq(RamTerm.RowLoad(rowVar, i, toFullSym(atom)), t)
+                                        BoolExp.Eq(RamTerm.RowLoad(rowVar, i, getType(id, i, typeInfo), full), t)
                                     else
-                                        compileBoolForLatticeenal(t, leq, bot, rowVar, toFullSym(atom))
+                                        compileBoolForLatticeenal(t, leq, bot, rowVar, full)
                             })
-                    case BodyAtom(_, _, Polarity.Negative, _, terms) =>
-                        let ramTerms = Vector.mapWithIndex(compileBodyTerm, terms);
+                    case BodyAtom(PredSym(_, id), _, Polarity.Negative, _, terms) =>
+                        let ramTerms = Vector.mapWithIndex(compileBodyTerm(id), terms);
                         Vector#{BoolExp.NotMemberOf(ramTerms, Predicate.bodyAtomToRelSym(atom, Full, predicates))}
                     case Functional(_, _, _) => Vector.empty()
                     case Guard0(_) =>

--- a/main/src/library/Fixpoint3/Phase/Hoisting.flix
+++ b/main/src/library/Fixpoint3/Phase/Hoisting.flix
@@ -83,7 +83,7 @@
 /// When arriving at `if (...)` and `project(...)` `termMap` will remain unchanged.
 ///
 mod Fixpoint3.Phase.Hoisting {
-    use Fixpoint3.Ast.Ram.{arityOf, arityOfNonLat, BoolExp, RamId, RamProgram, RamStmt, RamTerm, RelOp, RelSym, RowVar}
+    use Fixpoint3.Ast.Ram.{arityOf, arityOfNonLat, BoolExp, RamProgram, RamStmt, RamTerm, RelOp, RelSym, RowVar}
     use Fixpoint3.Boxed
     use Fixpoint3.Phase.Compiler.functionalRelSym
     use Fixpoint3.Util.getOrCrash
@@ -93,7 +93,7 @@ mod Fixpoint3.Phase.Hoisting {
     ///
     @Internal
     pub def hoistProgram(program: RamProgram): RamProgram = match program {
-        case RamProgram.Program(stmt, facts, meta, index) => region rc {
+        case RamProgram.Program(stmt, facts, meta, index, typeInfo) => region rc {
             let equalitySets = MutDisjointSets.empty(rc);
             let constEqualities = MutMap.empty(rc);
             // Compute transitive equality
@@ -106,7 +106,7 @@ mod Fixpoint3.Phase.Hoisting {
             let termMap = (Map.empty(), constEqualities) ||>
                 MutMap.foldLeftWithKey(acc -> load -> listOfPairs ->
                     (acc, listOfPairs) ||>
-                        List.foldLeft(innerAcc -> match (val, id) -> {
+                        List.foldLeft(innerAcc -> match (val, ty) -> {
                             // `load` must have been registered by `unifyEqualitiesStmt`.
                             let rep = getOrCrash(MutDisjointSets.find(load, equalitySets));
                             match Map.get(rep, innerAcc) {
@@ -116,13 +116,13 @@ mod Fixpoint3.Phase.Hoisting {
                                     };
                                     innerAcc
                                 case Some(_) => bug!("In Fixpoint.Phase.Hoisting.hoistProgram: termMap contains non-literals before hoistStmt!")
-                                case None    => Map.insert(rep, RamTerm.Lit(val, id), innerAcc)
+                                case None    => Map.insert(rep, RamTerm.Lit(val, ty), innerAcc)
                             }
                         })
                 );
             match hoistStmt(rc, termMap, equalitySets, MutSet.toSet(impossible), stmt) {
-                case None => RamProgram.Program(RamStmt.Comment("No rules are satisfiable"), facts, meta, index)
-                case Some(hoistedStmt) => RamProgram.Program(hoistedStmt, facts, meta, index)
+                case None => RamProgram.Program(RamStmt.Comment("No rules are satisfiable"), facts, meta, index, typeInfo)
+                case Some(hoistedStmt) => RamProgram.Program(hoistedStmt, facts, meta, index, typeInfo)
             }
         }
     }
@@ -212,9 +212,9 @@ mod Fixpoint3.Phase.Hoisting {
     /// Only includes non-negative dependencies.
     ///
     def relSymsOfOp(op: RelOp): List[RelSym] = match op {
-        case RelOp.Search(_, relSym, body) => relSym :: relSymsOfOp(body)
-        case RelOp.Query(_, relSym, _, _, body) => relSym :: relSymsOfOp(body)
-        case RelOp.Functional(_, _, _, body, _) => relSymsOfOp(body)
+        case RelOp.Search(_, relSym, _, body) => relSym :: relSymsOfOp(body)
+        case RelOp.Query(_, relSym, _, _, _, body) => relSym :: relSymsOfOp(body)
+        case RelOp.Functional(_, _, _, body, _, _) => relSymsOfOp(body)
         case RelOp.Project(_, _, _) => Nil
         case RelOp.If(_, body) => relSymsOfOp(body)
     }
@@ -254,33 +254,33 @@ mod Fixpoint3.Phase.Hoisting {
         match op {
             // We here move every `BoolExp` into `Query` even though IndexSelection can only handle `Eq`.
             // This is done in case a newer index selection scheme makes use of those `BoolExp`.
-            case RelOp.Search(rowVar, relSym, body) =>
+            case RelOp.Search(rowVar, relSym, types, body) =>
                 if (Set.memberOf(rowVar, impossible))
                     None
                 else {
                     // Register all values `rowVar[i]`, for `0 <= i < arity`, as known when hoisting `body`.
-                    let termMapWithCur = registerNewTerms(rowVar, termMap, equalitySets, relSym);
+                    let termMapWithCur = registerNewTerms(rowVar, termMap, equalitySets, types, relSym);
                     let optHoistedBody = hoistOpRecNewTermMap(termMapWithCur, body);
                     match optHoistedBody {
                         case None => None
                         case Some(hoistedBody) =>
-                            let (intraEqualities, knownEqualities) = constructEqualityConstraints(rowVar, relSym, termMapWithCur, equalitySets);
+                            let (intraEqualities, knownEqualities) = constructEqualityConstraints(rowVar, relSym, types, termMapWithCur, equalitySets);
                             // Expressions are hoisted to this point if they are ground with `rowVar` bound,
                             // but not without `rowVar`.
                             let hoistedToHere = getBoolsHoistedToHere(rowVar, termMap, termMapWithCur, equalitySets, idToBool);
                             let combined = List.toVector(knownEqualities ::: intraEqualities ::: hoistedToHere);
                             let newOp =
                                 if (Vector.length(combined) != 0)
-                                    RelOp.Query(rowVar, relSym, combined, -1, hoistedBody)
-                                else RelOp.Search(rowVar, relSym, hoistedBody);
+                                    RelOp.Query(rowVar, relSym, combined, -1, types, hoistedBody)
+                                else RelOp.Search(rowVar, relSym, types, hoistedBody);
                             Some(newOp)
                     }
             }
-            case RelOp.Query(_, _, _, _, _) =>
+            case RelOp.Query(_, _, _, _, _, _) =>
                 bug!("In Fixpoint.Phase.Hoisting.hoistOp: Query should not exists when introducing Query")
-            case RelOp.Functional(rowVar, func, terms, body, arity) =>
+            case RelOp.Functional(rowVar, func, terms, body, arity, types) =>
                 let fakeRelSym = functionalRelSym(arity);
-                let termMapWithCur = registerNewTerms(rowVar, termMap, equalitySets, fakeRelSym);
+                let termMapWithCur = registerNewTerms(rowVar, termMap, equalitySets, types, fakeRelSym);
                 match hoistOpRec(body) {
                     case None => None
                     case Some(v) => {
@@ -290,9 +290,9 @@ mod Fixpoint3.Phase.Hoisting {
 
                         if (List.nonEmpty(hoistedToHere)) {
                             Some(RelOp.Functional(rowVar, func, terms, RelOp.If(List.toVector(hoistedToHere)
-                                |> Vector.map(replaceByRepBoolExp(termMapWithCur, equalitySets)), v), arity))
+                                |> Vector.map(replaceByRepBoolExp(termMapWithCur, equalitySets)), v), arity, types))
                         } else {
-                            Some(RelOp.Functional(rowVar, func, terms, v, arity))
+                            Some(RelOp.Functional(rowVar, func, terms, v, arity, types))
                         }
                     }
                 }
@@ -337,6 +337,7 @@ mod Fixpoint3.Phase.Hoisting {
     def constructEqualityConstraints(
         rowVar: RowVar,
         relSym: RelSym,
+        types: Vector[Int32],
         termMapCopy: Map[(RowVar, Int32), RamTerm],
         equalitySets: MutDisjointSets[(RowVar, Int32), r]
     ): (List[BoolExp], List[BoolExp]) \ r = region rc {
@@ -350,10 +351,12 @@ mod Fixpoint3.Phase.Hoisting {
                     // and we unbind it by removing it from `termMap`.
                     // Furthermore, if `rep => rowVar[i1]`, where `i1 != i`, then `rowVar[i] == rowVar[i1]`.
                     // We cannot currently use this for index selection, but need to keep this invariant, so it is pushed to `intraEqualities`
-                    case RamTerm.RowLoad(rv, i1, _) if (rv == rowVar and i1 == i) => ()
-                    case RamTerm.RowLoad(rv, i1, rel) if (rv == rowVar) =>
-                        intraEqualities |> MutList.push(BoolExp.Eq(RamTerm.RowLoad(rv, i, rel), RamTerm.RowLoad(rv, i1, rel)))
-                    case value => MutList.push(BoolExp.Eq(RamTerm.RowLoad(rowVar, i, relSym), value), knownEqualities)
+                    case RamTerm.RowLoad(rv, i1, _, _) if (rv == rowVar and i1 == i) => ()
+                    case RamTerm.RowLoad(rv, i1, t, rel) if (rv == rowVar) =>
+                        intraEqualities |> MutList.push(BoolExp.Eq(RamTerm.RowLoad(rv, i, t, rel), RamTerm.RowLoad(rv, i1, t, rel)))
+                    case value =>
+                        let t = Vector.get(i, types);
+                        MutList.push(BoolExp.Eq(RamTerm.RowLoad(rowVar, i, t, relSym), value), knownEqualities)
             }}
         };
         (MutList.toList(knownEqualities), MutList.toList(intraEqualities))
@@ -369,13 +372,14 @@ mod Fixpoint3.Phase.Hoisting {
         rv: RowVar,
         termMap: Map[(RowVar, Int32), RamTerm],
         equalitySets: MutDisjointSets[(RowVar, Int32), r],
+        types: Vector[Int32],
         relSym: RelSym
     ): Map[(RowVar, Int32), RamTerm] \ r = {
         // Register all values `rowVar[i]`, for `0 <= i < arity`, as known when hoisting `body`.
         (termMap, Vector.range(0, arityOf(relSym))) ||>
             Vector.foldLeft(acc -> i -> {
                 match MutDisjointSets.find((rv, i), equalitySets) {
-                    case Some(rep) => Map.insertWith(_ -> v -> v, rep, RamTerm.RowLoad(rv, i, relSym), acc)
+                    case Some(rep) => Map.insertWith(_ -> v -> v, rep, RamTerm.RowLoad(rv, i, Vector.get(i, types), relSym), acc)
                     case None => bug!("In Fixpoint.Phase.Hoisting: Everything should be in the equalitySet")
                 }
             })
@@ -464,7 +468,7 @@ mod Fixpoint3.Phase.Hoisting {
         match term {
             case RamTerm.Lit(_, _)                      => Set#{}
             case RamTerm.ProvMax(vec)                   => Vector.foldLeft(acc -> match (rv, _) -> Set.insert(rv, acc), Set#{}, vec)
-            case RamTerm.RowLoad(rv, i, _)              => getRepVar(rv, i)
+            case RamTerm.RowLoad(rv, i, _, _)              => getRepVar(rv, i)
             case RamTerm.Meet(_, t1, (rv, relSym), _)   => Set.union(termVarsOf(t1), getRepVar(rv, arityOfNonLat(relSym)))
             case RamTerm.App1(_, t1, _)                 => termVarsOf(t1)
             case RamTerm.App2(_, t1, t2, _) =>
@@ -496,7 +500,7 @@ mod Fixpoint3.Phase.Hoisting {
         match Map.get(repLoad, termMap) {
             case None => Set#{rv}
             case Some(rep) => match rep {
-                case RamTerm.RowLoad(rv1, _, _) => Set#{rv1}
+                case RamTerm.RowLoad(rv1, _, _, _) => Set#{rv1}
                 case RamTerm.Lit(_, _) => Set#{}
                 case _ => unreachable!()
             }
@@ -544,7 +548,7 @@ mod Fixpoint3.Phase.Hoisting {
         ramTerm: RamTerm
     ): RamTerm \ r =
         let getRep = term -> match term {
-            case RamTerm.RowLoad(rv, i, _) =>
+            case RamTerm.RowLoad(rv, i, _, _) =>
                 let load = MutDisjointSets.find((rv, i), equalitySets) |> getOrCrash;
                 match Map.get(load, termMap) {
                     case None => term
@@ -554,15 +558,15 @@ mod Fixpoint3.Phase.Hoisting {
         };
         let replaceRec = replaceByRepRamTerm(termMap, equalitySets);
         match ramTerm {
-            case RamTerm.Lit(_, _)                      => ramTerm
-            case RamTerm.ProvMax(_)                     => ramTerm
-            case RamTerm.RowLoad(_, _, _)               => getRep(ramTerm)
-            case RamTerm.Meet(_, _, _, _)               => ramTerm
-            case RamTerm.App1(f, t1, id)                => RamTerm.App1(f, replaceRec(t1), id)
-            case RamTerm.App2(f, t1, t2, id)            => RamTerm.App2(f, replaceRec(t1), replaceRec(t2), id)
-            case RamTerm.App3(f, t1, t2, t3, id)        => RamTerm.App3(f, replaceRec(t1), replaceRec(t2), replaceRec(t3), id)
-            case RamTerm.App4(f, t1, t2, t3, t4, id)    => RamTerm.App4(f, replaceRec(t1), replaceRec(t2), replaceRec(t3), replaceRec(t4), id)
-            case RamTerm.App5(f, t1, t2, t3, t4, t5, id)=> RamTerm.App5(f, replaceRec(t1), replaceRec(t2), replaceRec(t3), replaceRec(t4), replaceRec(t5), id)
+            case RamTerm.Lit(_, _)                        => ramTerm
+            case RamTerm.ProvMax(_)                          => ramTerm
+            case RamTerm.RowLoad(_, _, _, _)                 => getRep(ramTerm)
+            case RamTerm.Meet(_, _, _, _)                 => ramTerm
+            case RamTerm.App1(f, t1, ty)                 => RamTerm.App1(f, replaceRec(t1), ty)
+            case RamTerm.App2(f, t1, t2, ty)             => RamTerm.App2(f, replaceRec(t1), replaceRec(t2), ty)
+            case RamTerm.App3(f, t1, t2, t3, ty)         => RamTerm.App3(f, replaceRec(t1), replaceRec(t2), replaceRec(t3), ty)
+            case RamTerm.App4(f, t1, t2, t3, t4, ty)     => RamTerm.App4(f, replaceRec(t1), replaceRec(t2), replaceRec(t3), replaceRec(t4), ty)
+            case RamTerm.App5(f, t1, t2, t3, t4, t5, ty) => RamTerm.App5(f, replaceRec(t1), replaceRec(t2), replaceRec(t3), replaceRec(t4), replaceRec(t5), ty)
     }
 
 
@@ -611,7 +615,7 @@ mod Fixpoint3.Phase.Hoisting {
                     Vector.forAll(load -> {
                         Map.memberOf(MutDisjointSets.find(load, equalitySets) |> getOrCrash, termMap)
                     })
-            case RamTerm.RowLoad(rv, i, _) =>
+            case RamTerm.RowLoad(rv, i, _, _) =>
                 Map.memberOf(getOrCrash(MutDisjointSets.find((rv, i), equalitySets)), termMap)
             case RamTerm.Meet(_, t1, (rv, relSym), _) => termGround(t1) and Map.memberOf(getOrCrash(MutDisjointSets.find((rv, arityOfNonLat(relSym)), equalitySets)), termMap)
             case RamTerm.App1(_, t1, _) => termGround(t1)
@@ -634,7 +638,7 @@ mod Fixpoint3.Phase.Hoisting {
     @Internal
     pub def unifyEqualitiesStmt(
         equalitySets: MutDisjointSets[(RowVar, Int32), r],
-        constEqualities: MutMap[(RowVar, Int32), List[(Boxed, RamId)], r],
+        constEqualities: MutMap[(RowVar, Int32), List[(Boxed, Int32)], r],
         stmt: RamStmt
     ): Unit \ r = match stmt {
         case RamStmt.Seq(xs) => Vector.forEach(unifyEqualitiesStmt(equalitySets, constEqualities), xs)
@@ -657,15 +661,15 @@ mod Fixpoint3.Phase.Hoisting {
     @Internal
     pub def unifyEqualitiesOp(
         equalitySets: MutDisjointSets[(RowVar, Int32), r],
-        constEqualities: MutMap[(RowVar, Int32), List[(Boxed, RamId)], r],
+        constEqualities: MutMap[(RowVar, Int32), List[(Boxed, Int32)], r],
         op: RelOp
     ): Unit \ r = match op {
-        case RelOp.Search(rowVar, RelSym.Symbol(_, arity, _), body) =>
+        case RelOp.Search(rowVar, RelSym.Symbol(_, arity, _), _, body) =>
             loadsIntoOf(rowVar, arity, equalitySets);
             unifyEqualitiesOp(equalitySets, constEqualities, body)
-        case RelOp.Query(_, _, _, _, _) =>
+        case RelOp.Query(_, _, _, _, _, _) =>
             bug!("In Fixpoint.Phase.Hoisting.unifyEqualitiesOp: Query should not exist at this point!")
-        case RelOp.Functional(rowVar, _, _, body, arity) =>
+        case RelOp.Functional(rowVar, _, _, body, arity, _) =>
             loadsIntoOf(rowVar, arity, equalitySets);
             unifyEqualitiesOp(equalitySets, constEqualities, body)
         case RelOp.Project(_, _, _) => ()
@@ -681,17 +685,17 @@ mod Fixpoint3.Phase.Hoisting {
     ///
     def unifyBoolExp(
         equalitySets: MutDisjointSets[(RowVar, Int32), r],
-        constEqualities: MutMap[(RowVar, Int32), List[(Boxed, RamId)], r],
+        constEqualities: MutMap[(RowVar, Int32), List[(Boxed, Int32)], r],
         boolExp: BoolExp
     ): Unit \ r = match boolExp {
-        case BoolExp.Eq(RamTerm.RowLoad(rv1, i1, _), RamTerm.RowLoad(rv2, i2, _)) =>
+        case BoolExp.Eq(RamTerm.RowLoad(rv1, i1, _, _), RamTerm.RowLoad(rv2, i2, _, _)) =>
             MutDisjointSets.makeSet((rv1, i1), equalitySets);
             MutDisjointSets.makeSet((rv2, i2), equalitySets);
             MutDisjointSets.union((rv1, i1), (rv2, i2), equalitySets)
-        case BoolExp.Eq(RamTerm.RowLoad(rv, i, _), RamTerm.Lit(val, id)) =>
-            MutMap.putWith(_ -> list -> (val, id) :: list, (rv, i), (val, id) :: Nil, constEqualities)
-        case BoolExp.Eq(RamTerm.Lit(val, id), RamTerm.RowLoad(rv, i, _)) =>
-            MutMap.putWith(_ -> list -> (val, id) :: list, (rv, i), (val, id) :: Nil, constEqualities)
+        case BoolExp.Eq(RamTerm.RowLoad(rv, i, _, _), RamTerm.Lit(val, ty)) =>
+            MutMap.putWith(_ -> list -> (val, ty) :: list, (rv, i), (val, ty) :: Nil, constEqualities)
+        case BoolExp.Eq(RamTerm.Lit(val, ty), RamTerm.RowLoad(rv, i, _, _)) =>
+            MutMap.putWith(_ -> list -> (val, ty) :: list, (rv, i), (val, ty) :: Nil, constEqualities)
         case _ => ()
     }
 

--- a/main/src/library/Fixpoint3/Phase/IndexSelection.flix
+++ b/main/src/library/Fixpoint3/Phase/IndexSelection.flix
@@ -78,7 +78,7 @@ mod Fixpoint3.Phase.IndexSelection {
     ///
     @Internal
     pub def indexProgram(program: RamProgram): RamProgram = match program {
-        case RamProgram.Program(stmt, facts, meta, _) =>
+        case RamProgram.Program(stmt, facts, meta, _, typeInfo) =>
             // This type annotation is apparently needed?
             let (newIndexes, newStmt): (Map[RelSym, Vector[Search]], RamStmt) = region rc {
                 let indexes = MutMap.empty(rc);
@@ -125,7 +125,7 @@ mod Fixpoint3.Phase.IndexSelection {
                 let finalState = UniqueInts.toMap(indexState);
                 (indexedStmt, finalState)
             };
-            RamProgram.Program(indexedStmt, facts, meta, (indexes, indexPlacement))
+            RamProgram.Program(indexedStmt, facts, meta, (indexes, indexPlacement), typeInfo)
     }
 
     ///
@@ -187,22 +187,22 @@ mod Fixpoint3.Phase.IndexSelection {
     /// For details about memory positions see `lookupIndex`.
     ///
     def indexOp(op: RelOp, constructedIndexes: Indexes, indexState: UniqueInts[(RelSym, Int32), r]): RelOp \ r = match op {
-        case RelOp.Search(rowVar, relSym, body) =>
-            RelOp.Search(rowVar, relSym, indexOp(body, constructedIndexes, indexState))
-        case RelOp.Query(rowVar, relSym, boolExps, _, body) =>
+        case RelOp.Search(rowVar, relSym, t, body) =>
+            RelOp.Search(rowVar, relSym, t, indexOp(body, constructedIndexes, indexState))
+        case RelOp.Query(rowVar, relSym, boolExps, _, t, body) =>
             let search = (List.empty(), boolExps) ||>
                 Vector.foldLeft(acc -> exp -> match exp {
-                    case BoolExp.Eq(RamTerm.RowLoad(_, i, _), _) => i :: acc
-                    case BoolExp.Eq(_, RamTerm.RowLoad(_, i, _)) => i :: acc
+                    case BoolExp.Eq(RamTerm.RowLoad(_, i, _, _), _) => i :: acc
+                    case BoolExp.Eq(_, RamTerm.RowLoad(_, i, _, _)) => i :: acc
                     case _ =>
                         // This is only a bug when the only index type available is `BPlusTree`
                         bug!("In Fixpoint.Phase.IndexSelection.indexOp: Found non-equality BoolExp in indexOp!")
                 }) |> List.toVector;
             let index = lookupIndex(relSym, search, constructedIndexes);
             let absoluteIndex = UniqueInts.getIndex((relSym, index), indexState);
-            RelOp.Query(rowVar, relSym, boolExps, absoluteIndex, indexOp(body, constructedIndexes, indexState))
-        case RelOp.Functional(rowVar, func, terms, body, arity) =>
-            RelOp.Functional(rowVar, func, terms, indexOp(body, constructedIndexes, indexState), arity)
+            RelOp.Query(rowVar, relSym, boolExps, absoluteIndex, t, indexOp(body, constructedIndexes, indexState))
+        case RelOp.Functional(rowVar, func, terms, body, arity, t) =>
+            RelOp.Functional(rowVar, func, terms, indexOp(body, constructedIndexes, indexState), arity, t)
         case RelOp.Project(_, _, _) => op
         case RelOp.If(boolExps, body) => RelOp.If(boolExps, indexOp(body, constructedIndexes, indexState))
     }
@@ -242,16 +242,16 @@ mod Fixpoint3.Phase.IndexSelection {
         indexes: PrimitiveSearches[r],
         seenTuples: Set[RowVar]
     ): RelOp \ r = match op {
-        case RelOp.Search(rowVar, relSym, body) =>
+        case RelOp.Search(rowVar, relSym, t, body) =>
             let extendedSeenTuples = Set.insert(rowVar, seenTuples);
-            let res = RelOp.Search(rowVar, relSym, searchesOfOp(body, indexes, extendedSeenTuples));
+            let res = RelOp.Search(rowVar, relSym, t, searchesOfOp(body, indexes, extendedSeenTuples));
             res
-        case RelOp.Query(rowVar, relSym, boolExps, _, body) => region rc {
+        case RelOp.Query(rowVar, relSym, boolExps, _, t, body) => region rc {
             let otherBoolExpList = MutList.empty(rc);
             let equalExpList = MutList.empty(rc);
             let search = boolExps |>
                 Vector.foldLeft(acc -> exp -> match exp {
-                    case BoolExp.Eq(RamTerm.RowLoad(rv1, i, _), t2) if rv1 == rowVar =>
+                    case BoolExp.Eq(RamTerm.RowLoad(rv1, i, _, _), t2) if rv1 == rowVar =>
                         if (isTermGround(t2, seenTuples)) {
                             MutList.push(exp, equalExpList);
                             i :: acc
@@ -272,13 +272,13 @@ mod Fixpoint3.Phase.IndexSelection {
                 else RelOp.If(otherBoolExps, newBody);
             let equalExps = MutList.toVector(equalExpList);
             if (Vector.length(equalExps) == 0)
-                RelOp.Search(rowVar, relSym, nestedBody)
+                RelOp.Search(rowVar, relSym, t, nestedBody)
             else
-                RelOp.Query(rowVar, relSym, equalExps, -1, nestedBody)
+                RelOp.Query(rowVar, relSym, equalExps, -1, t, nestedBody)
         }
-        case RelOp.Functional(rowVar, func, terms, body, arity) =>
+        case RelOp.Functional(rowVar, func, terms, body, arity, t) =>
             let extendedSeenTuples = Set.insert(rowVar, seenTuples);
-            let res = RelOp.Functional(rowVar, func, terms, searchesOfOp(body, indexes, extendedSeenTuples), arity);
+            let res = RelOp.Functional(rowVar, func, terms, searchesOfOp(body, indexes, extendedSeenTuples), arity, t);
             res
         case RelOp.Project(_, _, _) => op
         case RelOp.If(boolExps, body) => RelOp.If(boolExps, searchesOfOp(body, indexes, seenTuples))
@@ -300,7 +300,7 @@ mod Fixpoint3.Phase.IndexSelection {
     ///
     def isTermGround(term: RamTerm, seenTuples: Set[RowVar]): Bool = match term {
         case RamTerm.Lit(_, _) => true
-        case RamTerm.RowLoad(rowVar, _, _) =>
+        case RamTerm.RowLoad(rowVar, _, _, _) =>
             Set.memberOf(rowVar, seenTuples)
         case _ => false
     }

--- a/main/src/library/Fixpoint3/Phase/Lowering.flix
+++ b/main/src/library/Fixpoint3/Phase/Lowering.flix
@@ -98,11 +98,13 @@ mod Fixpoint3.Phase.Lowering {
     use Fixpoint3.Ast.ExecutableRam
     use Fixpoint3.Ast.ExecutableRam.WriteTuple
     use Fixpoint3.Ast.Ram
-    use Fixpoint3.Ast.Ram.{arityOf, arityOfNonLat, getTermRamId, IndexInformation, RamId, RelSym, RowVar, Search, toDenotation}
+    use Fixpoint3.Ast.Ram.{arityOf, arityOfNonLat, getType, IndexInformation, RelSym, RowVar, Search, toDenotation, toId}
     use Fixpoint3.Ast.Shared.{Denotation, PredSym}
     use Fixpoint3.Boxed
     use Fixpoint3.Boxing
-    use Fixpoint3.BoxingType.{Boxing, RamIdToPos};
+    use Fixpoint3.BoxingType.Boxing;
+    use Fixpoint3.TypeInfo
+    use Fixpoint3.TypeInfo.{getTypeOf, TypeInformation}
     use Fixpoint3.UniqueInts
     use Fixpoint3.Util.getOrCrash
 
@@ -163,11 +165,11 @@ mod Fixpoint3.Phase.Lowering {
     ///
     @Internal
     pub def lowerProgram(rc: Region[r], withProv: Bool, program: Ram.RamProgram): (ExecutableRam.RamProgram[r], Boxing[r]) \ r = match program {
-        case Ram.RamProgram.Program(stmt, _, meta, indexInfo) =>
+        case Ram.RamProgram.Program(stmt, _, meta, indexInfo, typeInfo) =>
             let idToIndex = UniqueInts.empty(rc);
-            let (boxing, newFacts, idToBoxing) = Boxing.initialize(rc, withProv, program);
+            let (boxing, newFacts) = Boxing.initialize(rc, withProv, program);
             let writeTo = (MutMap.empty(rc), MutMap.empty(rc));
-            let loweredStmt = lowerStmt(rc, idToIndex, (idToBoxing, boxing), writeTo, indexInfo, stmt);
+            let loweredStmt = lowerStmt(rc, idToIndex, boxing, writeTo, indexInfo, stmt);
 
             let constWrites = snd(writeTo)
                 |> MutMap.foldWithKey(acc1 -> outerPos -> inner ->
@@ -181,7 +183,7 @@ mod Fixpoint3.Phase.Lowering {
             foreach ((rv, arity) <- arityInformation) {
                 Array.put(arity, UniqueInts.getIndex(rv, idToIndex), arities)
             };
-            (ExecutableRam.RamProgram.Program(loweredStmt, newFacts, meta, indexInfo, (Array.toVector(arities), constWrites), idToBoxing), boxing)
+            (ExecutableRam.RamProgram.Program(loweredStmt, newFacts, meta, indexInfo, (Array.toVector(arities), constWrites), typeInfo), boxing)
     }
 
     ///
@@ -199,15 +201,15 @@ mod Fixpoint3.Phase.Lowering {
     def lowerStmt(
         rc: Region[r],
         idToIndex: IdToIndex[r],
-        boxingInfo: (RamIdToPos, Boxing[r]),
+        boxing: Boxing[r],
         writeTo: (WriteTos[r], ConstWrites[r]),
         indexInfo: IndexInformation,
         stmt: Ram.RamStmt
     ): ExecutableRam.RamStmt \ r =
-        let lowerStmtRec = lowerStmt(rc, idToIndex, boxingInfo, writeTo, indexInfo);
+        let lowerStmtRec = lowerStmt(rc, idToIndex, boxing, writeTo, indexInfo);
         match stmt {
             case Ram.RamStmt.Insert(op) =>
-                let newOp = lowerOp(rc, idToIndex, boxingInfo, writeTo, indexInfo, (Nil, MutDisjointSets.empty(rc)), op);
+                let newOp = lowerOp(rc, idToIndex, boxing, writeTo, indexInfo, (Nil, MutDisjointSets.empty(rc)), op);
                 ExecutableRam.RamStmt.Insert(newOp)
             case Ram.RamStmt.MergeInto(newRel, otherRel) =>
                 // `MergeInto` should simply be repeated for all indexes built on `deltaRel`.
@@ -263,7 +265,7 @@ mod Fixpoint3.Phase.Lowering {
             case Ram.RamStmt.Par(xs) => Vector.map(x -> lowerStmtRec(x), xs) |> ExecutableRam.RamStmt.Par
             case Ram.RamStmt.Until(test, body) =>
                 let newTests = test |>
-                    Vector.filterMap(lowerBool(idToIndex, boxingInfo, indexInfo, (Nil, MutDisjointSets.empty(rc))));
+                    Vector.filterMap(lowerBool(idToIndex, boxing, indexInfo, (Nil, MutDisjointSets.empty(rc))));
                 let newBody = lowerStmtRec(body);
                 ExecutableRam.RamStmt.Until(newTests, newBody)
             case Ram.RamStmt.Comment(s) => ExecutableRam.RamStmt.Comment(s)
@@ -277,16 +279,16 @@ mod Fixpoint3.Phase.Lowering {
     def lowerOp(
         rc: Region[r],
         idToIndex: IdToIndex[r],
-        boxingInfo: (RamIdToPos, Boxing[r]),
+        boxing: Boxing[r],
         writeTo: (WriteTos[r], ConstWrites[r]),
         indexInfo: IndexInformation,
         meetWithMap: MeetWithMap[r],
         op: Ram.RelOp
     ): ExecutableRam.RelOp \ r =
-        let lowerOpRec = lowerOp(rc, idToIndex, boxingInfo, writeTo, indexInfo, meetWithMap);
-        let lowerOpRecNewRowVar = rv -> lowerOp(rc, idToIndex, boxingInfo, writeTo, indexInfo, addRowVarToMeetWithMap(rv, meetWithMap));
+        let lowerOpRec = lowerOp(rc, idToIndex, boxing, writeTo, indexInfo, meetWithMap);
+        let lowerOpRecNewRowVar = rv -> lowerOp(rc, idToIndex, boxing, writeTo, indexInfo, addRowVarToMeetWithMap(rv, meetWithMap));
         match op {
-            case Ram.RelOp.Search(rv, relSym, body) =>
+            case Ram.RelOp.Search(rv, relSym, _, body) =>
                 let den = toDenotation(relSym);
                 let loweredBody = lowerOpRecNewRowVar(rv, body);
                 let thisWriteTo = getWriteTo(rv, writeTo);
@@ -294,25 +296,24 @@ mod Fixpoint3.Phase.Lowering {
                 let relPos = getOrCrash(Map.get((relSym, 0), placements));
                 let oldPos = computeMeetWithPos(rv, relSym, idToIndex, meetWithMap);
                 ExecutableRam.RelOp.Search(lowerRowVar(rv, idToIndex), relPos, oldPos, den, thisWriteTo, loweredBody)
-            case Ram.RelOp.Query(rv, relSym, tests, index, body) =>
+            case Ram.RelOp.Query(rv, relSym, tests, index, _, body) =>
                 let den = toDenotation(relSym);
-                let (idToBoxing, boxing) = boxingInfo;
                 let loweredBody = lowerOpRecNewRowVar(rv, body);
                 let oldPos = computeMeetWithPos(rv, relSym, idToIndex, meetWithMap);
                 let thisWriteTo = getWriteTo(rv, writeTo);
                 let otherBools = Vector.filterMap(x -> match x {
-                    case Ram.BoolExp.Eq(Ram.RamTerm.RowLoad(rv1, i1, _), Ram.RamTerm.RowLoad(rv2, i2, _)) if rv == rv1 =>
+                    case Ram.BoolExp.Eq(Ram.RamTerm.RowLoad(rv1, i1, _, _), Ram.RamTerm.RowLoad(rv2, i2, _, _)) if rv == rv1 =>
                         addWriteTo(rv2, i2, rv1, i1, idToIndex, writeTo);
                         None
-                    case Ram.BoolExp.Eq(Ram.RamTerm.RowLoad(rv2, i2, _), Ram.RamTerm.RowLoad(rv1, i1, _)) if rv == rv1 =>
+                    case Ram.BoolExp.Eq(Ram.RamTerm.RowLoad(rv2, i2, _, _), Ram.RamTerm.RowLoad(rv1, i1, _, _)) if rv == rv1 =>
                         addWriteTo(rv2, i2, rv1, i1, idToIndex, writeTo);
                         None
-                    case Ram.BoolExp.Eq(Ram.RamTerm.RowLoad(rv1, i, _), Ram.RamTerm.Lit(val, id)) if rv == rv1 =>
-                        let unboxed = Boxing.unboxWith(val, getOrCrash(Map.get(id, idToBoxing)), boxing);
+                    case Ram.BoolExp.Eq(Ram.RamTerm.RowLoad(rv1, i, _, _), Ram.RamTerm.Lit(val, ty)) if rv == rv1 =>
+                        let unboxed = Boxing.unboxWith(val, ty, boxing);
                         addConstWriteTo(unboxed, rv, i, idToIndex, writeTo, rc);
                         None
-                    case Ram.BoolExp.Eq(Ram.RamTerm.Lit(val, id), Ram.RamTerm.RowLoad(rv1, i, _)) if rv == rv1 =>
-                        let unboxed = Boxing.unboxWith(val, getOrCrash(Map.get(id, idToBoxing)), boxing);
+                    case Ram.BoolExp.Eq(Ram.RamTerm.Lit(val, ty), Ram.RamTerm.RowLoad(rv1, i, _, _)) if rv == rv1 =>
+                        let unboxed = Boxing.unboxWith(val, ty, boxing);
                         addConstWriteTo(unboxed, rv, i, idToIndex, writeTo, rc);
                         None
                     case _ => Some(x)
@@ -321,27 +322,24 @@ mod Fixpoint3.Phase.Lowering {
                     unchecked_cast(bug!("Bug in Fixpoint.Lowering: Bools except equality in query") as _ \ r)
                 else ();
                 ExecutableRam.RelOp.Query(lowerRowVar(rv, idToIndex), index, oldPos, den, thisWriteTo, loweredBody)
-            case Ram.RelOp.Functional(rv, f, terms, body, arity) =>
-                let (idToBoxing, _) = boxingInfo;
-                let idToMarhsalled = id -> getOrCrash(Map.get(id, idToBoxing));
+            case Ram.RelOp.Functional(rv, f, terms, body, _, thisType) =>
                 let loweredBody = lowerOpRec(body);
                 let thisWriteTo = getWriteTo(rv, writeTo);
-                let to = Vector.map(i -> idToMarhsalled(RamId.TuplePos(rv, i)), Vector.range(0, arity));
                 ExecutableRam.RelOp.Functional(
                     lowerRowVar(rv, idToIndex), f,
-                    Vector.map(lowerTerm(idToIndex, boxingInfo, meetWithMap), terms),
-                    thisWriteTo, loweredBody, to
+                    Vector.map(lowerTerm(idToIndex, boxing, meetWithMap), terms),
+                    thisWriteTo, loweredBody, thisType
                 )
             case Ram.RelOp.Project(terms, s, _) =>
                 let (_, placements) = indexInfo;
                 let newRelPos = getOrCrash(Map.get((s, 0), placements));
                 let den = toDenotation(s);
-                let loweredTerms = Vector.map(lowerTerm(idToIndex, boxingInfo, meetWithMap), terms);
+                let loweredTerms = Vector.map(lowerTerm(idToIndex, boxing, meetWithMap), terms);
                 ExecutableRam.RelOp.Project(
                     loweredTerms, newRelPos, den
                 )
             case Ram.RelOp.If(boolExps, body) =>
-                ExecutableRam.RelOp.If(Vector.filterMap(lowerBool(idToIndex, boxingInfo, indexInfo, meetWithMap), boolExps), lowerOpRec(body))
+                ExecutableRam.RelOp.If(Vector.filterMap(lowerBool(idToIndex, boxing, indexInfo, meetWithMap), boolExps), lowerOpRec(body))
         }
 
     ///
@@ -359,38 +357,38 @@ mod Fixpoint3.Phase.Lowering {
     ///
     def lowerTerm(
         idToIndex: IdToIndex[r],
-        boxingInfo: (RamIdToPos, Boxing[r]),
+        boxingInfo: Boxing[r],
         meetWithMap: MeetWithMap[r],
         term: Ram.RamTerm
     ): ExecutableRam.RamTerm \ r =
         let lowerT = lowerTerm(idToIndex, boxingInfo, meetWithMap);
-        let (idToBoxing, boxing) = boxingInfo;
-        let termToBoxing = t -> getOrCrash(Map.get(getTermRamId(t), idToBoxing));
+        let boxing = boxingInfo;
+        // let termToBoxing = t -> getType(t);
         match term {
-            case Ram.RamTerm.Lit(val, id) => ExecutableRam.RamTerm.Lit(Boxing.unboxWith(val, getOrCrash(Map.get(id, idToBoxing)), boxing), val)
+            case Ram.RamTerm.Lit(val, ty) => ExecutableRam.RamTerm.Lit(Boxing.unboxWith(val, ty, boxing), val)
             case Ram.RamTerm.ProvMax(vec) =>
                 vec
                     |> Vector.map(match (rv, i) -> (UniqueInts.getIndex(rv, idToIndex), i))
                     |> ExecutableRam.RamTerm.ProvMax
-            case Ram.RamTerm.RowLoad(rv, index, RelSym.Symbol(_, arity, den)) =>
+            case Ram.RamTerm.RowLoad(rv, index, ty, RelSym.Symbol(_, arity, den)) =>
                 match den {
-                    case Denotation.Relational => ExecutableRam.RamTerm.LoadFromTuple(UniqueInts.getIndex(rv, idToIndex), index, termToBoxing(term))
+                    case Denotation.Relational => ExecutableRam.RamTerm.LoadFromTuple(UniqueInts.getIndex(rv, idToIndex), index, ty)
                     case Denotation.Latticenal(_, _, _, _) =>
                         if (index < arity - 1) {
-                            ExecutableRam.RamTerm.LoadFromTuple(UniqueInts.getIndex(rv, idToIndex), index, termToBoxing(term))
+                            ExecutableRam.RamTerm.LoadFromTuple(UniqueInts.getIndex(rv, idToIndex), index, ty)
                         } else {
-                            ExecutableRam.RamTerm.LoadLatVar(UniqueInts.getIndex(rv, idToIndex), termToBoxing(term))
+                            ExecutableRam.RamTerm.LoadLatVar(UniqueInts.getIndex(rv, idToIndex), ty)
                         }
                 }
-            case Ram.RamTerm.Meet(_, _, _, _) =>
+            case Ram.RamTerm.Meet(_, _, _, ty) =>
                 let representingRowVar = lowerMeet(term, idToIndex, meetWithMap);
                 let pos = computeLatticeMeetPos(representingRowVar, idToIndex, meetWithMap);
-                ExecutableRam.RamTerm.LoadLatVar(pos, termToBoxing(term))
-            case Ram.RamTerm.App1(f, t1, _)                   => ExecutableRam.RamTerm.App1(f, lowerT(t1), termToBoxing(term))
-            case Ram.RamTerm.App2(f, t1, t2, _)               => ExecutableRam.RamTerm.App2(f, lowerT(t1), lowerT(t2), termToBoxing(term))
-            case Ram.RamTerm.App3(f, t1, t2, t3, _)           => ExecutableRam.RamTerm.App3(f, lowerT(t1), lowerT(t2), lowerT(t3), termToBoxing(term))
-            case Ram.RamTerm.App4(f, t1, t2, t3, t4, _)       => ExecutableRam.RamTerm.App4(f, lowerT(t1), lowerT(t2), lowerT(t3), lowerT(t4), termToBoxing(term))
-            case Ram.RamTerm.App5(f, t1, t2, t3, t4, t5, _)   => ExecutableRam.RamTerm.App5(f, lowerT(t1), lowerT(t2), lowerT(t3), lowerT(t4), lowerT(t5), termToBoxing(term))
+                ExecutableRam.RamTerm.LoadLatVar(pos, ty)
+            case Ram.RamTerm.App1(f, t1, ty)                   => ExecutableRam.RamTerm.App1(f, lowerT(t1), ty)
+            case Ram.RamTerm.App2(f, t1, t2, ty)               => ExecutableRam.RamTerm.App2(f, lowerT(t1), lowerT(t2), ty)
+            case Ram.RamTerm.App3(f, t1, t2, t3, ty)           => ExecutableRam.RamTerm.App3(f, lowerT(t1), lowerT(t2), lowerT(t3), ty)
+            case Ram.RamTerm.App4(f, t1, t2, t3, t4, ty)       => ExecutableRam.RamTerm.App4(f, lowerT(t1), lowerT(t2), lowerT(t3), lowerT(t4), ty)
+            case Ram.RamTerm.App5(f, t1, t2, t3, t4, t5, ty)   => ExecutableRam.RamTerm.App5(f, lowerT(t1), lowerT(t2), lowerT(t3), lowerT(t4), lowerT(t5), ty)
         }
 
     ///
@@ -403,7 +401,7 @@ mod Fixpoint3.Phase.Lowering {
         idToIndex: IdToIndex[r],
         meetWithMap: MeetWithMap[r]
     ): RowVar \ r = match term {
-        case Ram.RamTerm.RowLoad(rv, _, _) =>
+        case Ram.RamTerm.RowLoad(rv, _, _, _) =>
             let (_, meetDisjointSet) = meetWithMap;
             MutDisjointSets.makeSet(rv, meetDisjointSet);
             rv
@@ -428,7 +426,7 @@ mod Fixpoint3.Phase.Lowering {
     ///
     def lowerBool(
         idToIndex: IdToIndex[r],
-        boxingInfo: (RamIdToPos, Boxing[r]),
+        boxingInfo: Boxing[r],
         indexInfo: IndexInformation,
         meetWithMap: MeetWithMap[r],
         boolExp: Ram.BoolExp
@@ -596,7 +594,7 @@ mod Fixpoint3.Phase.Lowering {
     /// Returns a list of pairs `(RowVar, RelSym)` in `program` in the order of the nesting.
     ///
     def rowVarRelSymOf(program: Ram.RamProgram): List[(RowVar, RelSym)] = match program {
-        case Ram.RamProgram.Program(stmt, _, _, _) => rowVarRelSymOfStmt(stmt)
+        case Ram.RamProgram.Program(stmt, _, _, _, _) => rowVarRelSymOfStmt(stmt)
     }
 
     ///
@@ -617,9 +615,9 @@ mod Fixpoint3.Phase.Lowering {
     /// Returns a list of pairs `(RowVar, RelSym)` in `op` in the order of nesting.
     ///
     def rowVarRelSymOfOp(op: Ram.RelOp): List[(RowVar, RelSym)] \ r = match op {
-        case Ram.RelOp.Search(rv, relSym, rest)      => (rv, relSym) :: rowVarRelSymOfOp(rest)
-        case Ram.RelOp.Query(rv, relSym, _, _, rest) => (rv, relSym) :: rowVarRelSymOfOp(rest)
-        case Ram.RelOp.Functional(_, _, _, rest, _)  => rowVarRelSymOfOp(rest)
+        case Ram.RelOp.Search(rv, relSym, _, rest)      => (rv, relSym) :: rowVarRelSymOfOp(rest)
+        case Ram.RelOp.Query(rv, relSym, _, _, _, rest) => (rv, relSym) :: rowVarRelSymOfOp(rest)
+        case Ram.RelOp.Functional(_, _, _, rest, _, _)  => rowVarRelSymOfOp(rest)
         case Ram.RelOp.Project(_, _, _)              => Nil
         case Ram.RelOp.If(_, rest)                   => rowVarRelSymOfOp(rest)
     }

--- a/main/src/library/Fixpoint3/Phase/Provenance.flix
+++ b/main/src/library/Fixpoint3/Phase/Provenance.flix
@@ -28,10 +28,11 @@
 ///
  mod Fixpoint3.Phase.Provenance {
     use Fixpoint3.Ast.Ram
-    use Fixpoint3.Ast.Ram.{RamProgram, RamStmt, RelOp, RamTerm, RelSym, arityOf, RowVar, RamId, BoolExp}
+    use Fixpoint3.Ast.Ram.{RamProgram, RamStmt, RelOp, RamTerm, RelSym, arityOf, RowVar, BoolExp}
     use Fixpoint3.Boxed
     use Fixpoint3.Boxed.BoxedInt64
     use Fixpoint3.Counter
+    use Fixpoint3.TypeInfo.{expandTypeToProv, expandTypeInfoToProv, provType}
 
     ///
     /// If `withProv` is `False`: `program` is returned unchanged.
@@ -49,13 +50,14 @@
     /// Further extend facts to contain a depth and rule.
     ///
     def augmentProgramInternal(program: RamProgram): RamProgram = match program {
-        case RamProgram.Program(stmt, facts, predicates, indexInfo) => unsafely IO run {
+        case RamProgram.Program(stmt, facts, predicates, indexInfo, typeInfo) => unsafely IO run {
             let (f1, f2) = facts;
             let augmentedF1 = f1 |> Map.map(augmentFacts);
             let augmentedF2 = f2 |> Map.map(augmentFacts);
             let augmentedFacts = (augmentedF1, augmentedF2);
             let augmentedStmt = augmentStmt(stmt);
-            RamProgram.Program(augmentedStmt, augmentedFacts, predicates, indexInfo) |>
+            let newTypeInfo = expandTypeInfoToProv(typeInfo, predicates);
+            RamProgram.Program(augmentedStmt, augmentedFacts, predicates, indexInfo, newTypeInfo) |>
                 Fixpoint3.Debugging.notifyPreLowering("Provenance")
         }
     }
@@ -96,20 +98,20 @@
     /// Augments `op` with `ProvMax` terms.
     ///
     def augmentOp(rowVarsArity: List[(RowVar, Int32)], op: RelOp): RelOp \ r = match op {
-        case RelOp.Search(rowVar, relSym, body) =>
+        case RelOp.Search(rowVar, relSym, t, body) =>
             augmentOp((rowVar, arityOf(relSym)) :: rowVarsArity, body) |>
-                RelOp.Search(rowVar, relSym)
-        case RelOp.Query(rowVar, relSym, bools, index, body) =>
+                RelOp.Search(rowVar, relSym, t)
+        case RelOp.Query(rowVar, relSym, bools, index, t, body) =>
             augmentOp((rowVar, arityOf(relSym)) :: rowVarsArity, body) |>
-                RelOp.Query(rowVar, relSym, bools, index)
-        case RelOp.Functional(rowVar, func, terms, body, arity) =>
+                RelOp.Query(rowVar, relSym, bools, index, t)
+        case RelOp.Functional(rowVar, func, terms, body, arity, t) =>
             // Do not add this to `rowVarsArity`. We use this in `ProvMax` as `Functional`
             // has no concept of depth.
-            RelOp.Functional(rowVar, func, terms, augmentOp(rowVarsArity, body), arity)
+            RelOp.Functional(rowVar, func, terms, augmentOp(rowVarsArity, body), arity, t)
         case RelOp.Project(terms, relSym, ruleNum) =>
             let newTerms = terms ++ Vector#{
                 RamTerm.ProvMax(List.toVector(rowVarsArity)),
-                RamTerm.Lit(BoxedInt64(Int32.toInt64(ruleNum)), RamId.Id(-1))
+                RamTerm.Lit(BoxedInt64(Int32.toInt64(ruleNum)), provType())
             };
             RelOp.Project(newTerms, relSym, ruleNum)
         case RelOp.If(boolExps, body) =>

--- a/main/src/library/Fixpoint3/Phase/Simplifier.flix
+++ b/main/src/library/Fixpoint3/Phase/Simplifier.flix
@@ -41,14 +41,14 @@ mod Fixpoint3.Phase.Simplifier {
     ///
     @Internal
     pub def simplifyProgram(program: RamProgram): RamProgram = unsafely IO run match program {
-        case RamProgram.Program(stmt, facts, predicates, index) =>
+        case RamProgram.Program(stmt, facts, predicates, index, typeInfo) =>
             // Compute the a set of all relations which are initialized with facts, i.e. have some EDB facts.
             let filterOutEmpty = fact -> fact
                 |> Map.filter(x -> (not BPlusTree.isEmpty(x)))
                 |> Map.foldRightWithKey(k -> _ -> Set.insert(k), Set#{})
                 |> Set.map(rel -> getRelSymAsType(rel, PredType.Full, predicates));
             let nonEmpty = filterOutEmpty(fst(facts)) `Set.union` filterOutEmpty(snd(facts));
-            RamProgram.Program(simplifyStmt(stmt, nonEmpty, predicates), facts, predicates, index)
+            RamProgram.Program(simplifyStmt(stmt, nonEmpty, predicates), facts, predicates, index, typeInfo)
     }
 
     ///
@@ -140,12 +140,12 @@ mod Fixpoint3.Phase.Simplifier {
         let recurseNewRel = rel -> simplifyOp(nonEmpty, predicates, inUntil, Set.insert(rel, seenPreds));
         let recurse = simplifyOp(nonEmpty, predicates, inUntil, seenPreds);
         match op {
-            case RelOp.Search(rowVar, relSym, body) =>
-                recurseNewRel(relSym, body) |> Option.map(newBody -> RelOp.Search(rowVar, relSym, newBody))
-            case RelOp.Query(rowVar, relSym, qry, _, body) =>
-                recurseNewRel(relSym, body) |> Option.map(RelOp.Query(rowVar, relSym, qry, -1))
-            case RelOp.Functional(rowVar, f, terms, body, arity) =>
-                recurse(body) |> Option.map(newBody -> RelOp.Functional(rowVar, f, terms, newBody, arity))
+            case RelOp.Search(rowVar, relSym, typeInfo, body) =>
+                recurseNewRel(relSym, body) |> Option.map(newBody -> RelOp.Search(rowVar, relSym, typeInfo, newBody))
+            case RelOp.Query(rowVar, relSym, qry, _, t, body) =>
+                recurseNewRel(relSym, body) |> Option.map(RelOp.Query(rowVar, relSym, qry, -1, t))
+            case RelOp.Functional(rowVar, f, terms, body, arity, t) =>
+                recurse(body) |> Option.map(newBody -> RelOp.Functional(rowVar, f, terms, newBody, arity, t))
             case RelOp.Project(_, rel, _) =>
                 // If we are not in an until and we insert in the new relation for `rel`,
                 // we depend on `rel`, and `rel` is empty beforehand the code is dead.
@@ -159,7 +159,7 @@ mod Fixpoint3.Phase.Simplifier {
                 let (memberOf, rest) = test
                     // Delete checks of the form `x[i] == x[i]`.
                     |> Vector.filter(e -> match e {
-                        case BoolExp.Eq(RowLoad(lhs1, lhs2, _), RowLoad(rhs1, rhs2, _)) =>
+                        case BoolExp.Eq(RowLoad(lhs1, lhs2, _, _), RowLoad(rhs1, rhs2, _, _)) =>
                             (lhs1, lhs2) != (rhs1, rhs2)
                         case _ => true
                     })

--- a/main/src/library/Fixpoint3/Predicate.flix
+++ b/main/src/library/Fixpoint3/Predicate.flix
@@ -69,7 +69,8 @@ mod Fixpoint3.Predicate {
     ///
     /// Returns 1 plus the maximum full predicate in `predicates`.
     ///
-    def getMax(predicates: Predicates): Int64 = {
+    @Internal
+    pub def getMax(predicates: Predicates): Int64 = {
         let (_, _, res) = predicates;
         res
     }
@@ -113,7 +114,7 @@ mod Fixpoint3.Predicate {
     /// a full `RelSym`.
     ///
     @Internal
-    pub def fullRelSymToType(relSym: RelSym, wantedType: PredType, predInfo: Predicates): RelSym = 
+    pub def fullRelSymToType(relSym: RelSym, wantedType: PredType, predInfo: Predicates): RelSym =
         fullRelSymToTypeInternal(relSym, wantedType, getMax(predInfo))
 
     ///
@@ -209,7 +210,15 @@ mod Fixpoint3.Predicate {
     ///
     @Internal
     pub def relSymsOfProgram(program: RamProgram): List[RelSym] = match program {
-        case RamProgram.Program(_, _, predInfo, _) => allRelSyms(predInfo)
+        case RamProgram.Program(_, _, predInfo, _, _) => allRelSyms(predInfo)
+    }
+
+    ///
+    /// Returns a list of all `RelSym` known in `program`.
+    ///
+    @Internal
+    pub def fullRelSymsOfProgram(program: RamProgram): List[RelSym] = match program {
+        case RamProgram.Program(_, _, predInfo, _, _) => allFullRelSyms(predInfo)
     }
 
     ///
@@ -274,7 +283,7 @@ mod Fixpoint3.Predicate {
     ///
     def bodyAtomToFullRelSym(body: BodyPredicate): RelSym = match body {
         case BodyAtom(pred, den, _, _, terms) => RelSym.Symbol(pred, Vector.length(terms), den)
-        case _ => unreachable!()
+        case _                                => unreachable!()
     }
 
 }

--- a/main/src/library/Fixpoint3/Solver.flix
+++ b/main/src/library/Fixpoint3/Solver.flix
@@ -65,7 +65,7 @@ mod Fixpoint3.Solver {
     def runWithStratification(d0: Datalog, stf: Map[PredSym, (Int32, Int32)], withProv: Bool): Datalog = region rc {
         let d = Debugging.notifyPreSolve(d0);
         def compiler(cs: Datalog, db: Ram.Facts): (ExecutableRam.RamProgram[rc], Boxing[rc]) \ rc = {
-            Phase.Compiler.compile(cs, db, stf)
+            Phase.Compiler.compile(cs, db, stf, withProv)
                 |> Debugging.notifyPreLowering("Compiler")
                 |> Phase.Simplifier.simplifyProgram
                 |> Debugging.notifyPreLowering("Simplifier")

--- a/main/src/library/Fixpoint3/Solver.flix
+++ b/main/src/library/Fixpoint3/Solver.flix
@@ -80,7 +80,7 @@ mod Fixpoint3.Solver {
             case Datalog(_, r) =>
                 compiler(d, Map.empty())
                     |> Debugging.notifyPreInterpret
-                    |> Interpreter.interpret(rc, withProv)
+                    |> Interpreter.interpret(rc)
                     |> toModelOnlyFull(withProv, r)
             case Model(_) =>
                 d
@@ -90,7 +90,7 @@ mod Fixpoint3.Solver {
                 let cs = Datalog(f, r);
                 compiler(cs, m)
                     |> Debugging.notifyPreInterpret
-                    |> Interpreter.interpret(rc, withProv)
+                    |> Interpreter.interpret(rc)
                     |> toModelOnlyFull(withProv, r)
             case Join(Provenance(_, model), Datalog(f, r)) =>
                 let cs = Datalog(f, r);
@@ -98,7 +98,7 @@ mod Fixpoint3.Solver {
                 let m = provenanceModeltoModel(model);
                 compiler(cs, m)
                     |> Debugging.notifyPreInterpret
-                    |> Interpreter.interpret(rc, withProv)
+                    |> Interpreter.interpret(rc)
                     |> toModelOnlyFull(withProv, r)
             case _ => bug!("Datalog Boxing bug")
         };

--- a/main/src/library/Fixpoint3/TypeInfo.flix
+++ b/main/src/library/Fixpoint3/TypeInfo.flix
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2025 Casper Dalgaard Nielsen
+ *                Adam Yasser Tallouzi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+///
+/// This module defines and offers and interface for dealing with the types of the Datalog engine.
+///
+/// A `Type` is uniquely defined by its `UnifiedTypePos` which is computed by `typeDatalog`.
+///
+/// This module has a tight coupling with `Compiler` (most assign functionals identifiers in same order)
+/// and `Lowering`, which assumes that a `Type` is the same as a `UnifiedTypePoss`.
+///
+mod Fixpoint3.TypeInfo {
+    use Fixpoint3.Ast.Datalog.{BodyPredicate, BodyTerm, Datalog, Constraint, HeadPredicate, HeadTerm, VarSym}
+    use Fixpoint3.Ast.Ram.{RamProgram, RelSym, Predicates}
+    use Fixpoint3.Ast.Shared.PredSym
+    use Fixpoint3.Ast.Shared.PredSym.PredSym
+    use Fixpoint3.Boxed
+    use Fixpoint3.BoxingType.UnifiedTypePos
+    use Fixpoint3.Counter
+    use Fixpoint3.Predicate.{allFullRelSyms, getMax}
+    use Fixpoint3.Util.getOrCrash
+
+    ///
+    /// As far as we are concerned a `Type` is simply a description of where
+    /// its boxing/unboxing information is saved.
+    ///
+    @Internal
+    pub type alias Type = UnifiedTypePos
+
+    ///
+    /// The type of a relation is simply a vector of its types.
+    ///
+    @Internal
+    pub type alias RelType = Vector[Type]
+
+    ///
+    /// The type of a program is a vector where position `i` stores the type of
+    /// the relation with predicate `PredSym(_, i)`.
+    ///
+    /// For functionals the vector contains the types of the
+    /// functionals in the same order they are met by the compiler.
+    ///
+    @Internal
+    pub type alias TypeInformation = Vector[RelType]
+
+    type alias TypeUnifier[r: Region] = MutDisjointSets[(Int64, Int32), r]
+
+    type alias VarSymUnifier[r: Region] = MutMap[String, (Int64, Int32), r]
+
+    type alias PseudoStrataOrder[r: Region] = MutMap[Int32, MutMap[Int32, List[(Int32, Constraint)], r], r]
+
+    ///
+    /// Cast `i` to an `Int64` and crash if `i` does not fit.
+    ///
+    def toInt32(i: Int64): Int32 = getOrCrash(Int64.tryToInt32(i))
+
+    ///
+    /// Returns the type of provenance annotations.
+    ///
+    pub def provType(): Type = 0
+
+    ///
+    /// Returns the type information of `d`
+    ///
+    /// For functionals the vector returned vector contains the types of the
+    /// functionals in the same order they are met by the compiler.
+    ///
+    @Internal
+    pub def typeDatalog(d: Datalog, pseudoStratums: PseudoStrataOrder[r], predicates: Predicates, withProv: Bool): TypeInformation \ r = match d {
+        case Datalog.Datalog(_, _) => region rc {
+            let idCreator = Counter.fresh(rc);
+            // Ensure that the first index is 1.
+            let rels = allFullRelSyms(predicates);
+            let relNum = getOrCrash(Int64.tryToInt32(getMax(predicates)));
+            // The first functional will get an id 1 greater than the largest PredSym.
+            Counter.set(relNum, idCreator);
+            let typeUnifier = MutDisjointSets.empty(rc);
+            // Have to traverse in same order as `Compuler.flix`
+            foreach ((_, pseudStrat) <- pseudoStratums) {
+                MutMap.foldLeft(_ -> rules2 -> {
+                    List.forEach(match (_, rule) -> typeConstraint(rule, typeUnifier, idCreator), rules2)
+                }, (), pseudStrat)
+            };
+
+            let maxId = Counter.get(idCreator);
+            let arr = Array.empty(rc, maxId);
+            // Register `RelSym`s.
+            foreach(RelSym.Symbol(PredSym(_, id), arity, _) <- rels) {
+                Array.put(Array.repeat(rc, arity, -1), toInt32(id), arr)
+            };
+            // Register functionals.
+            foreach (id <- Vector.range(relNum, maxId)) {
+                let arity = computeSizeOfFunctional(Int32.toInt64(id), 0, typeUnifier);
+                Array.put(Array.repeat(rc, arity, -1), id, arr)
+            };
+
+            let typeCreator = Counter.fresh(rc);
+            if (withProv) {
+                // Reserve position 0 for provenance values.
+                Counter.increment(typeCreator)
+            } else {
+                ()
+            };
+            foreach (id <- Vector.range(0, maxId)) {
+                let curArr = Array.get(id, arr);
+                foreach (index <- Vector.range(0, Array.length(curArr))) match MutDisjointSets.find((Int32.toInt64(id), index), typeUnifier) {
+                    case None => Array.put(Counter.getAndIncrement(typeCreator), index, curArr)
+                    case Some((id2Int64, index2)) =>
+                        let id2 = toInt32(id2Int64);
+                        let otherArr = Array.get(id2, arr);
+                        match Array.get(index2, otherArr) {
+                            case -1 =>
+                                let newType = Counter.getAndIncrement(typeCreator);
+                                Array.put(newType, index2, otherArr);
+                                Array.put(newType, index, curArr)
+                            case someType =>
+                                Array.put(someType, index, curArr)
+                        }
+                }
+            };
+            // Don't copy arrays, just cast them.
+            unchecked_cast(arr as TypeInformation)
+        }
+        case _ => unreachable!()
+    }
+
+    ///
+    /// Expands `typeInfo` to include the provenance annotations types.
+    ///
+    pub def expandTypeInfoToProv(typeInfo: TypeInformation, predicates: Predicates): TypeInformation =
+        let max = getMax(predicates);
+        Vector.mapWithIndex(i -> v -> match Int32.toInt64(i) < max {
+            case true => expandTypeToProv(v)
+            case false => v
+        }, typeInfo)
+
+
+    ///
+    /// Expands `relType` to include the provenance annotations types.
+    ///
+    pub def expandTypeToProv(relType: RelType): RelType = relType ++ Vector#{provType(), provType()}
+
+    ///
+    /// Returns the size of the output of the functional with assigned identifier `id`.
+    ///
+    def computeSizeOfFunctional(id: Int64, count: Int32, typeUnifier: TypeUnifier[r]): Int32 \ r =
+        match MutDisjointSets.find((id, count), typeUnifier) {
+            case None => count
+            case Some(_) => computeSizeOfFunctional(id, count + 1, typeUnifier)
+        }
+
+    ///
+    /// Returns the type of the `index`'th value of the relation with predicate `PredSym(_, id)`.
+    ///
+    @Internal
+    pub def getType(id: Int64, index: Int32, typeInfo: TypeInformation): Type = {
+        Vector.get(index, getTypeOf(id, typeInfo))
+    }
+
+    ///
+    /// Returns the type of the relation with predicate `PredSym(_, id)`.
+    ///
+    @Internal
+    pub def getTypeOf(id: Int64, typeInfo: TypeInformation): RelType = {
+        Vector.get(toInt32(id), typeInfo)
+    }
+
+    ///
+    /// Unifies the types of `rule`.
+    ///
+    def typeConstraint(rule: Constraint, typeUnifier: TypeUnifier[r], counter: Counter[r]): Unit \ r = match rule {
+        case Constraint.Constraint(head, body) => region rc {
+            let varSymUnifier = MutMap.empty(rc);
+            typeHead(head, varSymUnifier, typeUnifier);
+            Vector.forEach(bodyPred -> typeBodyPred(bodyPred, varSymUnifier, typeUnifier, counter), body)
+        }
+    }
+
+    ///
+    /// Unifies the types of `head`.
+    ///
+    def typeHead(head: HeadPredicate, varSymUnifier: VarSymUnifier[r1], typeUnifier: TypeUnifier[r2]): Unit \ r1 + r2 =
+        let HeadPredicate.HeadAtom(PredSym(_, id), _, terms) = head;
+        foreach((i, t) <- ForEach.withIndex(terms)) {
+            match t {
+                case HeadTerm.Var(VarSym.VarSym(sym)) =>
+                    typeVar(id, i, sym, varSymUnifier, typeUnifier)
+                case _ => ()
+            }
+        }
+
+    ///
+    /// Unifies the types of `bodyPred`.
+    ///
+    def typeBodyPred(bodyPred: BodyPredicate, varSymUnifier: VarSymUnifier[r1], typeUnifier: TypeUnifier[r2], counter: Counter[r2]): Unit \ r1 + r2 = match bodyPred {
+        case BodyPredicate.BodyAtom(PredSym(_, id), _, _, _, terms) =>
+            Vector.forEachWithIndex(index -> term -> typeBodyTerm(id, index, term, varSymUnifier, typeUnifier), terms)
+        case BodyPredicate.Functional(outVars, _, _inVars) =>
+            let id = Int32.toInt64(Counter.getAndIncrement(counter));
+            Vector.forEachWithIndex(index -> match VarSym.VarSym(sym) -> typeVar(id, index, sym, varSymUnifier, typeUnifier), outVars)
+        case _ => ()
+    }
+
+    ///
+    /// Register that `(id, index) == sym`.
+    ///
+    def typeVar(id: Int64, index: Int32, sym: String, varSymUnifier: VarSymUnifier[r1], typeUnifier: TypeUnifier[r2]): Unit \ r1 + r2 = {
+        let (repId, repIndex) = MutMap.getOrElsePut(sym, (id, index), varSymUnifier);
+        if(id == repId and repIndex == index) {
+            MutDisjointSets.makeSet((repId, repIndex), typeUnifier)
+        } else {
+            MutDisjointSets.union((repId, repIndex), (id, index), typeUnifier)
+        }
+    }
+
+    ///
+    /// Register that `(id, index) == term`.
+    ///
+    def typeBodyTerm(id: Int64, index: Int32, term: BodyTerm, varSymUnifier: VarSymUnifier[r1], typeUnifier: TypeUnifier[r2]): Unit \ r1 + r2 = match term {
+        case BodyTerm.Wild => ()
+        case BodyTerm.Lit(_) => ()
+        case BodyTerm.Var(VarSym.VarSym(sym)) => typeVar(id, index, sym, varSymUnifier, typeUnifier)
+    }
+
+}


### PR DESCRIPTION
Hopefully removes some overhead relating to compiling Datalog programs. Simplifies `Lowering`, `Boxing` and `Ram` somewhat.