### PR TITLE
ci: increase compiler fuzzing time

### DIFF
--- a/main/test/flix/fuzzers/FuzzDeleteLines.scala
+++ b/main/test/flix/fuzzers/FuzzDeleteLines.scala
@@ -28,7 +28,7 @@ class FuzzDeleteLines extends AnyFunSuite with TestUtils {
   /**
     * Number of variants to make for each file. Each variant has a single line deleted.
     */
-  private val N = 30
+  private val N = 60
 
   test("simple-card-game") {
     val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")

--- a/main/test/flix/fuzzers/FuzzDuplicateLines.scala
+++ b/main/test/flix/fuzzers/FuzzDuplicateLines.scala
@@ -28,7 +28,7 @@ class FuzzDuplicateLines extends AnyFunSuite with TestUtils {
   /**
     * Number of variants to make of each file. Each variant has a single line duplicated.
     */
-  private val N = 30
+  private val N = 60
 
   test("simple-card-game") {
     val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")

--- a/main/test/flix/fuzzers/FuzzPrefixes.scala
+++ b/main/test/flix/fuzzers/FuzzPrefixes.scala
@@ -27,7 +27,7 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
   /**
     * The number of prefixes to compile for each program.
     */
-  private val N: Int = 100
+  private val N: Int = 200
 
   test("simple-card-game") {
     val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")

--- a/main/test/flix/fuzzers/FuzzSwapLines.scala
+++ b/main/test/flix/fuzzers/FuzzSwapLines.scala
@@ -29,9 +29,9 @@ class FuzzSwapLines extends AnyFunSuite with TestUtils {
   // In a file with just 100 lines, there is (100 * 99) / 2 unique non-equal swaps.
   // That's 4950 compiles if we try them all.
   // Assuming each take 1sec to run that ends up at 1.3 hours.
-  // Instead we select numSwapLines and try to swap those with each-other.
+  // Instead, we select numSwapLines and try to swap those with each-other.
   // For instance numSwapLines = 10 gives a total of 330 swaps per file.
-  private val numSwapLines = 20
+  private val numSwapLines = 25
 
   test("simple-card-game") {
     val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")

--- a/main/test/flix/fuzzers/FuzzSwapLines.scala
+++ b/main/test/flix/fuzzers/FuzzSwapLines.scala
@@ -31,7 +31,7 @@ class FuzzSwapLines extends AnyFunSuite with TestUtils {
   // Assuming each take 1sec to run that ends up at 1.3 hours.
   // Instead we select numSwapLines and try to swap those with each-other.
   // For instance numSwapLines = 10 gives a total of 330 swaps per file.
-  private val numSwapLines = 15
+  private val numSwapLines = 20
 
   test("simple-card-game") {
     val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")


### PR DESCRIPTION
We have significantly increased the time taken by the compiler test suite, so this adds a bit more compiler fuzzing "for free".