### PR TITLE
fix: use iterated locs in `TypeContext.expectTypeArguments`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
@@ -193,7 +193,7 @@ class TypeContext {
     while (es.nonEmpty && as.nonEmpty) {
       val expectedType = es.head
       val actualType = as.head
-      val loc = actualLocs.head
+      val loc = ls.head
 
       val prov = Provenance.ExpectArgument(expectedType, actualType, sym, idx, loc)
       val constr = TypeConstraint.Equality(expectedType, actualType, prov)


### PR DESCRIPTION
In `master` / the buggy version, it would always use the head of all locs. This seems like just a typo.

Closes #11310 