### PR TITLE
chore: remove CPS from `List`

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -956,7 +956,7 @@ mod List {
     def groupByHelper(value: a, f: (a, a) -> Bool, currentNels: List[Nel[a]]): List[Nel[a]] =
         // Record seen elements in reverse order in `acc`.
         def loop(cur, acc) = match cur {
-            case Nil => reverse((Nel.singleton(value) :: acc))
+            case Nil => reverse(Nel.singleton(value) :: acc)
             case x :: xs =>
                 if (Nel.forAll(v -> f(value, v) and f(v, value), x)) {
                     let newNel = Nel.cons(value, x);

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -219,6 +219,14 @@ mod List {
         foldRight((x, acc) -> x :: acc, l2, l1)
 
     ///
+    /// Returns `l2` appended to `reverse(l1)`.
+    ///
+    /// More efficient implementation than `append(reverse(l1), l2)` as it has 1 less reverse.
+    ///
+    def reverseAppend(l1: List[a], l2: List[a]): List[a] =
+        foldLeft((acc, x) -> x :: acc, l2, l1)
+
+    ///
     /// Returns `true` if and only if `l` contains the element `x`.
     ///
     pub def memberOf(a: a, l: List[a]): Bool with Eq[a] = match l {
@@ -324,13 +332,13 @@ mod List {
     /// That is, the result is of the form: `s :: f(s, x1) :: f(f(s, x1), x2) ...`.
     ///
     pub def scanLeft(f: (b, a) -> b \ ef, s: b, l: List[a]): List[b] \ ef =
-        def loop(ll, k, acc) = match ll {
-            case Nil     => k(Nil)
+        def loop(ll, accRes, acc) = match ll {
+            case Nil     => reverse(accRes)
             case x :: xs =>
                 let y = f(acc, x);
-                loop(xs, ks -> k(y :: ks), y)
+                loop(xs, y :: accRes, y)
         };
-        loop(l, ks -> s :: ks, s)
+        loop(l, s :: Nil, s)
 
     ///
     /// Accumulates the result of applying `f` to `l` going right to left.
@@ -338,13 +346,13 @@ mod List {
     /// That is, the result is of the form: `... f(xn-1, f(xn, s)) :: f(xn, s) :: s`.
     ///
     pub def scanRight(f: (a, b) -> b \ ef, s: b, l: List[a]): List[b] \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k(s :: Nil)
-            case x :: xs => loop(xs, ks -> match ks {
-                case ss :: _ => k(f(x, ss) :: ks)
-                case _       => unreachable!()})
+        def loop(ll, accRes, acc) = match ll {
+            case Nil     => accRes
+            case x :: xs =>
+                let y = f(x, acc);
+                loop(xs, y :: accRes, y)
         };
-        loop(l, x -> checked_ecast(x))
+        loop(reverse(l), s :: Nil, s)
 
     ///
     /// Returns the result of applying `f` to every element in `l`.
@@ -353,10 +361,10 @@ mod List {
     ///
     pub def map(f: a -> b \ ef, l: List[a]): List[b] \ ef =
         def loop(ll, acc) = match ll {
-            case Nil     => acc
+            case Nil     => reverse(acc)
             case x :: xs => loop(xs, f(x) :: acc)
         };
-        reverse(loop(l, Nil))
+        loop(l, Nil)
 
     ///
     /// Return the singleton list with element `x`.
@@ -411,13 +419,13 @@ mod List {
     /// That is, the result is of the form: `f(x1, 0) :: f(x2, 1) :: ...`.
     ///
     pub def mapWithIndex(f: (Int32, a) -> b \ ef, l: List[a]): List[b] \ ef =
-        def loop(ll, i, k) = match ll {
-            case Nil     => k(Nil)
+        def loop(ll, i, acc) = match ll {
+            case Nil     => reverse(acc)
             case x :: xs =>
                 let y = f(i, x);
-                loop(xs, i + 1, ys -> k(y :: ys))
+                loop(xs, i + 1, y :: acc)
         };
-        loop(l, 0, identity)
+        loop(l, 0, Nil)
 
     ///
     /// Returns the result of applying `f` to every element in `l` and concatenating the results.
@@ -469,12 +477,12 @@ mod List {
     /// Returns `l` if `i < 0` or `i > length(l)-1`.
     ///
     pub def update(i: Int32, a: a, l: List[a]): List[a] =
-        def loop(ll, j, k) = match (j, ll) {
-            case (_, Nil)     => k(Nil)
-            case (0, _ :: xs) => k(a :: xs)
-            case (_, x :: xs) => loop(xs, j - 1, ks -> k(x :: ks))
+        def loop(ll, j, acc) = match (j, ll) {
+            case (_, Nil)     => l
+            case (0, _ :: xs) => reverseAppend(acc, a :: xs)
+            case (_, x :: xs) => loop(xs, j - 1, x :: acc)
         };
-        loop(l, i, identity)
+        loop(l, i, Nil)
 
     ///
     /// Returns `l` with every occurrence of `src` replaced by `dst`.
@@ -490,16 +498,16 @@ mod List {
     /// If patching occurs at index `i+j` in `l2`, then the element at index `j` in `l1` is used.
     ///
     pub def patch(i: Int32, n: Int32, l1: List[a], l2: List[a]): List[a] =
-        def loop(ll1, ll2, c, k) = match (ll1, ll2) {
+        def loop(ll1, ll2, c, acc) = match (ll1, ll2) {
             case (x :: xs, y :: ys) => {
                 if (c >= i and c < i + n)
-                    loop(xs, ys, c + 1, ks -> k(x :: ks))
+                    loop(xs, ys, c + 1, x :: acc)
                 else
-                    loop(l1, ys, c + 1, ks -> k(y :: ks))
+                    loop(l1, ys, c + 1, y :: acc)
             }
-            case _ => k(ll2)
+            case _ => reverseAppend(acc, ll2)
         };
-        loop(drop(-i, l1), l2, 0, identity)
+        loop(drop(-i, l1), l2, 0, Nil)
 
     ///
     /// Returns all permutations of `l` in lexicographical order by element indices in `l`.
@@ -556,7 +564,7 @@ mod List {
     ///
     pub def removeAdjDupsWith(f: a -> a -> Bool \ ef, l: List[a]): List[a] \ ef = {
         def loop(head, acc, ll) = match ll {
-            case Nil     => List.reverse(acc)
+            case Nil     => reverse(acc)
             case x :: xs =>
                 if (f(head, x)) {
                     loop(head, acc, xs)
@@ -587,21 +595,25 @@ mod List {
     /// Returns `l` with `x` added to the beginning of each element in `l`.
     ///
     def applyHelper(a: a, l: List[List[a]]): List[List[a]] =
-        def loop(ll, k) = match ll {
-            case Nil     => k(Nil)
-            case x :: xs => loop(xs, ks -> k((a :: x) :: ks))
+        def loop(ll, acc) = match ll {
+            case Nil     => reverse(acc)
+            case x :: xs => loop(xs, (a :: x) :: acc)
         };
-        loop(l, identity)
+        loop(l, Nil)
 
     ///
     /// Returns `l` with `x` inserted between every two adjacent elements.
     ///
     pub def intersperse(a: a, l: List[a]): List[a] =
-        def loop(ll, k) = match ll {
-            case x1 :: x2 :: xs => loop(x2 :: xs, ks -> k(x1 :: a :: ks))
-            case _              => k(ll)
+        def loop(ll, acc) = match ll {
+            case x1 :: Nil      => reverse(x1 :: acc)
+            case x1 :: xs       => loop(xs, a :: x1 :: acc)
+            case _              => unreachable!()
         };
-        loop(l, identity)
+        match l {
+            case Nil => Nil
+            case _ => loop(l, Nil)
+        }
 
     ///
     /// Returns the concatenation of the elements in `l2` with the elements of `l1` inserted between every two adjacent elements.
@@ -609,12 +621,15 @@ mod List {
     /// That is, returns `y1 :: x1 ... xn :: y2 :: ... yn-1 :: x1 :: ... :: xn :: yn :: Nil`.
     ///
     pub def intercalate(l1: List[a], l2: List[List[a]]): List[a] =
-        def loop(ll, k) = match ll {
-            case Nil            => k(Nil)
-            case y :: Nil       => k(y)
-            case y1 :: y2 :: ys => loop(y2 :: ys, ks -> k(y1 ::: l1 ::: ks))
+        def loop(ll, acc) = match ll {
+            case x :: Nil       => reverse(reverseAppend(x, acc))
+            case x1 :: xs       => loop(xs, reverseAppend(l1, reverseAppend(x1, acc)))
+            case _              => unreachable!()
         };
-        loop(l2, identity)
+        match l2 {
+            case Nil => Nil
+            case _ => loop(l2, Nil)
+        }
 
     ///
     /// Returns the transpose of `l`.
@@ -697,11 +712,11 @@ mod List {
     /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, s))...)`.
     ///
     pub def foldRight(f: (a, b) -> b \ ef, s: b, l: List[a]): b \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k(s)
-            case x :: xs => loop(xs, ks -> k(f(x, ks)))
+        def loop(ll, acc) = match ll {
+            case Nil     => acc
+            case x :: xs => loop(xs, f(x, acc))
         };
-        loop(l, x -> checked_ecast(x))
+        loop(reverse(l), s)
 
     ///
     /// Applies `f` to a start value `z` and all elements in `l` going from right to left.
@@ -734,14 +749,14 @@ mod List {
     /// Returns `None` if `l` is empty.
     ///
     pub def reduceRight(f: (a, a) -> a \ ef, l: List[a]): Option[a] \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k(None)
-            case x :: xs => loop(xs, ks -> k(match ks {
-                case None    => Some(x)
-                case Some(v) => Some(f(x, v))
-            }))
+        def loop(ll, acc) = match ll {
+            case Nil     => Some(acc)
+            case x :: xs => loop(xs, f(x, acc))
         };
-        loop(l, x -> checked_ecast(x))
+        match reverse(l) {
+            case Nil => None
+            case x :: xs => loop(xs, x)
+        }
 
     ///
     /// Returns the number of elements in `l` that satisfy the predicate `f`.
@@ -753,11 +768,11 @@ mod List {
     /// Returns the concatenation of the elements in `l`.
     ///
     pub def flatten(l: List[List[a]]): List[a] =
-        def loop(ll, k) = match ll {
-            case Nil     => k(Nil)
-            case x :: xs => loop(xs, ks -> k(x ::: ks))
+        def loop(ll, acc) = match ll {
+            case Nil     => reverse(acc)
+            case x :: xs => loop(xs, reverseAppend(x, acc))
         };
-        loop(l, identity)
+        loop(l, Nil)
 
     ///
     /// Returns `true` if and only if at least one element in `l` satisfies the predicate `f`.
@@ -783,23 +798,23 @@ mod List {
     /// Returns a list of every element in `l` that satisfies the predicate `f`.
     ///
     pub def filter(f: a -> Bool \ ef, l: List[a]): List[a] \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k(Nil)
-            case x :: xs => if (f(x)) loop(xs, ks -> k(x :: ks)) else loop(xs, k)
+        def loop(ll, acc) = match ll {
+            case Nil     => reverse(acc)
+            case x :: xs => if (f(x)) loop(xs, x :: acc) else loop(xs, acc)
         };
-        loop(l, identity)
+        loop(l, Nil)
 
     ///
     /// Returns the sublist of `l` without the last element.
     /// Returns `None` if the list `l` is `Nil`.
     ///
     pub def init(l: List[a]): Option[List[a]] =
-        def loop(ll, k) = match ll {
+        def loop(ll, acc) = match ll {
             case Nil      => None
-            case _ :: Nil => Some(k(Nil))
-            case x :: xs  => loop(xs, ks -> k(x :: ks))
+            case _ :: Nil => Some(reverse(acc))
+            case x :: xs  => loop(xs, x :: acc)
         };
-        loop(l, identity)
+        loop(l, Nil)
 
     ///
     /// Returns the sublist of `l` from index `start` (inclusive) to index `end` (exclusive).
@@ -808,17 +823,17 @@ mod List {
     /// Note: Indices that are out of bounds in `l` are not considered (i.e. slice(start, end, l) = slice(max(0, start), min(length(l), end), l)).
     ///
     pub def slice(start: {start = Int32}, end: {end = Int32}, l: List[a]): List[a] =
-        def loop(ll, i, k) = match ll {
-            case Nil     => k(Nil)
+        def loop(ll, i, acc) = match ll {
+            case Nil     => reverse(acc)
             case x :: xs =>
                 if (i < start#start)
-                    loop(xs, i + 1, k)
+                    loop(xs, i + 1, acc)
                 else if (i >= end#end)
-                    k(Nil)
+                    reverse(acc)
                 else
-                    loop(xs, i + 1, ks -> k(x :: ks))
+                    loop(xs, i + 1, x :: acc)
         };
-        if (start#start < end#end) loop(l, 0, identity) else Nil
+        if (start#start < end#end) loop(l, 0, Nil) else Nil
 
     ///
     /// Returns a pair of lists `(l1, l2)`.
@@ -827,15 +842,15 @@ mod List {
     /// `l2` contains all elements of `l` that do not satisfy the predicate `f`.
     ///
     pub def partition(f: a -> Bool \ ef, l: List[a]): (List[a], List[a]) \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k((Nil, Nil))
+        def loop(ll, acc1, acc2) = match ll {
+            case Nil     => (reverse(acc1), reverse(acc2))
             case x :: xs =>
                 if (f(x))
-                    loop(xs, match (ks, ls) -> k((x :: ks, ls)))
+                    loop(xs, x :: acc1, acc2)
                 else
-                    loop(xs, match (ks, ls) -> k((ks, x :: ls)))
+                    loop(xs, acc1, x :: acc2)
         };
-        loop(l, identity)
+        loop(l, Nil, Nil)
 
     ///
     /// Returns a pair of lists `(l1, l2)`.
@@ -846,15 +861,15 @@ mod List {
     /// The function `f` must be pure.
     ///
     pub def span(f: a -> Bool, l: List[a]): (List[a], List[a]) =
-        def loop(ll, k) = match ll {
-            case Nil     => k((Nil, Nil))
+        def loop(ll, acc) = match ll {
+            case Nil     => (reverse(acc), Nil)
             case x :: xs =>
                 if (f(x))
-                    loop(xs, match (ks, ls) -> k((x :: ks, ls)))
+                    loop(xs, x :: acc)
                 else
-                    k((Nil, ll))
+                    (reverse(acc), ll)
         };
-        loop(l, identity)
+        loop(l, Nil)
 
     ///
     /// Returns `l` without the first `n` elements.
@@ -883,25 +898,25 @@ mod List {
     /// Returns `Nil` if `n < 0`.
     ///
     pub def take(n: Int32, l: List[a]): List[a] =
-        def loop(ll, i, k) =
+        def loop(ll, i, acc) =
             if (i <= 0)
-                k(Nil)
+                reverse(acc)
             else
                 match ll {
-                    case Nil     => k(Nil)
-                    case x :: xs => loop(xs, i - 1, ks -> k(x :: ks))
+                    case Nil     => reverse(acc)
+                    case x :: xs => loop(xs, i - 1, x :: acc)
                 };
-        loop(l, n, identity)
+        loop(l, n, Nil)
 
     ///
     /// Returns the longest prefix of `l` that satisfies the predicate `f`.
     ///
     pub def takeWhile(f: a -> Bool \ ef, l: List[a]): List[a] \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k(Nil)
-            case x :: xs => if (f(x)) loop(xs, ks -> k(x :: ks)) else k(Nil)
+        def loop(ll, acc) = match ll {
+            case Nil     => reverse(acc)
+            case x :: xs => if (f(x)) loop(xs, x :: acc) else reverse(acc)
         };
-        loop(l, identity)
+        loop(l, Nil)
 
     ///
     /// Split the list `xs` at the position `n` returning the left and right parts.
@@ -959,11 +974,11 @@ mod List {
     /// If either `l1` or `l2` becomes depleted, then no further elements are added to the resulting list.
     ///
     pub def zip(l1: List[a], l2: List[b]): List[(a, b)] =
-        def loop(ll1, ll2, k) = match (ll1, ll2) {
-            case (x :: xs, y :: ys) => loop(xs, ys, ks -> k((x, y) :: ks))
-            case _                  => k(Nil)
+        def loop(ll1, ll2, acc) = match (ll1, ll2) {
+            case (x :: xs, y :: ys) => loop(xs, ys, (x, y) :: acc)
+            case _                  => reverse(acc)
         };
-        loop(l1, l2, identity)
+        loop(l1, l2, Nil)
 
     ///
     /// Returns a list where the element at index `i` is `f(a, b)` where
@@ -972,24 +987,24 @@ mod List {
     /// If either `l1` or `l2` becomes depleted, then no further elements are added to the resulting list.
     ///
     pub def zipWith(f: (a, b) -> c \ ef, l1: List[a], l2: List[b]): List[c] \ ef =
-        def loop(ll1, ll2, k) = match (ll1, ll2) {
+        def loop(ll1, ll2, acc) = match (ll1, ll2) {
             case (x :: xs, y :: ys) =>
                 let z = f(x, y);
-                loop(xs, ys, ks -> k(z :: ks))
-            case _ => k(Nil)
+                loop(xs, ys, z :: acc)
+            case _ => reverse(acc)
         };
-        loop(l1, l2, identity)
+        loop(l1, l2, Nil)
 
     ///
     /// Returns a list where each element `e` is mapped to `(i, e)` where `i`
     /// is the index of `e`.
     ///
     pub def zipWithIndex(l: List[a]): List[(Int32, a)] =
-        def loop(ll, i, k) = match ll {
-            case Nil       => k(Nil)
-            case (x :: xs) => loop(xs, i + 1, ks -> k((i, x) :: ks))
+        def loop(ll, i, acc) = match ll {
+            case Nil       => reverse(acc)
+            case (x :: xs) => loop(xs, i + 1, (i, x) :: acc)
         };
-        loop(l, 0, identity)
+        loop(l, 0, Nil)
 
     ///
     /// Generalize `zipWith` to an applicative functor `f`.
@@ -1008,11 +1023,11 @@ mod List {
     /// and the second containing all second components in `l`.
     ///
     pub def unzip(l: List[(a, b)]): (List[a], List[b]) =
-        def loop(ll, k) = match ll {
-            case Nil            => k((Nil, Nil))
-            case (x1, x2) :: xs => loop(xs, match (ks, ls) -> k((x1 :: ks, x2 :: ls)))
+        def loop(ll, acc1, acc2) = match ll {
+            case Nil            => (reverse(acc1), reverse(acc2))
+            case (x1, x2) :: xs => loop(xs, x1 :: acc1, x2 :: acc2)
         };
-        loop(l, identity)
+        loop(l, Nil, Nil)
 
     ///
     /// Returns a list where the element at index `i` is `(a, b, c)` where
@@ -1032,13 +1047,13 @@ mod List {
     /// If any one of `l1`, `l2` or `l3` become depleted, then no further elements are added to the resulting list.
     ///
     pub def zipWith3(f: (a, b, c) -> d \ ef, l1: List[a], l2: List[b], l3: List[c]): List[d] \ ef =
-        def loop(ll1, ll2, ll3, k) = match (ll1, ll2, ll3) {
+        def loop(ll1, ll2, ll3, acc) = match (ll1, ll2, ll3) {
             case (x :: xs, y :: ys, z :: zs) =>
                 let r = f(x, y, z);
-                loop(xs, ys, zs, ks -> k(r :: ks))
-            case _ => k(Nil)
+                loop(xs, ys, zs, r :: acc)
+            case _ => reverse(acc)
         };
-        loop(l1, l2, l3, identity)
+        loop(l1, l2, l3, Nil)
 
     ///
     /// Returns a triple of lists, the first containing all first components in `l`
@@ -1046,11 +1061,11 @@ mod List {
     /// third components in `l`.
     ///
     pub def unzip3(l: List[(a, b, c)]): (List[a], List[b], List[c]) =
-        def loop(ll, k) = match ll {
-            case Nil             => k((Nil, Nil, Nil))
-            case (x, y, z) :: xs => loop(xs, match (ks, ls, ms) -> k((x :: ks, y :: ls, z :: ms)))
+        def loop(ll, acc1, acc2, acc3) = match ll {
+            case Nil             => (reverse(acc1), reverse(acc2), reverse(acc3))
+            case (x, y, z) :: xs => loop(xs, x :: acc1, y :: acc2, z :: acc3)
         };
-        loop(l, identity)
+        loop(l, Nil, Nil, Nil)
 
     ///
     /// Alias for `foldLeft2`.
@@ -1071,13 +1086,11 @@ mod List {
     /// starting with the initial value `c` and going from right to left.
     ///
     pub def foldRight2(f: (a, b, c) -> c \ ef, c: c, l1: List[a], l2: List[b]): c \ ef =
-        def loop(ll1, ll2, k) = match (ll1, ll2) {
-            case (x :: xs, y :: ys) => loop(xs, ys, ks -> k(f(x, y, ks)))
-            case _                  => k(c)
+        def loop(ll1, ll2, acc) = match (ll1, ll2) {
+            case (x :: xs, y :: ys) => loop(xs, ys, f(x, y, acc))
+            case _                  => acc
         };
-        let len1 = length(l1);
-        let len2 = length(l2);
-        loop(drop(len1 - len2, l1), drop(len2 - len1, l2), x -> checked_ecast(x))
+        loop(reverse(l1), reverse(l2), c)
 
     ///
     /// Returns the result of mapping each element and combining the results.
@@ -1089,14 +1102,14 @@ mod List {
     /// Collects the results of applying the partial function `f` to every element in `l`.
     ///
     pub def filterMap(f: a -> Option[b] \ ef, l: List[a]): List[b] \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k(Nil)
+        def loop(ll, acc) = match ll {
+            case Nil     => reverse(acc)
             case x :: xs => match f(x) {
-                case None    => loop(xs, k)
-                case Some(v) => loop(xs, ks -> k(v :: ks))
+                case None    => loop(xs, acc)
+                case Some(v) => loop(xs, v :: acc)
             }
         };
-        loop(l, identity)
+        loop(l, Nil)
 
     ///
     /// Returns the first non-None result of applying the partial function `f` to each element of `l`.
@@ -1279,11 +1292,11 @@ mod List {
     /// `f` should return `None` to signal the end of building the list.
     ///
     pub def unfold(f: s -> Option[(a, s)] \ ef, st: s): List[a] \ ef =
-        def loop(sst, k) = match f(sst) {
-            case None           => k(Nil)
-            case Some((a, st1)) => loop(st1, ks -> k(a :: ks))
+        def loop(sst, acc) = match f(sst) {
+            case None           => reverse(acc)
+            case Some((a, st1)) => loop(st1, a :: acc)
         };
-        loop(st, identity)
+        loop(st, Nil)
 
     ///
     /// Build a list by applying the function `next` to `()`. `next` is expected to encapsulate
@@ -1294,11 +1307,11 @@ mod List {
     /// `next` should return `None` to signal the end of building the list.
     ///
     pub def unfoldWithIter(next: Unit -> Option[a] \ ef): List[a] \ ef =
-        def loop(k) = match next() {
-            case None    => k(Nil)
-            case Some(x) => loop(ks -> k(x :: ks))
+        def loop(acc) = match next() {
+            case None    => reverse(acc)
+            case Some(x) => loop(x :: acc)
         };
-        loop(identity)
+        loop(Nil)
 
     ///
     /// Build a list by applying the function `next` to `()`. `next` is expected to encapsulate
@@ -1311,12 +1324,12 @@ mod List {
     /// `next` should return `Err(e)` to signal that an error occurred. The function returns `Err(e)`.
     ///
     pub def unfoldWithOkIter(next: Unit -> Result[e, Option[a]] \ ef): Result[e, List[a]] \ ef =
-        def loop(k) = match next() {
-            case Ok(None)    => k(Ok(Nil))
-            case Err(e)      => k(Err(e))
-            case Ok(Some(x)) => loop(Result.flatMap(ks -> k(Ok(x :: ks))))
+        def loop(acc) = match next() {
+            case Ok(None)    => Ok(reverse(acc))
+            case Err(e)      => Err(e)
+            case Ok(Some(x)) => loop(x :: acc)
         };
-        loop(identity)
+        loop(Nil)
 
     ///
     /// Returns the list `l` with duplicates removed. The first occurrence of
@@ -1327,15 +1340,15 @@ mod List {
     /// need a custom equality test.
     ///
     pub def distinct(l: List[a]): List[a] with Eq[a] =
-        def loop(ll1, ll2, k) = match ll1 {
-            case Nil     => k(Nil)
+        def loop(ll, acc) = match ll {
+            case Nil     => reverse(acc)
             case x :: xs =>
-                if (memberOf(x, ll2))
-                    loop(xs, ll2, k)
+                if (memberOf(x, acc))
+                    loop(xs, acc)
                 else
-                    loop(xs, x :: ll2, ks -> k(x :: ks))
+                    loop(xs, x :: acc)
         };
-        loop(l, Nil, identity)
+        loop(l, Nil)
 
     ///
     /// Returns the list `l` with duplicates removed using the supplied function
@@ -1343,15 +1356,15 @@ mod List {
     /// for the removal of subsequent duplicates the order of `l` is preserved.
     ///
     pub def distinctWith(f: (a, a) -> Bool, l: List[a]): List[a] =
-        def loop(ll1, ll2, k) = match ll1 {
-            case Nil     => k(Nil)
+        def loop(ll, acc) = match ll {
+            case Nil     => reverse(acc)
             case x :: xs =>
-                if (exists(f(x), ll2))
-                    loop(xs, ll2, k)
+                if (exists(f(x), acc))
+                    loop(xs, acc)
                 else
-                    loop(xs, x :: ll2, ks -> k(x :: ks))
+                    loop(xs, x :: acc)
         };
-        loop(l, Nil, identity)
+        loop(l, Nil)
 
     ///
     /// Returns the sum of all elements in the list `l`.
@@ -1431,17 +1444,16 @@ mod List {
     /// If two elements compare `EqualTo`, then the element of `l1` is first in the result.
     ///
     pub def merge(l1: List[a], l2: List[a]): List[a] with Order[a] =
-        def loop(acc1, acc2, k) = match (acc1, acc2) {
+        def loop(ll1, ll2, acc) = match (ll1, ll2) {
             case (x :: xs, y :: ys) => {
                 let cmp = x <=> y;
-                if (cmp == Comparison.LessThan or cmp == Comparison.EqualTo) loop(xs, acc2, ks -> k(x :: ks))
-                else                                   loop(acc1, ys, ks -> k(y :: ks))
+                if (cmp == Comparison.LessThan or cmp == Comparison.EqualTo) loop(xs, ll2, x :: acc)
+                else                                   loop(ll1, ys, y :: acc)
             }
-            case (Nil    , y :: ys) => k(y :: ys)
-            case (x :: xs, Nil    ) => k(x :: xs)
-            case (Nil    , Nil    ) => k(Nil)
+            case (Nil    , _) => reverse(reverseAppend(ll2, acc))
+            case (_, Nil    ) => reverse(reverseAppend(ll1, acc))
         };
-        loop(l1, l2, identity)
+        loop(l1, l2, Nil)
 
     ///
     /// Shuffles `l` using the Fisher–Yates shuffle.

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -221,7 +221,7 @@ mod List {
     ///
     /// Returns `l2` appended to `reverse(l1)`.
     ///
-    /// More efficient implementation than `append(reverse(l1), l2)` as it has 1 less reverse.
+    /// More efficient than `append(reverse(l1), l2)` as it does not use reverse.
     ///
     def reverseAppend(l1: List[a], l2: List[a]): List[a] =
         foldLeft((acc, x) -> x :: acc, l2, l1)
@@ -956,11 +956,11 @@ mod List {
     def groupByHelper(value: a, f: (a, a) -> Bool, currentNels: List[Nel[a]]): List[Nel[a]] =
         // Record seen elements in reverse order in `acc`.
         def loop(cur, acc) = match cur {
-            case Nil => (Nel.singleton(value) :: acc) |> List.reverse
+            case Nil => reverse((Nel.singleton(value) :: acc))
             case x :: xs =>
                 if (Nel.forAll(v -> f(value, v) and f(v, value), x)) {
                     let newNel = Nel.cons(value, x);
-                    List.reverse(newNel :: acc) ::: xs
+                    reverseAppend(acc, newNel :: xs)
                 } else {
                     loop(xs, x :: acc)
                 }


### PR DESCRIPTION
Changes most CPS uses to use an accumulator which is often reversed afterwards. Added `reverseAppend` for that purpose. The changes are strictly related to rewriting from CPS to accumulation, smart rewrites have not been done. Related to #10518.

Not updated: `List.sequence` and.`List.traverse`.

Performance has not been a strict focus, but it appears to be better for the tested `update`, though the tests are too small to see this improvement.