### PR TITLE
feat: preliminary assert effect related to #11323

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -83,3 +83,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Ry Wiese](https://github.com/rywiese)
 - [Michał Kukieła](https://github.com/kukimik)
 - [Alex Asafov](https://github.com/Alex1005a)
+- [Daniel Neo López Martínez](https://github.com/NeonOxide)

--- a/main/src/library/Assert.flix
+++ b/main/src/library/Assert.flix
@@ -13,7 +13,136 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+///
+/// An effect used to perform assertions during program execution.
+///
+pub eff Assert {
+
+    ///
+    /// Asserts that the given condition `cond` is `true` with a message `msg`.
+    /// The provided functions in the associated module treat this message as
+    /// the reason of failure, but it does not necessarily have to be that.
+    ///
+    /// If the assertion fails, the behavior depends on the effect handler.
+    ///
+    def assert(cond: Bool, msg: String): Unit
+
+}
+
 mod Assert {
+    import java.lang.AssertionError;
+
+    ///
+    /// Asserts that the given condition `cond` is `true`.
+    ///
+    pub def assertTrue(cond: Bool): Unit \ Assert =
+        Assert.assert(cond, "Assertion failed: expected true")
+
+    ///
+    /// Asserts that the given condition `cond` is `true` with the given message `msg`.
+    ///
+    pub def assertTrueWithMsg(cond: Bool, msg: String): Unit \ Assert =
+        Assert.assert(cond, msg)
+
+    ///
+    /// Asserts that the given condition `cond` is `false`.
+    ///
+    pub def assertFalse(cond: Bool): Unit \ Assert =
+        Assert.assert(not cond, "Assertion failed: expected false")
+
+    ///
+    /// Asserts that the given condition `cond` is `false` with the given message `msg`.
+    ///
+    pub def assertFalseWithMsg(cond: Bool, msg: String): Unit \ Assert =
+        Assert.assert(not cond, msg)
+
+    ///
+    /// Asserts that the given values `expected` and `actual` are equal.
+    ///
+    pub def assertEq(exp: {expected = a}, actual: a): Unit \ Assert with Eq[a], ToString[a] =
+        Assert.assert(actual == exp#expected, "Assertion failed: expected `${exp#expected}`, but got `${actual}`")
+
+    ///
+    /// Asserts that the given values `expected` and `actual` are equal with the given message `msg`.
+    ///
+    pub def assertEqWithMsg(exp: {expected = a}, actual: a, msg: String): Unit \ Assert with Eq[a] =
+        Assert.assert(actual == exp#expected, msg)
+
+    ///
+    /// Asserts that the given values `unexpected` and `actual` are not equal.
+    ///
+    pub def assertNeq(unexp: {unexpected = a}, actual: a): Unit \ Assert with Eq[a], ToString[a] =
+        Assert.assert(actual != unexp#unexpected, "Assertion failed: expected values to be different, but both were `${actual}`")
+
+    ///
+    /// Asserts that the given values `unexpected` and `actual` are not equal with the given message `msg`.
+    ///
+    pub def assertNeqWithMsg(unexp: {unexpected = a}, actual: a, msg: String): Unit \ Assert with Eq[a] =
+        Assert.assert(actual != unexp#unexpected, msg)
+
+    ///
+    /// Asserts that the given Option `o` is `Some(v)`.
+    ///
+    pub def assertSome(o: Option[a]): Unit \ Assert =
+        Assert.assert(Option.nonEmpty(o), "Assertion failed: expected Some(_), but got None")
+
+    ///
+    /// Asserts that the given Option `o` is `None`.
+    ///
+    pub def assertNone(o: Option[a]): Unit \ Assert =
+        Assert.assert(Option.isEmpty(o), "Assertion failed: expected None, but got Some(_)")
+
+    ///
+    /// Asserts that the given Result `r` is `Ok(v)`.
+    ///
+    pub def assertOk(r: Result[e, a]): Unit \ Assert =
+        Assert.assert(Result.isOk(r), "Assertion failed: expected Ok(_), but got Err(_)")
+
+    ///
+    /// Asserts that the given Result `r` is `Err(e)`.
+    ///
+    pub def assertErr(r: Result[e, a]): Unit \ Assert =
+        Assert.assert(Result.isErr(r), "Assertion failed: expected Err(_), but got Ok(_)")
+
+    ///
+    /// Unconditionally fails with the given message `msg`.
+    ///
+    pub def fail(msg: String): Unit \ Assert =
+        Assert.assert(false, msg)
+
+    ///
+    /// Handles the `Assert` effect of the given function `f` by throwing exceptions on assertion failures.
+    ///
+    /// In other words, re-interprets the `Assert` effect using the `IO` effect.
+    ///
+    pub def handle(f: a -> b \ ef): (a -> b \ (ef - Assert) + IO + Sys) =
+        x ->
+        run {
+            f(x)
+        } with handler Assert {
+            def assert(cond, msg, resume) =
+            {
+                if (cond)
+                    resume(())
+                else {
+                    use Chalk.{red, bold};
+                    run {
+                        println("");
+                        println("${red("Assertion Failed:")} ${bold(msg)}");
+                        println("");
+                        throw new AssertionError(msg)
+                    } with Environment.runWithIO
+                }
+            }
+        }
+
+    ///
+    /// Runs the `Assert` effect of the given function `f` by throwing exceptions on assertion failures.
+    ///
+    /// In other words, re-interprets the `Assert` effect using the `IO` effect.
+    ///
+    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Assert) + IO + Sys = handle(f)()
 
     ///
     /// Asserts that `expected` must equal `actual`.


### PR DESCRIPTION
Created a preliminary version of the Assert effect and some utility functions like assertTrue, assertEq, etc.

There are some extra things to consider as: 

- Should isSome et al. print require toString and print the unexpected contents?
- I also think we should expose some interface where the message is generated from a function with the offending element as argument, in order to not force users to use their toString implementation.
- Should runWithIO expose the Sys Effect or the Environment effect from Chalk?
- I removed the hole present in the old eq in order to avoid the super exception and just returned false and it seems to work fine, but I do not know if there was any reason for the hole's existence or it was just left there. 
- Right now, handleWithCount returns a tuple (result, number_of_errors) and handleWithCollection returns a Result[errorList, result). I think both of these should be consistent with each other. However, I do not know which one is preferable (or even using Validation instead of result). What do you think?
- Right now runWithIO throws an Assertion error that gives a very ugly stacktrace, I guess once the code generation around the Assert effect is done, it can be managed that the handler just returns early with false in order to give the users what they expect. However then the signature of runWithIO would require to take an a -> Bool instead of a -> b. But given its use I think it merits its own function to fit with the Test framework.
- I have been researching other similar frameworks and one essential operation that would be really nice to support is something like assertThrows or assertNotThrows (which in our case could be generalized to assertCallsEffect or assertDoesNotCallEffect). 
 However, I have not been able to find a way of emulating this at Flix user level (at compiler level it would just need to introduce a handler that for every function either fails when called or fails at the end if not called). The user interface can be done quite seamlessly with something like assertCallsEffect(function, (ef: Eff[effect_equation])). Where Eff or another name is just an enum with a phantom effect kind. 
 - With typematch you could also do some assertIsPure or assertHasEffect that instead of simply not compiling use typematch and return true or false depending on the effects. However, I fail to see why an user would prefer to obtain these errors at test time instead of at compile time. However, I do not know how typematch works with subeffecting, if a pure function is treated as IO by subeffecting, when used with typematch will it match on Pure or on IO?
 
 Thanks in advance for your time! This is the first of a series of pull requests that will be done regarding Assert, once this is done, I will go into allowing Assert at the top level of tests and including a default handler for it if that is the case.