### PR TITLE
refactor: split `Provenance.getMatchingBody` into smaller methods

### DIFF
--- a/main/src/library/Fixpoint3/Provenance.flix
+++ b/main/src/library/Fixpoint3/Provenance.flix
@@ -315,53 +315,7 @@ mod Fixpoint3.Provenance {
                 // Filter out Guard0. They must be true.
                 case _                                 => false
             });
-        ///
-        /// Returns the current value of `varName`.
-        ///
-        def getVal(varName, valToVar) = getOrCrash(Map.get(varName, valToVar));
 
-        ///
-        /// Register the values new values of `varNames` to be `matchedFacts`.
-        ///
-        /// Concretely, we update the `varSymToVal` to contain `varNames[i] => matchedFacts[i]`.
-        ///
-        def registerVars(varNames, matchedFact, varSymToVal) = {
-            let result = Map.toMutMap(rc, varSymToVal);
-            foreach ((i, v) <- ForEach.withIndex(varNames)) {
-                MutMap.put(v, Vector.get(i, matchedFact), result)
-            };
-            MutMap.toMap(result)
-        };
-
-        ///
-        /// Returns true if all guards are satisfied by the current variable assignment.
-        ///
-        def areGuardsSatisfied(varSymToVal): Bool = {
-            guards |>
-                Vector.forAll(guard -> match guard {
-                    case BodyPredicate.Guard1(f, v1)                 => f(getVal(v1, varSymToVal))
-                    case BodyPredicate.Guard2(f, v1, v2)             => f(getVal(v1, varSymToVal), getVal(v2, varSymToVal))
-                    case BodyPredicate.Guard3(f, v1, v2, v3)         => f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal))
-                    case BodyPredicate.Guard4(f, v1, v2, v3, v4)     => f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal), getVal(v4, varSymToVal))
-                    case BodyPredicate.Guard5(f, v1, v2, v3, v4, v5) => f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal), getVal(v4, varSymToVal), getVal(v5, varSymToVal))
-                    case _                                           => unreachable!()
-                })
-        };
-
-        ///
-        /// Returns true if all head applications are satisfied by the current variable assignment.
-        ///
-        def areHeadApplicationsSatisfied(varSymToVal): Bool = {
-            headApps |>
-                Vector.forAll(match (app, val) -> match app {
-                    case (HeadTerm.App1(f, v1))                 => val == f(getVal(v1, varSymToVal))
-                    case (HeadTerm.App2(f, v1, v2))             => val == f(getVal(v1, varSymToVal), getVal(v2, varSymToVal))
-                    case (HeadTerm.App3(f, v1, v2, v3))         => val == f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal))
-                    case (HeadTerm.App4(f, v1, v2, v3, v4))     => val == f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal), getVal(v4, varSymToVal))
-                    case (HeadTerm.App5(f, v1, v2, v3, v4, v5)) => val == f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal), getVal(v4, varSymToVal), getVal(v5, varSymToVal))
-                    case _ => unreachable!()
-                })
-        };
         ///
         /// This is a top down evaluation of `rule`.
         ///
@@ -374,7 +328,7 @@ mod Fixpoint3.Provenance {
         def loop(index, varSymToVal) = {
             if (index == Vector.length(bodyPreds)) {
                 // Base case. We have satisfied all atoms and found a satisfying assignment.
-                areHeadApplicationsSatisfied(varSymToVal) and areGuardsSatisfied(varSymToVal)
+                areHeadApplicationsSatisfied(headApps, varSymToVal) and areGuardsSatisfied(guards, varSymToVal)
             } else {
                 match Vector.get(index, bodyPreds) {
                     case BodyPredicate.BodyAtom(pred, _, Polarity.Positive, _, expected) =>
@@ -382,28 +336,10 @@ mod Fixpoint3.Provenance {
                         // to by `lookup`.
                         // `(2, val)` being in the list means that attribute 3 of the tuple
                         // must have value `val`. View this as a `zipWithIndex |> filter`.
-                        let filterAsList: Vector[(Int32, Boxed)] = ((Nil, 0), expected)
-                            ||> Vector.foldLeft(match (acc, i) -> t -> match t {
-                                case BodyTerm.Wild   => (acc, i + 1)
-                                case BodyTerm.Var(v) => match Map.get(v, varSymToVal) {
-                                    case None      => (acc, i + 1)
-                                    case Some(val) => ((i, val) :: acc, i + 1)
-                                }
-                                case BodyTerm.Lit(val) => ((i, val) :: acc, i + 1)
-                            }) |> fst |> List.toVector |> Vector.reverse;
+                        let filterAsList = evalGroundTerms(expected, varSymToVal);
                         // List of `VarSym` that become bound when the atom is
                         // satisfied.
-                        let freeVars = expected |>
-                            Vector.filterMap(t -> match t {
-                                case BodyTerm.Var(v) => match Map.memberOf(v, varSymToVal) {
-                                    case false => Some(v)
-                                    case true  => None
-                                }
-                                // We need to keep the order and positions for `registerVars`.
-                                // We do not care about what `_` has been assigned to.
-                                case BodyTerm.Wild => Some(VarSym.VarSym("_"))
-                                case _             => None
-                            });
+                        let freeVars = getFreeVarSyms(expected, varSymToVal);
                         // Get a list of all values that match the current assignment of body atoms.
                         let matches = lookup(rc, provIdb, filterAsList, Vector.length(expected), lookupStruct, pred);
                         match matches {
@@ -416,7 +352,7 @@ mod Fixpoint3.Provenance {
                                     List.exists(match (bodyFact, bodyDepth, bodyRule) -> {
                                         if (bodyDepth >= depth) {
                                             // The depth of the body fact is higher than the depth of the head.
-                                            // Reject this t oavoid infinite loops.
+                                            // Reject this to avoid infinite loops.
                                             false
                                         } else {
                                             // This combination could be delayed until we knew we had a satisfying assignment.
@@ -429,12 +365,7 @@ mod Fixpoint3.Provenance {
                         }
                     case BodyPredicate.BodyAtom(pred, _, Polarity.Negative, _, expected) =>
                         // `not pred(tuple)` is true if `pred(tuple)` is not in the model.
-                        let tuple = expected |>
-                            Vector.map(t -> match t {
-                                case BodyTerm.Var(v) => getVal(v, varSymToVal)
-                                case BodyTerm.Lit(val) => val
-                                case BodyTerm.Wild => unreachable!()
-                            });
+                        let tuple = evalOrCrash(expected, varSymToVal);
                         let isMatch = match Map.get(makeFakeRelSym(pred), provIdb) {
                             case None        => false
                             case Some(facts) => BPlusTree.memberOf(tuple, facts)
@@ -479,6 +410,107 @@ mod Fixpoint3.Provenance {
         };
         loop(0, MutMap.toMap(varSymToVal));
         bodyValues |> Array.filterMap(rc, identity)
+    }
+
+    ///
+    /// Returns the current value of `varName`.
+    ///
+    def getVal(varName: VarSym, varSymToVal: Map[VarSym, Boxed]): Boxed = getOrCrash(Map.get(varName, varSymToVal))
+
+    ///
+    /// Evaluates `terms` with respect to `varSymToVal`. Crashes if a free variable is met.
+    ///
+    /// `BodyTerm.Wild` counts as free variables for this purpose.
+    ///
+    def evalOrCrash(terms: Vector[BodyTerm], varSymToVal: Map[VarSym, Boxed]): Vector[Boxed] =
+        terms |>
+            Vector.map(t -> match t {
+                case BodyTerm.Var(v) => getVal(v, varSymToVal)
+                case BodyTerm.Lit(val) => val
+                case BodyTerm.Wild => unreachable!()
+            })
+
+    ///
+    /// Evaluates the ground terms in `terms` with respect to `varSymToVal` and return a vector of
+    /// `(index, value)` where `eval(terms[index]) == value`. The list is sorted by the `index`,
+    /// smallest to largest.
+    ///
+    def evalGroundTerms(terms: Vector[BodyTerm], varSymToVal: Map[VarSym, Boxed]): Vector[(Int32, Boxed)] =
+        let (filterAsList, _) = ((Nil, 0), terms)
+            ||> Vector.foldLeft(match (acc, i) -> t -> match t {
+                case BodyTerm.Wild   => (acc, i + 1)
+                case BodyTerm.Var(v) => match Map.get(v, varSymToVal) {
+                    case None      => (acc, i + 1)
+                    case Some(val) => ((i, val) :: acc, i + 1)
+                }
+                case BodyTerm.Lit(val) => ((i, val) :: acc, i + 1)
+            });
+        List.reverse(filterAsList) |> List.toVector
+
+
+    ///
+    /// Return a Vector of `VarSym` in `terms` which are currently free, according to `varSymToVal`.
+    ///
+    /// `BodyTerm.Wild` is considered free and will be returned as `VarSym.VarSym("_")`.
+    ///
+    def getFreeVarSyms(terms: Vector[BodyTerm], varSymToVal: Map[VarSym, Boxed]): Vector[VarSym] =
+        terms |>
+            Vector.filterMap(t -> match t {
+                case BodyTerm.Var(v) => match Map.memberOf(v, varSymToVal) {
+                    case false => Some(v)
+                    case true  => None
+                }
+                // We need to keep the order and positions for `registerVars`.
+                // We do not care about what `_` has been assigned to.
+                case BodyTerm.Wild => Some(VarSym.VarSym("_"))
+                case _             => None
+            })
+
+    ///
+    /// Register the values new values of `varNames` to be `matchedFacts`.
+    ///
+    /// Concretely, we update the `varSymToVal` to contain `varNames[i] => matchedFacts[i]`.
+    ///
+    def registerVars(
+        varNames: Vector[VarSym],
+        matchedFact: Vector[Boxed],
+        varSymToVal: Map[VarSym, Boxed]
+    ): Map[VarSym, Boxed] = region rc {
+        let result = Map.toMutMap(rc, varSymToVal);
+        foreach ((i, v) <- ForEach.withIndex(varNames)) {
+            MutMap.put(v, Vector.get(i, matchedFact), result)
+        };
+        MutMap.toMap(result)
+    }
+
+    ///
+    /// Returns true if all guards are satisfied by the current variable assignment.
+    ///
+    def areGuardsSatisfied(guards: Vector[BodyPredicate], varSymToVal: Map[VarSym, Boxed]): Bool = {
+        guards |>
+            Vector.forAll(guard -> match guard {
+                case BodyPredicate.Guard1(f, v1)                 => f(getVal(v1, varSymToVal))
+                case BodyPredicate.Guard2(f, v1, v2)             => f(getVal(v1, varSymToVal), getVal(v2, varSymToVal))
+                case BodyPredicate.Guard3(f, v1, v2, v3)         => f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal))
+                case BodyPredicate.Guard4(f, v1, v2, v3, v4)     => f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal), getVal(v4, varSymToVal))
+                case BodyPredicate.Guard5(f, v1, v2, v3, v4, v5) => f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal), getVal(v4, varSymToVal), getVal(v5, varSymToVal))
+                case _                                           => unreachable!()
+            })
+    }
+
+    ///
+    /// Returns true if all head applications are satisfied by the current variable assignment.
+    ///
+    def areHeadApplicationsSatisfied(headApps: Vector[(HeadTerm, Boxed)], varSymToVal: Map[VarSym, Boxed]): Bool = {
+        headApps |>
+            Vector.forAll(match (app, val) -> match app {
+                case (HeadTerm.App1(f, v1))                 => val == f(getVal(v1, varSymToVal))
+                case (HeadTerm.App2(f, v1, v2))             => val == f(getVal(v1, varSymToVal), getVal(v2, varSymToVal))
+                case (HeadTerm.App3(f, v1, v2, v3))         => val == f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal))
+                case (HeadTerm.App4(f, v1, v2, v3, v4))     => val == f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal), getVal(v4, varSymToVal))
+                case (HeadTerm.App5(f, v1, v2, v3, v4, v5)) => val == f(getVal(v1, varSymToVal), getVal(v2, varSymToVal), getVal(v3, varSymToVal), getVal(v4, varSymToVal), getVal(v5, varSymToVal))
+                case _ => unreachable!()
+            })
     }
 
     ///


### PR DESCRIPTION
Progress towards #11416.
Follow up questions:
1. Do we want to further extract `loop` from `getMatchingBody`? It will need quite a lot of constant parameters...
2. Do we want to extract handling of `case BodyPredicate.BodyAtom(pred, _, Polarity.Positive, _, expected)`?
3. Do we want to extract handling of `case BodyPredicate.BodyAtom(pred, _, Polarity.Negative, _, expected)`?