### PR TITLE
chore: make `#| A() |#` illegal

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -677,6 +677,24 @@ object WeederError {
   }
 
   /**
+    * An error raised to indicate illegal syntax: empty argument list of predicate.
+    *
+    * @param loc the location where the error occurs.
+    */
+  case class IllegalEmptyPredicateArgument(loc: SourceLocation) extends WeederError {
+    def summary: String = "Illegal syntax: empty argument list of predicate."
+
+    def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Illegal syntax: empty argument list of predicate..
+         |
+         |${code(loc, "empty argument list of predicate")}
+         |
+         |""".stripMargin
+    }
+  }
+
+  /**
     * An error raised to indicate an illegal trait constraint parameter.
     *
     * @param loc the location where the error occurred.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -3575,17 +3575,22 @@ object Parser2 {
         arguments()
         close(mark, TreeKind.Type.PredicateWithAlias)
       } else {
-        zeroOrMore(
-          namedTokenSet = NamedTokenSet.Type,
-          getItem = () => ttype(),
-          checkForItem = _.isFirstType,
-          breakWhen = _.isRecoverType,
-          optionallyWith = Some((TokenKind.Semi, () => {
-            val mark = open()
-            ttype()
-            close(mark, TreeKind.Predicate.LatticeTerm)
-          }))
-        )
+
+        if(at(TokenKind.ParenL)) {
+          val argMark = open()
+          zeroOrMore(
+            namedTokenSet = NamedTokenSet.Type,
+            getItem = () => ttype(),
+            checkForItem = _.isFirstType,
+            breakWhen = _.isRecoverType,
+            optionallyWith = Some((TokenKind.Semi, () => {
+              val mark = open()
+              ttype()
+              close(mark, TreeKind.Predicate.LatticeTerm)
+            }))
+          )
+          close(argMark, TreeKind.Type.ArgumentList)
+        }
         close(mark, TreeKind.Type.PredicateWithTypes)
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3013,7 +3013,8 @@ object Weeder2 {
               pickAll(TreeKind.Type.Type, typeTree) match {
                 case Nil =>
                   val error = IllegalEmptyPredicateArgument(typeTree.loc)
-                  Failure(error)
+                  sctx.errors.add(error)
+                  Success(Type.Error(typeTree.loc))
                 case types =>
                   val maybeLatTerm = tryPick(TreeKind.Predicate.LatticeTerm, typeTree)
                   mapN(pickQName(tree), traverse(types)(Types.visitType), traverseOpt(maybeLatTerm)(Types.pickType)) {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -640,7 +640,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
   test("BadType.04") {
     val input =
       """
-        |def foo(): #{ Node() | = ???
+        |def foo(): #{ Node | = ???
         |def main(): Unit = ()
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -268,6 +268,32 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalAnnotation](result)
   }
 
+  test("IllegalEmptyPredicateArgument.01") {
+    val input =
+      """
+        |def a() : #| A() |# = xvar A
+        |
+        |@test
+        |def main3438472856(): Unit = let _ = a(); ()
+        |
+        """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEmptyPredicateArgument](result)
+  }
+
+  test("IllegalEmptyPredicateArgument.02") {
+    val input =
+      """
+        |def a() : #{ A() }# = #{}
+        |
+        |@test
+        |def main3438472856(): Unit = let _ = a(); ()
+        |
+        """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEmptyPredicateArgument](result)
+  }
+
   test("IllegalEnum.01") {
     val input =
       """

--- a/main/test/flix/Test.Exp.Fixpoint.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.flix
@@ -26,20 +26,20 @@ mod Test.Exp.Fixpoint {
 
     def _testOpenSchema01(p1: #{}): #{ | r} = p1
 
-    def _testOpenSchema02(p1: #{A()}): #{A() | r} = p1
+    def _testOpenSchema02(p1: #{A}): #{A | r} = p1
 
-    def _testOpenSchema03(p1: #{A(), B()}): #{A(), B() | r} = p1
+    def _testOpenSchema03(p1: #{A, B}): #{A, B | r} = p1
 
-    def _testOpenSchema04(p1: #{}, p2: #{A()}): #{A() | r} = p1 <+> p2
+    def _testOpenSchema04(p1: #{}, p2: #{A}): #{A | r} = p1 <+> p2
 
-    def _testOpenSchema05(p1: #{A()}, p2: #{}): #{A() | r} = p1 <+> p2
+    def _testOpenSchema05(p1: #{A}, p2: #{}): #{A | r} = p1 <+> p2
 
-    def _testOpenSchema06(p1: #{A()}, p2: #{B()}): #{A(), B() | r} = p1 <+> p2
+    def _testOpenSchema06(p1: #{A}, p2: #{B}): #{A, B | r} = p1 <+> p2
 
-    def _testOpenSchema07(p1: #{A()}, p2: #{B()}): #{B(), A() | r} = p1 <+> p2
+    def _testOpenSchema07(p1: #{A}, p2: #{B}): #{B, A | r} = p1 <+> p2
 
-    def _testOpenSchema08(p1: #{A(), B()}, p2: #{B(), C()}): #{A(), B(), C() | r} = p1 <+> p2
+    def _testOpenSchema08(p1: #{A, B}, p2: #{B, C}): #{A, B, C | r} = p1 <+> p2
 
-    def _testOpenSchema09(p1: #{A(), B()}, p2: #{B(), C()}): #{C(), B(), A() | r} = p1 <+> p2
+    def _testOpenSchema09(p1: #{A, B}, p2: #{B, C}): #{C, B, A | r} = p1 <+> p2
 
 }

--- a/main/test/flix/Test.Stratification.flix
+++ b/main/test/flix/Test.Stratification.flix
@@ -69,7 +69,7 @@ mod Test.Stratification {
         }
 
         @test
-        def test0NonRecursiveStratification07(): #{ A007(Int32), N007() } = solve #{
+        def test0NonRecursiveStratification07(): #{ A007(Int32), N007 } = solve #{
             A007(1).
             A007(2).
             A007(3).
@@ -79,7 +79,7 @@ mod Test.Stratification {
         }
 
         @test
-        def test0NonRecursiveStratification08(): #{ A008(Int32), B008(Int32), N008() } = solve #{
+        def test0NonRecursiveStratification08(): #{ A008(Int32), B008(Int32), N008 } = solve #{
             A008(1). A008(2).
             B008(1). B008(2).
             N008() :- not A008(1), not B008(1).


### PR DESCRIPTION
This makes `#| A() |#` and `#{ A() }#` (as a type) illegal following discussion on #11411.

I'm unsure how this could be made nicer. Currently the program
```
def main() : #| A(2) |# = xvar A
```
reports
```
Illegal syntax: empty argument list of predicate.(Syntax Error)
Expected <type> before LiteralInt.(Parse Error (Unknown))
```
Also as long as the error is getting thrown linting seems to halt here...