### PR TITLE
fix: allow nullary predicates in `pquery`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1814,7 +1814,7 @@ object Lowering {
     */
   private def termTypesOfRelation(rel: Type, loc: SourceLocation): List[Type] = {
     def f(rel0: Type, loc0: SourceLocation): List[Type] = rel0 match {
-      case Type.Apply(Type.Cst(TypeConstructor.Relation(_), _), t, _) => t :: Nil
+      case Type.Cst(TypeConstructor.Relation(_), _) => Nil
       case Type.Apply(rest, t, loc1) => t :: f(rest, loc1)
       case t => throw InternalCompilerException(s"Expected Type.Apply(_, _, _), but got ${t}", loc0)
     }

--- a/main/test/flix/Test.Exp.Fixpoint.PQuery.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.PQuery.flix
@@ -84,6 +84,14 @@ mod Test.Exp.Fixpoint.PQuery {
         let pp = pquery pr select A((1, 2)) with {A};
         Vector.map(v -> ematch v { case A(x) => x }, pp) `Assert.eq` Vector#{(1, 2)}
 
+    @Test
+    def testPQueryNullary(): Bool =
+        let pr = #{
+            A.
+        };
+        let pp = pquery pr select A with {A};
+        Vector.map(v -> ematch v { case A => 42 }, pp) `Assert.eq` Vector#{42}
+
     ///////////////////////////////////////////////////////////////////////////
     // Provenance at depth 2
     ///////////////////////////////////////////////////////////////////////////
@@ -187,6 +195,16 @@ mod Test.Exp.Fixpoint.PQuery {
         };
         let pp = pquery pr select R((1, 2)) with {A};
         Vector.map(v -> ematch v { case A(x) => x }, pp) `Assert.eq` Vector#{(1, 2), (1, 2)}
+
+    @Test
+    def testPQueryDepth2Nullary(): Bool =
+        let pr = #{
+            A.
+            B :- A.
+            R :- B, B.
+        };
+        let pp = pquery pr select R with {A};
+        Vector.map(v -> ematch v { case A => 42 }, pp) `Assert.eq` Vector#{42, 42}
 
     ///////////////////////////////////////////////////////////////////////////
     // Provenance for cycles


### PR DESCRIPTION
Fixes #11284 (I think)