### PR TITLE
refactor: remove CPS from simple left-to-right List folds

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -419,13 +419,13 @@ mod List {
     /// That is, the result is of the form: `f(x1, 0) :: f(x2, 1) :: ...`.
     ///
     pub def mapWithIndex(f: (Int32, a) -> b \ ef, l: List[a]): List[b] \ ef =
-        def loop(ll, i, k) = match ll {
-            case Nil     => k(Nil)
+        def loop(ll, i, acc) = match ll {
+            case Nil     => acc
             case x :: xs =>
                 let y = f(i, x);
-                loop(xs, i + 1, ys -> k(y :: ys))
+                loop(xs, i + 1, y :: acc)
         };
-        loop(l, 0, identity)
+        reverse(loop(l, 0, Nil))
 
     ///
     /// Returns the result of applying `f` to every element in `l` and concatenating the results.
@@ -798,11 +798,11 @@ mod List {
     /// Returns a list of every element in `l` that satisfies the predicate `f`.
     ///
     pub def filter(f: a -> Bool \ ef, l: List[a]): List[a] \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k(Nil)
-            case x :: xs => if (f(x)) loop(xs, ks -> k(x :: ks)) else loop(xs, k)
+        def loop(ll, acc) = match ll {
+            case Nil     => acc
+            case x :: xs => if (f(x)) loop(xs, x :: acc) else loop(xs, acc)
         };
-        loop(l, identity)
+        reverse(loop(l, Nil))
 
     ///
     /// Returns the sublist of `l` without the last element.
@@ -845,15 +845,16 @@ mod List {
     /// `l2` contains all elements of `l` that do not satisfy the predicate `f`.
     ///
     pub def partition(f: a -> Bool \ ef, l: List[a]): (List[a], List[a]) \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k((Nil, Nil))
+        def loop(ll, acc1, acc2) = match ll {
+            case Nil     => (acc1, acc2)
             case x :: xs =>
                 if (f(x))
-                    loop(xs, match (ks, ls) -> k((x :: ks, ls)))
+                    loop(xs, x :: acc1, acc2)
                 else
-                    loop(xs, match (ks, ls) -> k((ks, x :: ls)))
+                    loop(xs, acc1, x :: acc2)
         };
-        loop(l, identity)
+        let (l1, l2) = loop(l, Nil, Nil);
+        (reverse(l1), reverse(l2))
 
     ///
     /// Returns a pair of lists `(l1, l2)`.
@@ -864,15 +865,16 @@ mod List {
     /// The function `f` must be pure.
     ///
     pub def span(f: a -> Bool, l: List[a]): (List[a], List[a]) =
-        def loop(ll, k) = match ll {
-            case Nil     => k((Nil, Nil))
+        def loop(ll, acc) = match ll {
+            case Nil     => (acc, Nil)
             case x :: xs =>
                 if (f(x))
-                    loop(xs, match (ks, ls) -> k((x :: ks, ls)))
+                    loop(xs, x :: acc)
                 else
-                    k((Nil, ll))
+                    (acc, ll)
         };
-        loop(l, identity)
+        let (l1, l2) = loop(l, Nil);
+        (reverse(l1), l2)
 
     ///
     /// Returns `l` without the first `n` elements.
@@ -915,11 +917,11 @@ mod List {
     /// Returns the longest prefix of `l` that satisfies the predicate `f`.
     ///
     pub def takeWhile(f: a -> Bool \ ef, l: List[a]): List[a] \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k(Nil)
-            case x :: xs => if (f(x)) loop(xs, ks -> k(x :: ks)) else k(Nil)
+        def loop(ll, acc) = match ll {
+            case Nil     => acc
+            case x :: xs => if (f(x)) loop(xs, x :: acc) else acc
         };
-        loop(l, identity)
+        reverse(loop(l, Nil))
 
     ///
     /// Split the list `xs` at the position `n` returning the left and right parts.
@@ -990,13 +992,13 @@ mod List {
     /// If either `l1` or `l2` becomes depleted, then no further elements are added to the resulting list.
     ///
     pub def zipWith(f: (a, b) -> c \ ef, l1: List[a], l2: List[b]): List[c] \ ef =
-        def loop(ll1, ll2, k) = match (ll1, ll2) {
+        def loop(ll1, ll2, acc) = match (ll1, ll2) {
             case (x :: xs, y :: ys) =>
                 let z = f(x, y);
-                loop(xs, ys, ks -> k(z :: ks))
-            case _ => k(Nil)
+                loop(xs, ys, z :: acc)
+            case _ => acc
         };
-        loop(l1, l2, identity)
+        reverse(loop(l1, l2, Nil))
 
     ///
     /// Returns a list where each element `e` is mapped to `(i, e)` where `i`
@@ -1051,13 +1053,13 @@ mod List {
     /// If any one of `l1`, `l2` or `l3` become depleted, then no further elements are added to the resulting list.
     ///
     pub def zipWith3(f: (a, b, c) -> d \ ef, l1: List[a], l2: List[b], l3: List[c]): List[d] \ ef =
-        def loop(ll1, ll2, ll3, k) = match (ll1, ll2, ll3) {
+        def loop(ll1, ll2, ll3, acc) = match (ll1, ll2, ll3) {
             case (x :: xs, y :: ys, z :: zs) =>
                 let r = f(x, y, z);
-                loop(xs, ys, zs, ks -> k(r :: ks))
-            case _ => k(Nil)
+                loop(xs, ys, zs, r :: acc)
+            case _ => acc
         };
-        loop(l1, l2, l3, identity)
+        reverse(loop(l1, l2, l3, Nil))
 
     ///
     /// Returns a triple of lists, the first containing all first components in `l`
@@ -1108,14 +1110,14 @@ mod List {
     /// Collects the results of applying the partial function `f` to every element in `l`.
     ///
     pub def filterMap(f: a -> Option[b] \ ef, l: List[a]): List[b] \ ef =
-        def loop(ll, k) = match ll {
-            case Nil     => k(Nil)
+        def loop(ll, acc) = match ll {
+            case Nil     => acc
             case x :: xs => match f(x) {
-                case None    => loop(xs, k)
-                case Some(v) => loop(xs, ks -> k(v :: ks))
+                case None    => loop(xs, acc)
+                case Some(v) => loop(xs, v :: acc)
             }
         };
-        loop(l, identity)
+        reverse(loop(l, Nil))
 
     ///
     /// Returns the first non-None result of applying the partial function `f` to each element of `l`.
@@ -1346,15 +1348,15 @@ mod List {
     /// need a custom equality test.
     ///
     pub def distinct(l: List[a]): List[a] with Eq[a] =
-        def loop(ll1, ll2, k) = match ll1 {
-            case Nil     => k(Nil)
+        def loop(ll, acc) = match ll {
+            case Nil     => acc
             case x :: xs =>
-                if (memberOf(x, ll2))
-                    loop(xs, ll2, k)
+                if (memberOf(x, acc))
+                    loop(xs, acc)
                 else
-                    loop(xs, x :: ll2, ks -> k(x :: ks))
+                    loop(xs, x :: acc)
         };
-        loop(l, Nil, identity)
+        reverse(loop(l, Nil))
 
     ///
     /// Returns the list `l` with duplicates removed using the supplied function
@@ -1362,15 +1364,15 @@ mod List {
     /// for the removal of subsequent duplicates the order of `l` is preserved.
     ///
     pub def distinctWith(f: (a, a) -> Bool, l: List[a]): List[a] =
-        def loop(ll1, ll2, k) = match ll1 {
-            case Nil     => k(Nil)
+        def loop(ll, acc) = match ll {
+            case Nil     => acc
             case x :: xs =>
-                if (exists(f(x), ll2))
-                    loop(xs, ll2, k)
+                if (exists(f(x), acc))
+                    loop(xs, acc)
                 else
-                    loop(xs, x :: ll2, ks -> k(x :: ks))
+                    loop(xs, x :: acc)
         };
-        loop(l, Nil, identity)
+        reverse(loop(l, Nil))
 
     ///
     /// Returns the sum of all elements in the list `l`.


### PR DESCRIPTION
Fixes the simple right-to-left CPS functions from #11399

Simple here means that the loop is (mostly) of the form: `loop(restOfList, accumulatedResultToBeReversed) = ???`