### PR TITLE
refactor: remove type from `KindedAst.Enum`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -51,7 +51,7 @@ object KindedAst {
 
   case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], sc: Scheme, tpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
 
-  case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], tpe: Type, loc: SourceLocation)
+  case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], loc: SourceLocation)
 
   case class Struct(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], sc: Scheme, fields: List[StructField], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -59,21 +59,6 @@ object Deriver {
   }
 
   /**
-    * Reconstructs the type of the enum.
-    * @param sym The [[Symbol]] of the enum.
-    * @param tparams The list of [[TypeParam]] of the enum.
-    */
-  private def deriveEnumType(sym: Symbol.EnumSym, tparams: List[TypeParam]): Type = {
-    val tvars = tparams.map(tparam => Type.Var(tparam.sym, tparam.loc.asSynthetic))
-    val kinds = tvars.map(symm => symm.kind)
-//    See `Phase.Kinder.visitEnum`.
-    val kind = kinds.foldRight(Kind.Star: Kind) {
-      case (tparam, acc) => tparam ->: acc
-    }
-    Type.mkApply(Type.Cst(TypeConstructor.Enum(sym, kind), sym.loc.asSynthetic), tvars, sym.loc.asSynthetic)
-  }
-
-  /**
     * Builds the instances derived from this enum.
     */
   private def getDerivedInstances(enum0: KindedAst.Enum, root: KindedAst.Root)(implicit sctx: SharedContext, flix: Flix): List[KindedAst.Instance] = enum0 match {
@@ -135,7 +120,7 @@ object Deriver {
     case KindedAst.Enum(_, _, _, sym, tparams, _, _, _) =>
       assert(loc.isSynthetic)
 
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
 
       val eqTraitSym = PredefinedTraits.lookupTraitSym("Eq", root)
       val eqDefSym = Symbol.mkDefnSym("Eq.eq", Some(flix.genSym.freshId()))
@@ -190,7 +175,7 @@ object Deriver {
     */
   private def mkEqSpec(enum0: KindedAst.Enum, param1: Symbol.VarSym, param2: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root): KindedAst.Spec = enum0 match {
     case KindedAst.Enum(_, _, _, sym, tparams, _, _, _) =>
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
       val eqTraitSym = PredefinedTraits.lookupTraitSym("Eq", root)
       KindedAst.Spec(
         doc = Doc(Nil, loc),
@@ -296,7 +281,7 @@ object Deriver {
   private def mkOrderInstance(enum0: KindedAst.Enum, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.Instance = enum0 match {
     case KindedAst.Enum(_, _, _, sym, tparams, _, _, _) =>
       assert(loc.isSynthetic)
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
 
       val orderTraitSym = PredefinedTraits.lookupTraitSym("Order", root)
       val compareDefSym = Symbol.mkDefnSym("Order.compare", Some(flix.genSym.freshId()))
@@ -396,7 +381,7 @@ object Deriver {
     */
   private def mkCompareSpec(enum0: KindedAst.Enum, param1: Symbol.VarSym, param2: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root): KindedAst.Spec = enum0 match {
     case KindedAst.Enum(_, _, _, sym, tparams, _, _, _) =>
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
       val orderTraitSym = PredefinedTraits.lookupTraitSym("Order", root)
       val comparisonEnumSym = PredefinedTraits.lookupEnumSym("Comparison", root)
 
@@ -531,7 +516,7 @@ object Deriver {
   private def mkToStringInstance(enum0: KindedAst.Enum, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.Instance = enum0 match {
     case KindedAst.Enum(_, _, _, sym, tparams, _, _, _) =>
       assert(loc.isSynthetic)
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
 
       val toStringTraitSym = PredefinedTraits.lookupTraitSym("ToString", root)
       val toStringDefSym = Symbol.mkDefnSym("ToString.toString", Some(flix.genSym.freshId()))
@@ -581,7 +566,7 @@ object Deriver {
     */
   private def mkToStringSpec(enum0: KindedAst.Enum, param: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root): KindedAst.Spec = enum0 match {
     case KindedAst.Enum(_, _, _, sym, tparams, _, _, _) =>
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
       val toStringTraitSym = PredefinedTraits.lookupTraitSym("ToString", root)
       KindedAst.Spec(
         doc = Doc(Nil, loc),
@@ -675,7 +660,7 @@ object Deriver {
   private def mkHashInstance(enum0: KindedAst.Enum, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.Instance = enum0 match {
     case KindedAst.Enum(_, _, _, sym, tparams, _, _, _) =>
       assert(loc.isSynthetic)
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
 
       val hashTraitSym = PredefinedTraits.lookupTraitSym("Hash", root)
       val hashDefSym = Symbol.mkDefnSym("Hash.hash", Some(flix.genSym.freshId()))
@@ -726,7 +711,7 @@ object Deriver {
     */
   private def mkHashSpec(enum0: KindedAst.Enum, param: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root): KindedAst.Spec = enum0 match {
     case KindedAst.Enum(_, _, _, sym, tparams, _, _, _) =>
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
       val hashTraitSym = PredefinedTraits.lookupTraitSym("Hash", root)
       KindedAst.Spec(
         doc = Doc(Nil, loc),
@@ -815,7 +800,7 @@ object Deriver {
   private def mkCoerceInstance(enum0: KindedAst.Enum, loc: SourceLocation, root: KindedAst.Root)(implicit sctx: SharedContext, flix: Flix): Option[KindedAst.Instance] = enum0 match {
     case KindedAst.Enum(_, _, _, sym, tparams, _, cases, _) =>
       assert(loc.isSynthetic)
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
 
       if (cases.size == 1) {
         val coerceTraitSym = PredefinedTraits.lookupTraitSym("Coerce", root)
@@ -881,7 +866,7 @@ object Deriver {
     */
   private def mkCoerceSpec(enum0: KindedAst.Enum, param: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root): KindedAst.Spec = enum0 match {
     case KindedAst.Enum(_, _, _, sym, tparams, _, cases, _) =>
-      val tpe = deriveEnumType(sym, tparams)
+      val tpe = getEnumType(sym, tparams)
       val coerceTraitSym = PredefinedTraits.lookupTraitSym("Coerce", root)
       val (_, caze) = cases.head
       val retTpe = Type.mkTuplish(caze.tpes, loc)
@@ -988,6 +973,20 @@ object Deriver {
     case Nil => Nil
     case last :: Nil => last :: Nil
     case head :: neck :: tail => head :: sep :: intersperse(neck :: tail, sep)
+  }
+
+  /**
+    * Reconstructs the type of the enum.
+    * @param sym The [[Symbol]] of the enum.
+    * @param tparams The list of [[TypeParam]] of the enum.
+    */
+  private def getEnumType(sym: Symbol.EnumSym, tparams: List[TypeParam]): Type = {
+    val tvars = tparams.map(tparam => Type.Var(tparam.sym, tparam.loc.asSynthetic))
+    val kinds = tvars.map(symm => symm.kind)
+    val kind = kinds.foldRight(Kind.Star: Kind) {
+      case (kindParam, acc) => kindParam ->: acc
+    }
+    Type.mkApply(Type.Cst(TypeConstructor.Enum(sym, kind), sym.loc.asSynthetic), tvars, sym.loc.asSynthetic)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -983,9 +983,7 @@ object Deriver {
   private def getEnumType(sym: Symbol.EnumSym, tparams: List[TypeParam]): Type = {
     val tvars = tparams.map(tparam => Type.Var(tparam.sym, tparam.loc.asSynthetic))
     val kinds = tvars.map(symm => symm.kind)
-    val kind = kinds.foldRight(Kind.Star: Kind) {
-      case (kindParam, acc) => kindParam ->: acc
-    }
+    val kind = Kind.mkArrow(kinds)
     Type.mkApply(Type.Cst(TypeConstructor.Enum(sym, kind), sym.loc.asSynthetic), tvars, sym.loc.asSynthetic)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -101,7 +101,7 @@ object Kinder {
       val targs = tparams.map(tparam => Type.Var(tparam.sym, tparam.loc.asSynthetic))
       val t = Type.mkApply(Type.Cst(TypeConstructor.Enum(sym, getEnumKind(enum0)), sym.loc.asSynthetic), targs, sym.loc.asSynthetic)
       val cases = cases0.map(visitCase(_, tparams, t, kenv, root)).map(caze => caze.sym -> caze).toMap
-      KindedAst.Enum(doc, ann, mod, sym, tparams, derives, cases, t, loc)
+      KindedAst.Enum(doc, ann, mod, sym, tparams, derives, cases, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -300,7 +300,7 @@ object Typer {
     * Reconstructs types in the given enum.
     */
   private def visitEnum(enum0: KindedAst.Enum): TypedAst.Enum = enum0 match {
-    case KindedAst.Enum(doc, ann, mod, enumSym, tparams0, derives, cases0, _, loc) =>
+    case KindedAst.Enum(doc, ann, mod, enumSym, tparams0, derives, cases0, loc) =>
       val tparams = tparams0.map(visitTypeParam)
       val cases = MapOps.mapValues(cases0) {
         case KindedAst.Case(caseSym, tagTypes, sc, caseLoc) =>


### PR DESCRIPTION
Closes #8720.

Removes `tpe: Type` from `KindedAst.Enum` and instead reconstruct it as needed in `Deriver`.

Also as a side note: What is `ResolvedAst.TypeParam.Implicit` and why can it occur in `Enum`?