### PR TITLE
ci: trim community builds

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -40,16 +40,11 @@ jobs:
       max-parallel: 1
       matrix:
         repo:
-          - "JonathanStarup/Flix-ANSI-Terminal"
           - "JonathanStarup/ListSet"
           - "JonathanStarup/talpin1992-in-flix"
-          - "flix/museum"
-          - "jaschdoc/flix-parsers"
           - "mlutze/flix-json"
           - "mlutze/flixball"
           - "rywiese/scope-graphs"
-          - "stephentetley/charset-locale"
-          - "stephentetley/flix-either"
           - "stephentetley/flix-htmldoc"
           - "stephentetley/flix-pretty"
     runs-on: ubuntu-latest


### PR DESCRIPTION
I am removing community builds that are small. 

I think apps should be at least 500 lines of non-trival code whereas reusable libraries can be a bit smaller. 