### PR TITLE
feat: better number parsing

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -26,27 +26,6 @@ sealed trait LexerError extends CompilationMessage {
 object LexerError {
 
   /**
-    * An error raised when more than one decimal dot is found in a number.
-    * For instance `123.456.78f32`.
-    *
-    * @param loc The location of the double dotted number literal.
-    */
-  case class DoubleDottedNumber(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Number has two decimal dots."
-
-    override def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> Number has two decimal dots.
-         |
-         |${code(loc, "Second decimal dot is here.")}
-         |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
     * An error raised when a period has whitespace before it.
     * This is problematic because we want to disallow tokens like: "Rectangle   .Shape".
     *
@@ -65,6 +44,24 @@ object LexerError {
     }
 
     override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+    * An error raised when a hexadecimal number suffix is unrecognized.
+    */
+  case class IncorrectHexNumberSuffix(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Incorrect hexadecimal number suffix."
+
+    override def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Incorrect hexadecimal number suffix.
+         |
+         |${code(loc, "Here")}
+         |
+         |Hexadecimal number suffixes are i8, i16, i32, i64, and ii.
+         |
+         |""".stripMargin
+    }
   }
 
   /**
@@ -104,18 +101,16 @@ object LexerError {
   }
 
   /**
-    * An error raised when a hexadecimal number suffix is unrecognized.
+    * An error raised when a hexadecimal number is malformed.
     */
-  case class IncorrectHexNumberSuffix(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Incorrect hexadecimal number suffix."
+  case class MalformedHexNumber(found: String, loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Malformed hexadecimal number, found '$found'."
 
     override def message(formatter: Formatter): String = {
       import formatter.*
-      s""">> Incorrect hexadecimal number suffix.
+      s""">> Malformed hexadecimal number, found '$found'.
          |
-         |${code(loc, "Here")}
-         |
-         |Hexadecimal number suffixes are i8, i16, i32, i64, and ii.
+         |${code(loc, "Number was correct up to here")}
          |
          |""".stripMargin
     }
@@ -130,22 +125,6 @@ object LexerError {
     override def message(formatter: Formatter): String = {
       import formatter.*
       s""">> Malformed number, found '$found'.
-         |
-         |${code(loc, "Number was correct up to here")}
-         |
-         |""".stripMargin
-    }
-  }
-
-  /**
-    * An error raised when a hexadecimal number is malformed.
-    */
-  case class MalformedHexNumber(found: String, loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Malformed hexadecimal number, found '$found'."
-
-    override def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> Malformed hexadecimal number, found '$found'.
          |
          |${code(loc, "Number was correct up to here")}
          |
@@ -254,7 +233,10 @@ object LexerError {
     override def explain(formatter: Formatter): Option[String] = None
   }
 
-  case class MissingDigit(loc: SourceLocation) extends LexerError {
+  /**
+    * An error raised when a digit is expected in a number (e.g. `1.` or `1.2e`).
+    */
+  case class ExpectedDigit(loc: SourceLocation) extends LexerError {
     override def summary: String = s"A digit (0-9) is expected here."
 
     override def message(formatter: Formatter): String = {

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -47,46 +47,6 @@ object LexerError {
   }
 
   /**
-    * An error raised when more than one `e` (used for scientific notation) is found in a number.
-    *
-    * @param loc The location of the double e number literal.
-    */
-  case class DoubleEInNumber(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Number has two scientific notation indicators."
-
-    override def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> Number has two scientific notation indicators.
-         |
-         |${code(loc, "Second 'e' is here.")}
-         |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised when a number contains a sequence of underscores.
-    *
-    * @param loc The location of the number literal.
-    */
-  case class DoubleUnderscoreInNumber(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Number has sequence of '_'"
-
-    override def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> Number has sequence of '_'.
-         |
-         |${code(loc, "Ending here")}
-         |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
     * An error raised when a period has whitespace before it.
     * This is problematic because we want to disallow tokens like: "Rectangle   .Shape".
     *
@@ -108,6 +68,42 @@ object LexerError {
   }
 
   /**
+    * An error raised when a number suffix is unrecognized.
+    */
+  case class IncorrectNumberSuffix(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Incorrect number suffix."
+
+    override def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Incorrect number suffix.
+         |
+         |${code(loc, "Here")}
+         |
+         |Number suffixes are i8, i16, i32, i64, ii, f32, f64, and ff.
+         |
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * An error raised when an integer suffix is put on a decimal number.
+    */
+  case class IntegerSuffixOnFloat(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"A decimal number cannot have integer suffix."
+
+    override def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> A decimal number cannot have integer suffix.
+         |
+         |${code(loc, "Here")}
+         |
+         |Float suffixes are f32, f64, and ff.
+         |
+         |""".stripMargin
+    }
+  }
+
+  /**
     * An error raised when a hexadecimal number suffix is unrecognized.
     */
   case class IncorrectHexNumberSuffix(loc: SourceLocation) extends LexerError {
@@ -120,6 +116,22 @@ object LexerError {
          |${code(loc, "Here")}
          |
          |Hexadecimal number suffixes are i8, i16, i32, i64, and ii.
+         |
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * An error raised when a number is malformed.
+    */
+  case class MalformedNumber(found: String, loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Malformed number, found '$found'."
+
+    override def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Malformed number, found '$found'.
+         |
+         |${code(loc, "Number was correct up to here")}
          |
          |""".stripMargin
     }
@@ -139,26 +151,6 @@ object LexerError {
          |
          |""".stripMargin
     }
-  }
-
-  /**
-    * An error raised when a number ends on an underscore.
-    *
-    * @param loc The location of the number literal.
-    */
-  case class TrailingUnderscoreInNumber(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Number ends on a '_'."
-
-    override def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> Number ends on a '_'.
-         |
-         |${code(loc, "Here")}
-         |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -260,6 +252,18 @@ object LexerError {
     }
 
     override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  case class MissingDigit(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"A digit (0-9) is expected here."
+
+    override def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> A digit (0-9) is expected here.
+         |
+         |${code(loc, "Here")}
+         |""".stripMargin
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -845,7 +845,7 @@ object Lexer {
     * * It is optional to have a trailing type indicator on number literals.
     * * If it is missing Flix defaults to `f64` for decimals and `i32` for integers.
     *
-    * A number is accepted by `\D([.]\D)?(e\D([.]\D)?)?(i8|i16|i32|i64|ii|f32|f64|ff)?` where `\D = [0-9]+(_[0-9]+)*`.
+    * A number is accepted by `\D([.]\D)?(e([+]|[-])?\D([.]\D)?)?(i8|i16|i32|i64|ii|f32|f64|ff)?` where `\D = [0-9]+(_[0-9]+)*`.
     *
     * Note that any characters in `[0-9a-zA-Z_.]` following a number should be treated as an error
     * * part of the same number, e.g., `32q` should be parsed as a single wrong number, and not a
@@ -858,7 +858,7 @@ object Lexer {
     // N.B.: an initial \d has already been consumed before this function, so its actually '[0-9]*(_[0-9]+)*'.
     s.sc.advanceWhile(_.isDigit)
     while(s.sc.advanceIfMatch('_')) {
-      if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.MissingDigit(sourceLocationAtCurrent()))
+      if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
     }
 
     // Consume a '([.]\D)?' string.
@@ -866,20 +866,24 @@ object Lexer {
       mustBeFloat = true
 
       // Consume a '\D' string.
-      if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.MissingDigit(sourceLocationAtCurrent()))
+      if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
       while(s.sc.advanceIfMatch('_')) {
-        if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.MissingDigit(sourceLocationAtCurrent()))
+        if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
       }
     }
 
     // Consume a '(e\D([.]\D)?)?' string.
     if (s.sc.advanceIfMatch('e')) {
       mustBeFloat = true
+      // Consume a '([+]|[-])?' string.
+      if (!s.sc.advanceIfMatch('+')) {
+        s.sc.advanceIfMatch('-')
+      }
 
       // Consume a '\D' string.
-      if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.MissingDigit(sourceLocationAtCurrent()))
+      if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
       while(s.sc.advanceIfMatch('_')) {
-        if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.MissingDigit(sourceLocationAtCurrent()))
+        if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
       }
 
       // Consume a '(.\D)?' string.
@@ -887,9 +891,9 @@ object Lexer {
         mustBeFloat = true
 
         // Consume a '\D' string.
-        if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.MissingDigit(sourceLocationAtCurrent()))
+        if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
         while(s.sc.advanceIfMatch('_')) {
-          if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.MissingDigit(sourceLocationAtCurrent()))
+          if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
         }
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -858,11 +858,17 @@ object Lexer {
   private def acceptNumber()(implicit s: State): TokenKind = {
     var mustBeFloat = false
 
+    /** Consumes digits and returns `true` if any were found.  */
+    def acceptDigits(): Boolean = s.sc.advanceWhileWithCount(_.isDigit) > 0
+
+    /** Returns an error token indicating a missing digit. */
+    def expectDigitError(): TokenKind = wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
+
     // Consume a '\D' string.
     // N.B.: an initial \d has already been consumed before this function, so its actually '[0-9]*(_[0-9]+)*'.
     s.sc.advanceWhile(_.isDigit)
     while(s.sc.advanceIfMatch('_')) {
-      if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
+      if (!acceptDigits()) return expectDigitError()
     }
 
     // Consume a '([.]\D)?' string.
@@ -870,9 +876,9 @@ object Lexer {
       mustBeFloat = true
 
       // Consume a '\D' string.
-      if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
+      if (!acceptDigits()) return expectDigitError()
       while(s.sc.advanceIfMatch('_')) {
-        if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
+        if (!acceptDigits()) return expectDigitError()
       }
     }
 
@@ -885,9 +891,9 @@ object Lexer {
       }
 
       // Consume a '\D' string.
-      if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
+      if (!acceptDigits()) return expectDigitError()
       while(s.sc.advanceIfMatch('_')) {
-        if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
+        if (!acceptDigits()) return expectDigitError()
       }
 
       // Consume a '(.\D)?' string.
@@ -895,9 +901,9 @@ object Lexer {
         mustBeFloat = true
 
         // Consume a '\D' string.
-        if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
+        if (!acceptDigits()) return expectDigitError()
         while(s.sc.advanceIfMatch('_')) {
-          if (s.sc.advanceWhileWithCount(_.isDigit) == 0) return wrapAndConsume(LexerError.ExpectedDigit(sourceLocationAtCurrent()))
+          if (!acceptDigits()) return expectDigitError()
         }
       }
     }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
@@ -19,25 +19,61 @@ class TestLexer extends AnyFunSuite with TestUtils {
     expectError[LexerError.MalformedNumber](result)
   }
 
-  test("LexerError.MissingDigit.01") {
+  test("LexerError.MalformedNumber.03") {
+    val input = "1i32A"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.MalformedNumber](result)
+  }
+
+  test("LexerError.MalformedNumber.04") {
+    val input = "1x"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.MalformedNumber](result)
+  }
+
+  test("LexerError.IncorrectNumberSuffix.01") {
+    val input = "1_2i3"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.IncorrectNumberSuffix](result)
+  }
+
+  test("LexerError.IncorrectNumberSuffix.02") {
+    val input = "3.1_2e-23f223"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.IncorrectNumberSuffix](result)
+  }
+
+  test("LexerError.IntegerSuffixOnFloat.01") {
+    val input = "1_000.00_01i32"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.IntegerSuffixOnFloat](result)
+  }
+
+  test("LexerError.IntegerSuffixOnFloat.02") {
+    val input = "1e32i32"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.IntegerSuffixOnFloat](result)
+  }
+
+  test("LexerError.ExpectedDigit.01") {
     val input = "12..3"
     val result = compile(input, Options.TestWithLibNix)
     expectError[LexerError.ExpectedDigit](result)
   }
 
-  test("LexerError.MissingDigit.02") {
+  test("LexerError.ExpectedDigit.02") {
     val input = "123.."
     val result = compile(input, Options.TestWithLibNix)
     expectError[LexerError.ExpectedDigit](result)
   }
 
-  test("LexerError.MissingDigit.03") {
+  test("LexerError.ExpectedDigit.03") {
     val input = "123..32f32"
     val result = compile(input, Options.TestWithLibNix)
     expectError[LexerError.ExpectedDigit](result)
   }
 
-  test("LexerError.MissingDigit.04") {
+  test("LexerError.ExpectedDigit.04") {
     val input = "12332..f32"
     val result = compile(input, Options.TestWithLibNix)
     expectError[LexerError.ExpectedDigit](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
@@ -20,7 +20,7 @@ class TestLexer extends AnyFunSuite with TestUtils {
   }
 
   test("LexerError.MalformedNumber.03") {
-    val input = "1i32A"
+    val input = "1e32A"
     val result = compile(input, Options.TestWithLibNix)
     expectError[LexerError.MalformedNumber](result)
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
@@ -7,37 +7,41 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class TestLexer extends AnyFunSuite with TestUtils {
 
-  test("LexerError.DoubleDottedNumber.01") {
+  test("LexerError.MalformedNumber.01") {
     val input = "1.2.3"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.DoubleDottedNumber](result)
+    expectError[LexerError.MalformedNumber](result)
   }
 
-  test("LexerError.DoubleDottedNumber.02") {
+  test("LexerError.MalformedNumber.02") {
+    val input = "1.2e1e2"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.MalformedNumber](result)
+  }
+
+  test("LexerError.MissingDigit.01") {
     val input = "12..3"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.DoubleDottedNumber](result)
+    expectError[LexerError.ExpectedDigit](result)
   }
 
-  test("LexerError.DoubleDottedNumber.03") {
+  test("LexerError.MissingDigit.02") {
     val input = "123.."
     val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.DoubleDottedNumber](result)
+    expectError[LexerError.ExpectedDigit](result)
   }
 
-  test("LexerError.DoubleDottedNumber.04") {
+  test("LexerError.MissingDigit.03") {
     val input = "123..32f32"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.DoubleDottedNumber](result)
+    expectError[LexerError.ExpectedDigit](result)
   }
 
-  test("LexerError.DoubleDottedNumber.05") {
+  test("LexerError.MissingDigit.04") {
     val input = "12332..f32"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.DoubleDottedNumber](result)
+    expectError[LexerError.ExpectedDigit](result)
   }
-
-  // DoubleEInNumber
 
   test("LexerError.StringInterpolationTooDeep.01") {
     val input = """ "${"${"${"${"${"${"${"${"${"${"${"${"${"${"${${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}}"}"}"}"}"}"}"}"}"}"}"}"}"}"}" """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1051,18 +1051,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.InlineAndDontInline](result)
   }
 
-  test("MalformedFloat64.01") {
-    val input = "def f(): Float64 = 1.7976931348623158e+308"
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedFloat](result)
-  }
-
-  test("MalformedFloat64.02") {
-    val input = "def f(): Float64 = -1.7976931348623158e+308"
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedFloat](result)
-  }
-
   // This is supposed to check that the identifier does not include '$'.
   // But since a user defined operation like '<$>' is perfectly valid,
   // checking the identifier becomes tricky,


### PR DESCRIPTION
- [Fix] Treats e.g. `42i32x` as a single wrong number (previously int `42i32` and variable `x`)
- [Fix] Allows `12e+12`.
- [Feat] Errors are better
  - `32i31` says that `i31` is an invalid suffix (previously "Undefined name 'i31'")
  - `12e12e` says that a digit was expected instead of `e` (second occurrence) (previously "malformed float")
  - `12.4i32` says that decimals cannot have integer suffixes (previously "malformed float")
- [Test] More tests
- [Docs] Documented a regex describing valid numbers.
- [Refactor] The regex based function makes it easier to read
- [Performance] `--Xbenchmark-phases`
  - `    PR: 164,5 ms (07,2%)` 
  - `Master: 165,6 ms (07,2%)`

Follow up work: sort `LexerError` and `TestLexer`