### PR TITLE
refactor: clean up `EntryPoints`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -29,7 +29,7 @@ sealed trait Symbol
 object Symbol {
 
   /**
-    * The Assert effect
+    * The Assert effect.
     */
   val Assert: EffSym = mkEffSym(Name.RootNS, Ident("Assert", SourceLocation.Unknown))
 

--- a/main/src/ca/uwaterloo/flix/util/collection/CofiniteSet.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/CofiniteSet.scala
@@ -50,6 +50,12 @@ sealed trait CofiniteSet[T] {
     case Compl(s) => s.isEmpty
   }
 
+  /** Returns `true` if `this` contains `x`. */
+  def contains(x: T): Boolean = this match {
+    case Set(s) => s.contains(x)
+    case Compl(s) => !s.contains(x)
+  }
+
 }
 
 object CofiniteSet {


### PR DESCRIPTION
- [Fix] made `hasAssert` sound.
- [Refactor] reduced subset code duplication.
- [Refactor] removed "always Nil" return value from `WrapMain`
- [Style] fixed formatting inconsistencies.