### PR TITLE
fix: use less fuel when handling records

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -282,10 +282,6 @@ object SyntaxTree {
 
       case object LiteralMapKeyValueFragment extends Expr
 
-      case object LiteralRecord extends Expr
-
-      case object LiteralRecordFieldFragment extends Expr
-
       case object LiteralStructFieldFragment extends Expr
 
       case object LiteralSet extends Expr

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -617,6 +617,26 @@ object WeederError {
   }
 
   /**
+    * An error raised to indicate that a record literal contained an operation.
+    *
+    * @param loc the location where the error occurred.
+    */
+  case class IllegalRecordOperation(loc: SourceLocation) extends WeederError {
+    override def summary: String = "Illegal record extension in record literal"
+
+    override def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Illegal record extension in record literal.
+         |
+         |${code(loc, "A record literal may not contain record extensions or restrictions.")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
     * An error raised to indicate an illegal regex pattern.
     *
     * @param loc the location where the illegal regex pattern occurs.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1992,7 +1992,7 @@ object Parser2 {
       val mark = open()
       expect(TokenKind.CurlyL)
       if (eat(TokenKind.CurlyR)) { // Handle an empty block.
-        return close(mark, TreeKind.Expr.LiteralRecord)
+        return close(mark, TreeKind.Expr.RecordOperation)
       }
       statement()
       expect(TokenKind.CurlyR)
@@ -2300,67 +2300,10 @@ object Parser2 {
              | (TokenKind.NameLowerCase, TokenKind.Equal)
              | (TokenKind.Plus, TokenKind.NameLowerCase)
              | (TokenKind.Minus, TokenKind.NameLowerCase) =>
-          // Now check for record operation or record literal,
-          // by looking for a '|' before the closing '}'.
-//          val isRecordOp = {
-//            val tokensLeft = s.tokens.length - s.position
-//            var lookahead = 1
-//            var nestingLevel = 0
-//            var isRecordOp = false
-//            var continue = true
-//            while (continue && lookahead < tokensLeft) {
-//              nth(lookahead) match {
-//                // Found closing '}' so stop seeking.
-//                case TokenKind.CurlyR if nestingLevel == 0 => continue = false
-//                // Found '|' before closing '}' which means that it is a record operation.
-//                case TokenKind.Bar if nestingLevel == 0 =>
-//                  isRecordOp = true
-//                  continue = false
-//                case TokenKind.CurlyL | TokenKind.HashCurlyL =>
-//                  nestingLevel += 1
-//                  lookahead += 1
-//                case TokenKind.CurlyR =>
-//                  nestingLevel -= 1
-//                  lookahead += 1
-//                case _ => lookahead += 1
-//              }
-//            }
-//            isRecordOp
-//          }
-//          if (isRecordOp) {
             recordOperation()
-//          } else {
-//            recordLiteral()
-//          }
         case _ => block()
       }
     }
-
-    @unused
-    private def recordLiteral()(implicit s: State): Mark.Closed = {
-      implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr
-      assert(at(TokenKind.CurlyL))
-      val mark = open()
-      zeroOrMore(
-        namedTokenSet = NamedTokenSet.FromKinds(NAME_FIELD),
-        getItem = recordLiteralField,
-        checkForItem = NAME_FIELD.contains,
-        breakWhen = _.isRecoverExpr,
-        delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
-      )
-      close(mark, TreeKind.Expr.LiteralRecord)
-    }
-
-    private def recordLiteralField()(implicit s: State): Mark.Closed = {
-      implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr
-      val mark = open()
-      nameUnqualified(NAME_FIELD)
-      expect(TokenKind.Equal)
-      expression()
-      close(mark, TreeKind.Expr.LiteralRecordFieldFragment)
-    }
-
 
     private def recordOperation()(implicit s: State): Mark.Closed = {
       implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -25,7 +25,7 @@ import ca.uwaterloo.flix.language.errors.ParseError.*
 import ca.uwaterloo.flix.language.errors.{ParseError, WeederError}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Result}
 
-import scala.annotation.{tailrec, unused}
+import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
 /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1653,10 +1653,9 @@ object Weeder2 {
     }
     private def visitRecordOperationOrLiteralExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       hasToken(TokenKind.Bar, tree) match {
-        case true => visitRecordOperationExpr(tree)
+        case true  => visitRecordOperationExpr(tree)
         case false => visitLiteralRecordExpr(tree)
       }
-
     }
 
     private def visitRecordOperationExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {


### PR DESCRIPTION
Closes #11446.

This implements the fix I described in the issue.

Specifically the solution promises that:

- Record literals and record operations are parsed in the same way
- The weeder checks the following
  - Record operations contain at least one element before the bar (`|`) (as the parser did before)
  - Record literals does not contain any record operations (as the parser did before)

Out of scope (did not happen before anyway):

- Reporting an error for `{ +y = 2 | {y = 2}}` (Could be type error)
- Reporting an error for `{ y = 2, y = 2}` (Could be weeder error)
- Reporting an error for `{ +y = 2, +y = 2 | {x = 2}}` (Could be weeder error)

If we want to go forward with this I could add some tests that the illegal records now checked by the weeder are still illegal, though no such tests exist today for the parser.