### PR TITLE
Experiment: Controlled .class output

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -160,7 +160,7 @@ object Main {
             bootstrap =>
               val flix = new Flix().setFormatter(formatter)
               flix.setOptions(options.copy(loadClassFiles = false))
-              bootstrap.build(flix)
+              bootstrap.build(flix, outputJvm = true)
           }.toResult match {
             case Result.Ok(_) =>
               System.exit(0)

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -166,7 +166,7 @@ class Shell(bootstrap: Bootstrap, options: Options) {
       case Command.Eval(s) => execEval(s)
       case Command.ReloadAndEval(s) => execReloadAndEval(s)
       case Command.Init => execBootstrap(Bootstrap.init(bootstrap.projectPath))
-      case Command.Build => execBootstrap(bootstrap.build(flix))
+      case Command.Build => execBootstrap(bootstrap.build(flix, outputJvm = true))
       case Command.BuildJar => execBootstrap(bootstrap.buildJar(flix))
       case Command.BuildFatJar => execBootstrap(bootstrap.buildFatJar(flix))
       case Command.BuildPkg => execBootstrap(bootstrap.buildPkg())

--- a/main/test/ca/uwaterloo/flix/tools/TestBootstrap.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestBootstrap.scala
@@ -32,7 +32,7 @@ class TestBootstrap extends AnyFunSuite {
     val p = Files.createTempDirectory(ProjectPrefix)
     Bootstrap.init(p)(System.out)
     val b = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
-    b.build(new Flix())
+    b.build(new Flix(), outputJvm = true)
   }
 
   test("build-jar") {
@@ -40,7 +40,7 @@ class TestBootstrap extends AnyFunSuite {
     Bootstrap.init(p)(System.out)
     val b = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
     val flix = new Flix
-    b.build(flix)
+    b.build(flix, outputJvm = true)
     b.buildJar(flix)(Formatter.getDefault)
 
     val packageName = p.getFileName.toString
@@ -54,7 +54,7 @@ class TestBootstrap extends AnyFunSuite {
     Bootstrap.init(p)(System.out)
     val b = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
     val flix = new Flix
-    b.build(flix)
+    b.build(flix, outputJvm = true)
     b.buildJar(flix)(Formatter.getDefault)
 
     val packageName = p.getFileName.toString
@@ -76,12 +76,12 @@ class TestBootstrap extends AnyFunSuite {
     val flix = new Flix()
 
     val b = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
-    b.build(flix)
+    b.build(flix, outputJvm = true)
     b.buildJar(flix)(Formatter.getDefault)
 
     def hash1 = calcHash(jarPath)
 
-    b.build(flix)
+    b.build(flix, outputJvm = true)
     b.buildJar(flix)(Formatter.getDefault)
 
     def hash2 = calcHash(jarPath)


### PR DESCRIPTION
This is not really the correct solution. but it shows which class do want jvm output and which doesn't

It is awkward since `build` is used both as the `:build` command and as a generic way to build the project.