### PR TITLE
chore: remove unused binding in `Parser2.extTagExpr`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1884,7 +1884,7 @@ object Parser2 {
       assert(at(TokenKind.KeywordXvar))
       val mark = open()
       expect(TokenKind.KeywordXvar)
-      val lhs = nameUnqualified(NAME_TAG)
+      nameUnqualified(NAME_TAG)
       nth(0) match {
         case TokenKind.ParenL => arguments()
         case _ => ()


### PR DESCRIPTION
Closes #11555 