### PR TITLE
refactor: include `ByteCodeAst.Root` in `CompilationResult`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -766,8 +766,7 @@ class Flix {
     val loaderResult = JvmLoader.run(bytecodeAst)
 
     // Construct the compilation result.
-    val totalSize = bytecodeAst.classes.values.map(_.bytecode.length).sum
-    val result = new CompilationResult(loaderResult.main, loaderResult.tests, loaderResult.sources, totalTime, totalSize)
+    val result = new CompilationResult(loaderResult.main, loaderResult.tests, loaderResult.sources, bytecodeAst, totalTime)
 
     // Shutdown fork-join thread pool.
     shutdownForkJoinPool()

--- a/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
@@ -26,15 +26,17 @@ import ca.uwaterloo.flix.language.phase.jvm.{JvmClass, JvmName}
   * @param main      the reflected main function, if present.
   * @param tests     the tests in the program.
   * @param sources   the sources of the program.
+  * @param root      the jvm byte code representation of the program (the compiled output).
   * @param totalTime the total compilation time, excluding class writing/loading.
-  * @param codeSize   the number of bytes the compiler generated.
   */
 class CompilationResult(main: Option[Array[String] => Unit],
                         tests: Map[Symbol.DefnSym, TestFn],
                         sources: Map[Source, SourceLocation],
+                        root: BytecodeAst.Root,
                         val totalTime: Long,
-                        val codeSize: Int
                        ) {
+
+  val codeSize: Int = root.classes.values.map(_.bytecode.length).sum
 
   /** Optionally returns the main function. */
   def getMain: Option[Array[String] => Unit] =


### PR DESCRIPTION
Includes the `ByteCodeAst` representation of the program, i.e., the compiled output in the `CompilationResult` type. The reason for this change is that `Bootstrap` may call `flix.compile()` without emitting class files. Instead, it directly obtains the byte code representation and can write it directly to a jar.

Related to #11436 