### PR TITLE
feat: remove Interpolation nesting threshold

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -134,24 +134,6 @@ object LexerError {
   }
 
   /**
-    * An error raised when block-comments are nested too deep.
-    *
-    * @param loc The location of the opening "${".
-    */
-  case class StringInterpolationTooDeep(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"String interpolation nested too deep."
-
-    override def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> String interpolation nested too deep.
-         |
-         |${code(loc, "This is nested too deep.")}
-         |
-         |""".stripMargin
-    }
-  }
-
-  /**
     * An error raised when an unexpected character, such as €, is encountered.
     *
     * @param s   the problematic character.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -37,9 +37,6 @@ import scala.util.Random
   */
 object Lexer {
 
-  /** The maximal allowed nesting level of string interpolation. */
-  private val InterpolatedStringMaxNestingLevel = 32
-
   /** The end-of-file character (`'\u0000'`). */
   private val EOF = '\u0000'
 
@@ -742,10 +739,6 @@ object Lexer {
   private def acceptStringInterpolation(isDebug: Boolean = false)(implicit s: State): TokenKind = {
     // Handle max nesting level.
     s.interpolationNestingLevel += 1
-    if (s.interpolationNestingLevel > InterpolatedStringMaxNestingLevel) {
-      s.interpolationNestingLevel = 0
-      return TokenKind.Err(LexerError.StringInterpolationTooDeep(sourceLocationAtCurrent()))
-    }
     val startLocation = sourceLocationAtCurrent()
     advance() // Consume '{'.
     if (isDebug) addToken(TokenKind.LiteralDebugStringL)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
@@ -430,28 +430,6 @@ class TestLexer extends AnyFunSuite with TestUtils {
     expectError[LexerError.MalformedNumber](result)
   }
 
-  test("LexerError.StringInterpolationTooDeep.01") {
-    val input = """ "${"${"${"${"${"${"${"${"${"${"${"${"${"${"${${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}}"}"}"}"}"}"}"}"}"}"}"}"}"}"}" """
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.StringInterpolationTooDeep](result)
-  }
-
-  test("LexerError.StringInterpolationTooDeep.02") {
-    // Note: The innermost interpolation is unterminated,
-    // but the lexer should stop after bottoming out so this should still be a 'too deep' error.
-    val input = """ "${"${"${"${"${"${"${"${"${"${"${"${"${"${"${${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${unterminated"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}}"}"}"}"}"}"}"}"}"}"}"}"}"}"}" """
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.StringInterpolationTooDeep](result)
-  }
-
-  test("LexerError.StringInterpolationTooDeep.03") {
-    // Note: The innermost interpolation is unterminated,
-    // but the lexer should stop after bottoming out so this should still be a 'too deep' error.
-    val input = """ "${"${"${"${"${"${"${"${"${"${"${"${"${"${"${${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${unclosed and deep"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}}"}"}"}"}"}"}"}"}"}"}"}"}"}"}" """
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.StringInterpolationTooDeep](result)
-  }
-
   ignore("LexerError.UnexpectedChar.01") {
     val input = "€"
     val result = compile(input, Options.TestWithLibNix)
@@ -712,6 +690,22 @@ class TestLexer extends AnyFunSuite with TestUtils {
 
   test("LexerError.UnterminatedStringInterpolation.03") {
     val input = """ "${"Hi ${name!}"" """
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.UnterminatedStringInterpolation](result)
+  }
+
+  test("LexerError.UnterminatedStringInterpolation.04") {
+    // Note: The innermost interpolation is unterminated,
+    // but the lexer should stop after bottoming out so this should still be a 'too deep' error.
+    val input = """ "${"${"${"${"${"${"${"${"${"${"${"${"${"${"${${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${unterminated"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}}"}"}"}"}"}"}"}"}"}"}"}"}"}"}" """
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.UnterminatedStringInterpolation](result)
+  }
+
+  test("LexerError.UnterminatedStringInterpolation.05") {
+    // Note: The innermost interpolation is unterminated,
+    // but the lexer should stop after bottoming out so this should still be a 'too deep' error.
+    val input = """ "${"${"${"${"${"${"${"${"${"${"${"${"${"${"${${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${"${unclosed and deep"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}"}}"}"}"}"}"}"}"}"}"}"}"}"}"}"}" """
     val result = compile(input, Options.TestWithLibNix)
     expectError[LexerError.UnterminatedStringInterpolation](result)
   }


### PR DESCRIPTION
- No reason to arbitrarily limit it
- other places in the lexer don't have this recursion counter (block comments, numbers, keywords, ..)