### PR TITLE
fix: replace backticks with single quotes in prints

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -380,10 +380,10 @@ object Bootstrap {
     val bootstrap = new Bootstrap(path, apiKey)
     val tomlPath = getManifestFile(path)
     if (Files.exists(tomlPath)) {
-      out.println(s"Found `${formatter.blue("flix.toml")}`. Checking dependencies...")
+      out.println(s"Found '${formatter.blue("flix.toml")}'. Checking dependencies...")
       Validation.mapN(bootstrap.projectMode())(_ => bootstrap)
     } else {
-      out.println(s"""No `${formatter.blue("flix.toml")}`. Will load source files from `${formatter.blue("*.flix")}`, `${formatter.blue("src/**")}`, and `${formatter.blue("test/**")}`.""")
+      out.println(s"""No '${formatter.blue("flix.toml")}'. Will load source files from '${formatter.blue("*.flix")}', '${formatter.blue("src/**")}', and '${formatter.blue("test/**")}'.""")
       Validation.mapN(bootstrap.folderMode())(_ => bootstrap)
     }
   }


### PR DESCRIPTION
`Bootstrap` uses `'` quoted strings in all printed messages except here.