### PR TITLE
feat: check file extension input in `Bootstrap`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -317,8 +317,10 @@ object Bootstrap {
   /**
     * Returns all files in the given path `p` ending with .`ext`.
     */
-  private def getAllFilesWithExt(p: Path, ext: String): List[Path] =
+  private def getAllFilesWithExt(p: Path, ext: String): List[Path] = {
+    require(!ext.startsWith("."), "The file extension must not start with '.' -- This is handled by `getAllFilesWithExt`.")
     getAllFiles(p).filter(p => p.getFileName.toString.endsWith(s".$ext"))
+  }
 
   /**
     * Returns all files in the given path `p`.

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -385,10 +385,10 @@ object Bootstrap {
     val bootstrap = new Bootstrap(path, apiKey)
     val tomlPath = getManifestFile(path)
     if (Files.exists(tomlPath)) {
-      out.println(s"Found `${formatter.blue("flix.toml")}`. Checking dependencies...")
+      out.println(s"Found '${formatter.blue("flix.toml")}'. Checking dependencies...")
       Validation.mapN(bootstrap.projectMode())(_ => bootstrap)
     } else {
-      out.println(s"""No `${formatter.blue("flix.toml")}`. Will load source files from `${formatter.blue("*.flix")}`, `${formatter.blue("src/**")}`, and `${formatter.blue("test/**")}`.""")
+      out.println(s"""No '${formatter.blue("flix.toml")}'. Will load source files from '${formatter.blue("*.flix")}', '${formatter.blue("src/**")}', and '${formatter.blue("test/**")}'.""")
       Validation.mapN(bootstrap.folderMode())(_ => bootstrap)
     }
   }

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -316,6 +316,9 @@ object Bootstrap {
 
   /**
     * Returns all files in the given path `p` ending with .`ext`.
+    *
+    * @param p   the path from which files a considered.
+    * @param ext the file extension to match. Must not begin with `.`
     */
   private def getAllFilesWithExt(p: Path, ext: String): List[Path] = {
     require(!ext.startsWith("."), "The file extension must not start with '.' -- This is handled by `getAllFilesWithExt`.")

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -321,7 +321,7 @@ object Bootstrap {
     * @param ext the file extension to match. Must not begin with `.`
     */
   private def getAllFilesWithExt(p: Path, ext: String): List[Path] = {
-    require(!ext.startsWith("."), "The file extension must not start with '.' -- This is handled by `getAllFilesWithExt`.")
+    require(!ext.startsWith("."), "The file extension must not start with '.' -- This is handled by 'getAllFilesWithExt'.")
     getAllFiles(p).filter(p => p.getFileName.toString.endsWith(s".$ext"))
   }
 
@@ -385,10 +385,10 @@ object Bootstrap {
     val bootstrap = new Bootstrap(path, apiKey)
     val tomlPath = getManifestFile(path)
     if (Files.exists(tomlPath)) {
-      out.println(s"Found '${formatter.blue("flix.toml")}'. Checking dependencies...")
+      out.println(s"Found `${formatter.blue("flix.toml")}`. Checking dependencies...")
       Validation.mapN(bootstrap.projectMode())(_ => bootstrap)
     } else {
-      out.println(s"""No '${formatter.blue("flix.toml")}'. Will load source files from '${formatter.blue("*.flix")}', '${formatter.blue("src/**")}', and '${formatter.blue("test/**")}'.""")
+      out.println(s"""No `${formatter.blue("flix.toml")}`. Will load source files from `${formatter.blue("*.flix")}`, `${formatter.blue("src/**")}`, and `${formatter.blue("test/**")}`.""")
       Validation.mapN(bootstrap.folderMode())(_ => bootstrap)
     }
   }


### PR DESCRIPTION
The function `getAlFilesWithExt` could easily be misunderstood, so I added a check to ensure it is used correctly. This can also be done via a `Validation` type. What do you think is best?