### PR TITLE
refactor: merge file operations in `Bootstrap` with `FileOps`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -750,8 +750,8 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       */
     def addLocalFlixFiles(): List[Path] = {
       val filesHere = FileOps.getFlixFilesIn(projectPath, Int.MaxValue)
-      val filesSrc = FileOps.getFilesWithExtIn(Bootstrap.getSourceDirectory(projectPath), "flix", Int.MaxValue)
-      val filesTest = FileOps.getFilesWithExtIn(Bootstrap.getTestDirectory(projectPath), "flix", Int.MaxValue)
+      val filesSrc = FileOps.getFlixFilesIn(Bootstrap.getSourceDirectory(projectPath), Int.MaxValue)
+      val filesTest = FileOps.getFlixFilesIn(Bootstrap.getTestDirectory(projectPath), Int.MaxValue)
       val result = filesHere ::: filesSrc ::: filesTest
       sourcePaths = result
       result

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -30,9 +30,7 @@ import ca.uwaterloo.flix.util.{FileOps, Formatter, Result, Validation}
 
 import java.io.PrintStream
 import java.nio.file.*
-import java.nio.file.attribute.BasicFileAttributes
 import java.util.zip.{ZipInputStream, ZipOutputStream}
-import scala.collection.mutable
 import scala.io.StdIn.readLine
 import scala.util.{Failure, Success, Using}
 

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.api
 
-import ca.uwaterloo.flix.api.Bootstrap.{EXT_FPKG, EXT_JAR, FLIX_TOML, getArtifactDirectory, getManifestFile, getPkgFile}
+import ca.uwaterloo.flix.api.Bootstrap.{EXT_FPKG, EXT_JAR, FLIX_TOML, LICENSE, README, getArtifactDirectory, getManifestFile, getPkgFile}
 import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.phase.HtmlDocumentor
@@ -523,8 +523,8 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     Using(new ZipOutputStream(Files.newOutputStream(pkgFile))) { zip =>
       // Add required resources.
       FileOps.addToZip(zip, FLIX_TOML, Bootstrap.getManifestFile(projectPath))
-      FileOps.addToZip(zip, "LICENSE.md", Bootstrap.getLicenseFile(projectPath))
-      FileOps.addToZip(zip, "README.md", Bootstrap.getReadmeFile(projectPath))
+      FileOps.addToZip(zip, LICENSE, Bootstrap.getLicenseFile(projectPath))
+      FileOps.addToZip(zip, README, Bootstrap.getReadmeFile(projectPath))
 
       // Add all source files.
       // Here we sort entries by relative file name to apply https://reproducible-builds.org/

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -316,16 +316,6 @@ object Bootstrap {
     root.relativize(path).toString.replace('\\', '/')
 
   /**
-    * Returns all files in the given path `p` ending with `.ext`.
-    *
-    * @param p   the path from which files a considered.
-    * @param ext the file extension to match. Must not begin with `.`
-    */
-  private def getAllFilesWithExt(p: Path, ext: String): List[Path] = {
-    FileOps.getFilesWithExtIn(p, ext, Int.MaxValue)
-  }
-
-  /**
     * Returns all files in the given path `p`.
     * If this is used for a build, you probably want to use [[getAllFilesSorted]]
     */
@@ -493,7 +483,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       if (includeDependencies) {
         // First, we get all jar files inside the lib folder.
         // If the lib folder doesn't exist, we suppose there is simply no dependency and trigger no error.
-        val jarDependencies = if (libFolder.toFile.exists()) Bootstrap.getAllFilesWithExt(libFolder, "jar") else List[Path]()
+        val jarDependencies = if (libFolder.toFile.exists()) FileOps.getFilesWithExtIn(libFolder, "jar", Int.MaxValue) else List[Path]()
         // Add jar dependencies.
         jarDependencies.foreach(dep => {
           if (!Bootstrap.isJarFile(dep))
@@ -760,8 +750,8 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       */
     def addLocalFlixFiles(): List[Path] = {
       val filesHere = FileOps.getFlixFilesIn(projectPath, Int.MaxValue)
-      val filesSrc = Bootstrap.getAllFilesWithExt(Bootstrap.getSourceDirectory(projectPath), "flix")
-      val filesTest = Bootstrap.getAllFilesWithExt(Bootstrap.getTestDirectory(projectPath), "flix")
+      val filesSrc = FileOps.getFilesWithExtIn(Bootstrap.getSourceDirectory(projectPath), "flix", Int.MaxValue)
+      val filesTest = FileOps.getFilesWithExtIn(Bootstrap.getTestDirectory(projectPath), "flix", Int.MaxValue)
       val result = filesHere ::: filesSrc ::: filesTest
       sourcePaths = result
       result
@@ -772,7 +762,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       * The cached result is stored in [[flixPackagePaths]].
       */
     private def addLocalFlixLibs(): List[Path] = {
-      val flixFilesLib = Bootstrap.getAllFilesWithExt(Bootstrap.getLibraryDirectory(projectPath), "fpkg")
+      val flixFilesLib = FileOps.getFilesWithExtIn(Bootstrap.getLibraryDirectory(projectPath), "fpkg", Int.MaxValue)
       flixPackagePaths = flixFilesLib
       flixFilesLib
     }
@@ -782,7 +772,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       * The cached result is stored in [[jarPackagePaths]].
       */
     private def addLocalJars(): List[Path] = {
-      val jarFilesLib = Bootstrap.getAllFilesWithExt(Bootstrap.getLibraryDirectory(projectPath).resolve(JarPackageManager.FolderName), "jar")
+      val jarFilesLib = FileOps.getFilesWithExtIn(Bootstrap.getLibraryDirectory(projectPath).resolve(JarPackageManager.FolderName), "jar", Int.MaxValue)
       jarPackagePaths = jarFilesLib
       jarFilesLib
     }
@@ -805,7 +795,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       * The cached result is stored in [[mavenPackagePaths]].
       */
     private def addLocalMavenJars(): List[Path] = {
-      val mavenFilesLib = Bootstrap.getAllFilesWithExt(Bootstrap.getLibraryDirectory(projectPath).resolve(MavenPackageManager.FolderName), "jar")
+      val mavenFilesLib = FileOps.getFilesWithExtIn(Bootstrap.getLibraryDirectory(projectPath).resolve(MavenPackageManager.FolderName), "jar", Int.MaxValue)
       mavenPackagePaths = mavenFilesLib
       mavenFilesLib
     }

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -350,13 +350,6 @@ object Bootstrap {
     }.sortBy(_._2)
   }
 
-  /**
-    * Returns all .flix files directly in the directory given by `p`.
-    */
-  private def getAllFlixFilesHere(path: Path): List[Path] = {
-    FileOps.getFlixFilesIn(path, Int.MaxValue)
-  }
-
   private class FileVisitor extends SimpleFileVisitor[Path] {
     val result: mutable.ListBuffer[Path] = mutable.ListBuffer.empty
 
@@ -767,7 +760,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       * Returns and caches all `.flix` files from `src/` and `test/`.
       */
     def addLocalFlixFiles(): List[Path] = {
-      val filesHere = Bootstrap.getAllFlixFilesHere(projectPath)
+      val filesHere = FileOps.getFlixFilesIn(projectPath, Int.MaxValue)
       val filesSrc = Bootstrap.getAllFilesWithExt(Bootstrap.getSourceDirectory(projectPath), "flix")
       val filesTest = Bootstrap.getAllFilesWithExt(Bootstrap.getTestDirectory(projectPath), "flix")
       val result = filesHere ::: filesSrc ::: filesTest

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -44,7 +44,7 @@ object Bootstrap {
     *
     * The project must not already exist.
     */
-  def init(p: Path)(implicit out: PrintStream): Validation[Unit, BootstrapError] = {
+  def init(p: Path): Validation[Unit, BootstrapError] = {
     //
     // Check that the current working directory is usable.
     //
@@ -73,10 +73,10 @@ object Bootstrap {
     //
     // Create the project directories and files.
     //
-    newDirectoryIfAbsent(sourceDirectory)
-    newDirectoryIfAbsent(testDirectory)
+    FileOps.newDirectoryIfAbsent(sourceDirectory)
+    FileOps.newDirectoryIfAbsent(testDirectory)
 
-    newFileIfAbsent(manifestFile) {
+    FileOps.newFileIfAbsent(manifestFile) {
       s"""[package]
          |name        = "$packageName"
          |description = "test"
@@ -86,7 +86,7 @@ object Bootstrap {
          |""".stripMargin
     }
 
-    newFileIfAbsent(gitignoreFile) {
+    FileOps.newFileIfAbsent(gitignoreFile) {
       s"""*.fpkg
          |*.jar
          |.GITHUB_TOKEN
@@ -97,12 +97,12 @@ object Bootstrap {
          |""".stripMargin
     }
 
-    newFileIfAbsent(licenseFile) {
+    FileOps.newFileIfAbsent(licenseFile) {
       """Enter license information here.
         |""".stripMargin
     }
 
-    newFileIfAbsent(readmeFile) {
+    FileOps.newFileIfAbsent(readmeFile) {
       s"""# $packageName
          |
          |Enter some useful information.
@@ -110,14 +110,14 @@ object Bootstrap {
          |""".stripMargin
     }
 
-    newFileIfAbsent(mainSourceFile) {
+    FileOps.newFileIfAbsent(mainSourceFile) {
       """// The main entry point.
         |def main(): Unit \ IO =
         |    println("Hello World!")
         |""".stripMargin
     }
 
-    newFileIfAbsent(mainTestFile) {
+    FileOps.newFileIfAbsent(mainTestFile) {
       """@Test
         |def test01(): Bool = 1 + 1 == 2
         |""".stripMargin
@@ -256,28 +256,6 @@ object Bootstrap {
     * Returns `true` if the given path `p` is a fpkg-file.
     */
   private def isPkgFile(p: Path): Boolean = p.normalize().getFileName.toString.endsWith(s".$EXT_FPKG") && FileOps.isZipArchive(p)
-
-  /**
-    * Creates a new directory at the given path `p`.
-    *
-    * The path must not already contain a non-directory.
-    */
-  private def newDirectoryIfAbsent(p: Path)(implicit out: PrintStream): Unit = {
-    if (!Files.exists(p)) {
-      out.println(s"Creating '$p'.")
-      Files.createDirectories(p)
-    }
-  }
-
-  /**
-    * Creates a new text file at the given path `p` with the given content `s` if the file does not already exist.
-    */
-  private def newFileIfAbsent(p: Path)(s: String)(implicit out: PrintStream): Unit = {
-    if (!Files.exists(p)) {
-      out.println(s"Creating '$p'.")
-      Files.writeString(p, s, StandardOpenOption.CREATE)
-    }
-  }
 
   /**
     * Creates a new Bootstrap object and initializes it.

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -26,7 +26,7 @@ import ca.uwaterloo.flix.tools.pkg.github.GitHub
 import ca.uwaterloo.flix.tools.pkg.{FlixPackageManager, JarPackageManager, Manifest, ManifestParser, MavenPackageManager, PackageModules, ReleaseError}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import ca.uwaterloo.flix.util.Validation.{flatMapN, mapN}
-import ca.uwaterloo.flix.util.{Formatter, Result, Validation}
+import ca.uwaterloo.flix.util.{FileOps, Formatter, Result, Validation}
 
 import java.io.PrintStream
 import java.nio.file.*
@@ -354,12 +354,7 @@ object Bootstrap {
     * Returns all .flix files directly in the directory given by `p`.
     */
   private def getAllFlixFilesHere(path: Path): List[Path] = {
-    val files = path.toFile.listFiles()
-    if (files == null) {
-      List.empty
-    } else {
-      files.toList.map(f => f.toPath).filter(p => p.getFileName.toString.endsWith(s".flix"))
-    }
+    FileOps.getFlixFilesIn(path, Int.MaxValue)
   }
 
   private class FileVisitor extends SimpleFileVisitor[Path] {

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -322,8 +322,7 @@ object Bootstrap {
     * @param ext the file extension to match. Must not begin with `.`
     */
   private def getAllFilesWithExt(p: Path, ext: String): List[Path] = {
-    require(!ext.startsWith("."), "The file extension must not start with '.' -- This is handled by 'getAllFilesWithExt'.")
-    getAllFiles(p).filter(p => p.getFileName.toString.endsWith(s".$ext"))
+    FileOps.getFilesWithExtIn(p, ext, Int.MaxValue)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -749,7 +749,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       * Returns and caches all `.flix` files from `src/` and `test/`.
       */
     def addLocalFlixFiles(): List[Path] = {
-      val filesHere = FileOps.getFlixFilesIn(projectPath, Int.MaxValue)
+      val filesHere = FileOps.getFlixFilesIn(projectPath, 1)
       val filesSrc = FileOps.getFlixFilesIn(Bootstrap.getSourceDirectory(projectPath), Int.MaxValue)
       val filesTest = FileOps.getFlixFilesIn(Bootstrap.getTestDirectory(projectPath), Int.MaxValue)
       val result = filesHere ::: filesSrc ::: filesTest

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -31,8 +31,7 @@ import ca.uwaterloo.flix.util.{FileOps, Formatter, Result, Validation}
 import java.io.PrintStream
 import java.nio.file.*
 import java.nio.file.attribute.BasicFileAttributes
-import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
-import java.util.{Calendar, GregorianCalendar}
+import java.util.zip.{ZipInputStream, ZipOutputStream}
 import scala.collection.mutable
 import scala.io.StdIn.readLine
 import scala.util.{Failure, Success, Using}

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -42,7 +42,7 @@ object Bootstrap {
     *
     * The project must not already exist.
     */
-  def init(p: Path): Validation[Unit, BootstrapError] = {
+  def init(p: Path)(implicit out: PrintStream): Validation[Unit, BootstrapError] = {
     //
     // Check that the current working directory is usable.
     //

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -483,7 +483,7 @@ class Flix {
       return Result.Err(new IllegalArgumentException(s"'$pNorm' must be a .fpkg file."))
     }
     if (!FileOps.isZipArchive(pNorm)) {
-      Result.Err(new IllegalArgumentException(s"'$pNorm' must be a zip archive."))
+      return Result.Err(new IllegalArgumentException(s"'$pNorm' must be a zip archive."))
     }
     Result.Ok(())
   }

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -482,21 +482,9 @@ class Flix {
     if (!pNorm.getFileName.toString.endsWith(".fpkg")) {
       return Result.Err(new IllegalArgumentException(s"'$pNorm' must be a .fpkg file."))
     }
-
-    // Read the first four bytes of the file.
-    val isZipArchive = Using(Files.newInputStream(pNorm)) { is =>
-      val b1 = is.read()
-      val b2 = is.read()
-      val b3 = is.read()
-      val b4 = is.read()
-      // Check if the four first bytes match 0x50, 0x4b, 0x03, 0x04
-      b1 == 0x50 && b2 == 0x4b && b3 == 0x03 && b4 == 0x04
-    }.getOrElse(false)
-
-    if (!isZipArchive) {
-      return Result.Err(new IllegalArgumentException(s"'$pNorm' must be a zip archive."))
+    if (!FileOps.isZipArchive(pNorm)) {
+      Result.Err(new IllegalArgumentException(s"'$pNorm' must be a zip archive."))
     }
-
     Result.Ok(())
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -145,7 +145,7 @@ object LspServer {
         FileOps.getFilesIn(path.resolve("test"), Int.MaxValue)
 
       flixSources.foreach { case p =>
-        if (FileOps.checkExt(p, ".flix")) {
+        if (FileOps.checkExt(p, "flix")) {
           val source = Files.readString(p)
           addSourceCode(p.toUri.toString, source)
         }
@@ -161,10 +161,10 @@ object LspServer {
       FileOps.getFilesIn(path.resolve("lib"), Int.MaxValue)
         .foreach{ case p =>
           // Load all JAR files in the workspace, the pattern should be lib/**/*.jar.
-          if (FileOps.checkExt(p, ".jar"))
+          if (FileOps.checkExt(p, "jar"))
             flix.addJar(p)
           // Load all Flix package files in the workspace, the pattern should be lib/**/*.fpkg.
-          if (FileOps.checkExt(p, ".fpkg")) {
+          if (FileOps.checkExt(p, "fpkg")) {
             flix.addPkg(p)(SecurityContext.AllPermissions)
           }
         }

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -103,7 +103,7 @@ object FileOps {
     * The depth parameter is the maximum number of levels of directories to visit.
     *   Use a depth of 0 to only visit the given directory.
     *   Use a depth of 1 to only visit the files in the given directory.
-    *   Use a depth of MaxValue to visit all files in the directory and its subdirectories.
+    * Use a depth of [[Int.MaxValue]] to visit all files in the directory and its subdirectories.
     */
   def getFilesIn(path: Path, depth: Int): List[Path] = {
     if (Files.exists(path) && Files.isDirectory(path))

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -97,7 +97,7 @@ object FileOps {
   }
 
   /**
-    * Returns an iterator of all files in the given path, visited recursively.
+    * Returns a list of all files in the given path, visited recursively.
     * The depth parameter is the maximum number of levels of directories to visit.
     * Use a depth of 0 to only visit the given directory.
     * Use a depth of 1 to only visit the files in the given directory.
@@ -113,11 +113,24 @@ object FileOps {
       List.empty
   }
 
+  def getFilesWithExtIn(path: Path, ext: String, depth: Int): List[Path] = {
+    if (Files.exists(path) && Files.isDirectory(path))
+      Files.walk(path, depth).iterator()
+        .asScala
+        .filter(checkExt(_, ext))
+        .toList
+    else
+      List.empty
+  }
+
   /**
     * Checks if the given path is a regular file with the expected extension.
+    *
+    * @param p           the path to the file to check.
+    * @param expectedExt the file extension to match. Must not begin with `.`
     */
   def checkExt(p: Path, expectedExt: String): Boolean = {
-    val ext = if (expectedExt.startsWith(".")) expectedExt else s".$expectedExt"
-    Files.isRegularFile(p) && p.getFileName.toString.endsWith(ext)
+    require(!expectedExt.startsWith("."), "The file extension must not start with '.' -- This is handled by 'checkExt'.")
+    Files.isRegularFile(p) && p.getFileName.toString.endsWith(expectedExt)
   }
 }

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -105,8 +105,8 @@ object FileOps {
     */
   def getFilesIn(path: Path, depth: Int): List[Path] = {
     if (Files.exists(path) && Files.isDirectory(path))
-      Files.walk(path, depth).iterator()
-        .asScala
+      Files.walk(path, depth)
+        .iterator().asScala
         .filter(Files.isRegularFile(_))
         .toList
     else
@@ -125,8 +125,8 @@ object FileOps {
     */
   def getFilesWithExtIn(path: Path, ext: String, depth: Int): List[Path] = {
     if (Files.exists(path) && Files.isDirectory(path))
-      Files.walk(path, depth).iterator()
-        .asScala
+      Files.walk(path, depth)
+        .iterator().asScala
         .filter(checkExt(_, ext))
         .toList
     else

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -78,6 +78,26 @@ object FileOps {
   }
 
   /**
+    * Creates a new directory at the given path `p`.
+    *
+    * The path must not already contain a non-directory.
+    */
+  def newDirectoryIfAbsent(p: Path): Unit = {
+    if (!Files.exists(p)) {
+      Files.createDirectories(p)
+    }
+  }
+
+  /**
+    * Creates a new file at the given path `p` with the given content `s` if the file does not already exist.
+    */
+  def newFileIfAbsent(p: Path)(s: String): Unit = {
+    if (!Files.exists(p)) {
+      Files.writeString(p, s, StandardOpenOption.CREATE)
+    }
+  }
+
+  /**
     * Returns all files ending with `.flix` in `path`.
     *
     * The search is limited at `depth - 1` levels of subdirectories.

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -36,12 +36,12 @@ object FileOps {
   }
 
   /**
-   * Writes the given string `s` to the given file path `p`.
-   *
-   * Creates the parent directory of `p` if needed.
-   *
-   * @param append if set to true, the content will be appended to the file
-   */
+    * Writes the given string `s` to the given file path `p`.
+    *
+    * Creates the parent directory of `p` if needed.
+    *
+    * @param append if set to true, the content will be appended to the file
+    */
   def writeString(p: Path, s: String, append: Boolean = false): Unit = {
     Files.createDirectories(p.getParent)
 
@@ -66,10 +66,10 @@ object FileOps {
   }
 
   /**
-   * Writes the given json `j` to the given file path `p`.
-   *
-   * Creates the parent directory of `p` if needed.
-   */
+    * Writes the given json `j` to the given file path `p`.
+    *
+    * Creates the parent directory of `p` if needed.
+    */
   def writeJSON(p: Path, j: JValue): Unit = {
     FileOps.writeString(p, JsonMethods.pretty(JsonMethods.render(j)))
   }
@@ -88,8 +88,6 @@ object FileOps {
     * └── subdir
     *     └── Subfile.flix
     * }}}
-    *
-    *
     */
   def getFlixFilesIn(path: String, depth: Int): List[Path] = {
     Files.walk(Paths.get(path), depth)
@@ -101,8 +99,8 @@ object FileOps {
   /**
     * Returns an iterator of all files in the given path, visited recursively.
     * The depth parameter is the maximum number of levels of directories to visit.
-    *   Use a depth of 0 to only visit the given directory.
-    *   Use a depth of 1 to only visit the files in the given directory.
+    * Use a depth of 0 to only visit the given directory.
+    * Use a depth of 1 to only visit the files in the given directory.
     * Use a depth of [[Int.MaxValue]] to visit all files in the directory and its subdirectories.
     */
   def getFilesIn(path: Path, depth: Int): List[Path] = {

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -141,6 +141,6 @@ object FileOps {
     */
   def checkExt(p: Path, expectedExt: String): Boolean = {
     require(!expectedExt.startsWith("."), "The file extension must not start with '.' -- This is handled by 'checkExt'.")
-    Files.isRegularFile(p) && p.getFileName.toString.endsWith(expectedExt)
+    Files.isRegularFile(p) && p.getFileName.toString.endsWith(s".$expectedExt")
   }
 }

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -90,10 +90,13 @@ object FileOps {
     * }}}
     */
   def getFlixFilesIn(path: Path, depth: Int): List[Path] = {
-    Files.walk(path, depth)
-      .iterator().asScala
-      .filter(checkExt(_, "flix"))
-      .toList.sorted
+    if (Files.exists(path) && Files.isDirectory(path))
+      Files.walk(path, depth)
+        .iterator().asScala
+        .filter(checkExt(_, "flix"))
+        .toList.sorted
+    else
+      List.empty
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -89,8 +89,8 @@ object FileOps {
     *     └── Subfile.flix
     * }}}
     */
-  def getFlixFilesIn(path: String, depth: Int): List[Path] = {
-    Files.walk(Paths.get(path), depth)
+  def getFlixFilesIn(path: Path, depth: Int): List[Path] = {
+    Files.walk(path, depth)
       .iterator().asScala
       .filter(checkExt(_, "flix"))
       .toList.sorted

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -198,4 +198,31 @@ object FileOps {
     false
   }
 
+  /**
+    * Sorts `paths` using `prefix`.
+    *
+    * The `prefix` parameter must be a prefix of all paths in `paths`.
+    *
+    * Given a `p` in `paths` defined as `prefix/p1`, it converts `p1` to a string
+    * representation and replaces `\` (backslash) with `/` (forward slash) and sorts
+    * the list of paths on their new string representations.
+    *
+    * Returns the list of paths along with their string representations.
+    */
+  def sortPlatformIndependently(prefix: Path, paths: List[Path]): List[(Path, String)] = {
+    require(paths.forall(_.startsWith(prefix)), "All paths in 'paths' must start with 'prefix'.")
+    paths.map { path =>
+      (path, convertPathToRelativeFileName(prefix, path))
+    }.sortBy(_._2)
+  }
+
+  /**
+    * @param prefix the root directory to compute a relative path from the given path
+    * @param path   the path to be converted to a relative path based on the given root directory
+    * @return relative file name separated by slashes, like `path/to/file.ext`
+    */
+  private def convertPathToRelativeFileName(prefix: Path, path: Path): String = {
+    prefix.relativize(path).toString.replace('\\', '/')
+  }
+
 }

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -113,6 +113,16 @@ object FileOps {
       List.empty
   }
 
+  /**
+    * Returns a list of all files in the given path with the extension `.ext`, visited recursively.
+    *
+    * @param path  the path to start the file walk from.
+    * @param ext   the file extension to match. Must not begin with `.`
+    * @param depth the maximum number of levels of directories to visit.
+    *              Use a depth of 0 to only visit the given directory.
+    *              Use a depth of 1 to only visit the files in the given directory.
+    *              Use a depth of [[Int.MaxValue]] to visit all files in the directory and its subdirectories.
+    */
   def getFilesWithExtIn(path: Path, ext: String, depth: Int): List[Path] = {
     if (Files.exists(path) && Files.isDirectory(path))
       Files.walk(path, depth).iterator()

--- a/main/src/ca/uwaterloo/flix/util/FileOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/FileOps.scala
@@ -19,7 +19,7 @@ import ca.uwaterloo.flix.language.ast.SourceLocation
 import org.json4s.JValue
 import org.json4s.native.JsonMethods
 
-import java.nio.file.{Files, LinkOption, Path, Paths, StandardOpenOption}
+import java.nio.file.{Files, LinkOption, Path, StandardOpenOption}
 import java.util.{Calendar, GregorianCalendar}
 import java.util.zip.{ZipEntry, ZipOutputStream}
 import scala.jdk.CollectionConverters.IteratorHasAsScala

--- a/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
+++ b/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
@@ -62,7 +62,7 @@ class FlixSuite(incremental: Boolean) extends AnyFunSuite {
     *
     */
   def mkTestDirCollected(path: String, name: String)(implicit options: Options): Unit = {
-    val files = FileOps.getFlixFilesIn(path, 1)
+    val files = FileOps.getFlixFilesIn(Paths.get(path), 1)
     test(name)(compileAndRun(files))
   }
 
@@ -76,7 +76,7 @@ class FlixSuite(incremental: Boolean) extends AnyFunSuite {
     *
     */
   def mkTestDir(path: String)(implicit options: Options): Unit = {
-    val files = FileOps.getFlixFilesIn(path, 1)
+    val files = FileOps.getFlixFilesIn(Paths.get(path), 1)
     for (p <- files) {
       mkTest(p.toString)
     }


### PR DESCRIPTION
This PR removes file operations from `Bootstrap` and merges them into `FileOps`. The reason is threefold:
1. `Bootstrap` had many functions related to file operations. Removing them from the class allows it to focus more cleanly on what it must achieve, i.e., less clutter more meaningful code.
2. `Bootstrap` and `FileOps` had code duplication, so this PR improves code reuse.
3. `isZipArchive` was used in both `Bootstrap` and `Flix` but defined twice. As it seems to be a predicate that relies solely on a file and its first four bytes, it seems natural to move it to `FileOps`. This improves code reuse again.