### PR TITLE
work

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -38,6 +38,19 @@ object LexerError {
     }
   }
 
+  /** An error raised when a hexadecimal digit is expected in a number (e.g. `0x` or `0xFF_`). */
+  case class ExpectedHexDigit(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"A hexadecimal digit (0-9, a-f, or A-F) is expected here."
+
+    override def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> A hexadecimal digit (0-9, a-f, or A-F) is expected here.
+         |
+         |${code(loc, "Here")}
+         |""".stripMargin
+    }
+  }
+
   /**
     * An error raised when a period has whitespace before it.
     * This is problematic because we want to disallow tokens like: "Rectangle   .Shape".
@@ -201,20 +214,6 @@ object LexerError {
       s""">> Missing `'` in char.
          |
          |${code(loc, "Char starts here")}
-         |
-         |""".stripMargin
-    }
-  }
-
-  /** An error raised when a hexadecimal number is unterminated (e.g. `0x` or `0xff_`). */
-  case class UnterminatedHexNumber(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unterminated Hexadecimal number."
-
-    override def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> Unterminated Hexadecimal number.
-         |
-         |${code(loc, "Here")}
          |
          |""".stripMargin
     }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
@@ -546,31 +546,40 @@ class TestLexer extends AnyFunSuite with TestUtils {
     expectError[LexerError.UnterminatedChar](result)
   }
 
-  test("LexerError.UnterminatedHexNumber.01") {
+  test("LexerError.ExpectedHexDigit.01") {
     val input =
       s"""
          |def f(): Int32 = 0x
            """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.UnterminatedHexNumber](result)
+    expectError[LexerError.ExpectedHexDigit](result)
   }
 
-  test("LexerError.UnterminatedHexNumber.02") {
+  test("LexerError.ExpectedHexDigit.02") {
     val input =
       s"""
          |def f(): Int32 = 0xF_
            """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.UnterminatedHexNumber](result)
+    expectError[LexerError.ExpectedHexDigit](result)
   }
 
-  test("LexerError.UnterminatedHexNumber.03") {
+  test("LexerError.ExpectedHexDigit.03") {
     val input =
       s"""
          |def f(): Int32 = 0x1_
            """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.UnterminatedHexNumber](result)
+    expectError[LexerError.ExpectedHexDigit](result)
+  }
+
+  test("LexerError.ExpectedHexDigit.04") {
+    val input =
+      s"""
+         |def f(): Int32 = 0x1__2
+           """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.ExpectedHexDigit](result)
   }
 
   test("LexerError.UnterminatedInfixFunction.01") {


### PR DESCRIPTION
Simplifying hex parsing, inspired by the number parsing PR.

- [Refactor] The new grammar is equivalent but the code is simpler
- [feat] `0x42_` now says `expected hexacimal digit` (pointing after the `_`) instead of `Unterminated hexadicimal number`