### PR TITLE
feat: harden keywords in lexer

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -445,12 +445,11 @@ object Lexer {
 
   /**
     * Check that the potential keyword is sufficiently separated.
-    * A keyword is separated if it is surrounded by anything __but__ a character, digit a dot or
-    * underscore.
+    * A keyword is separated if it is surrounded by anything __but__ a character, digit, or underscore.
     * Note that __comparison includes current__.
     */
   private def isSeparated(keyword: String)(implicit s: State): Boolean = {
-    def isSep(c: Char) = !(c.isLetter || c.isDigit || c == '_' || c == '.')
+    def isSep(c: Char) = !(c.isLetter || c.isDigit || c == '_')
 
     s.sc.nthIsPOrOutOfBounds(-2, isSep) && s.sc.nthIsPOrOutOfBounds(keyword.length - 1, isSep)
   }

--- a/main/src/library/BigInt.flix
+++ b/main/src/library/BigInt.flix
@@ -133,25 +133,25 @@ mod BigInt {
     /// Returns the bitwise AND of `x` and `y`.
     ///
     pub def bitwiseAnd(x: BigInt, y: BigInt): BigInt =
-        unsafe x.and(y)
+        unsafe x.$and(y)
 
     ///
     /// Returns the bitwise NOT of `x`.
     ///
     pub def bitwiseNot(x: BigInt): BigInt =
-        unsafe x.not()
+        unsafe x.$not()
 
     ///
     /// Returns the bitwise OR of `x` and `y`.
     ///
     pub def bitwiseOr(x: BigInt, y: BigInt): BigInt =
-        unsafe x.or(y)
+        unsafe x.$or(y)
 
     ///
     /// Returns the bitwise XOR of `x` and `y`.
     ///
     pub def bitwiseXor(x: BigInt, y: BigInt): BigInt =
-        unsafe x.xor(y)
+        unsafe x.$xor(y)
 
     ///
     /// Return a string representation of `x`.

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod2.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod2.flix
@@ -33,12 +33,12 @@ mod Test.Exp.Jvm.InvokeMethod {
    @test
    def testInvokeMethod_07(): Bool \ IO =
        let val = 150ii;
-       val.and(-100ii) == 148ii
+       val.$and(-100ii) == 148ii
 
     @test
     def testInvokeMethod_08(): Bool \ IO =
        let val = 123488ii;
-       val.mod(23ii) == 1ii
+       val.$mod(23ii) == 1ii
 
    @test
    def testInvokeMethod_09(): Bool \ IO =


### PR DESCRIPTION
current keywords are interpreted as names if prefixed by `.`. This means that `something.and` does not see `and` as a keyword. I propose that we remove this edge case since we have `$and` to allow keywords as names.

| Input | Before | PR | Fix |
| --- | --- | --- | --- |
| `x.not(y)` |  accepted | `expected <name> instead of 'not'` | `x.$not(y)` |