### PR TITLE
refactor: remove operator lexing look-behind

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -457,15 +457,12 @@ object Lexer {
 
   /**
     * Check that the potential operator is sufficiently separated.
-    * An operator is separated if it is surrounded by anything __but__ another valid user operator
+    * An operator is separated if it is followed by anything __but__ another valid user operator
     * character.
     * Note that __comparison includes current__.
     */
-  private def isSeparatedOperator(keyword: String)(implicit s: State): Boolean = {
-    def isSep(c: Char) = isUserOp(c).isEmpty
-
-    s.sc.nthIsPOrOutOfBounds(-2, isSep) && s.sc.nthIsPOrOutOfBounds(keyword.length - 1, isSep)
-  }
+  private def isSeparatedOperator(keyword: String)(implicit s: State): Boolean =
+    s.sc.nthIsPOrOutOfBounds(keyword.length - 1, c => isUserOp(c).isEmpty)
 
   /**
     * Checks whether the previous char and the following substring matches a keyword.


### PR DESCRIPTION
The lexer doesn't partially consume operators, so if an operator is being lexer then there will never be a operator symbol immediately before it.

Profiler suggests this is a hot spot so performance might actually be noticeably better