### PR TITLE
feat: Lexer `SimpleTokens` prefix map

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -132,7 +132,6 @@ object Lexer {
       ("xor", TokenKind.KeywordXor),
       ("xvar", TokenKind.KeywordXvar),
       ("yield", TokenKind.KeywordYield),
-      ("???", TokenKind.HoleAnonymous),
     )
     PrefixTree.mk(keywords)
   }
@@ -148,6 +147,7 @@ object Lexer {
       (",", TokenKind.Comma),
       (".{", TokenKind.DotCurlyL),
       (";", TokenKind.Semi),
+      ("???", TokenKind.HoleAnonymous),
       ("[", TokenKind.BracketL),
       ("\\", TokenKind.Backslash),
       ("]", TokenKind.BracketR),


### PR DESCRIPTION
I've described what a simple token is in the code, but keywords, simple tokens, and operators just differ on what their tail condition is.