### PR TITLE
refactor: allow empty cparams for closures

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -32,7 +32,7 @@ object LiftedAst {
                   entryPoints: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], exp: Expr, tpe: SimpleType, loc: SourceLocation)
+  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], isClosure: Boolean, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, loc: SourceLocation)
 
   case class Enum(ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], cases: Map[Symbol.CaseSym, Case], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -43,7 +43,7 @@ object ReducedAst {
   /**
     * pcPoints is initialized by [[ca.uwaterloo.flix.language.phase.Reducer]].
     */
-  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], lparams: List[LocalParam], pcPoints: Int, expr: Expr, tpe: SimpleType, unboxedType: UnboxedType, loc: SourceLocation) {
+  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], isClosure: Boolean, fparams: List[FormalParam], lparams: List[LocalParam], pcPoints: Int, expr: Expr, tpe: SimpleType, unboxedType: UnboxedType, loc: SourceLocation) {
     val arrowType: SimpleType.Arrow = SimpleType.mkArrow(fparams.map(_.tpe), tpe)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -28,7 +28,7 @@ object LiftedAstPrinter {
     */
   def print(root: LiftedAst.Root): DocAst.Program = {
     val defs = root.defs.values.map {
-      case LiftedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe, _) =>
+      case LiftedAst.Def(ann, mod, sym, cparams, _, fparams, exp, tpe, _) =>
         DocAst.Def(
           ann,
           mod,

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -28,7 +28,7 @@ object ReducedAstPrinter {
     */
   def print(root: ReducedAst.Root): DocAst.Program = {
     val defs = root.defs.values.map {
-      case ReducedAst.Def(ann, mod, sym, cparams, fparams, _, _, stmt, tpe, _, _) =>
+      case ReducedAst.Def(ann, mod, sym, cparams, _, fparams, _, _, stmt, tpe, _, _) =>
         DocAst.Def(
           ann,
           mod,

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -71,12 +71,12 @@ object EffectBinder {
     * operand stack.
     */
   private def visitDef(defn: LiftedAst.Def)(implicit flix: Flix): ReducedAst.Def = defn match {
-    case LiftedAst.Def(ann, mod, sym, cparams0, fparams0, exp0, tpe, loc) =>
+    case LiftedAst.Def(ann, mod, sym, cparams0, isClosure, fparams0, exp0, tpe, loc) =>
       val cparams = cparams0.map(visitParam)
       val fparams = fparams0.map(visitParam)
       val lparams = Nil
       val exp = visitExpr(exp0)
-      ReducedAst.Def(ann, mod, sym, cparams, fparams, lparams, -1, exp, tpe, ReducedAst.UnboxedType(tpe), loc)
+      ReducedAst.Def(ann, mod, sym, cparams, isClosure, fparams, lparams, -1, exp, tpe, ReducedAst.UnboxedType(tpe), loc)
   }
 
   private def visitEnum(enm: LiftedAst.Enum): ReducedAst.Enum = enm match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -47,10 +47,10 @@ object Eraser {
   }
 
   private def visitDef(defn: Def): Def = defn match {
-    case Def(ann, mod, sym, cparams, fparams, lparams, pcPoints, exp, tpe, originalTpe, loc) =>
+    case Def(ann, mod, sym, cparams, isClosure, fparams, lparams, pcPoints, exp, tpe, originalTpe, loc) =>
       val eNew = visitExp(exp)
       val e = Expr.ApplyAtomic(AtomicOp.Box, List(eNew), box(tpe), exp.purity, loc)
-      Def(ann, mod, sym, cparams.map(visitParam), fparams.map(visitParam), lparams.map(visitLocalParam), pcPoints, e, box(tpe), UnboxedType(erase(originalTpe.tpe)), loc)
+      Def(ann, mod, sym, cparams.map(visitParam), isClosure, fparams.map(visitParam), lparams.map(visitLocalParam), pcPoints, e, box(tpe), UnboxedType(erase(originalTpe.tpe)), loc)
   }
 
   private def visitParam(fp: FormalParam): FormalParam = fp match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -54,7 +54,7 @@ object Reducer {
   }
 
   private def visitDef(d: Def)(implicit root: Root, ctx: SharedContext): Def = d match {
-    case Def(ann, mod, sym, cparams, fparams, lparams, _, exp, tpe, unboxedType, loc) =>
+    case Def(ann, mod, sym, cparams, isClosure, fparams, lparams, _, exp, tpe, unboxedType, loc) =>
       implicit val lctx: LocalContext = LocalContext.mk(exp.purity)
       assert(lparams.isEmpty, s"Unexpected def local params before Reducer: $lparams")
       val e = visitExpr(exp)
@@ -71,7 +71,7 @@ object Reducer {
       ctx.defTypes.put(unboxedType.tpe, ())
       cParamTypes.foreach(t => ctx.defTypes.put(t, ()))
 
-      Def(ann, mod, sym, cparams, fparams, ls, pcPoints, e, tpe, unboxedType, loc)
+      Def(ann, mod, sym, cparams, isClosure, fparams, ls, pcPoints, e, tpe, unboxedType, loc)
   }
 
   private def visitExpr(exp0: Expr)(implicit lctx: LocalContext, root: Root, ctx: SharedContext): Expr = {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1095,7 +1095,7 @@ object GenExpression {
 
       case ExpPosition.NonTail =>
         val defn = root.defs(sym)
-        val targetIsFunction = defn.cparams.isEmpty
+        val targetIsFunction = !defn.isClosure
         val canCallStaticMethod = Purity.isControlPure(defn.expr.purity) && targetIsFunction
         if (canCallStaticMethod) {
           val paramTpes = defn.fparams.map(fp => BackendType.toBackendType(fp.tpe))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -56,9 +56,9 @@ object GenFunAndClosureClasses {
     }, _ ++ _)
   }
 
-  private def isClosure(defn: Def): Boolean = defn.cparams.nonEmpty
+  private def isClosure(defn: Def): Boolean = defn.isClosure
 
-  private def isFunction(defn: Def): Boolean = defn.cparams.isEmpty
+  private def isFunction(defn: Def): Boolean = !defn.isClosure
 
   private def isControlPure(defn: Def): Boolean = Purity.isControlPure(defn.expr.purity)
 


### PR DESCRIPTION
Fixes #11586

There is the possibility that `isClosure = false && cparams.nonEmpty` would cause bugs, but thats also basically how it was before. So this PR does not worsen the situation.