### PR TITLE
feat: use Datalog types instead of RamId

### DIFF
--- a/main/src/library/Fixpoint3/Ast/ExecutableRam.flix
+++ b/main/src/library/Fixpoint3/Ast/ExecutableRam.flix
@@ -23,7 +23,7 @@ mod Fixpoint3.Ast.ExecutableRam {
     use Fixpoint3.Ast.Ram.{Predicates, RelSym, IndexInformation}
     use Fixpoint3.Ast.Shared.{BoxedDenotation => Denotation}
     use Fixpoint3.Boxed
-    use Fixpoint3.BoxingType.{UnifiedTypePos, RamIdToPos}
+    use Fixpoint3.BoxingType.UnifiedTypePos
     use Fixpoint3.TypeInfo.TypeInformation
 
     /////////////////////////////////////////////////////////////////////////////
@@ -35,7 +35,7 @@ mod Fixpoint3.Ast.ExecutableRam {
     /// by the interpreter.
     ///
     pub enum RamProgram[r: Region] {
-        case Program(RamStmt, Facts[r], Predicates, IndexInformation, (Arities, ConstWrites), RamIdToPos, TypeInformation)
+        case Program(RamStmt, Facts[r], Predicates, IndexInformation, (Arities, ConstWrites), TypeInformation)
     }
     ///
     /// The extensible database (EDB) of a program.

--- a/main/src/library/Fixpoint3/Boxing.flix
+++ b/main/src/library/Fixpoint3/Boxing.flix
@@ -47,75 +47,68 @@ mod Fixpoint3.Boxing {
     use Fixpoint3.Ast.Datalog.Datalog
     use Fixpoint3.Ast.ExecutableRam.{Facts => EFacts}
     use Fixpoint3.Ast.Ram
-    use Fixpoint3.Ast.Ram.{arityOf, BoolExp, RamId, RamProgram, RamStmt, RelSym, RamTerm, RelOp, toDenotation}
+    use Fixpoint3.Ast.Ram.{arityOf, BoolExp, RamProgram, RamStmt, RelSym, RamTerm, RelOp, toDenotation}
     use Fixpoint3.Ast.Shared.{PredSym, isRelational, Denotation}
     use Fixpoint3.Boxable
     use Fixpoint3.Boxed
     use Fixpoint3.Boxed.{BoxedBool, BoxedChar, BoxedFloat32, BoxedFloat64, BoxedInt8, BoxedInt16, BoxedInt32, BoxedInt64, BoxedObject}
-    use Fixpoint3.BoxingType.{Boxing, getType, RamIdToPos, setType, Types, TypeInfo, UnifiedTypePos}
+    use Fixpoint3.BoxingType
+    use Fixpoint3.BoxingType.{Boxing, setType, Types, TypeInfo, UnifiedTypePos}
     use Fixpoint3.Options.usedArity
-    use Fixpoint3.Predicate.relSymsOfProgram
+    use Fixpoint3.Predicate.{fullRelSymsOfProgram, relSymsOfProgram}
     use Fixpoint3.ReadWriteLock
+    use Fixpoint3.TypeInfo
     use Fixpoint3.Util.getOrCrash
 
     ///
     /// Returns a `(boxing, facts, idToBoxing)` where `Boxing` is information as described above,
-    /// `facts` are the EDB of `program` as `Int64`, with respect to `boxing` and `idToBoxing`
-    /// described where the boxing information associated with a specific `RamId` is placed,
-    /// aka the `UnifiedTypePos`.
+    /// `facts` are the EDB of `program` as `Int64`, with respect to `boxing`.
     ///
     @Internal
-    pub def initialize(rc: Region[r], withProv: Bool, program: RamProgram): (Boxing[r], EFacts[r], RamIdToPos) \ r =
-        let mapping = Equality.computeMapping(program, withProv);
-        let boxingInfo = initializeInternal(rc, program, mapping, withProv);
-        let facts = unsafely IO run initializeFacts(rc, program, boxingInfo, mapping, withProv);
-        (boxingInfo, facts, mapping)
+    pub def initialize(rc: Region[r], withProv: Bool, program: RamProgram): (Boxing[r], EFacts[r]) \ r =
+        let boxingInfo = initializeInternal(rc, program, withProv);
+        let facts = unsafely IO run initializeFacts(rc, program, boxingInfo);
+        (boxingInfo, facts)
 
     ///
     /// Returns `(facts, boxing)` where `facts` consists of the `Int64` representatives of
     /// the facts in `program`, with respect to `boxing`. Note that the old `boxingInfo` is
     /// invalid for the returned `facts`.
     ///
-    def initializeFacts(rc1: Region[r], program: RamProgram, boxingInfo: Boxing[r], mapping: RamIdToPos, withProv: Bool): EFacts[r] \ r + IO =
-        let RamProgram.Program(_, facts, _, (indexes, _), _) = program;
+    def initializeFacts(rc1: Region[r], program: RamProgram, boxingInfo: Boxing[r]): EFacts[r] \ r + IO =
+        let RamProgram.Program(_, facts, _, (indexes, _), typeInfo) = program;
         let (f1, f2) = facts;
         let newFacts = MutMap.empty(rc1);
         foreach ((relSym, relFacts) <- f1) {
+            let RelSym.Symbol(PredSym.PredSym(_, id), _, _) = relSym;
             // Get some search. This means that we have to create one less index in the interpreter.
             let search = getOrCrash(Map.get(relSym, indexes)) |> Vector.get(0);
             let newTree = BPlusTree.emptyWithArityAndSearch(rc1, usedArity(), search);
-            mapAllFacts(relSym, relFacts, boxingInfo, mapping, withProv, newTree);
+            // `id` will always be a full `id`.
+            mapAllFacts(relFacts, boxingInfo, TypeInfo.getTypeOf(id, typeInfo), newTree);
             MutMap.put(relSym, newTree, newFacts)
         };
         foreach ((relSym, relFacts) <- f2) {
+            let RelSym.Symbol(PredSym.PredSym(_, id), _, _) = relSym;
             let newTree = MutMap.getOrElsePut(relSym, BPlusTree.empty(rc1), newFacts);
-            mapAllFacts(relSym, relFacts, boxingInfo, mapping, withProv, newTree)
+            // `id` will always be a full `id`.
+            mapAllFacts(relFacts, boxingInfo, TypeInfo.getTypeOf(id, typeInfo), newTree)
         };
         newFacts |> MutMap.toMap
 
     def mapAllFacts(
-        relSym: RelSym,
         facts: BPlusTree[Vector[Boxed], Boxed, Static],
         boxingInfo: Boxing[r],
-        mapping: RamIdToPos,
-        withProv: Bool,
+        mapping: Vector[Int32],
         newTree: BPlusTree[Vector[Int64], Boxed, r]
     ): Unit \ r + IO = unchecked_cast({
-        let relSymId = Ram.toId(relSym);
-        let nonExtendedPositions = Vector.range(0, arityOf(relSym)) |>
-            Vector.map(i -> getOrCrash(Map.get(RamId.RelPos(relSymId, i), mapping)));
-        let positions = if (not withProv) {
-            nonExtendedPositions
-        } else {
-            nonExtendedPositions ++ Vector#{getOrCrash(Map.get(RamId.Id(-1), mapping)), getOrCrash(Map.get(RamId.Id(-1), mapping))}
-        };
         facts |>
-            BPlusTree.parForEach(tuple -> lat -> {
+            BPlusTree.forEach(tuple -> lat -> {
                 // `facts` and `newTree` must have same the same region. Cast to achieve this.
                 unchecked_cast(({
                     let savedVec = tuple |>
                         Vector.mapWithIndex(index -> boxedVal ->
-                            let unifiedPos = Vector.get(index, positions);
+                            let unifiedPos = Vector.get(index, mapping);
                             unboxWith(boxedVal, unifiedPos, boxingInfo)
                         );
                     BPlusTree.put(savedVec, lat, newTree)
@@ -125,18 +118,19 @@ mod Fixpoint3.Boxing {
     } as _ \ IO + r)
 
     ///
-    /// Construct a `Boxing` from `program` given a map from `RamId` to `UnifiedTypePos`.
+    /// Construct a `Boxing` from `program`.
     ///
-    def initializeInternal(rc: Region[r], program: RamProgram, map: RamIdToPos, withProv: Bool): Boxing[r] \ r =
-        let max = 1 + snd(Option.getWithDefault((RamId.Id(-1), -1), Map.maximumValue(map)));
+    def initializeInternal(rc: Region[r], program: RamProgram, withProv: Bool): Boxing[r] \ r =
+        let RamProgram.Program(_, _, _, _, typeInfo) = program;
+        let max = 1 + Vector.map(v -> Option.getWithDefault(0, Vector.maximum(v)), typeInfo) |> Vector.maximum |> Option.getWithDefault(-1);
         let intToBox = Vector.init(_ -> MutList.empty(rc), max);
         let boxToInt = Vector.init(_ -> BPlusTree.empty(rc), max);
         let locks = Vector.init(_ -> ReadWriteLock.mkLock(rc), max);
-        let posToIndex = Array.init(rc, _ -> Types.TyUnknown, max);
+        let posToIndex = Array.repeat(rc, max, Types.TyUnknown);
         let info = (intToBox, boxToInt, posToIndex, locks);
-        let relSyms = relSymsOfProgram(program);
+        let relSyms = fullRelSymsOfProgram(program);
         if (withProv) {
-            setType(Types.TyInt64, getOrCrash(Map.get(RamId.Id(-1), map)), posToIndex)
+            setType(Types.TyInt64, TypeInfo.provType(), posToIndex)
         } else {
             ()
         };
@@ -144,7 +138,7 @@ mod Fixpoint3.Boxing {
         foreach (x <- relSyms) {
             match x {
                 case RelSym.Symbol(PredSym.PredSym(_, index), arity, Denotation.Latticenal(bot, _, _, _)) =>
-                    unboxWith(bot, getOrCrash(Map.get(RamId.RelPos(index, arity - 1), map)), info); ()
+                    unboxWith(bot, TypeInfo.getType(index, arity - 1, typeInfo), info); ()
                 case _ => ()
             }
         };
@@ -236,7 +230,7 @@ mod Fixpoint3.Boxing {
     @Internal
     pub def boxWith(v: Int64, index: UnifiedTypePos, info: Boxing[r]): Boxed \ r =
         let (_, _, typeInfo, _) = info;
-        match getType(index, typeInfo) {
+        match BoxingType.getType(index, typeInfo) {
             case Types.TyBool      => Boxed.BoxedBool(not(v == 0i64))
             case Types.TyChar      => BoxedChar(unchecked_cast(Array.get(0, Character.toChars(getOrCrash(Int64.tryToInt32(v)))) as _ \ {}))
             case Types.TyInt8      => BoxedInt8(getOrCrash(Int64.tryToInt8(v)))
@@ -248,431 +242,5 @@ mod Fixpoint3.Boxing {
             case Types.TyObject    => deMarshalObject(v, index, info)
             case Types.TyUnknown   => bug!("Unormalizing value, which has never been normalized")
         }
-
-    ///
-    /// Construct a map from `RamId` to `UnifiedTypePos`.
-    ///
-    /// See the description of the Boxing module.
-    ///
-    mod Equality {
-        use Fixpoint3.Ast.Ram.getTermRamId
-        use Fixpoint3.Ast.Ram
-        use Fixpoint3.Ast.Ram.{RamId, Predicates, RamStmt, RelOp, RamTerm, BoolExp, RamProgram, RowVar}
-        use Fixpoint3.Ast.Ram.{RelSym, RamProgram}
-        use Fixpoint3.Ast.Shared.PredSym
-        use Fixpoint3.BoxingType.RamIdToPos
-        use Fixpoint3.Counter
-        use Fixpoint3.Util.getOrCrash
-        use Fixpoint3.Predicate.{PredType, fullRelSymToType, relSymFromPredType, relSymsOfProgram}
-
-        ///
-        /// Returns a map from `RamId` to `UnifiedTypePos` constructed from `program`.
-        ///
-        @Internal
-        pub def computeMapping(program: RamProgram, withProv: Bool): RamIdToPos = region rc {
-            // First compute the equivalence relation for `RamId`s in program
-            // and afterwards use this to assign unique ints to each
-            // equivalence relation.
-            let disjointSet = MutDisjointSets.empty(rc);
-            let RamProgram.Program(stmt, _, _, _, _) = program;
-            unifyRamIds(program, disjointSet, withProv);
-            let relSyms = relSymsOfProgram(program);
-            let mutMap = MutMap.empty(rc);
-            let counter = Counter.fresh(rc);
-            foreach (RelSym.Symbol(PredSym.PredSym(_, id), arity, _) <- relSyms) {
-                foreach (i <- Vector.range(0, getProvSafeIdArity(arity, withProv))) {
-                    registerRamId(disjointSet, mutMap, counter, RamId.RelPos(id, i))
-                }
-            };
-            // Given the equivalence relation just computed assign unique positions for each
-            // equivalence relation.
-            computeMappingStmt(disjointSet, mutMap, counter, withProv, stmt);
-            if (withProv) {
-                registerRamId(disjointSet, mutMap, counter, RamId.Id(-1))
-            } else ();
-            MutMap.toMap(mutMap)
-        }
-
-        ///
-        /// Unify all `RamId`s in `program` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIds(program: RamProgram, set: MutDisjointSets[RamId, r], withProv: Bool): Unit \ r = match program {
-            case RamProgram.Program(stmt, _, predicates, _, _) =>
-                let relSyms = relSymsOfProgram(program);
-                List.forEach(unifyPredTypes(predicates, set, withProv), relSyms);
-                unifyRamIdsStmt(predicates, set, withProv, stmt)
-        }
-
-        ///
-        /// Unify all `RamId`s in `stmt` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIdsStmt(predicates: Predicates, set: MutDisjointSets[RamId, r], withProv: Bool, stmt: RamStmt): Unit \ r = match stmt {
-            case RamStmt.Insert(body)          => unifyRamIdsOp(predicates, set, withProv, body)
-            case RamStmt.MergeInto(rel1, rel2) => unifyRelSyms(rel1, rel2, set, withProv)
-            case RamStmt.Swap(rel1, rel2)      => unifyRelSyms(rel1, rel2, set, withProv)
-            case RamStmt.Purge(_)              => ()
-            case RamStmt.Seq(stmts)            => Vector.forEach(unifyRamIdsStmt(predicates, set, withProv), stmts)
-            case RamStmt.Par(stmts)            => Vector.forEach(unifyRamIdsStmt(predicates, set, withProv), stmts)
-            case RamStmt.Until(bools, body) =>
-                unifyRamIdsStmt(predicates, set, withProv, body);
-                Vector.forEach(unifyRamIdsBool(set), bools)
-            case RamStmt.Comment(_) => ()
-        }
-
-        ///
-        /// Unify all `RamId`s in `op` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIdsOp(predicates: Predicates, set: MutDisjointSets[RamId, r], withProv: Bool, op: RelOp): Unit \ r = match op {
-            case RelOp.Search(rv, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _), _, body) =>
-                let usedArity = getProvSafeIdArity(arity, withProv);
-                foreach (i <- Vector.range(0, usedArity)) {
-                    MutDisjointSets.union(RamId.TuplePos(rv, i), RamId.RelPos(predSym, i), set)
-                };
-                unifyRamIdsOp(predicates, set, withProv, body)
-            case RelOp.Query(rv, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _), bools, _, _, body) =>
-                let usedArity = getProvSafeIdArity(arity, withProv);
-                foreach (i <- Vector.range(0, usedArity)) {
-                    MutDisjointSets.union(RamId.TuplePos(rv, i), RamId.RelPos(predSym, i), set)
-                };
-                Vector.forEach(unifyRamIdsBool(set), bools);
-                unifyRamIdsOp(predicates, set, withProv, body)
-            case RelOp.Functional(rv, _, inputTerms, body, arity, _) =>
-                let RowVar.Named(id) = rv;
-                foreach ((i, curTerm) <- ForEach.withIndex(inputTerms)) {
-                    let termID = Ram.getTermRamId(curTerm);
-                    MutDisjointSets.union(RamId.InId(id, i), termID, set);
-                    unifyRamIdsTerm(set, curTerm)
-                };
-                foreach (i <- Vector.range(0, arity)) {
-                    MutDisjointSets.makeSet(RamId.TuplePos(rv, i), set)
-                };
-                unifyRamIdsOp(predicates, set, withProv, body)
-            case RelOp.Project(terms, RelSym.Symbol(PredSym.PredSym(_, predSym), _, _), _) =>
-                foreach ((i, term) <- ForEach.withIndex(terms)) {
-                    unifyRamIdsTerm(set, term);
-                    let termID = Ram.getTermRamId(term);
-                    MutDisjointSets.union(RamId.RelPos(predSym, i), termID, set)
-                }
-            case RelOp.If(bools, body) =>
-                Vector.forEach(unifyRamIdsBool(set), bools);
-                unifyRamIdsOp(predicates, set, withProv, body)
-        }
-
-        ///
-        /// Unify all `RamId`s in `boolExp` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIdsBool(set: MutDisjointSets[RamId, r], boolExp: BoolExp): Unit \ r = match boolExp {
-            case BoolExp.Not(bexp) => unifyRamIdsBool(set, bexp)
-            case BoolExp.IsEmpty(_) => ()
-            case BoolExp.NotMemberOf(terms, RelSym.Symbol(PredSym.PredSym(_, id), _, _)) =>
-                Vector.forEach(unifyRamIdsTerm(set), terms);
-                foreach ((i, term) <- ForEach.withIndex(terms)) {
-                    MutDisjointSets.union(Ram.getTermRamId(term), RamId.RelPos(id, i), set)
-                }
-            case BoolExp.NotBot(term, _, _) => unifyRamIdsTerm(set, term)
-            case BoolExp.Leq(_, _, _) => ()
-            case BoolExp.Eq(term1, term2) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2);
-                MutDisjointSets.union(Ram.getTermRamId(term1), Ram.getTermRamId(term2), set)
-            case BoolExp.Guard1(_, term1) =>
-                unifyRamIdsTerm(set, term1)
-            case BoolExp.Guard2(_, term1, term2) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2)
-            case BoolExp.Guard3(_, term1, term2, term3) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2);
-                unifyRamIdsTerm(set, term3)
-            case BoolExp.Guard4(_, term1, term2, term3, term4) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2);
-                unifyRamIdsTerm(set, term3);
-                unifyRamIdsTerm(set, term4)
-            case BoolExp.Guard5(_, term1, term2, term3, term4, term5) =>
-                unifyRamIdsTerm(set, term1);
-                unifyRamIdsTerm(set, term2);
-                unifyRamIdsTerm(set, term3);
-                unifyRamIdsTerm(set, term4);
-                unifyRamIdsTerm(set, term5)
-        }
-
-        ///
-        /// Unify all `RamId`s in `term` which can be proven to be equivalent, type-wise.
-        ///
-        def unifyRamIdsTerm(set: MutDisjointSets[RamId, r], term: RamTerm): Unit \ r = match term {
-            case RamTerm.Lit(_, _, _) => ()
-            case RamTerm.RowLoad(_, _, _, _) => ()
-            case RamTerm.ProvMax(vec) =>
-                let id = Ram.getTermRamId(term);
-                foreach ((rv, index) <- vec) {
-                    MutDisjointSets.union(RamId.TuplePos(rv, index), id, set)
-                }
-            case RamTerm.Meet(_, t1, (rv, relSym), id, _) =>
-                unifyRamIdsTerm(set, t1);
-                let id1 = Ram.getTermRamId(t1);
-                let id2 = Ram.getLatVarRamId(rv, relSym);
-                MutDisjointSets.union(id1, id, set);
-                MutDisjointSets.union(id1, id2, set)
-            case RamTerm.App1(_, t1, RamId.Id(id), _) =>
-                unifyAppTerms(Vector#{t1}, id, set)
-            case RamTerm.App2(_, t1, t2, RamId.Id(id), _) =>
-                unifyAppTerms(Vector#{t1, t2}, id, set)
-            case RamTerm.App3(_, t1, t2, t3, RamId.Id(id), _) =>
-                unifyAppTerms(Vector#{t1, t2, t3}, id, set)
-            case RamTerm.App4(_, t1, t2, t3, t4, RamId.Id(id), _) =>
-                unifyAppTerms(Vector#{t1, t2, t3, t4}, id, set)
-            case RamTerm.App5(_, t1, t2, t3, t4, t5, RamId.Id(id), _) =>
-                unifyAppTerms(Vector#{t1, t2, t3, t4, t4, t5}, id, set)
-            case _ => unreachable!()
-        }
-
-        ///
-        /// Unify all `RamId`s that can be associated with `relSym1` and `relSym2`.
-        ///
-        /// Concretely, unify `RamId.RelPos(id1, i)` and `RamId.RelPos(id2, i)` for `0 <= i < arity`
-        /// for symbols `RelSym(id1, arity, _)` and `RelSym(id2, arity, _)`.
-        ///
-        def unifyRelSyms(relSym1: RelSym, relSym2: RelSym, set: MutDisjointSets[RamId, r], withProv: Bool): Unit \ r =
-            let arity = Ram.arityOf(relSym1);
-            let usedArity = getProvSafeIdArity(arity, withProv);
-            let id1 = Ram.toId(relSym1);
-            let id2 = Ram.toId(relSym2);
-            foreach (i <- Vector.range(0, usedArity)) {
-                MutDisjointSets.union(RamId.RelPos(id1, i), RamId.RelPos(id2, i), set)
-            }
-
-        ///
-        /// For `predSym = 'P'` unify all indexes for `(P, ΔP, ΔP')`.
-        ///
-        def unifyPredTypes(predicates: Predicates, set: MutDisjointSets[RamId, r], withProv: Bool, relSym: RelSym): Unit \ r =
-            let fullSymbol = relSymFromPredType(relSym, PredType.Full, predicates);
-            let deltaSymbol = fullRelSymToType(fullSymbol, PredType.Delta, predicates);
-            let newSymbol = fullRelSymToType(fullSymbol, PredType.New, predicates);
-            unifyRelSyms(fullSymbol, deltaSymbol, set, withProv);
-            unifyRelSyms(fullSymbol, newSymbol, set, withProv);
-            let arity = Ram.arityOf(fullSymbol);
-            let id1 = Ram.toId(fullSymbol);
-            if (withProv) {
-                MutDisjointSets.union(RamId.RelPos(id1, arity), RamId.Id(-1), set);
-                MutDisjointSets.union(RamId.RelPos(id1, arity + 1), RamId.Id(-1), set)
-            } else ()
-
-        ///
-        /// Unify the `i`'th `RamTerm` in `terms` with `RamId.InId(id, i)`.
-        ///
-        /// This should be understood as 'register that term `i` will be input to
-        /// the function at position `i`'.
-        ///
-        def unifyAppTerms(terms: Vector[RamTerm], id: Int32, set: MutDisjointSets[RamId, r]): Unit \ r =
-            foreach ((i, t) <- ForEach.withIndex(terms)) {
-                unifyRamIdsTerm(set, t);
-                let id1 = Ram.getTermRamId(t);
-                MutDisjointSets.union(id1, RamId.InId(id, i), set)
-            }
-
-        ///
-        /// Based on the equivalence `disjoint` assign all unique `RamId`'s a `Boxing` position.
-        ///
-        def computeMappingStmt(disjoint: MutDisjointSets[RamId, r], map: MutMap[RamId, Int32, r], counter: Counter[r], withProv: Bool, stmt: RamStmt): Unit \ r = match stmt {
-            case RamStmt.Insert(rest) => computeMappingOp(disjoint, map, counter, withProv, rest)
-            case RamStmt.MergeInto(rel1, rel2) =>
-                insertIndexRelSym(rel1, disjoint, map, counter, withProv);
-                insertIndexRelSym(rel2, disjoint, map, counter, withProv)
-            case RamStmt.Swap(rel1, rel2) =>
-                insertIndexRelSym(rel1, disjoint, map, counter, withProv);
-                insertIndexRelSym(rel2, disjoint, map, counter, withProv)
-            case RamStmt.Purge(_) => ()
-            case RamStmt.Seq(stmts) => Vector.forEach(computeMappingStmt(disjoint, map, counter, withProv), stmts)
-            case RamStmt.Par(stmts) => Vector.forEach(computeMappingStmt(disjoint, map, counter, withProv), stmts)
-            case RamStmt.Until(bools, body) =>
-                computeMappingStmt(disjoint, map, counter, withProv, body);
-                Vector.forEach(computeMappingBool(disjoint, map, counter), bools)
-            case RamStmt.Comment(_) => ()
-        }
-
-        ///
-        /// Based on the equivalence `disjoint` assign all unique `RamId`'s a `Boxing` position.
-        ///
-        def computeMappingOp(set: MutDisjointSets[RamId, r], map: MutMap[RamId, Int32, r], counter: Counter[r], withProv: Bool, op: RelOp): Unit \ r =
-            let recurse = computeMappingOp(set, map, counter, withProv);
-            let insert = registerRamId(set, map, counter);
-            match op {
-                case RelOp.Search(rv, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _), _, body) =>
-                    let usedArity = getProvSafeIdArity(arity, withProv);
-                    foreach (i <- Vector.range(0, usedArity)) {
-                        insert(RamId.TuplePos(rv, i));
-                        insert(RamId.RelPos(predSym, i))
-                    };
-                    recurse(body)
-                case RelOp.Query(rv, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _), bools, _, _, body) =>
-                    let usedArity = getProvSafeIdArity(arity, withProv);
-                    foreach (i <- Vector.range(0, usedArity)) {
-                        insert(RamId.TuplePos(rv, i));
-                        insert(RamId.RelPos(predSym, i))
-                    };
-                    Vector.forEach(computeMappingBool(set, map, counter), bools);
-                    recurse(body)
-                case RelOp.Functional(RowVar.Named(id), _, inputTerms, body, arity, _) => // equality on the input should be handled elsewhere.
-                    Vector.forEach(i -> insert(RamId.TuplePos(RowVar.Named(id), i)), Vector.range(0, arity));
-                    Vector.forEach(i -> insert(RamId.InId(id, i)), Vector.range(0, Vector.length(inputTerms)));
-                    Vector.forEach(computeMappingTerm(set, map, counter), inputTerms);
-                    recurse(body)
-                case RelOp.Project(terms, RelSym.Symbol(PredSym.PredSym(_, predSym), _, _), _) =>
-                    terms |> Vector.forEachWithIndex(i -> _ -> insert(RamId.RelPos(predSym, i)));
-                    terms |> Vector.forEach(computeMappingTerm(set, map, counter))
-                case RelOp.If(bools, body) =>
-                    recurse(body);
-                    Vector.forEach(computeMappingBool(set, map, counter), bools)
-            }
-
-        ///
-        /// Assign all `RamId`s in `boolExp` `UnifiedTypePos`.
-        ///
-        def computeMappingBool(
-            set: MutDisjointSets[RamId, r],
-            map: MutMap[RamId, Int32, r],
-            counter: Counter[r],
-            boolExp: BoolExp
-        ): Unit \ r =
-            let insert = registerRamId(set, map, counter);
-            let computeMappingTermRec = computeMappingTerm(set, map, counter);
-            match boolExp {
-                case BoolExp.Not(bexp) => computeMappingBool(set, map, counter, bexp)
-                case BoolExp.IsEmpty(_) => ()
-                case BoolExp.NotMemberOf(terms, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _)) =>
-                    Vector.forEach(computeMappingTermRec, terms);
-                    Vector.forEach(i -> insert(RamId.RelPos(predSym, i)), Vector.range(0, arity))
-                case BoolExp.Eq(t1, t2) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2)
-                case BoolExp.NotBot(t1, _, _) =>
-                    computeMappingTermRec(t1)
-                case BoolExp.Leq(_, _, RelSym.Symbol(PredSym.PredSym(_, predSym), arity, _)) =>
-                    insert(RamId.RelPos(predSym, arity - 1))
-                case BoolExp.Guard1(_, t1) =>
-                    computeMappingTermRec(t1)
-                case BoolExp.Guard2(_, t1, t2) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2)
-                case BoolExp.Guard3(_, t1, t2, t3) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2);
-                    computeMappingTermRec(t3)
-                case BoolExp.Guard4(_, t1, t2, t3, t4) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2);
-                    computeMappingTermRec(t3);
-                    computeMappingTermRec(t4)
-                case BoolExp.Guard5(_, t1, t2, t3, t4, t5) =>
-                    computeMappingTermRec(t1);
-                    computeMappingTermRec(t2);
-                    computeMappingTermRec(t3);
-                    computeMappingTermRec(t4);
-                    computeMappingTermRec(t5)
-            }
-
-        ///
-        /// Assign all `RamId`s in `term` `UnifiedTypePos`.
-        ///
-        def computeMappingTerm(
-            set: MutDisjointSets[RamId, r],
-            map: MutMap[RamId, Int32, r],
-            counter: Counter[r],
-            term: RamTerm
-        ): Unit \ r =
-            let registerRamIdRec = registerRamId(set, map, counter);
-            let computeMappingTermRec = computeMappingTerm(set, map, counter);
-            let computeMappingTermAppRec = computeMappingTermApp(computeMappingTermRec, registerRamIdRec, getTermRamId(term));
-            match term {
-                case RamTerm.Lit(_, id, _) => registerRamIdRec(id)
-                case RamTerm.RowLoad(_, _, _, _) => registerRamIdRec(getTermRamId(term))
-                case RamTerm.Meet(_, t1, (rv, relSym), RamId.Id(id), _) =>
-                    computeMappingTermRec(t1);
-                    registerRamIdRec(Ram.getLatVarRamId(rv, relSym));
-                    registerRamIdRec(RamId.Id(id))
-                case RamTerm.App1(_, t1, _, _) =>
-                    Vector#{t1} |> computeMappingTermAppRec
-                case RamTerm.App2(_, t1, t2, _, _) =>
-                    Vector#{t1, t2} |> computeMappingTermAppRec
-                case RamTerm.App3(_, t1, t2, t3, _, _) =>
-                    Vector#{t1, t2, t3} |> computeMappingTermAppRec
-                case RamTerm.App4(_, t1, t2, t3, t4, _, _) =>
-                    Vector#{t1, t2, t3, t4} |> computeMappingTermAppRec
-                case RamTerm.App5(_, t1, t2, t3, t4, t5, _, _) =>
-                    Vector#{t1, t2, t3, t4, t5} |> computeMappingTermAppRec
-                case RamTerm.ProvMax(loads) =>
-                    loads |> Vector.forEach(match (rv, index) -> registerRamIdRec(RamId.TuplePos(rv, index)))
-                case RamTerm.Meet(_, _, _, _, _) => unreachable!()
-            }
-
-        ///
-        /// Based on the equivalence `disjoint` assign all unique `RamId`'s a `Boxing` position.
-        ///
-        def computeMappingTermApp(
-            computeMappingTermRec: RamTerm -> Unit \ r,
-            registerRamIdRec: RamId -> Unit \ r,
-            id: RamId,
-            terms: Vector[RamTerm]
-        ): Unit \ r =
-            registerRamIdRec(id);
-            let id1 = match id {
-                case RamId.Id(i) => i
-                case _ => unreachable!()
-            };
-            foreach ((i, t) <- ForEach.withIndex(terms)) {
-                computeMappingTermRec(t);
-                registerRamIdRec(RamId.InId(id1, i))
-            }
-
-        ///
-        /// If `withProv` is true return `arity + 2`. Otherwise return `arity`.
-        ///
-        def getProvSafeIdArity(arity: Int32, withProv: Bool): Int32 =
-            if (withProv) arity + 2
-            else arity
-
-        ///
-        /// Add all `RamId`'s associated with `relSym` to `map`.
-        ///
-        /// Concretely, add `RamId.RelPos(id, i)` where `0 <= i <= arity` for `RelSym(id, arity, _)`.
-        ///
-        def insertIndexRelSym(
-            relSym: RelSym,
-            disjoint: MutDisjointSets[RamId, r],
-            map: MutMap[RamId, Int32, r],
-            counter: Counter[r],
-            withProv: Bool
-        ): Unit \ r =
-            let arity = Ram.arityOf(relSym);
-            let id = Ram.toId(relSym);
-            let usedArity = getProvSafeIdArity(arity, withProv);
-            foreach (i <- Vector.range(0, usedArity)) {
-                registerRamId(disjoint, map, counter, RamId.RelPos(id, i))
-            }
-
-        ///
-        /// Add `id` to `map` pointing to the `Int32` representing its boxing-information.
-        ///
-        /// Concretely, lookup `id` in `disjoint` to get `rep`. If `map[rep] => v` add
-        /// [id => v]. Otherwise add `[id => newID]` and `[rep => newID]`.
-        ///
-        /// `counter` is used to generate new identifiers.
-        ///
-        def registerRamId(
-            disjoint: MutDisjointSets[RamId, r],
-            ramIdToBoxingPos: MutMap[RamId, Int32, r],
-            counter: Counter[r],
-            ramID: RamId
-        ): Unit \ r =
-            let repID = getOrCrash(MutDisjointSets.find(ramID, disjoint));
-            match MutMap.get(repID, ramIdToBoxingPos) {
-                case Some(v) => MutMap.put(ramID, v, ramIdToBoxingPos)
-                case None =>
-                    let newID = Counter.getAndIncrement(counter);
-                    MutMap.put(ramID, newID, ramIdToBoxingPos);
-                    MutMap.put(repID, newID, ramIdToBoxingPos)
-            }
-    }
 
 }

--- a/main/src/library/Fixpoint3/Debugging.flix
+++ b/main/src/library/Fixpoint3/Debugging.flix
@@ -121,7 +121,7 @@ mod Fixpoint3.Debugging {
     pub def notifyPreInterpret(
         input: (ExecutableRam.RamProgram[r], BoxingType.Boxing[r])
     ): (ExecutableRam.RamProgram[r], BoxingType.Boxing[r]) = match fst(input) {
-        case ExecutableRam.RamProgram.Program(stmt, _, _, (index, indexPos), _, _, _) => unsafely IO run {
+        case ExecutableRam.RamProgram.Program(stmt, _, _, (index, indexPos), _, _) => unsafely IO run {
             if (Options.enableDebugging()) region rc {
                 let strings = MutList.empty(rc);
                 let psh = s -> MutList.push(s, strings);

--- a/main/src/library/Fixpoint3/Interpreter.flix
+++ b/main/src/library/Fixpoint3/Interpreter.flix
@@ -18,15 +18,17 @@
 
 mod Fixpoint3.Interpreter {
     use Fixpoint3.Ast.ExecutableRam.{BoolExp, RamProgram, RamStmt, RamTerm, RelOp, WriteTuple}
-    use Fixpoint3.Ast.Ram.{arityOfNonLat, Predicates, RamId, RelSym, Search, toDenotation, toId}
+    use Fixpoint3.Ast.Ram.{arityOfNonLat, Predicates, RelSym, Search, toDenotation, toId}
     use Fixpoint3.Ast.Shared.{BoxedDenotation => Denotation}
     use Fixpoint3.Ast.Shared.Denotation.{Latticenal, Relational}
     use Fixpoint3.Boxed
     use Fixpoint3.Boxing.{boxWith, unboxWith}
-    use Fixpoint3.BoxingType.{Boxing, RamIdToPos}
+    use Fixpoint3.BoxingType.Boxing
     use Fixpoint3.Counter
     use Fixpoint3.Options.{usedArity, parLevel}
-    use Fixpoint3.Predicate.allFullRelSyms
+    use Fixpoint3.Predicate.{allFullRelSyms, getRelSymAsType}
+    use Fixpoint3.Predicate.PredType.Full
+    use Fixpoint3.TypeInfo.{TypeInformation, getTypeOf}
     use Fixpoint3.Util.getOrCrash
 
     ///
@@ -140,10 +142,10 @@ mod Fixpoint3.Interpreter {
     /// Executes the `RamProgram` in `fst(input)` using the `Boxing` in `snd(input)`.
     ///
     @Internal
-    pub def interpret(rc: Region[r], withProv: Bool, input: (RamProgram[r], Boxing[r])): (Database[r], Predicates) \ r =
+    pub def interpret(rc: Region[r], input: (RamProgram[r], Boxing[r])): (Database[r], Predicates) \ r =
         let (program, boxing) = input;
         // Create `Indexes` from `program`.
-        let RamProgram.Program(_, facts, _, (indexMap, posMap), _, _, _) = program;
+        let RamProgram.Program(_, facts, _, (indexMap, posMap), _, _) = program;
         let indexNum = match Map.maximumValue(posMap) {
             case None         => 0
             case Some((_, v)) => v + 1
@@ -159,7 +161,7 @@ mod Fixpoint3.Interpreter {
                 storeIndex(mkIndex(rc, relSym, search, tuples), pos, indexes)
             }
         };
-        interpretWithDatabase(rc, indexes, boxing, withProv, program)
+        interpretWithDatabase(rc, indexes, boxing, program)
 
     ///
     /// Executes `program` using `boxing` as `Boxing` information and `db` as initial
@@ -169,10 +171,9 @@ mod Fixpoint3.Interpreter {
         rc: Region[r],
         db: Indexes[r],
         boxing: Boxing[r],
-        withProv: Bool,
         program: RamProgram[r]
     ): (Database[r], Predicates) \ r = match program {
-        case RamProgram.Program(stmt, _, predState, (_, indexPos), (arities, constWrites), marshallIndexes, _types) =>
+        case RamProgram.Program(stmt, _, predState, (_, indexPos), (arities, constWrites), typeInfo) =>
             let minEnv = arities |> Vector.map(x -> Array.repeat(rc, x, Int64.minValue()));
             let maxEnv = arities |> Vector.map(x -> Array.repeat(rc, x, Int64.maxValue()));
             foreach ((id1, id2, val) <- constWrites) {
@@ -185,7 +186,7 @@ mod Fixpoint3.Interpreter {
             let ctx = (db, env, boxing);
             evalStmt(rc, ctx, parLevel(), stmt);
             // Remove the `IO` effect from dealing with static.
-            let boxedFacts = unsafely IO run marshallDb(rc, db, boxing, indexPos, predState, marshallIndexes, withProv);
+            let boxedFacts = unsafely IO run marshallDb(rc, db, boxing, indexPos, predState, typeInfo);
             (boxedFacts, predState)
     }
 
@@ -201,21 +202,12 @@ mod Fixpoint3.Interpreter {
         boxing: Boxing[r],
         indexPos: Map[(RelSym, Int32), Int32],
         predTrack: Predicates,
-        boxingIndexes: RamIdToPos,
-        withProv: Bool
+        typeInfo: TypeInformation
     ): Database[r] \ r + IO =
         let res = MutMap.empty(rc);
         foreach (relSym <- allFullRelSyms(predTrack)) {
             let innerMap = BPlusTree.empty(Static);
-            // If we are doing provenance computations we need to also rebox the annotations.
-            // Since there are 2 annotations we add 2 in this case.
-            let usedArity =
-                if (withProv) arityOfNonLat(relSym) + 2
-                else arityOfNonLat(relSym);
-            let curBoxingInfo = Vector.range(0, usedArity) |>
-                Vector.map(i ->
-                    getOrCrash(Map.get(RamId.RelPos(toId(relSym), i), boxingIndexes))
-                );
+            let curBoxingInfo = getTypeOf(toId(relSym), typeInfo);
             Array.get(getOrCrash(Map.get((relSym, 0), indexPos)), db) |>
                 BPlusTree.forEach(vec -> latticeElem -> {
                     let boxedVec = vec |>

--- a/main/src/library/Fixpoint3/Phase/Compiler.flix
+++ b/main/src/library/Fixpoint3/Phase/Compiler.flix
@@ -273,10 +273,10 @@ mod Fixpoint3.Phase.Compiler {
         case Constraint(headAtom, body) =>
             let HeadAtom(PredSym(_, headId), _, headTerms) = headAtom;
             let augBody = augmentBody(body, counter);
-            let env = unifyVars(predicates, counter, functionalCounter, typeInfo, augBody);
+            let env = unifyVars(predicates, functionalCounter, typeInfo, augBody);
             let ramTerms = Vector.mapWithIndex(i -> atom -> compileHeadTerm(env, counter, getType(headId, i, typeInfo), atom), headTerms);
             let projection = RelOp.Project(ramTerms, Predicate.headAtomToRelSym(headAtom, New, predicates), ruleNum);
-            match compileBody(env, augBody, predicates, counter, typeInfo) {
+            match compileBody(env, augBody, predicates, typeInfo) {
                 case None       => ()
                 case Some(join) =>
                     let loopBody = RelOp.If(join, projection);
@@ -337,10 +337,10 @@ mod Fixpoint3.Phase.Compiler {
             let compileSomething = deltaIndex -> { // `delta` designates the focused atom.
                 let augBody = augmentBody(body, counter);
                 let delta = snd(Vector.get(deltaIndex, augBody));
-                let env = unifyVars(predicates, counter, functionalCounter, typeInfo, augBody);
+                let env = unifyVars(predicates, functionalCounter, typeInfo, augBody);
                 let ramTerms = Vector.mapWithIndex(i -> atom -> compileHeadTerm(env, counter, getType(headId, i, typeInfo), atom), headTerms);
                 let projection = RelOp.Project(ramTerms, Predicate.headAtomToRelSym(headAtom, New, predicates), ruleNum);
-                match compileBody(env, augBody, predicates, counter, typeInfo) {
+                match compileBody(env, augBody, predicates, typeInfo) {
                     case None       => ()
                     case Some(join) =>
                         let relSym = Predicate.headAtomToRelSym(headAtom, Full, predicates);
@@ -398,29 +398,29 @@ mod Fixpoint3.Phase.Compiler {
         case HeadTerm.Lit(v)     => RamTerm.Lit(v, RamId.Id(Counter.getAndIncrement(counter)), ty)
         case HeadTerm.App1(f, v) =>
             let t = getOrCrash(Map.get(v, env));
-            RamTerm.App1(f, t, RamId.Id(Counter.getAndIncrement(counter)), ty)
+            RamTerm.App1(f, t, RamId.Id(-42), ty)
         case HeadTerm.App2(f, v1, v2) =>
             let t1 = getOrCrash(Map.get(v1, env));
             let t2 = getOrCrash(Map.get(v2, env));
-            RamTerm.App2(f, t1, t2, RamId.Id(Counter.getAndIncrement(counter)), ty)
+            RamTerm.App2(f, t1, t2, RamId.Id(-42), ty)
         case HeadTerm.App3(f, v1, v2, v3) =>
             let t1 = getOrCrash(Map.get(v1, env));
             let t2 = getOrCrash(Map.get(v2, env));
             let t3 = getOrCrash(Map.get(v3, env));
-            RamTerm.App3(f, t1, t2, t3, RamId.Id(Counter.getAndIncrement(counter)), ty)
+            RamTerm.App3(f, t1, t2, t3, RamId.Id(-42), ty)
         case HeadTerm.App4(f, v1, v2, v3, v4) =>
             let t1 = getOrCrash(Map.get(v1, env));
             let t2 = getOrCrash(Map.get(v2, env));
             let t3 = getOrCrash(Map.get(v3, env));
             let t4 = getOrCrash(Map.get(v4, env));
-            RamTerm.App4(f, t1, t2, t3, t4, RamId.Id(Counter.getAndIncrement(counter)), ty)
+            RamTerm.App4(f, t1, t2, t3, t4, RamId.Id(-42), ty)
         case HeadTerm.App5(f, v1, v2, v3, v4, v5) =>
             let t1 = getOrCrash(Map.get(v1, env));
             let t2 = getOrCrash(Map.get(v2, env));
             let t3 = getOrCrash(Map.get(v3, env));
             let t4 = getOrCrash(Map.get(v4, env));
             let t5 = getOrCrash(Map.get(v5, env));
-            RamTerm.App5(f, t1, t2, t3, t4, t5, RamId.Id(Counter.getAndIncrement(counter)), ty)
+            RamTerm.App5(f, t1, t2, t3, t4, t5, RamId.Id(-42), ty)
     }
 
     ///
@@ -445,7 +445,7 @@ mod Fixpoint3.Phase.Compiler {
     ///
     /// Does not change `functionalCounter`
     ///
-    def unifyVars(predicates: Predicates, counter: Counter[r], functionalCounter: Counter[r], typeInfo: TypeInformation, body: Vector[(BodyPredicate, RowVar)]): Map[VarSym, RamTerm] \ r =
+    def unifyVars(predicates: Predicates, functionalCounter: Counter[r], typeInfo: TypeInformation, body: Vector[(BodyPredicate, RowVar)]): Map[VarSym, RamTerm] \ r =
         let functionalCountBackUp = Counter.get(functionalCounter);
         let toFullSym = bodyAtom -> (Predicate.bodyAtomToRelSym(bodyAtom, Full, predicates));
         let innerFunc = {
@@ -466,7 +466,7 @@ mod Fixpoint3.Phase.Compiler {
                                     if (i < Vector.length(terms) - 1)
                                         Map.insertWith(_ -> t -> t, var, RamTerm.RowLoad(rowVar, i, sType, toFullSym(atom)), acc1)
                                     else
-                                        let f = _ -> t2 -> RamTerm.Meet(glb, t2, (rowVar, toFullSym(atom)), RamId.Id(Counter.getAndIncrement(counter)), getType(id, i, typeInfo));
+                                        let f = _ -> t2 -> RamTerm.Meet(glb, t2, (rowVar, toFullSym(atom)), RamId.Id(-42), getType(id, i, typeInfo));
                                         Map.insertWith(f, var, RamTerm.RowLoad(rowVar, i, sType, toFullSym(atom)), acc1)
                             }
                             case _ => acc1
@@ -506,9 +506,9 @@ mod Fixpoint3.Phase.Compiler {
     /// (2) comes from the negative atom `not A(x)`.
     /// (3) is a function call that computes the expression `x > 0`.
     ///
-    def compileBody(env: Map[VarSym, RamTerm], body: Vector[(BodyPredicate, RowVar)], predicates: Predicates, counter: Counter[r], typeInfo: TypeInformation): Option[Vector[BoolExp]] \ r =
+    def compileBody(env: Map[VarSym, RamTerm], body: Vector[(BodyPredicate, RowVar)], predicates: Predicates, typeInfo: TypeInformation): Option[Vector[BoolExp]] =
         if (isImpossible(body)) None
-        else Some(compileBodyWithoutGuard0(env, body, predicates, counter, typeInfo))
+        else Some(compileBodyWithoutGuard0(env, body, predicates, typeInfo))
 
     ///
     /// Returns true if a rule is impossible to satisfy. Used for removing `Guard0()` from the AST.
@@ -533,14 +533,14 @@ mod Fixpoint3.Phase.Compiler {
     ///
     /// Compiles `body` under substitution `env`, assuming any `Guard0` is true.
     ///
-    def compileBodyWithoutGuard0(env: Map[VarSym, RamTerm], body: Vector[(BodyPredicate, RowVar)], predicates: Predicates, counter: Counter[r], typeInfo: TypeInformation): Vector[BoolExp] \ r =
+    def compileBodyWithoutGuard0(env: Map[VarSym, RamTerm], body: Vector[(BodyPredicate, RowVar)], predicates: Predicates, typeInfo: TypeInformation): Vector[BoolExp] =
         let toFullSym = bodyAtom -> (Predicate.bodyAtomToRelSym(bodyAtom, Full, predicates));
         body |>
             Vector.flatMap(match (atom, rowVar) ->
                 let compileBodyTerm = id -> j -> term -> match term {
                     case BodyTerm.Wild      => RamTerm.RowLoad(rowVar, j, getType(id, j, typeInfo), toFullSym(atom))
                     case BodyTerm.Var(var)  => getOrCrash(Map.get(var, env))
-                    case BodyTerm.Lit(v)    => RamTerm.Lit(v, RamId.Id(Counter.getAndIncrement(counter)), getType(id, j, typeInfo))
+                    case BodyTerm.Lit(v)    => RamTerm.Lit(v, RamId.Id(-42), getType(id, j, typeInfo))
                 };
                 match atom {
                     case BodyAtom(PredSym(_, id), denotation, Polarity.Positive, _, terms) =>

--- a/main/src/library/Fixpoint3/Phase/Lowering.flix
+++ b/main/src/library/Fixpoint3/Phase/Lowering.flix
@@ -98,11 +98,11 @@ mod Fixpoint3.Phase.Lowering {
     use Fixpoint3.Ast.ExecutableRam
     use Fixpoint3.Ast.ExecutableRam.WriteTuple
     use Fixpoint3.Ast.Ram
-    use Fixpoint3.Ast.Ram.{arityOf, arityOfNonLat, getTermRamId, IndexInformation, Predicates, RamId, RelSym, RowVar, Search, toDenotation}
+    use Fixpoint3.Ast.Ram.{arityOf, arityOfNonLat, IndexInformation, Predicates, RelSym, RowVar, Search, toDenotation, toId}
     use Fixpoint3.Ast.Shared.{Denotation, PredSym}
     use Fixpoint3.Boxed
     use Fixpoint3.Boxing
-    use Fixpoint3.BoxingType.{Boxing, RamIdToPos};
+    use Fixpoint3.BoxingType.Boxing;
     use Fixpoint3.Predicate.{getRelSymAsType, PredType}
     use Fixpoint3.TypeInfo
     use Fixpoint3.TypeInfo.{getTypeOf, TypeInformation}
@@ -168,9 +168,9 @@ mod Fixpoint3.Phase.Lowering {
     pub def lowerProgram(rc: Region[r], withProv: Bool, program: Ram.RamProgram): (ExecutableRam.RamProgram[r], Boxing[r]) \ r = match program {
         case Ram.RamProgram.Program(stmt, _, meta, indexInfo, typeInfo) =>
             let idToIndex = UniqueInts.empty(rc);
-            let (boxing, newFacts, idToBoxing) = Boxing.initialize(rc, withProv, program);
+            let (boxing, newFacts) = Boxing.initialize(rc, withProv, program);
             let writeTo = (MutMap.empty(rc), MutMap.empty(rc));
-            let loweredStmt = lowerStmt(rc, idToIndex, (idToBoxing, boxing), writeTo, indexInfo, meta, withProv, stmt);
+            let loweredStmt = lowerStmt(rc, idToIndex, boxing, writeTo, indexInfo, meta, withProv, stmt);
 
             let constWrites = snd(writeTo)
                 |> MutMap.foldWithKey(acc1 -> outerPos -> inner ->
@@ -184,7 +184,7 @@ mod Fixpoint3.Phase.Lowering {
             foreach ((rv, arity) <- arityInformation) {
                 Array.put(arity, UniqueInts.getIndex(rv, idToIndex), arities)
             };
-            (ExecutableRam.RamProgram.Program(loweredStmt, newFacts, meta, indexInfo, (Array.toVector(arities), constWrites), idToBoxing, typeInfo), boxing)
+            (ExecutableRam.RamProgram.Program(loweredStmt, newFacts, meta, indexInfo, (Array.toVector(arities), constWrites), typeInfo), boxing)
     }
 
     ///
@@ -202,17 +202,17 @@ mod Fixpoint3.Phase.Lowering {
     def lowerStmt(
         rc: Region[r],
         idToIndex: IdToIndex[r],
-        boxingInfo: (RamIdToPos, Boxing[r]),
+        boxing: Boxing[r],
         writeTo: (WriteTos[r], ConstWrites[r]),
         indexInfo: IndexInformation,
         predicates: Predicates,
         withProv: Bool,
         stmt: Ram.RamStmt
     ): ExecutableRam.RamStmt \ r =
-        let lowerStmtRec = lowerStmt(rc, idToIndex, boxingInfo, writeTo, indexInfo, predicates, withProv);
+        let lowerStmtRec = lowerStmt(rc, idToIndex, boxing, writeTo, indexInfo, predicates, withProv);
         match stmt {
             case Ram.RamStmt.Insert(op) =>
-                let newOp = lowerOp(rc, idToIndex, boxingInfo, writeTo, indexInfo, (Nil, MutDisjointSets.empty(rc)), predicates, withProv, op);
+                let newOp = lowerOp(rc, idToIndex, boxing, writeTo, indexInfo, (Nil, MutDisjointSets.empty(rc)), predicates, withProv, op);
                 ExecutableRam.RamStmt.Insert(newOp)
             case Ram.RamStmt.MergeInto(newRel, otherRel) =>
                 // `MergeInto` should simply be repeated for all indexes built on `deltaRel`.
@@ -268,7 +268,7 @@ mod Fixpoint3.Phase.Lowering {
             case Ram.RamStmt.Par(xs) => ExecutableRam.RamStmt.Par(Vector.map(x -> lowerStmtRec(x), xs))
             case Ram.RamStmt.Until(test, body) =>
                 let newTests = test |>
-                    Vector.filterMap(lowerBool(idToIndex, boxingInfo, indexInfo, (Nil, MutDisjointSets.empty(rc))));
+                    Vector.filterMap(lowerBool(idToIndex, boxing, indexInfo, (Nil, MutDisjointSets.empty(rc))));
                 let newBody = lowerStmtRec(body);
                 ExecutableRam.RamStmt.Until(newTests, newBody)
             case Ram.RamStmt.Comment(s) => ExecutableRam.RamStmt.Comment(s)
@@ -282,7 +282,7 @@ mod Fixpoint3.Phase.Lowering {
     def lowerOp(
         rc: Region[r],
         idToIndex: IdToIndex[r],
-        boxingInfo: (RamIdToPos, Boxing[r]),
+        boxing: Boxing[r],
         writeTo: (WriteTos[r], ConstWrites[r]),
         indexInfo: IndexInformation,
         meetWithMap: MeetWithMap[r],
@@ -290,8 +290,8 @@ mod Fixpoint3.Phase.Lowering {
         withProv: Bool,
         op: Ram.RelOp
     ): ExecutableRam.RelOp \ r =
-        let lowerOpRec = lowerOp(rc, idToIndex, boxingInfo, writeTo, indexInfo, meetWithMap, predicates, withProv);
-        let lowerOpRecNewRowVar = rv -> lowerOp(rc, idToIndex, boxingInfo, writeTo, indexInfo, addRowVarToMeetWithMap(rv, meetWithMap), predicates, withProv);
+        let lowerOpRec = lowerOp(rc, idToIndex, boxing, writeTo, indexInfo, meetWithMap, predicates, withProv);
+        let lowerOpRecNewRowVar = rv -> lowerOp(rc, idToIndex, boxing, writeTo, indexInfo, addRowVarToMeetWithMap(rv, meetWithMap), predicates, withProv);
         match op {
             case Ram.RelOp.Search(rv, relSym, _, body) =>
                 let den = toDenotation(relSym);
@@ -303,7 +303,6 @@ mod Fixpoint3.Phase.Lowering {
                 ExecutableRam.RelOp.Search(lowerRowVar(rv, idToIndex), relPos, oldPos, den, thisWriteTo, loweredBody)
             case Ram.RelOp.Query(rv, relSym, tests, index, _, body) =>
                 let den = toDenotation(relSym);
-                let (idToBoxing, boxing) = boxingInfo;
                 let loweredBody = lowerOpRecNewRowVar(rv, body);
                 let oldPos = computeMeetWithPos(rv, relSym, idToIndex, meetWithMap);
                 let thisWriteTo = getWriteTo(rv, writeTo);
@@ -314,12 +313,12 @@ mod Fixpoint3.Phase.Lowering {
                     case Ram.BoolExp.Eq(Ram.RamTerm.RowLoad(rv2, i2, _, _), Ram.RamTerm.RowLoad(rv1, i1, _, _)) if rv == rv1 =>
                         addWriteTo(rv2, i2, rv1, i1, idToIndex, writeTo);
                         None
-                    case Ram.BoolExp.Eq(Ram.RamTerm.RowLoad(rv1, i, _, _), Ram.RamTerm.Lit(val, id, _)) if rv == rv1 =>
-                        let unboxed = Boxing.unboxWith(val, getOrCrash(Map.get(id, idToBoxing)), boxing);
+                    case Ram.BoolExp.Eq(Ram.RamTerm.RowLoad(rv1, i, _, _), Ram.RamTerm.Lit(val, _, ty)) if rv == rv1 =>
+                        let unboxed = Boxing.unboxWith(val, ty, boxing);
                         addConstWriteTo(unboxed, rv, i, idToIndex, writeTo, rc);
                         None
-                    case Ram.BoolExp.Eq(Ram.RamTerm.Lit(val, id, _), Ram.RamTerm.RowLoad(rv1, i, _, _)) if rv == rv1 =>
-                        let unboxed = Boxing.unboxWith(val, getOrCrash(Map.get(id, idToBoxing)), boxing);
+                    case Ram.BoolExp.Eq(Ram.RamTerm.Lit(val, _, ty), Ram.RamTerm.RowLoad(rv1, i, _, _)) if rv == rv1 =>
+                        let unboxed = Boxing.unboxWith(val, ty, boxing);
                         addConstWriteTo(unboxed, rv, i, idToIndex, writeTo, rc);
                         None
                     case _ => Some(x)
@@ -328,22 +327,19 @@ mod Fixpoint3.Phase.Lowering {
                     unchecked_cast(bug!("Bug in Fixpoint.Lowering: Bools except equality in query") as _ \ r)
                 else ();
                 ExecutableRam.RelOp.Query(lowerRowVar(rv, idToIndex), index, oldPos, den, thisWriteTo, loweredBody)
-            case Ram.RelOp.Functional(rv, f, terms, body, arity, _) =>
-                let (idToBoxing, _) = boxingInfo;
-                let idToMarhsalled = id -> getOrCrash(Map.get(id, idToBoxing));
+            case Ram.RelOp.Functional(rv, f, terms, body, _, thisType) =>
                 let loweredBody = lowerOpRec(body);
                 let thisWriteTo = getWriteTo(rv, writeTo);
-                let to = Vector.map(i -> idToMarhsalled(RamId.TuplePos(rv, i)), Vector.range(0, arity));
                 ExecutableRam.RelOp.Functional(
                     lowerRowVar(rv, idToIndex), f,
-                    Vector.map(lowerTerm(idToIndex, boxingInfo, meetWithMap), terms),
-                    thisWriteTo, loweredBody, to
+                    Vector.map(lowerTerm(idToIndex, boxing, meetWithMap), terms),
+                    thisWriteTo, loweredBody, thisType
                 )
             case Ram.RelOp.Project(terms, s, _) =>
                 let (_, placements) = indexInfo;
                 let newRelPos = getOrCrash(Map.get((s, 0), placements));
                 let den = toDenotation(s);
-                let loweredTerms = Vector.map(lowerTerm(idToIndex, boxingInfo, meetWithMap), terms);
+                let loweredTerms = Vector.map(lowerTerm(idToIndex, boxing, meetWithMap), terms);
                 if (not withProv) {
                     ExecutableRam.RelOp.Project(loweredTerms, newRelPos, den)
                 } else {
@@ -352,7 +348,7 @@ mod Fixpoint3.Phase.Lowering {
                     ExecutableRam.RelOp.ProvProject(loweredTerms, newRelPos, relPos)
                 }
             case Ram.RelOp.If(boolExps, body) =>
-                ExecutableRam.RelOp.If(Vector.filterMap(lowerBool(idToIndex, boxingInfo, indexInfo, meetWithMap), boolExps), lowerOpRec(body))
+                ExecutableRam.RelOp.If(Vector.filterMap(lowerBool(idToIndex, boxing, indexInfo, meetWithMap), boolExps), lowerOpRec(body))
         }
 
     ///
@@ -370,38 +366,37 @@ mod Fixpoint3.Phase.Lowering {
     ///
     def lowerTerm(
         idToIndex: IdToIndex[r],
-        boxingInfo: (RamIdToPos, Boxing[r]),
+        boxingInfo: Boxing[r],
         meetWithMap: MeetWithMap[r],
         term: Ram.RamTerm
     ): ExecutableRam.RamTerm \ r =
         let lowerT = lowerTerm(idToIndex, boxingInfo, meetWithMap);
-        let (idToBoxing, boxing) = boxingInfo;
-        let termToBoxing = t -> getOrCrash(Map.get(getTermRamId(t), idToBoxing));
+        let boxing = boxingInfo;
         match term {
-            case Ram.RamTerm.Lit(val, id, _) => ExecutableRam.RamTerm.Lit(Boxing.unboxWith(val, getOrCrash(Map.get(id, idToBoxing)), boxing), val)
+            case Ram.RamTerm.Lit(val, _, ty) => ExecutableRam.RamTerm.Lit(Boxing.unboxWith(val, ty, boxing), val)
             case Ram.RamTerm.ProvMax(vec) =>
                 vec
                     |> Vector.map(match (rv, i) -> (UniqueInts.getIndex(rv, idToIndex), i))
                     |> ExecutableRam.RamTerm.ProvMax
-            case Ram.RamTerm.RowLoad(rv, index, _, RelSym.Symbol(_, arity, den)) =>
+            case Ram.RamTerm.RowLoad(rv, index, ty, RelSym.Symbol(_, arity, den)) =>
                 match den {
-                    case Denotation.Relational => ExecutableRam.RamTerm.LoadFromTuple(UniqueInts.getIndex(rv, idToIndex), index, termToBoxing(term))
+                    case Denotation.Relational => ExecutableRam.RamTerm.LoadFromTuple(UniqueInts.getIndex(rv, idToIndex), index, ty)
                     case Denotation.Latticenal(_, _, _, _) =>
                         if (index < arity - 1) {
-                            ExecutableRam.RamTerm.LoadFromTuple(UniqueInts.getIndex(rv, idToIndex), index, termToBoxing(term))
+                            ExecutableRam.RamTerm.LoadFromTuple(UniqueInts.getIndex(rv, idToIndex), index, ty)
                         } else {
-                            ExecutableRam.RamTerm.LoadLatVar(UniqueInts.getIndex(rv, idToIndex), termToBoxing(term))
+                            ExecutableRam.RamTerm.LoadLatVar(UniqueInts.getIndex(rv, idToIndex), ty)
                         }
                 }
-            case Ram.RamTerm.Meet(_, _, _, _, _) =>
+            case Ram.RamTerm.Meet(_, _, _, _, ty) =>
                 let representingRowVar = lowerMeet(term, idToIndex, meetWithMap);
                 let pos = computeLatticeMeetPos(representingRowVar, idToIndex, meetWithMap);
-                ExecutableRam.RamTerm.LoadLatVar(pos, termToBoxing(term))
-            case Ram.RamTerm.App1(f, t1, _, _)                   => ExecutableRam.RamTerm.App1(f, lowerT(t1), termToBoxing(term))
-            case Ram.RamTerm.App2(f, t1, t2, _, _)               => ExecutableRam.RamTerm.App2(f, lowerT(t1), lowerT(t2), termToBoxing(term))
-            case Ram.RamTerm.App3(f, t1, t2, t3, _, _)           => ExecutableRam.RamTerm.App3(f, lowerT(t1), lowerT(t2), lowerT(t3), termToBoxing(term))
-            case Ram.RamTerm.App4(f, t1, t2, t3, t4, _, _)       => ExecutableRam.RamTerm.App4(f, lowerT(t1), lowerT(t2), lowerT(t3), lowerT(t4), termToBoxing(term))
-            case Ram.RamTerm.App5(f, t1, t2, t3, t4, t5, _, _)   => ExecutableRam.RamTerm.App5(f, lowerT(t1), lowerT(t2), lowerT(t3), lowerT(t4), lowerT(t5), termToBoxing(term))
+                ExecutableRam.RamTerm.LoadLatVar(pos, ty)
+            case Ram.RamTerm.App1(f, t1, _, ty)                   => ExecutableRam.RamTerm.App1(f, lowerT(t1), ty)
+            case Ram.RamTerm.App2(f, t1, t2, _, ty)               => ExecutableRam.RamTerm.App2(f, lowerT(t1), lowerT(t2), ty)
+            case Ram.RamTerm.App3(f, t1, t2, t3, _, ty)           => ExecutableRam.RamTerm.App3(f, lowerT(t1), lowerT(t2), lowerT(t3), ty)
+            case Ram.RamTerm.App4(f, t1, t2, t3, t4, _, ty)       => ExecutableRam.RamTerm.App4(f, lowerT(t1), lowerT(t2), lowerT(t3), lowerT(t4), ty)
+            case Ram.RamTerm.App5(f, t1, t2, t3, t4, t5, _, ty)   => ExecutableRam.RamTerm.App5(f, lowerT(t1), lowerT(t2), lowerT(t3), lowerT(t4), lowerT(t5), ty)
         }
 
     ///
@@ -439,7 +434,7 @@ mod Fixpoint3.Phase.Lowering {
     ///
     def lowerBool(
         idToIndex: IdToIndex[r],
-        boxingInfo: (RamIdToPos, Boxing[r]),
+        boxingInfo: Boxing[r],
         indexInfo: IndexInformation,
         meetWithMap: MeetWithMap[r],
         boolExp: Ram.BoolExp

--- a/main/src/library/Fixpoint3/Solver.flix
+++ b/main/src/library/Fixpoint3/Solver.flix
@@ -80,7 +80,7 @@ mod Fixpoint3.Solver {
             case Datalog(_, r) =>
                 compiler(d, Map.empty())
                     |> Debugging.notifyPreInterpret
-                    |> Interpreter.interpret(rc, withProv)
+                    |> Interpreter.interpret(rc)
                     |> toModelOnlyFull(withProv, r)
             case Model(_) =>
                 d
@@ -90,7 +90,7 @@ mod Fixpoint3.Solver {
                 let cs = Datalog(f, r);
                 compiler(cs, m)
                     |> Debugging.notifyPreInterpret
-                    |> Interpreter.interpret(rc, withProv)
+                    |> Interpreter.interpret(rc)
                     |> toModelOnlyFull(withProv, r)
             case Join(Provenance(_, model), Datalog(f, r)) =>
                 let cs = Datalog(f, r);
@@ -98,7 +98,7 @@ mod Fixpoint3.Solver {
                 let m = provenanceModeltoModel(model);
                 compiler(cs, m)
                     |> Debugging.notifyPreInterpret
-                    |> Interpreter.interpret(rc, withProv)
+                    |> Interpreter.interpret(rc)
                     |> toModelOnlyFull(withProv, r)
             case _ => bug!("Datalog Boxing bug")
         };


### PR DESCRIPTION
Third part of #11381.

Switches to use the `Type`s instead of `RamId` during lowering. After this the only thing left is cleanup, e.g. deleting `RamId` and removing it from the ast.

To show that `RamId` truly is not used I've hardcoded them to `RamId.Id(42)` in the compiler.