### PR TITLE
refactor: simplify operators

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -44,6 +44,7 @@ object Lexer {
 
   /** Keywords - tokens consumed as long as no name-like char follows. */
   private val Keywords: PrefixTree.Node[TokenKind] = {
+    // N.B.: `advanceIfInTree` takes the longest match, regardless of the ordering here.
     val keywords = Array(
       ("Array#", TokenKind.ArrayHash),
       ("List#", TokenKind.ListHash),
@@ -138,6 +139,7 @@ object Lexer {
 
   /** Simple tokens - tokens consumed no matter the following char. */
   private val SimpleTokens: PrefixTree.Node[TokenKind] = {
+    // N.B.: `advanceIfInTree` takes the longest match, regardless of the ordering here.
     val simpleTokens = Array(
       ("#", TokenKind.Hash),
       ("#(", TokenKind.HashParenL),
@@ -162,6 +164,7 @@ object Lexer {
 
   /** Operators - tokens consumed as long as no operator-like char follows (see [[isUserOp]]). */
   private val Operators: PrefixTree.Node[TokenKind] = {
+    // N.B.: `advanceIfInTree` takes the longest match, regardless of the ordering here.
     val simpleTokens = Array(
       ("!", TokenKind.Bang),
       ("!=", TokenKind.BangEqual),

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -164,8 +164,7 @@ object Lexer {
     val simpleTokens = Array(
       ("!", TokenKind.Bang),
       ("!=", TokenKind.BangEqual),
-      ("", TokenKind.Equal),
-      ("$", TokenKind.Dollar),
+      ("=", TokenKind.Equal),
       ("&", TokenKind.Ampersand),
       ("*", TokenKind.Star),
       ("**", TokenKind.StarStar),
@@ -360,6 +359,7 @@ object Lexer {
         // Don't include the $ sign in the name.
         s.resetStart()
         acceptName(isUpper = false)
+      case '$' if s.sc.peekIs(c => !isUserOp(c)) => TokenKind.Dollar
       case '\"' => acceptString()
       case '\'' => acceptChar()
       case '`' => acceptInfixFunction()
@@ -444,7 +444,7 @@ object Lexer {
 
   /** Advance the current position past an operator if any operator completely matches the current position. */
   private def acceptIfOperator()(implicit s: State): Option[TokenKind] =
-    advanceIfInTree(Operators, isUserOp)
+    advanceIfInTree(Operators, c => !isUserOp(c))
 
   /** Advance the current position past a simple token if any simple token matches the current position. */
   private def acceptIfSimpleToken()(implicit s: State): Option[TokenKind] =

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -345,7 +345,7 @@ object Lexer {
           TokenKind.Dot
         }
       case '%' if s.sc.peekIs(_ == '%') => acceptBuiltIn()
-      case '$' if s.sc.peekIs(_.isLetter) =>
+      case '$' if s.sc.peekIs(isFirstNameChar) =>
         // Don't include the $ sign in the name.
         s.resetStart()
         acceptName(isUpper = false)
@@ -392,7 +392,6 @@ object Lexer {
         } else TokenKind.Underscore
       case '0' if s.sc.peekIs(_ == 'x') => acceptHexNumber()
       case c if c.isDigit => acceptNumber()
-      // User defined operators.
       case c if isUserOp(c) => acceptUserDefinedOp()
       case c => TokenKind.Err(LexerError.UnexpectedChar(c.toString, sourceLocationAtStart()))
     }


### PR DESCRIPTION
Treats operators as uniformly as possible. Additionally it avoids a bunch of options