### PR TITLE
refactor: remove unused token `:=`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -46,7 +46,6 @@ sealed trait TokenKind {
       case TokenKind.Caret => "'^'"
       case TokenKind.Colon => "':'"
       case TokenKind.ColonColon => "'::'"
-      case TokenKind.ColonEqual => "':='"
       case TokenKind.ColonMinus => "':-'"
       case TokenKind.Comma => "','"
       case TokenKind.CurlyL => "'{'"
@@ -313,7 +312,6 @@ sealed trait TokenKind {
          | TokenKind.Caret
          | TokenKind.Colon
          | TokenKind.ColonColon
-         | TokenKind.ColonEqual
          | TokenKind.ColonMinus
          | TokenKind.Comma
          | TokenKind.CommentBlock
@@ -559,7 +557,6 @@ sealed trait TokenKind {
          | TokenKind.Caret
          | TokenKind.Colon
          | TokenKind.ColonColon
-         | TokenKind.ColonEqual
          | TokenKind.ColonMinus
          | TokenKind.Comma
          | TokenKind.CommentBlock
@@ -842,8 +839,6 @@ object TokenKind {
   case object Colon extends TokenKind
 
   case object ColonColon extends TokenKind
-
-  case object ColonEqual extends TokenKind
 
   case object ColonMinus extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -167,7 +167,6 @@ object Lexer {
       (":-", TokenKind.ColonMinus),
       ("::", TokenKind.ColonColon),
       (":::", TokenKind.TripleColon),
-      (":=", TokenKind.ColonEqual),
       ("<+>", TokenKind.AngledPlus),
       ("<-", TokenKind.ArrowThinL),
       ("<=", TokenKind.AngleLEqual),

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1530,7 +1530,7 @@ object Parser2 {
       * Note that [[OpKind]] is necessary for the cases where the same token kind can be both unary and binary, e.g., Plus or Minus.
       */
     private def PRECEDENCE: List[(OpKind, Array[TokenKind])] = List(
-      (OpKind.Binary, Array(TokenKind.ColonEqual, TokenKind.KeywordInstanceOf)),
+      (OpKind.Binary, Array(TokenKind.KeywordInstanceOf)),
       (OpKind.Binary, Array(TokenKind.KeywordOr)),
       (OpKind.Binary, Array(TokenKind.KeywordAnd)),
       (OpKind.Binary, Array(TokenKind.EqualEqual, TokenKind.AngledEqual, TokenKind.BangEqual)),


### PR DESCRIPTION
old ref assignment syntax