### PR TITLE
refactor: remove `<>` special lexing

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -400,9 +400,6 @@ object Lexer {
       case '0' if s.sc.peekIs(_ == 'x') => acceptHexNumber()
       case c if c.isDigit => acceptNumber()
       // User defined operators.
-      case '<' if s.sc.peekIs(_ == '>') && s.sc.nth(1).flatMap(isUserOp).isEmpty =>
-        // Make sure '<>' is read as AngleL, AngleR and not UserDefinedOperator for empty case sets.
-        TokenKind.AngleL
       case c if isUserOp(c).isDefined =>
         if (!eof()) {
           val p = s.sc.peek

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -1381,7 +1381,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |    case C2
         |}
         |
-        |def f(x: a[<>]): String = ???
+        |def f(x: a[< >]): String = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UninferrableKind](result)


### PR DESCRIPTION
An empty case set now requires a space, e.g. `Formula[< >]`