### PR TITLE
refactor: remove redundant lexer case

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -694,11 +694,6 @@ object Lexer {
         s.sc.advance()
         return TokenKind.LiteralChar
       }
-
-      if (prev == '/' && s.sc.peekIs(_ == '*')) {
-        // This handles block comment within a char.
-        return TokenKind.Err(LexerError.UnterminatedChar(sourceLocationAtStart()))
-      }
       prev = s.sc.peekAndAdvance()
     }
 


### PR DESCRIPTION
The `'\*` input will already give UnterminatedChar without this check