### PR TITLE
feat: add `SemiGroup` and `Monoid` instances to `RichString`

### DIFF
--- a/main/src/library/RichString.flix
+++ b/main/src/library/RichString.flix
@@ -29,6 +29,14 @@ instance ToString[RichString] {
     pub def toString(x: RichString): String = RichString.toString(x)
 }
 
+instance SemiGroup[RichString] {
+    pub def combine(x: RichString, y: RichString): RichString = RichString.combine(x, y)
+}
+
+instance Monoid[RichString] {
+    pub def empty(): RichString = RichString.empty()
+}
+
 mod RichString {
 
     ///


### PR DESCRIPTION
I'm writing a simple CLI app and would find these useful (so that I can use `Monoid.fold` with a `List[RichString]`).