### PR TITLE
feat: remove math names

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -161,7 +161,6 @@ sealed trait TokenKind {
       case TokenKind.Eof => "<end-of-file>"
       case TokenKind.NameLowerCase => "<name>"
       case TokenKind.NameUpperCase => "<Name>"
-      case TokenKind.NameMath => "<math name>"
       case TokenKind.UserDefinedOperator => "<user-defined operator>"
       case TokenKind.Annotation => "<annotation>"
       case TokenKind.BuiltIn => "<built in>"
@@ -357,7 +356,6 @@ sealed trait TokenKind {
          | TokenKind.MapHash
          | TokenKind.Minus
          | TokenKind.NameLowerCase
-         | TokenKind.NameMath
          | TokenKind.NameUpperCase
          | TokenKind.ParenL
          | TokenKind.ParenR
@@ -527,7 +525,6 @@ sealed trait TokenKind {
          | TokenKind.MapHash
          | TokenKind.Minus
          | TokenKind.NameLowerCase
-         | TokenKind.NameMath
          | TokenKind.NameUpperCase
          | TokenKind.ParenL
          | TokenKind.Plus
@@ -627,7 +624,6 @@ sealed trait TokenKind {
     */
   def isFirstType: Boolean = this match {
     case TokenKind.NameUpperCase
-         | TokenKind.NameMath
          | TokenKind.Underscore
          | TokenKind.NameLowerCase
          | TokenKind.KeywordUniv
@@ -650,7 +646,6 @@ sealed trait TokenKind {
     */
   def isFirstPattern: Boolean = this match {
     case TokenKind.NameLowerCase
-         | TokenKind.NameMath
          | TokenKind.Underscore
          | TokenKind.KeywordQuery
          | TokenKind.LiteralString
@@ -1082,8 +1077,6 @@ object TokenKind {
   case object Minus extends TokenKind
 
   case object NameLowerCase extends TokenKind
-
-  case object NameMath extends TokenKind
 
   case object NameUpperCase extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -72,7 +72,7 @@ object LexerError {
       import formatter.*
       s""">> '.' has leading whitespace.
          |
-         |${code(loc, "here")}
+         |${code(loc, "Here")}
          |
          |""".stripMargin
     }
@@ -144,11 +144,11 @@ object LexerError {
     * @param loc The location of `found`.
     */
   case class MalformedHexNumber(found: Char, loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Malformed hexadecimal number, found '$found'."
+    override def summary: String = s"Malformed hexadecimal number, found '${showChar(found)}'."
 
     override def message(formatter: Formatter): String = {
       import formatter.*
-      s""">> Malformed hexadecimal number, found '$found'.
+      s""">> Malformed hexadecimal number, found '${showChar(found)}'.
          |
          |${code(loc, "Number was correct up to here")}
          |
@@ -162,11 +162,11 @@ object LexerError {
     * @param loc the location of `found`.
     */
   case class MalformedNumber(found: Char, loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Malformed number, found '$found'."
+    override def summary: String = s"Malformed number, found '${showChar(found)}'."
 
     override def message(formatter: Formatter): String = {
       import formatter.*
-      s""">> Malformed number, found '$found'.
+      s""">> Malformed number, found '${showChar(found)}'.
          |
          |${code(loc, "Number was correct up to here")}
          |
@@ -180,11 +180,11 @@ object LexerError {
     * @param loc the location of `found`.
     */
   case class UnexpectedChar(found: Char, loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unexpected character '$found'."
+    override def summary: String = s"Unexpected character '${showChar(found)}'."
 
     override def message(formatter: Formatter): String = {
       import formatter.*
-      s""">> Unexpected character '${red(found.toString)}'.
+      s""">> Unexpected character '${red(showChar(found))}'.
          |
          |${code(loc, "Unexpected character.")}
          |
@@ -317,4 +317,16 @@ object LexerError {
          |""".stripMargin
     }
   }
+
+  /** Returns an ASCII printable version of `c`. */
+  private def showChar(c: Char): String = {
+    c match {
+      case '\r' => "\\r"
+      case '\n' => "\\n"
+      case '\t' => "\\t"
+      case _ if 32 <= c.toInt && c.toInt <= 126 => c.toString
+      case _ => s"\\u${c.toHexString.toUpperCase}"
+    }
+  }
+
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -614,12 +614,12 @@ object Parser2 {
     *
     * Use these together with [[nameUnqualified]] and [[nameAllowQualified]].
     */
-  private val NAME_DEFINITION: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.NameUpperCase, TokenKind.NameMath, TokenKind.UserDefinedOperator)
-  private val NAME_PARAMETER: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.NameMath, TokenKind.Underscore)
-  private val NAME_VARIABLE: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.NameMath, TokenKind.Underscore)
+  private val NAME_DEFINITION: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.NameUpperCase, TokenKind.UserDefinedOperator)
+  private val NAME_PARAMETER: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.Underscore)
+  private val NAME_VARIABLE: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.Underscore)
   private val NAME_JAVA: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.NameUpperCase)
   private val NAME_QNAME: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.NameUpperCase)
-  private val NAME_USE: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.NameUpperCase, TokenKind.NameMath, TokenKind.UserDefinedOperator)
+  private val NAME_USE: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.NameUpperCase, TokenKind.UserDefinedOperator)
   private val NAME_FIELD: Set[TokenKind] = Set(TokenKind.NameLowerCase)
   // TODO: Static is used as a type in Prelude.flix. Static is also an expression.
   //       refactor When Static is used as a region "@ Static" to "@ static" since lowercase is
@@ -1555,7 +1555,7 @@ object Parser2 {
       (OpKind.Binary, Array(TokenKind.AngledPlus)),
       (OpKind.Unary, Array(TokenKind.KeywordDiscard)),
       (OpKind.Binary, Array(TokenKind.InfixFunction)),
-      (OpKind.Binary, Array(TokenKind.UserDefinedOperator, TokenKind.NameMath)),
+      (OpKind.Binary, Array(TokenKind.UserDefinedOperator)),
       (OpKind.Unary, Array(TokenKind.KeywordLazy, TokenKind.KeywordForce)),
       (OpKind.Unary, Array(TokenKind.Plus, TokenKind.Minus)),
       (OpKind.Unary, Array(TokenKind.KeywordNot))
@@ -1645,8 +1645,7 @@ object Parser2 {
         case TokenKind.Underscore => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameUnqualified(NAME_VARIABLE)
         case TokenKind.NameLowerCase if nth(1) == TokenKind.ArrowThinR => unaryLambdaExpr()
         case TokenKind.NameLowerCase => nameAllowQualified(NAME_FIELD)
-        case TokenKind.NameUpperCase
-             | TokenKind.NameMath => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameAllowQualified(NAME_DEFINITION)
+        case TokenKind.NameUpperCase => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameAllowQualified(NAME_DEFINITION)
         case TokenKind.Minus
              | TokenKind.KeywordNot
              | TokenKind.Plus
@@ -3045,7 +3044,6 @@ object Parser2 {
       val mark = open()
       var lhs = nth(0) match {
         case TokenKind.NameLowerCase
-             | TokenKind.NameMath
              | TokenKind.Underscore
              | TokenKind.KeywordQuery => variablePat()
         case TokenKind.LiteralString
@@ -3341,8 +3339,7 @@ object Parser2 {
       val mark = open()
       nth(0) match {
         case TokenKind.NameUpperCase => nameAllowQualified(NAME_TYPE)
-        case TokenKind.NameMath
-             | TokenKind.Underscore => nameUnqualified(NAME_VARIABLE)
+        case TokenKind.Underscore => nameUnqualified(NAME_VARIABLE)
         case TokenKind.NameLowerCase => variableType()
         case TokenKind.KeywordUniv
              | TokenKind.KeywordFalse
@@ -3367,7 +3364,7 @@ object Parser2 {
       close(mark, TreeKind.Type.Type)
     }
 
-    private val TYPE_VAR: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.NameMath, TokenKind.Underscore)
+    private val TYPE_VAR: Set[TokenKind] = Set(TokenKind.NameLowerCase, TokenKind.Underscore)
 
     private def variableType()(implicit s: State): Mark.Closed = {
       implicit val sctx: SyntacticContext = SyntacticContext.Unknown
@@ -3701,11 +3698,10 @@ object Parser2 {
           breakWhen = kind => kind == TokenKind.Equal || kind.isFirstExpr
         )
         case TokenKind.NameLowerCase
-             | TokenKind.NameMath
              | TokenKind.Underscore => nameUnqualified(NAME_VARIABLE)
         case at =>
           val error = UnexpectedToken(
-            expected = NamedTokenSet.FromKinds(Set(TokenKind.ParenL, TokenKind.NameLowerCase, TokenKind.NameMath, TokenKind.Underscore)),
+            expected = NamedTokenSet.FromKinds(Set(TokenKind.ParenL, TokenKind.NameLowerCase, TokenKind.Underscore)),
             actual = Some(at),
             sctx,
             loc = currentSourceLocation()

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1069,8 +1069,7 @@ object Weeder2 {
           case TokenKind.LiteralBigDecimal => Validation.Success(Constants.toBigDecimal(token))
           case TokenKind.LiteralRegex => Validation.Success(Constants.toRegex(token))
           case TokenKind.NameLowerCase
-               | TokenKind.NameUpperCase
-               | TokenKind.NameMath => mapN(pickNameIdent(tree))(ident => Expr.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), tree.loc))
+               | TokenKind.NameUpperCase => mapN(pickNameIdent(tree))(ident => Expr.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), tree.loc))
           case _ =>
             val error = UnexpectedToken(expected = NamedTokenSet.Literal, actual = None, SyntacticContext.Expr.OtherExpr, loc = tree.loc)
             sctx.errors.add(error)

--- a/main/test/flix/Test.Unused.Def.flix
+++ b/main/test/flix/Test.Unused.Def.flix
@@ -5,11 +5,6 @@ mod Test.Unused.Def {
         ?hole
 
     // NB: Compile, but not execute.
-    // Unused math name
-    def _√(): Int32 =
-        ?hole
-
-    // NB: Compile, but not execute.
     // Unused greek name
     def _Χαίρετε(): Int32 =
         ?hole

--- a/main/test/flix/Test.Unused.Var.flix
+++ b/main/test/flix/Test.Unused.Var.flix
@@ -94,11 +94,6 @@ mod Test.Unused.Var {
 
     @test
     def testUnusedVar15(): Int32 =
-        let _⊆ = 123;
-        456
-
-    @test
-    def testUnusedVar16(): Int32 =
         let _αναγνωριστικό = 123;
         456
 


### PR DESCRIPTION
These symbols include (none of them the ascii version)
```
→ − ∗ ∣ ∼ ≺ ≻ ⋆
```