### PR TITLE
fix: disallow redefining trait parameter

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -460,13 +460,16 @@ object WeededAst {
 
   case class SelectChannelRule(ident: Name.Ident, exp1: Expr, exp2: Expr, loc: SourceLocation)
 
-  sealed trait TypeParam
+  sealed trait TypeParam {
+    def ident: Name.Ident
+    def loc: SourceLocation
+  }
 
   object TypeParam {
 
-    case class Unkinded(ident: Name.Ident) extends TypeParam
+    case class Unkinded(ident: Name.Ident, loc: SourceLocation) extends TypeParam
 
-    case class Kinded(ident: Name.Ident, kind: Kind) extends TypeParam
+    case class Kinded(ident: Name.Ident, kind: Kind, loc: SourceLocation) extends TypeParam
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -721,6 +721,36 @@ object WeederError {
   }
 
   /**
+    * An error raised to indicate that the type parameter `name` was re-defined illegally.
+    *
+    * @param name the name of the type parameter.
+    * @param loc1 the location of the original definition.
+    * @param loc2 the location of the redefinition.
+    */
+  case class IllegalTypeParamReuse(name: String, loc1: SourceLocation, loc2: SourceLocation) extends WeederError {
+    def summary: String = s"Redefinition fo type parameter '$name'."
+
+    def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Redefinition of type parameter '${red(name)}'.
+         |
+         |${code(loc1, "the original definition was here.")}
+         |
+         |${code(loc2, "the redefinition was here.")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = Some({
+      import formatter.*
+      s"${underline("Tip:")} Rename one of the two type parameters."
+    })
+
+    def loc: SourceLocation = loc2
+
+  }
+
+  /**
     * An error raised to indicate that the case of an alias does not match the case of the original value.
     *
     * @param fromName the original name.

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -209,8 +209,8 @@ object Desugar {
     * Desugars the given [[WeededAst.TypeParam]] `tparam0`.
     */
   private def visitTypeParam(tparam0: WeededAst.TypeParam): DesugaredAst.TypeParam = tparam0 match {
-    case WeededAst.TypeParam.Unkinded(ident) => DesugaredAst.TypeParam.Unkinded(ident)
-    case WeededAst.TypeParam.Kinded(ident, kind0) =>
+    case WeededAst.TypeParam.Unkinded(ident, _) => DesugaredAst.TypeParam.Unkinded(ident)
+    case WeededAst.TypeParam.Kinded(ident, kind0, _) =>
       val kind = visitKind(kind0)
       DesugaredAst.TypeParam.Kinded(ident, kind)
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1084,6 +1084,19 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.InlineAndDontInline](result)
   }
 
+  test("IllegalTypeParamReuse.01") {
+    val input =
+      """
+        |trait C[a] {
+        |    pub def f[a: Type](x: a): Int32
+        |}
+        |
+        |def f(): Unit = ()
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalTypeParamReuse](result)
+  }
+
   // This is supposed to check that the identifier does not include '$'.
   // But since a user defined operation like '<$>' is perfectly valid,
   // checking the identifier becomes tricky,


### PR DESCRIPTION
Closes #2114. The program

```
trait C[a] {
    pub def f[a: Type](x: a): Int32
}
```
Gives
```
Syntax Error  ----


>> Redefinition of type parameter 'a'.

1 | trait C[a] {
            ^
            the original definition was here.

2 |     pub def f[a: Type](x: a): Int32
                  ^
                  the redefinition was here.


Resolution Error ----

>> Unexpected signature 'f' which does not mention the type variable of the trait.

2 |     pub def f[a: Type](x: a): Int32
                ^
                unexpected signature.

```