### PR TITLE
fix: allow comments between `use`/`import`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -811,6 +811,7 @@ object Parser2 {
     val mark = open(consumeDocComments = false)
     var continue = true
     while (continue && !eof()) {
+      comments()
       nth(0) match {
         case TokenKind.KeywordUse =>
           use()

--- a/main/test/flix/Test.Import.flix
+++ b/main/test/flix/Test.Import.flix
@@ -1,12 +1,14 @@
 mod Test.Import {
 
-    import java.lang.{CharSequence => ASeqOfChars}
-    import java.lang.StringBuffer
-    import java.lang.{StringBuffer => RenamedBuffer1}
-    import java.sql.Time
+    import java.lang.{CharSequence => ASeqOfChars};
+    import java.lang.StringBuffer;
+    // Comment is fine.
+    import java.lang.{StringBuffer => RenamedBuffer1};
+    import java.sql.Time;
 
     // Doesn't cause an error because different names from above
     import java.lang.CharSequence
+    /* Comment is also fine here. */
     import java.lang.{StringBuffer => RenamedBuffer2}
 
     @test

--- a/main/test/flix/Test.Use.Def.flix
+++ b/main/test/flix/Test.Use.Def.flix
@@ -43,7 +43,9 @@ mod C {
     @test
     def testMod07(): Bool =
         use A.{f => fa};
+        // Comment
         use B.{f => fb};
+        /* More comment */
         use C.{f => fc};
         (fa() + fb() + fc()) == 6
 }


### PR DESCRIPTION
Fixes #7925