### PR TITLE
feat: parse bad names better

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -428,7 +428,8 @@ object Parser2 {
 
   /**
     * Advance past current token if it is of kind in `kinds`. Otherwise wrap it in an error.
-    * Optionally returns the error mark
+    * Returns true if it successfully advances.
+    * Returns false otherwise.
     */
   private def expectAny(kinds: Set[TokenKind], hint: Option[String] = None)(implicit sctx: SyntacticContext, s: State): Boolean = {
     if (eatAny(kinds)) {


### PR DESCRIPTION
Change: Allow `nameUnqualified` to eat any name-like tokens instead of the specified on error. Inspired by and closes #9534.

Question: Should `NAME_LIKE` include more 'names'?

Reduces the errors from 18 to 6 in the following program:
```
mod Bar {
    pub def _(): Int32 = 123

    pub def a(): Unit = {
        let _ = #{
            A :- not b.
        };
        ()
    }

    type alias c = Int32

    pub enum d {
        case d(Int32)
    }

    instance e[d] {}

    trait e[x] {}
}
```

Also why is `trait e[x] {}` allowed? You cannot implement it...