### PR TITLE
feat: prohibit constants in destructuring

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -701,13 +701,13 @@ object WeederError {
     * @param loc the location where the constant pattern occurs.
     */
   case class IllegalConstantPattern(loc: SourceLocation) extends WeederError {
-    def summary: String = "Illegal constant pattern"
+    def summary: String = "Unexpected constant pattern"
 
     def message(formatter: Formatter): String = {
       import formatter.*
-      s""">> Illegal constant pattern.
+      s""">> Unexpected constant pattern.
          |
-         |${code(loc, "Constants not allowed in destructuring pattern.")}
+         |${code(loc, "Constants are not allowed in let or lambda matches.")}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -696,6 +696,23 @@ object WeederError {
   }
 
   /**
+    * An error raised to indicate an illegal constant pattern.
+    *
+    * @param loc the location where the constant pattern occurs.
+    */
+  case class IllegalConstantPattern(loc: SourceLocation) extends WeederError {
+    def summary: String = "Illegal constant pattern"
+
+    def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Illegal constant pattern.
+         |
+         |${code(loc, "Constants not allowed in destructuring pattern.")}
+         |""".stripMargin
+    }
+  }
+
+  /**
     * An error raised to indicate illegal syntax: empty tuple type.
     *
     * @param loc the location where the error occurs.

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1203,8 +1203,7 @@ object Weeder2 {
     private def visitLambdaMatchExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.LambdaMatch)
       mapN(Patterns.pickPattern(tree), pickExpr(tree)) {
-        (pat, expr) =>
-          Expr.LambdaMatch(Patterns.restrictToNonConstant(pat), expr, tree.loc)
+        (pat, expr) => Expr.LambdaMatch(Patterns.restrictToNonConstant(pat), expr, tree.loc)
       }
     }
 
@@ -1550,16 +1549,14 @@ object Weeder2 {
     private def visitForFragmentGenerator(tree: Tree)(implicit sctx: SharedContext): Validation[ForFragment.Generator, CompilationMessage] = {
       expect(tree, TreeKind.Expr.ForFragmentGenerator)
       mapN(Patterns.pickPattern(tree), pickExpr(tree)) {
-        (pat, expr) =>
-          ForFragment.Generator(Patterns.restrictToNonConstant(pat), expr, tree.loc)
+        (pat, expr) => ForFragment.Generator(Patterns.restrictToNonConstant(pat), expr, tree.loc)
       }
     }
 
     private def visitForFragmentLet(tree: Tree)(implicit sctx: SharedContext): Validation[ForFragment.Let, CompilationMessage] = {
       expect(tree, TreeKind.Expr.ForFragmentLet)
       mapN(Patterns.pickPattern(tree), pickExpr(tree)) {
-        (pat, expr) =>
-          ForFragment.Let(Patterns.restrictToNonConstant(pat), expr, tree.loc)
+        (pat, expr) => ForFragment.Let(Patterns.restrictToNonConstant(pat), expr, tree.loc)
       }
     }
 
@@ -2097,8 +2094,7 @@ object Weeder2 {
     private def visitParYieldFragment(tree: Tree)(implicit sctx: SharedContext): Validation[ParYieldFragment, CompilationMessage] = {
       expect(tree, TreeKind.Expr.ParYieldFragment)
       mapN(Patterns.pickPattern(tree), pickExpr(tree)) {
-        (pat, expr) =>
-          ParYieldFragment(Patterns.restrictToNonConstant(pat), expr, tree.loc)
+        (pat, expr) => ParYieldFragment(Patterns.restrictToNonConstant(pat), expr, tree.loc)
       }
     }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestPatMatch.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestPatMatch.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.NonExhaustiveMatchError
+import ca.uwaterloo.flix.language.errors.WeederError.IllegalConstantPattern
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -167,7 +168,7 @@ class TestPatMatch extends AnyFunSuite with TestUtils {
         |def f(e: E): Int8 = let E.A(true, 'a', i) = e; i
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[NonExhaustiveMatchError](result)
+    expectError[IllegalConstantPattern](result)
   }
 
   test("Expression.LetMatch02") {
@@ -175,7 +176,7 @@ class TestPatMatch extends AnyFunSuite with TestUtils {
       """def f(e: (Int8, Int8)): Int8 = let (a,1i8) = e; a
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[NonExhaustiveMatchError](result)
+    expectError[IllegalConstantPattern](result)
   }
 
   test("Pattern.Deep.01") {
@@ -205,7 +206,7 @@ class TestPatMatch extends AnyFunSuite with TestUtils {
         |
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[NonExhaustiveMatchError](result)
+    expectError[IllegalConstantPattern](result)
   }
 
   test("Expression.MatchLambda.02") {
@@ -349,7 +350,7 @@ class TestPatMatch extends AnyFunSuite with TestUtils {
         |def f(): E = par (E.E1 <- if (true) E.E1 else E.E2) yield E.E1
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[NonExhaustiveMatchError](result)
+    expectError[IllegalConstantPattern](result)
   }
 
   test("Pattern.Guard.01") {


### PR DESCRIPTION
Disallow constants in destructuring patterns.

Overall change: For destructuring assignments, except `match`, constants will be reported as an error and replaced by `Pattern.Error` to prevent further errors (concretely `Non-exhaustive match`).

What will users experience?

1. Better error messages
2. Expressions of the form `let A.A = ???` are now illegal independent of how the enum `A` looks.

Reasoning:

1. The current error reporting is bad. See #11590.
2. Destructuring with constants is useless. It can be replaced by destructuring to `_`. The only exception would be to show what the value is, but I think that is a niche concern.

Not handled: Destructuring with `x :: xs`. It will always be reported as non-exhaustive, but we do not throw an error. It can be caught by the following, but the error is bad:
```
if (qname.ident.name == "Cons" && qname.namespace.idents.map(_.name) == List("List")) {
  // `_ :: _ `. Reason: Not exhaustive.
  sctx.errors.add(IllegalConstantPattern(loc))
  return Pattern.Error(loc)
}
```

With this change all of the following will be reported as errors:
```
enum A {
    case A
}
def f(): Unit \ IO = {
    let {a = A.A | _} = {a = A.A};
    let A.A = A.A;
    foreach(A.A <- A.A :: Nil) {
        println("")
    };
    let _ = forM(A.A <- A.A :: Nil) yield 2;
    let _ = forA(A.A <- A.A :: Nil) yield 2;
    let _ = par(A.A <- A.A) yield Nil;
    let 2 = ???;
    let (a, 2) = ???;
    let (b, (c, 3)) = ???;
    ()
}
```