### PR TITLE
feat: simplify `Reflect.default`

### DIFF
--- a/main/src/library/Reflect.flix
+++ b/main/src/library/Reflect.flix
@@ -6,17 +6,14 @@ mod Reflect {
     /// it acts as a placeholder to be replaced by a proper value.
     ///
     pub def default(): a = typematch (Proxy.Proxy: Proxy[a]) {
-        case _: Proxy[Unit]         => unchecked_cast(() as a)
         case _: Proxy[Bool]         => unchecked_cast(false as a)
         case _: Proxy[Char]         => unchecked_cast('0' as a)
         case _: Proxy[Float32]      => unchecked_cast(0.0f32 as a)
         case _: Proxy[Float64]      => unchecked_cast(0.0f64 as a)
-        case _: Proxy[BigDecimal]   => unchecked_cast(0.0ff as a)
         case _: Proxy[Int8]         => unchecked_cast(0i8 as a)
         case _: Proxy[Int16]        => unchecked_cast(0i16 as a)
         case _: Proxy[Int32]        => unchecked_cast(0i32 as a)
         case _: Proxy[Int64]        => unchecked_cast(0i64 as a)
-        case _: Proxy[BigInt]       => unchecked_cast(0ii as a)
         case _: _                   => unchecked_cast(null as a)
     }
 

--- a/main/test/ca/uwaterloo/flix/library/TestReflect.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestReflect.flix
@@ -24,7 +24,7 @@ mod TestReflect {
 
     @Test
     def defaultBigDecimal01(): Unit \ Assert =
-        assertEq(expected = 0.0ff, (Reflect.default(): BigDecimal))
+        assertTrue(Object.isNull((Reflect.default(): BigDecimal)))
 
     @Test
     def defaultInt801(): Unit \ Assert =
@@ -44,7 +44,7 @@ mod TestReflect {
 
     @Test
     def defaultBigInt01(): Unit \ Assert =
-        assertEq(expected = 0ii, (Reflect.default(): BigInt))
+        assertTrue(Object.isNull((Reflect.default(): BigInt)))
 
     @Test
     def defaultList01(): Unit \ Assert =


### PR DESCRIPTION
The doc says `The value returned should not be depended on` so we should use null for all object types