### PR TITLE
feat: improve performance of `PatMatch`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -27,6 +27,7 @@ import ca.uwaterloo.flix.language.fmt.FormatConstant
 import ca.uwaterloo.flix.util.ParOps
 
 import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.mutable
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 /**
@@ -377,7 +378,7 @@ object PatMatch {
     */
   private def checkFrags(frags: List[ParYieldFragment], root: TypedAst.Root, loc: SourceLocation)(implicit sctx: SharedContext): Unit = {
     // Call findNonMatchingPat for each pattern individually
-    frags.foreach(f => findNonMatchingPat(List(List(f.pat)), 1, root) match {
+    frags.foreach(f => findNonMatchingPatWrapper(List(List(f.pat)), 1, root) match {
       case Exhaustive => ()
       case NonExhaustive(ctors) => sctx.errors.add(NonExhaustiveMatchError(prettyPrintCtor(ctors.head), loc))
     })
@@ -395,13 +396,39 @@ object PatMatch {
     // Filter down to the unguarded rules.
     // Guarded rules cannot contribute to exhaustiveness (the guard could be e.g. `false`)
     val unguardedRules = rules.filter(r => r.guard.isEmpty)
-    findNonMatchingPat(unguardedRules.map(r => List(r.pat)), 1, root) match {
+    findNonMatchingPatWrapper(unguardedRules.map(r => List(r.pat)), 1, root) match {
       case Exhaustive => ()
       case NonExhaustive(ctors) => sctx.errors.add(NonExhaustiveMatchError(prettyPrintCtor(ctors.head), exp.loc))
     }
   }
 
   /**
+    * Given a list of patterns, computes a pattern vector of size n such
+    * that p doesn't match any rule in rules.
+    *
+    * Wraps `findNonMatchingPat` with a simple bail out fast check for catch all cases.
+    *
+    * @param rules The rules to check for exhaustion
+    * @param n     The size of resulting pattern vector
+    * @param root  The AST root of the expression
+    * @return If no such pattern exists, returns Exhaustive, else returns NonExhaustive(a matching pattern)
+    */
+  private def findNonMatchingPatWrapper(rules: List[List[Pattern]], n: Int, root: TypedAst.Root)(implicit sctx: SharedContext): Exhaustiveness = {
+    val hasMatchAll = rules.exists {
+      case head :: Nil => patToCtor(head) match {
+        case TyCon.Wild => true
+        case _ => false
+      }
+      case _ => false
+    }
+    if (hasMatchAll) {
+      Exhaustive
+    } else {
+      findNonMatchingPat(rules, n, root)
+    }
+  }
+
+    /**
     * Given a list of patterns, computes a pattern vector of size n such
     * that p doesn't match any rule in rules
     *
@@ -626,6 +653,9 @@ object PatMatch {
     * @return
     */
   private def missingFromSig(ctors: List[TyCon], root: TypedAst.Root): List[TyCon] = {
+    // Keep track of which enums we have added to `expCtors` to avoid adding them again.
+    val addedEnums = mutable.Set[Symbol.EnumSym]()
+
     // Enumerate all the constructors that we need to cover
     def getAllCtors(x: TyCon): List[TyCon] = x match {
       // Structural types have just one constructor
@@ -634,11 +664,15 @@ object PatMatch {
 
       // For Enums, we have to figure out what base enum is, then look it up in the enum definitions to get the
       // other cases
-      case TyCon.Enum(sym, _) => {
-        root.enums(sym.enumSym).cases.map {
-          case (otherSym, caze) => TyCon.Enum(otherSym, List.fill(caze.tpes.length)(TyCon.Wild))
+      case TyCon.Enum(sym, _) =>
+        if (addedEnums.contains(sym.enumSym)) {
+          Nil
+        } else {
+          addedEnums.add(sym.enumSym)
+          root.enums(sym.enumSym).cases.map {
+            case (otherSym, caze) => TyCon.Enum(otherSym, List.fill(caze.tpes.length)(TyCon.Wild))
+          }.toList
         }
-      }.toList
 
       // For Unit and Bool constants are enumerable
       case TyCon.Cst(Constant.Unit) => List(TyCon.Cst(Constant.Unit))


### PR DESCRIPTION
Fixes #8033.

I have no idea how the algorithm works exactly so I have no idea whether something smart can be done to improve it further.

I have done the following

1. Change `missingFromSig`

`expCtors.filterNot` took an inordinate amount of time for large enums (200+ cases). Every enum-case in a match added _all_ cases of their enum to `expCtors`.

This resulted in some `n^3` behavior in the existence check as `ctors` was already of size `n`.

2. Introduce `findNonMatchingPatWrapper`

This is a simple wrapper which just tests for catch-all cases (wild card, error or variable) and returns exhaustive if any is found.

Reason: The derived `Eq` and `Order` end with a `_` case.

3. Result

The first change reduces the worst case from `n^3` to `n^2`. The second changes all matches to `n` if they contain a default case.

I can now comfortably write in a file with an enum with 1000 cases of `case Case_i` and derived `Eq` and `Order`.

4. Note

I've focused on enums with many 0-ary cases. I have not tested performance on more complex enums. 