### PR TITLE
fix: lex `<=>` distinctly

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -173,7 +173,6 @@ object Lexer {
     val simpleTokens = Array(
       ("!", TokenKind.Bang),
       ("!=", TokenKind.BangEqual),
-      ("=", TokenKind.Equal),
       ("&", TokenKind.Ampersand),
       ("*", TokenKind.Star),
       ("+", TokenKind.Plus),
@@ -186,6 +185,8 @@ object Lexer {
       ("<+>", TokenKind.AngledPlus),
       ("<-", TokenKind.ArrowThinL),
       ("<=", TokenKind.AngleLEqual),
+      ("<=>", TokenKind.AngledEqual),
+      ("=", TokenKind.Equal),
       ("==", TokenKind.EqualEqual),
       ("=>", TokenKind.ArrowThickR),
       (">", TokenKind.AngleR),


### PR DESCRIPTION
Somewhere `<=>` got lost as an operator, but because `Weeder` does string matching, it only resulted in inproper precedence