### PR TITLE
fix: disallow capital name functions

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -618,6 +618,7 @@ object Parser2 {
     */
   private val NAME_LIKE: Set[TokenKind] = Set(TokenKind.NameLowercase, TokenKind.NameUppercase, TokenKind.NameMath, TokenKind.Underscore)
   private val NAME_DEFINITION: Set[TokenKind] = Set(TokenKind.NameLowercase, TokenKind.NameUppercase, TokenKind.NameMath, TokenKind.GenericOperator)
+  private val NAME_FUNCTION: Set[TokenKind] = Set(TokenKind.NameLowercase, TokenKind.NameMath, TokenKind.GenericOperator)
   private val NAME_PARAMETER: Set[TokenKind] = Set(TokenKind.NameLowercase, TokenKind.NameMath, TokenKind.Underscore)
   private val NAME_VARIABLE: Set[TokenKind] = Set(TokenKind.NameLowercase, TokenKind.NameMath, TokenKind.Underscore)
   private val NAME_JAVA: Set[TokenKind] = Set(TokenKind.NameLowercase, TokenKind.NameUppercase)
@@ -1023,7 +1024,7 @@ object Parser2 {
       implicit val sctx: SyntacticContext = SyntacticContext.Decl.Module
       assert(at(TokenKind.KeywordDef))
       expect(TokenKind.KeywordDef)
-      nameUnqualified(NAME_DEFINITION)
+      nameUnqualified(NAME_FUNCTION)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
@@ -1047,7 +1048,7 @@ object Parser2 {
       implicit val sctx: SyntacticContext = SyntacticContext.Decl.Module
       assert(at(declKind))
       expect(declKind)
-      nameUnqualified(NAME_DEFINITION)
+      nameUnqualified(NAME_FUNCTION)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
@@ -1083,7 +1084,7 @@ object Parser2 {
       implicit val sctx: SyntacticContext = SyntacticContext.Decl.Module
       assert(at(TokenKind.KeywordLaw))
       expect(TokenKind.KeywordLaw)
-      nameUnqualified(NAME_DEFINITION)
+      nameUnqualified(NAME_FUNCTION)
       expect(TokenKind.Colon)
       expect(TokenKind.KeywordForall)
       if (at(TokenKind.BracketL)) {
@@ -1301,7 +1302,7 @@ object Parser2 {
     private def operationDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       implicit val sctx: SyntacticContext = SyntacticContext.Decl.Module
       expect(TokenKind.KeywordDef)
-      nameUnqualified(NAME_DEFINITION)
+      nameUnqualified(NAME_FUNCTION)
 
       // Check for illegal type parameters.
       if (at(TokenKind.BracketL)) {
@@ -2121,7 +2122,7 @@ object Parser2 {
       Decl.docComment()
       Decl.annotations()
       expect(TokenKind.KeywordDef)
-      nameUnqualified(NAME_DEFINITION)
+      nameUnqualified(NAME_FUNCTION)
       Decl.parameters()
       if (eat(TokenKind.Colon)) {
         Type.typeAndEffect()

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -336,10 +336,6 @@ object Weeder2 {
         Types.tryPickEffect(tree)
       ) {
         (doc, ident, tparams, fparams, exp, ttype, tconstrs, constrs, eff) =>
-          if (ident.isUpper) {
-            val error = WeederError.UnexpectedNonLowerCaseName(ident.name, ident.loc)
-            sctx.errors.add(error)
-          }
           Declaration.Def(doc, ann, mod, ident, tparams, fparams, exp, ttype, eff, tconstrs, constrs, tree.loc)
       }
     }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -49,6 +49,98 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectError[ParseError](result)
   }
 
+  test("IllegalDefName.01") {
+    val input =
+      """
+        |def A(): Unit = ()
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("IllegalDefName.02") {
+    val input =
+      """
+        |pub trait A[a] {
+        |    pub def A(): Unit = ()
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("IllegalDefName.03") {
+    val input =
+      """
+        |trait A[x] {}
+        |instance A[Int32] {
+        |    pub def A(): Unit = ()
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("IllegalDefName.04") {
+    val input =
+      """
+        |trait A[x] {}
+        |instance A[Int32] {
+        |    pub redef A(): Unit = ()
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("IllegalDefName.05") {
+    val input =
+      """
+        |trait B[a] {
+        |    law A:forall() false
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("IllegalDefName.06") {
+    val input =
+      """
+        |pub eff C {
+        |    def A(): Unit
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("IllegalDefName.07") {
+    val input =
+      """
+        |def a(): Unit = {
+        |    def A() = ();
+        |    A()
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("Use.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1579,24 +1579,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalUse](result)
   }
 
-  test("UnexpectedNonLowerCaseName.01") {
-    val input =
-      """
-        |def F(): Int32 = 123
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.UnexpectedNonLowerCaseName](result)
-  }
-
-  test("UnexpectedNonLowerCaseName.02") {
-    val input =
-      """
-        |def Map(): Int32 = 123
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.UnexpectedNonLowerCaseName](result)
-  }
-
   test("UnqualifiedUse.01") {
     val input =
       """


### PR DESCRIPTION
With the change to `nameUnqualified` a more restricted set of `TokenKind` can be supplied to generate the needed errors by the parser while breaking parsing.

Disallows every function declaration in the following (except `def a()`):
```
trait A[a] {
    pub def A(_: a): Int32 = 0
}

trait B[a] {
    law A:forall() false
}

instance A[Int32] {
    pub def A(_: Int32): Int32 = 2
    pub redef B(_: Int32): Int32 = 2
}

pub eff C {
    def A(): Unit
}

def a(): Unit = {
    def A() = ();
    A()
}
``` 