### PR TITLE
test: do not depend on 3rd party library

### DIFF
--- a/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
@@ -201,7 +201,7 @@ class TestFlixPackageManager extends AnyFunSuite {
   }
 
   test("Give error for missing dependency") {
-    assertResult(expected = PackageError.ProjectNotFound(new URI("https://api.github.com/repos/AnnaBlume99/helloworld/releases").toURL, Project("AnnaBlume99", "helloworld")).message(f))(actual = {
+    assertResult(expected = PackageError.ProjectNotFound(new URI("https://api.github.com/repos/flix/does-not-exist/releases").toURL, Project("flix", "does-not-exist")).message(f))(actual = {
       val toml = {
         """
           |[package]
@@ -212,7 +212,7 @@ class TestFlixPackageManager extends AnyFunSuite {
           |authors = ["Anna Blume"]
           |
           |[dependencies]
-          |"github:AnnaBlume99/helloworld" = "1.0.0"
+          |"github:flix/does-not-exist" = "1.0.0"
           |
           |[mvn-dependencies]
           |


### PR DESCRIPTION
Moves url to the flix organization, just to safe guard against a very unlikely accident.