### PR TITLE
refactor: do not use reduce in `BootstrapError.GeneralError`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/BootstrapError.scala
+++ b/main/src/ca/uwaterloo/flix/api/BootstrapError.scala
@@ -52,8 +52,6 @@ object BootstrapError {
   }
 
   case class GeneralError(e: List[String]) extends BootstrapError {
-    override def message(f: Formatter): String = e.reduce[String] {
-      case (acc, s) => acc + System.lineSeparator() + s
-    }
+    override def message(f: Formatter): String = e.mkString(System.lineSeparator())
   }
 }


### PR DESCRIPTION
Avoids unnecessary string concatenation.