### PR TITLE
chore: `forFragments` should use `zeroOrMore`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2358,7 +2358,7 @@ object Parser2 {
 
     private def forFragments()(implicit s: State): Unit = {
       implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr
-      oneOrMore(
+      zeroOrMore(
         namedTokenSet = NamedTokenSet.ForFragment,
         checkForItem = t => t.isFirstPattern || t == TokenKind.KeywordIf,
         getItem = () =>


### PR DESCRIPTION
The return value was ignored and the weeder already handled it.