### PR TITLE
chore: `restrictableChooseExpr` should use `zeroOrMore`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2310,7 +2310,7 @@ object Parser2 {
         expect(TokenKind.KeywordChoose)
       }
       expression()
-      oneOrMore(
+      zeroOrMore(
         namedTokenSet = NamedTokenSet.MatchRule,
         checkForItem = _ == TokenKind.KeywordCase,
         getItem = matchRule,


### PR DESCRIPTION
This also stops the compiler from crashing when there are 0 cases.