### PR TITLE
chore: `matchOrMatchLambdaExpr` should use `zeroOrMore`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2152,7 +2152,7 @@ object Parser2 {
             close(mark, TreeKind.Expr.LambdaMatch)
           } else {
             expression()
-            oneOrMore(
+            zeroOrMore(
               namedTokenSet = NamedTokenSet.MatchRule,
               checkForItem = _ == TokenKind.KeywordCase,
               getItem = matchRule,

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1390,7 +1390,8 @@ object Weeder2 {
         // Case: no valid match rule found in match expr
         case (expr, Nil) =>
           val error = NeedAtleastOne(NamedTokenSet.MatchRule, SyntacticContext.Expr.OtherExpr, loc = expr.loc)
-          // Fall back on Expr.Error. Parser has reported an error here.
+          sctx.errors.add(error)
+          // Fall back on Expr.Error.
           Validation.Success(Expr.Error(error))
         case (expr, rules) => Validation.Success(Expr.Match(expr, rules, tree.loc))
       }


### PR DESCRIPTION
When there are no rules we get this before and after:
<img width="1246" height="451" alt="image" src="https://github.com/user-attachments/assets/ad714664-6f50-4e4b-9493-63e544b73fea" />
