### PR TITLE
feat: remove arrows as functions

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -512,9 +512,9 @@ object Lexer {
     TokenKind.NameMath
   }
 
-  /** Checks whether `c` lies in unicode range U+2190 to U+22FF. */
+  /** Checks whether `c` lies in unicode range U+2200 to U+22FF. */
   private def isMathNameChar(c: Char): Boolean =
-    0x2190 <= c && c <= 0x22FF
+    0x2200 <= c && c <= 0x22FF
 
   /** Moves current position past a named hole (e.g. "?foo"). */
   private def acceptNamedHole()(implicit s: State): TokenKind = {


### PR DESCRIPTION
Discussed in #11730

This PR removes math arrows as valid names: https://en.wikipedia.org/wiki/Arrow_(symbol)

IMO these are not really used even in mathy code. And we use `<=>` so its odd to also have `⇔` fx