### PR TITLE
chore: use `zeroOrMore` in `enumCases`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1206,19 +1206,14 @@ object Parser2 {
         if (at(TokenKind.ParenL)) {
           val mark = open()
           val markTuple = open()
-          oneOrMore(
+          zeroOrMore(
             namedTokenSet = NamedTokenSet.Type,
             getItem = () => Type.ttype(),
             checkForItem = _.isFirstInType,
             breakWhen = _.isRecoverInDecl
-          ) match {
-            case Some(error) =>
-              close(markTuple, TreeKind.Type.Tuple)
-              closeWithError(mark, error)
-            case None =>
-              close(markTuple, TreeKind.Type.Tuple)
-              close(mark, TreeKind.Type.Type)
-          }
+          )
+          close(markTuple, TreeKind.Type.Tuple)
+          close(mark, TreeKind.Type.Type)
         }
         close(mark, TreeKind.Case)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3002,17 +3002,12 @@ object Weeder2 {
       expectAny(tree, List(TreeKind.Type.Type, TreeKind.Type.Effect))
       // Visit first child and match its kind to know what to to
       val inner = unfold(tree)
-      inner.kind match {
-        case TreeKind.Type.Tuple =>
-          expect(inner, TreeKind.Type.Tuple)
-          mapN(traverse(pickAll(TreeKind.Type.Type, inner))(visitType)) {
-            case Nil => List(Type.Unit(inner.loc))
-            case types => types
-          }
-        case _ => visitType(tree) match {
-          case Success(t) => Success(List(t))
-          case Failure(errors) => Failure(errors)
-        }
+      val innerTypes = pickAll(TreeKind.Type.Type, inner)
+      mapN(traverse(innerTypes)(visitType)) {
+        case Nil =>
+          sctx.errors.add(NeedAtleastOne(NamedTokenSet.Type, SyntacticContext.Decl.Enum, loc = inner.loc))
+          List(Type.Error(inner.loc))
+        case types => types
       }
     }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -1026,17 +1026,6 @@ class TestParserSad extends AnyFunSuite with TestUtils {
     expectError[LexerError](result)
   }
 
-  test("ParseError.EnumCase.01") {
-    val input =
-      """
-        |enum E {
-        |    case C()
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
   test("ParseError.ParYield.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1876,4 +1876,15 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[ParseError.NeedAtleastOne](result)
   }
 
+  test("EmptyEnumCaseType.01") {
+    val input =
+      """
+        |enum E {
+        |    case C()
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError.NeedAtleastOne](result)
+  }
+
 }


### PR DESCRIPTION
This also fixes the hack for `Types.visitCaseType` in #11878, which should be rebased on this.