### PR TITLE
refactor: remove `foldRightWithCont`

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -794,21 +794,6 @@ mod Array {
         loop(length(arr) - 1, s)
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `a` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(a[0], ...f(a[n-1], f(a[n], z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ {ef, r}) -> b \ {ef, r}, z: b, arr: Array[a, r]): b \ { ef, r } =
-        def loop(i) = {
-            if (i == length(arr))
-                z
-            else
-                f(get(i, arr), _ -> loop(i + 1))
-        };
-        loop(0)
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, arr: Array[a, r]): b \ { ef, r } with Monoid[b] =

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -530,17 +530,6 @@ mod Chain {
     }
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `c` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, c: Chain[a]): b \ ef = match viewLeft(c) {
-        case ViewLeft.NoneLeft        => z
-        case ViewLeft.SomeLeft(x, xs) => f(x, _ -> foldRightWithCont(f, z, xs))
-    }
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, c: Chain[a]): b \ ef with Monoid[b] =

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -628,25 +628,6 @@ mod DelayList {
         loop(l, x -> checked_ecast(x))
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `l` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    ///
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    /// Calling the continuation forces the list `l`.
-    ///
-    @Experimental
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, l: DelayList[a]): b \ ef =
-        def loop(ll) = match ll {
-            case ENil         => z
-            case ECons(x, xs) => f(x, _ -> loop(xs))
-            case LCons(x, xs) => f(x, _ -> loop(force xs))
-            case LList(xs)    =>           loop(force xs)
-        };
-        loop(l)
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, l: DelayList[a]): b \ ef with Monoid[b] =

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -609,29 +609,6 @@ mod DelayMap {
         RedBlackTree.foldRight(f1, s, t)
 
     ///
-    /// Applies `f` to a start value `z` and all values in `m` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(v1, ...f(vn-1, f(vn, z)))`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    @Experimental
-    pub def foldRightWithCont(f: (v, Unit -> b \ ef) -> b \ ef, z: b, m: DelayMap[k, v]): b \ ef =
-        foldRightWithKeyCont((_, v, c) -> f(v, c), z, m)
-
-    ///
-    /// Applies `f` to a start value `s` and all key-value pairs in `m` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(k1, v1, ...f(kn-1, vn-1, f(kn, vn, s)))`.
-    /// A `foldRightWithKeyCont` allows early termination by not calling the continuation.
-    ///
-    @Experimental
-    pub def foldRightWithKeyCont(f: (k, v, Unit -> b \ ef) -> b \ ef, s: b, m: DelayMap[k, v]): b \ ef =
-        let _ = parallelForce(m);
-        let DMap(t) = m;
-        let f1 = (k1, v1, c) -> f(k1, force v1, c);
-        RedBlackTree.foldRightWithCont(f1, s, t)
-
-    ///
     /// Applies `f` to all values in `m` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(v1, v2), v3)..., vn))`

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -423,23 +423,6 @@ mod Iterator {
         loop(x -> checked_ecast(x))
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `iter` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    /// Consumes the entire iterator.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ { ef, r }) -> b \ ef, z: b, iter: Iterator[a, ef, r]): b \ { ef, r } =
-        let Iterator(_, iterF) = iter;
-        def loop() = match iterF() {
-            case Skip   => loop()
-            case Ans(a) => f(a, _ -> loop())
-            case Done   => z
-        };
-        loop()
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef2, iter: Iterator[a, ef1, r]): b \ { ef1, ef2, r } with Monoid[b] =

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -723,17 +723,6 @@ mod List {
         loop(reverse(l), s)
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `l` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, l: List[a]): b \ ef = match l {
-        case Nil     => z
-        case x :: xs => f(x, _ -> foldRightWithCont(f, z, xs))
-    }
-
-    ///
     /// Applies `f` to all elements in `l` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(x1, x2), x3)..., xn))`

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -520,25 +520,6 @@ mod Map {
         RedBlackTree.foldRight(f, s, t)
 
     ///
-    /// Applies `f` to a start value `z` and all values in `m` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(v1, ...f(vn-1, f(vn, z)))`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (v, Unit -> b \ ef) -> b \ ef, z: b, m: Map[k, v]): b \ ef =
-        foldRightWithKeyCont((_, v, c) -> f(v, c), z, m)
-
-    ///
-    /// Applies `f` to a start value `z` and all key-value pairs in `m` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(k1, v1, ...f(kn-1, vn-1, f(kn, vn, z)))`.
-    /// A `foldRightWithKeyCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithKeyCont(f: (k, v, Unit -> b \ ef) -> b \ ef, z: b, m: Map[k, v]): b \ ef =
-        let Map(t) = m;
-        RedBlackTree.foldRightWithCont(f, z, t)
-
-    ///
     /// Returns the result of mapping each key-value pair and combining the results.
     ///
     pub def foldMapWithKey(f: (k, v) -> b \ ef, m: Map[k, v]): b \ ef with Monoid[b] =

--- a/main/src/library/MultiMap.flix
+++ b/main/src/library/MultiMap.flix
@@ -327,25 +327,6 @@ mod MultiMap {
         Map.foldRightWithKey(outer, s, m1)
 
     ///
-    /// Applies `f` to a start value `z` and all values in `m` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(v1, ...f(vn-1, f(vn, z)))`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (v, Unit -> b \ ef) -> b \ ef, z: b, m: MultiMap[k, v]): b \ ef =
-        foldRightWithKeyCont((_, v, c) -> f(v, c), z, m)
-
-    ///
-    /// Applies `f` to a start value `z` and all key-value pairs in `m` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(k1, v1, ...f(kn-1, vn-1, f(kn, vn, z)))`.
-    /// A `foldRightWithKeyCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithKeyCont(f: (k, v, Unit -> b \ ef) -> b \ ef, z: b, m: MultiMap[k, v]): b \ ef =
-        let MultiMap(m1) = m;
-        Map.foldRightWithKeyCont((k, vs, b1) -> Set.foldRightWithCont((v1, fac) -> f(k, v1, fac), b1(), vs), z, m1)
-
-    ///
     /// Returns the result of mapping each key-value pair and combining the results.
     ///
     pub def foldMapWithKey(f: (k, v) -> b \ ef, m: MultiMap[k, v]): b \ ef with Monoid[b] =

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -164,22 +164,6 @@ mod MutDeque {
         loop(d->back, d->front, s)
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `d` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ {ef, r}) -> b \ {ef, r}, s: b, d: MutDeque[a, r]): b \ { ef, r } =
-        let c = capacity(d) - 1;
-        def loop(i, e) =
-            if (i == e)
-                s
-            else {
-                f(Array.get(i, d->values), _ -> loop(Int32.bitwiseAnd(i + 1, c), e))
-            };
-        loop(d->front, d->back)
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, d: MutDeque[a, r]): b \ { ef, r } with Monoid[b] =

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -502,22 +502,6 @@ mod MutList {
         loop(v->length - 1, s)
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `a` going from left to right.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ {ef, r}) -> b \ {ef, r}, z: b, v: MutList[a, r]): b \ { ef, r } =
-        def loop(i) = {
-            if (i >= v->length)
-                z
-            else {
-                f(Array.get(i, v->values), _ -> loop(i + 1))
-            }
-        };
-        loop(0)
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, v: MutList[a, r]): b \ {ef, r} with Monoid[b] =

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -394,24 +394,6 @@ mod MutMap {
         Map.foldRightWithKey(f, s, m->inner)
 
     ///
-    /// Applies `f` to a start value `z` and all values in the mutable map `m` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(v1, ...f(vn-1, f(vn, z)))`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (v, Unit -> b \ ef) -> b \ ef, z: b, m: MutMap[k, v, r]): b \ { ef, r } =
-        foldRightWithKeyCont((_, v, b) -> f(v, b), z, m)
-
-    ///
-    /// Applies `f` to a start value `z` and all key-value pairs in the mutable map `m` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(k1, v1, ...f(kn-1, vn-1, f(kn, vn, z)))`.
-    /// A `foldRightWithKeyCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithKeyCont(f: (k, v, Unit -> b \ ef) -> b \ ef, z: b, m: MutMap[k, v, r]): b \ { ef, r } =
-        Map.foldRightWithKeyCont(f, z, m->inner)
-
-    ///
     /// Applies `f` to all values in the mutable map `m` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(v1, v2), v3)..., vn))`

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -209,15 +209,6 @@ mod MutSet {
         Set.foldRight(f, z, s->inner)
 
     ///
-    /// Applies `f` to a start value `z` and all elements in the mutable set `s` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, s: MutSet[a, r]): b \ { ef, r } =
-        Set.foldRightWithCont(f, z, s->inner)
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, s: MutSet[a, r]): b \ {ef, r} with Monoid[b] =

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -587,17 +587,6 @@ mod Nec {
     }
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `c` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, c: Nec[a]): b \ ef = match viewLeft(c) {
-        case ViewLeft.OneLeft(x)      => f(x, _ -> checked_ecast(z))
-        case ViewLeft.SomeLeft(x, rs) => f(x, _ -> foldRightWithCont(f, z, rs))
-    }
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, c: Nec[a]): b \ ef with Monoid[b] =

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -381,16 +381,6 @@ mod Nel {
     }
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `l` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, l: Nel[a]): b \ ef = match l {
-        case Nel(x, xs) => f(x, _ -> List.foldRightWithCont(f, z, xs))
-    }
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, l: Nel[a]): b \ ef with Monoid[b] =

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -325,16 +325,6 @@ mod Option {
     }
 
     ///
-    /// Returns `f(v, z)` if `o` is `Some(v)`. Otherwise returns `z`.
-    ///
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, o: Option[a], z: b): b \ ef = match o {
-        case None    => z
-        case Some(v) => f(v, _ -> checked_ecast(z))
-    }
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, o: Option[a]): b \ ef with Monoid[b] =

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -331,17 +331,6 @@ mod RedBlackTree {
         foldLeft((acc, k, v) -> Monoid.combine(acc, f(k, v)), Monoid.empty(), t)
 
     ///
-    /// Applies `f` to a start value `z` and all key-value pairs in `t` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(k1, v1, ...f(kn-1, vn-1, f(kn, vn, s)))`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (k, v, Unit -> b \ ef) -> b \ ef, z: b, t: RedBlackTree[k, v]): b \ ef = match t {
-        case Node(_, a, k, v, b) => foldRightWithCont(f, f(k, v, _ -> foldRightWithCont(f, z, b)), a)
-        case _                   => z
-    }
-
-    ///
     /// Applies `f` to all key-value pairs in `tree` going from left to right until a single pair `(k, v)` is obtained.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(k1, v1, k2, v2), k3, v3)..., kn, vn))`

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -74,16 +74,6 @@ pub trait Reducible[t: Type -> Type] {
         Reducible.reduceRightTo(f, a -> f(a, s), t)
 
     ///
-    /// Right-associative fold of a structure.
-    /// Applies `f` to a start value `s` and all elements in `t` going from right to left.
-    ///
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, t: t[a]): b \ ef =
-        let f1 = (a, b) -> f(a, _ -> checked_ecast(b));
-        Reducible.reduceRightTo(f1, a -> f(a, _ -> checked_ecast(z)), t)
-
-    ///
     /// Alias for `reduce`.
     ///
     /// Reduce `t` using the derived `SemiGroup` instance.

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -188,16 +188,6 @@ mod Result {
     }
 
     ///
-    /// Returns `f(v, z)` if `r` is `Ok(v)`. Otherwise returns `z`.
-    ///
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (t, Unit -> a \ ef) -> a \ ef, z: a, r: Result[e, t]): a \ ef = match r {
-        case Ok(v)  => f(v, _ -> checked_ecast(z))
-        case Err(_) => z
-    }
-
-    ///
     /// Returns `Ok(v1 :: v2 :: ... :: vn)` if each of `l_i` is `Ok(v_i)`.
     /// Otherwise returns the first `Err` encountered.
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -319,16 +319,6 @@ mod Set {
         RedBlackTree.foldRight((k, _, c) -> f(k, c), s, t)
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `s` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, s: Set[a]): b \ ef =
-        let Set(t) = s;
-        RedBlackTree.foldRightWithCont((k, _, c) -> f(k, c), z, t)
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, s: Set[a]): b \ ef with Monoid[b] =

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -912,21 +912,6 @@ mod Vector {
         loop(length(v) - 1, s)
 
     ///
-    /// Applies `f` to a start value `z` and all elements in `v` going from right to left.
-    ///
-    /// That is, the result is of the form: `f(a[0], ...f(a[n-1], f(a[n], z))...)`.
-    /// A `foldRightWithCont` allows early termination by not calling the continuation.
-    ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, v: Vector[a]): b \ ef =
-        def loop(i) = {
-            if (i == length(v))
-                z
-            else
-                f(get(i, v), _ -> loop(i + 1))
-        };
-        loop(0)
-
-    ///
     /// Returns the result of mapping each element and combining the results.
     ///
     pub def foldMap(f: a -> b \ ef, v: Vector[a]): b \ ef with Monoid[b] =

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -2407,30 +2407,6 @@ mod TestArray {
     }
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = region rc {
-        assertEq(expected = 100, Array.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Array#{} @ rc))
-    }
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = region rc {
-        assertEq(expected = 198, Array.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Array#{1} @ rc))
-    }
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = region rc {
-        assertEq(expected = 194, Array.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Array#{1,2} @ rc))
-    }
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = region rc {
-        assertEq(expected = 382, Array.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Array#{1,2,3} @ rc))
-    }
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestChain.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChain.flix
@@ -896,22 +896,6 @@ mod TestChain {
     def foldRight04(): Unit \ Assert = assertEq(expected = 382, Chain.foldRight((e, acc) -> (acc - e) * (e `Int32.remainder` 2 + 1), 100, List.toChain(1 :: 2 :: 3 :: Nil)))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = assertEq(expected = 100, Chain.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Chain.empty()))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = assertEq(expected = 198, Chain.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Chain.singleton(1)))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = assertEq(expected = 194, Chain.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, List.toChain(1 :: 2 :: Nil)))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = assertEq(expected = 382, Chain.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, List.toChain(1 :: 2 :: 3 :: Nil)))
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
@@ -684,35 +684,6 @@ mod TestDelayList {
     	assertEq(expected = 1 :: 2 :: 3 :: Nil, DelayList.foldRight((x, acc) -> x :: acc, Nil, LList(lazy LCons(1, lazy LList(lazy ECons(2, ECons(3, LList(lazy ENil))))))))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert =
-    	assertEq(expected = 100, DelayList.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, ENil))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert =
-    	assertEq(expected = 100, DelayList.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, LList(lazy ENil)))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert =
-    	assertEq(expected = 198, DelayList.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, LCons(1, lazy LList(lazy ENil))))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert =
-    	assertEq(expected = 194, DelayList.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, ECons(1, LCons(2, lazy ENil))))
-
-    @Test
-    def foldRightWithCont05(): Unit \ Assert =
-    	assertEq(expected = 382, DelayList.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, LCons(1, lazy ECons(2, LCons(3, lazy LList(lazy ENil))))))
-
-    @Test
-    def foldRightWithCont06(): Unit \ Assert =
-    	assertEq(expected = 1 :: 2 :: 3 :: Nil, DelayList.foldRightWithCont((x, k) -> x :: k(), Nil, LList(lazy LCons(1, lazy LList(lazy ECons(2, ECons(3, LList(lazy ENil))))))))
-
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestDelayMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestDelayMap.flix
@@ -1220,56 +1220,6 @@ mod TestDelayMap {
             DelayMap.foldRightWithKey((k, v, acc) -> k + acc + v, 0))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert =
-        assertEq(expected = 0, Map#{} |> toDelayMap |>
-            DelayMap.foldRightWithCont((v, c) -> c() + v, 0))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert =
-        assertEq(expected = 2, Map#{1 => 2} |> toDelayMap |>
-            DelayMap.foldRightWithCont((v, c) -> c() + v, 0))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert =
-        assertEq(expected = 6, Map#{1 => 2, 3 => 4} |> toDelayMap |>
-            DelayMap.foldRightWithCont((v, c) -> c() + v, 0))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert =
-        assertEq(expected = 12, Map#{1 => 2, 3 => 4, 5 => 6} |> toDelayMap |>
-            DelayMap.foldRightWithCont((v, c) -> c() + v, 0))
-
-
-    /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithKeyCont                                                    //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithKeyCont01(): Unit \ Assert =
-        assertEq(expected = 0, Map#{} |> toDelayMap |>
-            DelayMap.foldRightWithKeyCont((k, v, c) -> k + c() + v, 0))
-
-    @Test
-    def foldRightWithKeyCont02(): Unit \ Assert =
-        assertEq(expected = 3, Map#{1 => 2} |> toDelayMap |>
-            DelayMap.foldRightWithKeyCont((k, v, c) -> k + c() + v, 0))
-
-    @Test
-    def foldRightWithKeyCont03(): Unit \ Assert =
-        assertEq(expected = 10, Map#{1 => 2, 3 => 4} |> toDelayMap |>
-            DelayMap.foldRightWithKeyCont((k, v, c) -> k + c() + v, 0))
-
-    @Test
-    def foldRightWithKeyCont04(): Unit \ Assert =
-        assertEq(expected = 21, Map#{1 => 2, 3 => 4, 5 => 6} |> toDelayMap |>
-            DelayMap.foldRightWithKeyCont((k, v, c) -> k + c() + v, 0))
-
-
-    /////////////////////////////////////////////////////////////////////////////
     // reduceLeft                                                              //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -837,35 +837,6 @@ mod TestIterator {
 
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = region rc {
-        let iter = List.iterator(rc, Nil);
-        assertEq(expected = 100, Iterator.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, iter))
-    }
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = region rc {
-        let iter = List.iterator(rc, 1 :: Nil);
-        assertEq(expected = 198, Iterator.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, iter))
-    }
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = region rc {
-        let iter = List.iterator(rc, 1 :: 2 :: Nil);
-        assertEq(expected = 194, Iterator.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, iter))
-    }
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = region rc {
-        let iter = List.iterator(rc, 1 :: 2 :: 3 :: Nil);
-        assertEq(expected = 382, Iterator.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, iter))
-    }
-
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1122,33 +1122,6 @@ mod TestList {
     def foldRight08(): Unit \ Assert = assertEq(expected = 382, List.foldRight((e, acc) -> (acc - e) * (e `Int32.remainder` 2 + 1), 100, 1 :: 2 :: 3 :: Nil))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = assertEq(expected = 100, List.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Nil))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = assertEq(expected = 198, List.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, 1 :: Nil))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = assertEq(expected = 194, List.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, 1 :: 2 :: Nil))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = assertEq(expected = 382, List.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, 1 :: 2 :: 3 :: Nil))
-
-    @Test
-    def foldRightWithCont05(): Unit \ Assert = assertEq(expected = 100, List.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Nil))
-
-    @Test
-    def foldRightWithCont06(): Unit \ Assert = assertEq(expected = 198, List.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, 1 :: Nil))
-
-    @Test
-    def foldRightWithCont07(): Unit \ Assert = assertEq(expected = 194, List.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, 1 :: 2 :: Nil))
-
-    @Test
-    def foldRightWithCont08(): Unit \ Assert = assertEq(expected = 382, List.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, 1 :: 2 :: 3 :: Nil))
-
-    /////////////////////////////////////////////////////////////////////////////
     // reduceLeft                                                              //
     /////////////////////////////////////////////////////////////////////////////
     @Test

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -1061,46 +1061,6 @@ mod TestMap {
         assertEq(expected = 21, Map.foldRightWithKey((k, v, acc) -> k + acc + v, 0, Map#{1 => 2, 3 => 4, 5 => 6}))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = 
-        assertEq(expected = 0, Map.foldRightWithCont((v, k) -> k() + v, 0, Map#{}))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = 
-        assertEq(expected = 2, Map.foldRightWithCont((v, k) -> k() + v, 0, Map#{1 => 2}))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = 
-        assertEq(expected = 6, Map.foldRightWithCont((v, k) -> k() + v, 0, Map#{1 => 2, 3 => 4}))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = 
-        assertEq(expected = 12, Map.foldRightWithCont((v, k) -> k() + v, 0, Map#{1 => 2, 3 => 4, 5 => 6}))
-
-    /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithKeyCont                                                    //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithKeyCont01(): Unit \ Assert = 
-        assertEq(expected = 0, Map.foldRightWithKeyCont((k, v, c) -> k + c() + v, 0, Map#{}))
-
-    @Test
-    def foldRightWithKeyCont02(): Unit \ Assert = 
-        assertEq(expected = 3, Map.foldRightWithKeyCont((k, v, c) -> k + c() + v, 0, Map#{1 => 2}))
-
-    @Test
-    def foldRightWithKeyCont03(): Unit \ Assert = 
-        assertEq(expected = 10, Map.foldRightWithKeyCont((k, v, c) -> k + c() + v, 0, Map#{1 => 2, 3 => 4}))
-
-    @Test
-    def foldRightWithKeyCont04(): Unit \ Assert = 
-        assertEq(expected = 21, Map.foldRightWithKeyCont((k, v, c) -> k + c() + v, 0, Map#{1 => 2, 3 => 4, 5 => 6}))
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMapWithKey                                                          //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestMutDeque.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutDeque.flix
@@ -810,46 +810,6 @@ mod TestMutDeque {
 
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = region rc {
-        assertEq(expected = 100, MutDeque.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, MutDeque.empty(rc)))
-    }
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = region rc {
-        let d = MutDeque.empty(rc);
-        MutDeque.pushBack(1, d);
-        assertEq(expected = 198, MutDeque.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, d))
-    }
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = region rc {
-        let d = MutDeque.empty(rc);
-        MutDeque.pushFront(1, d);
-        assertEq(expected = 198, MutDeque.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, d))
-    }
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = region rc {
-        let d = MutDeque.empty(rc);
-        MutDeque.pushFront(1, d);
-        MutDeque.pushBack(2, d);
-        assertEq(expected = 194, MutDeque.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, d))
-    }
-
-    @Test
-    def foldRightWithCont05(): Unit \ Assert = region rc {
-        let d = MutDeque.empty(rc);
-        MutDeque.pushBack(2, d);
-        MutDeque.pushBack(3, d);
-        MutDeque.pushFront(1, d);
-        assertEq(expected = 382, MutDeque.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, d))
-    }
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                       //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -1032,36 +1032,6 @@ mod TestMutList {
     }
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = region rc {
-        assertEq(expected = 10, MutList.foldRightWithCont((x, k) -> k() + x, 0, MutList.range(rc, 1, 5)))
-    }
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = region rc {
-        assertEq(expected = "34567", MutList.foldRightWithCont((x, k) -> Int32.toString(x) + k(), "", MutList.range(rc, 3, 8)))
-    }
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = region rc {
-        assertEq(expected = 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: Nil, MutList.foldRightWithCont((x, k) -> x :: k(), Nil, MutList.range(rc, 0, 6)))
-    }
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = region rc {
-        assertEq(expected = -50, MutList.foldRightWithCont((x, k) -> x - k(), 0, MutList.range(rc, 0, 100)))
-    }
-
-    @Test
-    def foldRightWithCont05(): Unit \ Assert = region rc {
-        assertEq(expected = 42, MutList.foldRightWithCont((x, k) -> x + k(), 42, MutList.empty(rc)))
-    }
-
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
@@ -255,39 +255,6 @@ mod TestMutSet {
     }
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = region rc {
-        assertEq(expected = 100, MutSet.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, MutSet.empty(rc)))
-    }
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = region rc {
-        let s = MutSet.empty(rc);
-        MutSet.add(1, s);
-        assertEq(expected = 198, MutSet.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, s))
-    }
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = region rc {
-        let s = MutSet.empty(rc);
-        MutSet.add(2, s);
-        MutSet.add(1, s);
-        assertEq(expected = 194, MutSet.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, s))
-    }
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = region rc {
-        let s = MutSet.empty(rc);
-        MutSet.add(3, s);
-        MutSet.add(2, s);
-        MutSet.add(1, s);
-        assertEq(expected = 382, MutSet.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, s))
-    }
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestNec.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNec.flix
@@ -789,20 +789,6 @@ mod TestNec {
     def foldRight03(): Unit \ Assert = assertEq(expected = -6, Nec.foldRight((x, acc) -> acc - x, 0, necOf3(1, 2, 3)))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = assertEq(expected = -1, Nec.foldRightWithCont((x, k) -> k() - x, 0, singleton(1)))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = assertEq(expected = -3, Nec.foldRightWithCont((x, k) -> k() - x, 0, necOf2(1, 2)))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = assertEq(expected = -6, Nec.foldRightWithCont((x, k) -> k() - x, 0, necOf3(1, 2, 3)))
-
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestNel.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNel.flix
@@ -397,19 +397,6 @@ mod TestNel {
     def foldRight03(): Unit \ Assert = assertEq(expected = -6, Nel.foldRight((x, acc) -> acc - x, 0, Nel(1, 2 :: 3 :: Nil)))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = assertEq(expected = -1, Nel.foldRightWithCont((x, k) -> k() - x, 0, Nel(1, Nil)))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = assertEq(expected = -3, Nel.foldRightWithCont((x, k) -> k() - x, 0, Nel(1, 2 :: Nil)))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = assertEq(expected = -6, Nel.foldRightWithCont((x, k) -> k() - x, 0, Nel(1, 2 :: 3 :: Nil)))
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestOption.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestOption.flix
@@ -355,24 +355,6 @@ mod TestOption {
     def foldRight05(): Unit \ Assert = assertTrue(Option.foldRight((i, acc) -> if (i == 2 and acc) true else false, Some(2), true))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = assertFalse(Option.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, None, false))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = assertFalse(Option.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, Some(1), false))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = assertFalse(Option.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, Some(2), false))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = assertFalse(Option.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, Some(1), true))
-
-    @Test
-    def foldRightWithCont05(): Unit \ Assert = assertTrue(Option.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, Some(2), true))
-
-    /////////////////////////////////////////////////////////////////////////////
     // sequence                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @Test

--- a/main/test/ca/uwaterloo/flix/library/TestReducible.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestReducible.flix
@@ -201,41 +201,6 @@ mod TestReducible {
     }
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert =
-        assertEq(expected = "a", Reducible.foldRightWithCont((a, k) -> a + k(), "", Nel.Nel("a", Nil)))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert =
-        assertEq(expected = "ab", Reducible.foldRightWithCont((a, k) -> a + k(), "", Nel.Nel("a", "b" :: Nil)))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert =
-        assertEq(expected = "abc", Reducible.foldRightWithCont((a, k) -> a + k(), "", Nel.Nel("a", "b" :: "c" :: Nil)))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert =
-        assertEq(expected = 198, Reducible.foldRightWithCont((a, k) -> (k() - a) * ((a `Int32.remainder` 2) + 1), 100, Nel.Nel(1, Nil)))
-
-    @Test
-    def foldRightWithCont05(): Unit \ Assert =
-        assertEq(expected = 194, Reducible.foldRightWithCont((a, k) -> (k() - a) * ((a `Int32.remainder` 2) + 1), 100, Nel.Nel(1, 2 :: Nil)))
-
-    @Test
-    def foldRightWithCont06(): Unit \ Assert =
-        assertEq(expected = 382, Reducible.foldRightWithCont((a, k) -> (k() - a) * ((a `Int32.remainder` 2) + 1), 100, Nel.Nel(1, 2 :: 3 :: Nil)))
-
-    @Test
-    def foldRightWithCont07(): Unit \ Assert = region rc {
-        let l = Ref.fresh(rc, Nil);
-        discard Reducible.foldRightWithCont((x, _) -> { Ref.put(x :: Ref.get(l), l); x == 1 }, false, Nel.Nel(1, 2 :: 3 :: Nil));
-        assertEq(expected = 1 :: 2 :: 3 :: Nil, Ref.get(l))
-    }
-
-    /////////////////////////////////////////////////////////////////////////////
     // head                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -271,25 +271,6 @@ mod TestResult {
     def foldRight05(): Unit \ Assert = assertTrue(Result.foldRight((i, acc) -> if (i == 2 and acc) true else false, true, Ok(2)))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-    @Test
-    def foldRightWithCont01(): Unit \ Assert = assertFalse(Result.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, false, Err(-1ii)))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert = assertFalse(Result.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, false, Ok(1)))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert = assertFalse(Result.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, true, Ok(1)))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert = assertFalse(Result.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, false, Ok(2)))
-
-    @Test
-    def foldRightWithCont05(): Unit \ Assert = assertTrue(Result.foldRightWithCont((i, k) -> if (i == 2 and k()) true else false, true, Ok(2)))
-
-
-    /////////////////////////////////////////////////////////////////////////////
     // sequence                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @Test

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -560,26 +560,6 @@ mod TestSet {
         assertEq(expected = 382, Set.foldRight((e, acc) -> (acc - e) * (e `Int32.remainder` 2 + 1), 100, Set#{3, 2, 1}))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert =
-        assertEq(expected = 100, Set.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Set#{}))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert =
-        assertEq(expected = 198, Set.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Set#{1}))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert =
-        assertEq(expected = 194, Set.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Set#{2, 1}))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert =
-        assertEq(expected = 382, Set.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Set#{3, 2, 1}))
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestVector.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestVector.flix
@@ -2012,26 +2012,6 @@ mod TestVector {
         assertEq(expected = 382, Vector.foldRight((e, i) -> (i - e) * (e `Int32.remainder` 2 + 1), 100, Vector#{1, 2, 3}))
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightWithCont                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def foldRightWithCont01(): Unit \ Assert =
-        assertEq(expected = 100, Vector.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Vector#{}))
-
-    @Test
-    def foldRightWithCont02(): Unit \ Assert =
-        assertEq(expected = 198, Vector.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Vector#{1}))
-
-    @Test
-    def foldRightWithCont03(): Unit \ Assert =
-        assertEq(expected = 194, Vector.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Vector#{1, 2}))
-
-    @Test
-    def foldRightWithCont04(): Unit \ Assert =
-        assertEq(expected = 382, Vector.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.remainder` 2 + 1), 100, Vector#{1, 2, 3}))
-
-    /////////////////////////////////////////////////////////////////////////////
     // foldMap                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Fixes #11760

Remove `foldRightWithCont`. All functions have already been refactored to not use it.