### PR TITLE
fix: allow shorthand struct decl

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1219,14 +1219,16 @@ object Parser2 {
       expect(TokenKind.KeywordStruct)
       nameUnqualified(NAME_TYPE)
       Type.parameters()
-      zeroOrMore(
-        namedTokenSet = NamedTokenSet.FromKinds(NAME_FIELD),
-        getItem = structField,
-        checkForItem = token => NAME_FIELD.contains(token) || token.isModifier,
-        breakWhen = _.isRecoverInExpr,
-        delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
-      )
+      if (at(TokenKind.CurlyL)) {
+        zeroOrMore(
+          namedTokenSet = NamedTokenSet.FromKinds(NAME_FIELD),
+          getItem = structField,
+          checkForItem = token => NAME_FIELD.contains(token) || token.isModifier,
+          breakWhen = _.isRecoverInExpr,
+          delimiterL = TokenKind.CurlyL,
+          delimiterR = TokenKind.CurlyR
+        )
+      }
       close(mark, TreeKind.Decl.Struct)
     }
 

--- a/main/test/flix/Test.Dec.Struct.flix
+++ b/main/test/flix/Test.Dec.Struct.flix
@@ -8,6 +8,8 @@ def foo(): Unit = ()
 mod Test.Dec.Struct {
     pub struct Empty[r] {}
 
+    pub struct ShortEmpty[r]
+
     pub struct Singleton[r] {
         singletonfield: Int32
     }


### PR DESCRIPTION
This would reenable `struct A[r]`

@magnus-madsen Probably discuss with @JonathanStarup (and others with opinions) whether you want this and close #8548 afterwards.