### PR TITLE
refactor: rename `Expr` -> `Exp`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Consumer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Consumer.scala
@@ -34,14 +34,14 @@ import ca.uwaterloo.flix.language.ast.shared.{Annotation, Derivation, Derivation
   * Example
   * {{{
   * object ExprListConsumer extends Consumer {
-  *   var stack: List[Expr] = Nil
-  *   override consumeExpr(exp: Expr): Unit = {
+  *   var stack: List[Exp] = Nil
+  *   override consumeExpr(exp: Exp): Unit = {
   *     stack = exp :: stack
   *   }
   * }
   * }}}
   *
-  * This consumer only cares about [[Expr]]s and simply collects all expressions visited.
+  * This consumer only cares about [[Exp]]s and simply collects all expressions visited.
   */
 trait Consumer {
   def consumeAnnotation(ann: Annotation): Unit = ()
@@ -80,7 +80,7 @@ trait Consumer {
 
   def consumeEqualityConstraint(ec: EqualityConstraint): Unit = ()
 
-  def consumeExpr(exp: Expr): Unit = ()
+  def consumeExpr(exp: Exp): Unit = ()
 
   def consumeFormalParam(fparam: FormalParam): Unit = ()
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -319,142 +319,142 @@ object Visitor {
     c.consumeTypeParam(tparam)
   }
 
-  private def visitExpr(expr: Expr)(implicit a: Acceptor, c: Consumer): Unit = {
-    if (!a.accept(expr.loc)) {
+  private def visitExpr(exp: Exp)(implicit a: Acceptor, c: Consumer): Unit = {
+    if (!a.accept(exp.loc)) {
       return
     }
 
-    c.consumeExpr(expr)
+    c.consumeExpr(exp)
 
-    expr match {
-      case Expr.Cst(_, _, _) => ()
-      case Expr.Var(_, _, _) => ()
-      case Expr.Hole(_, _, _, _, _) => ()
+    exp match {
+      case Exp.Cst(_, _, _) => ()
+      case Exp.Var(_, _, _) => ()
+      case Exp.Hole(_, _, _, _, _) => ()
 
-      case Expr.HoleWithExp(exp, _, _, _, _) =>
+      case Exp.HoleWithExp(exp, _, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.OpenAs(_, _, _, _) => () // Not visited, unsupported feature.
+      case Exp.OpenAs(_, _, _, _) => () // Not visited, unsupported feature.
 
-      case Expr.Use(_, _, exp, _) =>
+      case Exp.Use(_, _, exp, _) =>
         visitExpr(exp)
 
-      case Expr.Lambda(fparam, exp, _, _) =>
+      case Exp.Lambda(fparam, exp, _, _) =>
         visitFormalParam(fparam)
         visitExpr(exp)
 
-      case Expr.ApplyClo(exp1, exp2, _, _, _) =>
+      case Exp.ApplyClo(exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.ApplyDef(symUse, exps, _, _, _, _, _) =>
+      case Exp.ApplyDef(symUse, exps, _, _, _, _, _) =>
         visitDefSymUse(symUse)
         exps.foreach(visitExpr)
 
-      case Expr.ApplyLocalDef(symUse, exps, _, _, _, _) =>
+      case Exp.ApplyLocalDef(symUse, exps, _, _, _, _) =>
         visitLocalDefSymUse(symUse)
         exps.foreach(visitExpr)
 
-      case Expr.ApplyOp(op, exps, _, _, _) =>
+      case Exp.ApplyOp(op, exps, _, _, _) =>
         visitOpSymUse(op)
         exps.foreach(visitExpr)
 
-      case Expr.ApplySig(symUse, exps, _, _, _, _, _, _) =>
+      case Exp.ApplySig(symUse, exps, _, _, _, _, _, _) =>
         visitSigSymUse(symUse)
         exps.foreach(visitExpr)
 
-      case Expr.Unary(_, exp, _, _, _) =>
+      case Exp.Unary(_, exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.Binary(_, exp1, exp2, _, _, _) =>
+      case Exp.Binary(_, exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.Let(bnd, exp1, exp2, _, _, _) =>
+      case Exp.Let(bnd, exp1, exp2, _, _, _) =>
         visitBinder(bnd)
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.LocalDef(bnd, fparams, exp1, exp2, _, _, _) =>
+      case Exp.LocalDef(bnd, fparams, exp1, exp2, _, _, _) =>
         visitBinder(bnd)
         fparams.foreach(visitFormalParam)
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.Region(bnd, _, exp, _, _, _) =>
+      case Exp.Region(bnd, _, exp, _, _, _) =>
         visitBinder(bnd)
         visitExpr(exp)
 
-      case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
+      case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
         visitExpr(exp3)
 
-      case Expr.Stm(exp1, exp2, _, _, _) =>
+      case Exp.Stm(exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.Discard(exp, _, _) =>
+      case Exp.Discard(exp, _, _) =>
         visitExpr(exp)
 
-      case Expr.Match(exp, rules, _, _, _) =>
+      case Exp.Match(exp, rules, _, _, _) =>
         visitExpr(exp)
         rules.foreach(visitMatchRule)
 
-      case Expr.TypeMatch(exp, rules, _, _, _) =>
+      case Exp.TypeMatch(exp, rules, _, _, _) =>
         visitExpr(exp)
         rules.foreach(visitTypeMatchRule)
 
-      case Expr.RestrictableChoose(_, _, _, _, _, _) => () // Not visited, unsupported feature.
+      case Exp.RestrictableChoose(_, _, _, _, _, _) => () // Not visited, unsupported feature.
 
-      case Expr.ExtMatch(exp, rules, _, _, _) =>
+      case Exp.ExtMatch(exp, rules, _, _, _) =>
         visitExpr(exp)
         rules.foreach(visitExtMatchRule)
 
-      case Expr.Tag(symUse, exps, _, _, _) =>
+      case Exp.Tag(symUse, exps, _, _, _) =>
         visitCaseSymUse(symUse)
         exps.foreach(visitExpr)
 
-      case Expr.RestrictableTag(_, _, _, _, _) => () // Not visited, unsupported feature.
+      case Exp.RestrictableTag(_, _, _, _, _) => () // Not visited, unsupported feature.
 
-      case Expr.ExtTag(_, exps, _, _, _) =>
+      case Exp.ExtTag(_, exps, _, _, _) =>
         exps.foreach(visitExpr)
 
-      case Expr.Tuple(exps, _, _, _) =>
+      case Exp.Tuple(exps, _, _, _) =>
         exps.foreach(visitExpr)
 
-      case Expr.RecordSelect(exp, _, _, _, _) =>
+      case Exp.RecordSelect(exp, _, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.RecordExtend(_, exp1, exp2, _, _, _) =>
+      case Exp.RecordExtend(_, exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.RecordRestrict(_, exp, _, _, _) =>
+      case Exp.RecordRestrict(_, exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.ArrayLit(exps, exp, _, _, _) =>
+      case Exp.ArrayLit(exps, exp, _, _, _) =>
         visitExpr(exp)
         exps.foreach(visitExpr)
 
-      case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) =>
+      case Exp.ArrayNew(exp1, exp2, exp3, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
         visitExpr(exp3)
 
-      case Expr.ArrayLoad(exp1, exp2, _, _, _) =>
+      case Exp.ArrayLoad(exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.ArrayLength(exp, _, _) =>
+      case Exp.ArrayLength(exp, _, _) =>
         visitExpr(exp)
 
-      case Expr.ArrayStore(exp1, exp2, exp3, _, _) =>
+      case Exp.ArrayStore(exp1, exp2, exp3, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
         visitExpr(exp3)
 
-      case Expr.StructNew(_, fields, region, _, _, _) =>
+      case Exp.StructNew(_, fields, region, _, _, _) =>
         fields.foreach {
           case (symUse, exp) =>
             visitStructFieldSymUse(symUse)
@@ -462,145 +462,145 @@ object Visitor {
         }
         visitExpr(region)
 
-      case Expr.StructGet(exp, symUse, _, _, _) =>
+      case Exp.StructGet(exp, symUse, _, _, _) =>
         visitExpr(exp)
         visitStructFieldSymUse(symUse)
 
-      case Expr.StructPut(exp1, symUse, exp2, _, _, _) =>
+      case Exp.StructPut(exp1, symUse, exp2, _, _, _) =>
         visitExpr(exp1)
         visitStructFieldSymUse(symUse)
         visitExpr(exp2)
 
-      case Expr.VectorLit(exps, _, _, _) =>
+      case Exp.VectorLit(exps, _, _, _) =>
         exps.foreach(visitExpr)
 
-      case Expr.VectorLoad(exp1, exp2, _, _, _) =>
+      case Exp.VectorLoad(exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.VectorLength(exp, _) =>
+      case Exp.VectorLength(exp, _) =>
         visitExpr(exp)
 
-      case Expr.Ascribe(exp, _, _, _, _, _) =>
+      case Exp.Ascribe(exp, _, _, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.InstanceOf(exp, _, _) =>
+      case Exp.InstanceOf(exp, _, _) =>
         visitExpr(exp)
 
-      case Expr.CheckedCast(_, exp, _, _, _) =>
+      case Exp.CheckedCast(_, exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.UncheckedCast(exp, declaredType, declaredEff, _, _, _) =>
+      case Exp.UncheckedCast(exp, declaredType, declaredEff, _, _, _) =>
         visitExpr(exp)
         declaredType.foreach(visitType)
         declaredEff.foreach(visitType)
 
-      case Expr.Unsafe(exp, runEff, _, _, _) =>
+      case Exp.Unsafe(exp, runEff, _, _, _) =>
         // runEff is first syntactically
         visitType(runEff)
         visitExpr(exp)
 
-      case Expr.Without(exp, symUse, _, _, _) =>
+      case Exp.Without(exp, symUse, _, _, _) =>
         visitExpr(exp)
         visitEffSymUse(symUse)
 
-      case Expr.TryCatch(exp, rules, _, _, _) =>
+      case Exp.TryCatch(exp, rules, _, _, _) =>
         visitExpr(exp)
         rules.foreach(visitCatchRule)
 
-      case Expr.Throw(exp, _, _, _) =>
+      case Exp.Throw(exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.Handler(symUse, rules, _, _, _, _, _) =>
+      case Exp.Handler(symUse, rules, _, _, _, _, _) =>
         visitEffSymUse(symUse)
         rules.foreach(visitHandlerRule)
 
-      case Expr.RunWith(exp1, exp2, _, _, _) =>
+      case Exp.RunWith(exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.InvokeConstructor(_, exps, _, _, _) =>
+      case Exp.InvokeConstructor(_, exps, _, _, _) =>
         exps.foreach(visitExpr)
 
-      case Expr.InvokeMethod(_, exp, exps, _, _, _) =>
+      case Exp.InvokeMethod(_, exp, exps, _, _, _) =>
         visitExpr(exp)
         exps.foreach(visitExpr)
 
-      case Expr.InvokeStaticMethod(_, exps, _, _, _) =>
+      case Exp.InvokeStaticMethod(_, exps, _, _, _) =>
         exps.foreach(visitExpr)
 
-      case Expr.GetField(_, exp, _, _, _) =>
+      case Exp.GetField(_, exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.PutField(_, exp1, exp2, _, _, _) =>
+      case Exp.PutField(_, exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.GetStaticField(_, _, _, _) => ()
+      case Exp.GetStaticField(_, _, _, _) => ()
 
-      case Expr.PutStaticField(_, exp, _, _, _) =>
+      case Exp.PutStaticField(_, exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.NewObject(_, _, _, _, methods, _) =>
+      case Exp.NewObject(_, _, _, _, methods, _) =>
         methods.foreach(visitJvmMethod)
 
-      case Expr.NewChannel(exp, _, _, _) =>
+      case Exp.NewChannel(exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.GetChannel(exp, _, _, _) =>
+      case Exp.GetChannel(exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.PutChannel(exp1, exp2, _, _, _) =>
+      case Exp.PutChannel(exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.SelectChannel(rules, default, _, _, _) =>
+      case Exp.SelectChannel(rules, default, _, _, _) =>
         rules.foreach(visitSelectChannelRule)
         default.foreach(visitExpr)
 
-      case Expr.Spawn(exp1, exp2, _, _, _) =>
+      case Exp.Spawn(exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.ParYield(frags, exp, _, _, _) =>
+      case Exp.ParYield(frags, exp, _, _, _) =>
         visitExpr(exp)
         frags.foreach(visitParYieldFrag)
 
-      case Expr.Lazy(exp, _, _) =>
+      case Exp.Lazy(exp, _, _) =>
         visitExpr(exp)
 
-      case Expr.Force(exp, _, _, _) =>
+      case Exp.Force(exp, _, _, _) =>
         visitExpr(exp)
 
-      case Expr.FixpointConstraintSet(cs, _, _) =>
+      case Exp.FixpointConstraintSet(cs, _, _) =>
         cs.foreach(visitConstraint)
 
-      case Expr.FixpointLambda(pparams, exp, _, _, _) =>
+      case Exp.FixpointLambda(pparams, exp, _, _, _) =>
         pparams.foreach(visitPredicateParam)
         visitExpr(exp)
 
-      case Expr.FixpointMerge(exp1, exp2, _, _, _) =>
+      case Exp.FixpointMerge(exp1, exp2, _, _, _) =>
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.FixpointQueryWithProvenance(exps, select, _, _, _, _) =>
+      case Exp.FixpointQueryWithProvenance(exps, select, _, _, _, _) =>
         exps.foreach(visitExpr)
         visitPredicate(select)
 
-      case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
+      case Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
         exps.foreach(visitExpr)
         visitExpr(queryExp)
         selects.foreach(visitExpr)
         from.foreach(visitPredicate)
         where.foreach(visitExpr)
 
-      case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
+      case Exp.FixpointSolveWithProject(exps, _, _, _, _, _) =>
         exps.foreach(visitExpr)
 
-      case Expr.FixpointInjectInto(exps, _, _, _, _) =>
+      case Exp.FixpointInjectInto(exps, _, _, _, _) =>
         exps.foreach(visitExpr)
 
-      case Expr.Error(_, _, _) => ()
+      case Exp.Error(_, _, _) => ()
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/consumers/StackConsumer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/consumers/StackConsumer.scala
@@ -76,7 +76,7 @@ case class StackConsumer() extends Consumer {
 
   override def consumeEqualityConstraint(ec: EqualityConstraint): Unit = push(ec)
 
-  override def consumeExpr(exp: Expr): Unit = push(exp)
+  override def consumeExpr(exp: Exp): Unit = push(exp)
 
   override def consumeFormalParam(fparam: FormalParam): Unit = push(fparam)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -74,7 +74,7 @@ object CompletionProvider {
             OpCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             SignatureCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
             EnumTagCompleter.getCompletions(uri, pos, qn, range, ap, scp) ++
-            TraitCompleter.getCompletions(qn, TraitUsageKind.Expr, range, ap, scp) ++
+            TraitCompleter.getCompletions(qn, TraitUsageKind.Exp, range, ap, scp) ++
             ModuleCompleter.getCompletions(qn, range, ap, scp)
 
         case err: ResolutionError.UndefinedType =>
@@ -123,8 +123,8 @@ object CompletionProvider {
       Nil
     else e.sctx match {
       // Expressions.
-      case SyntacticContext.Expr.Constraint => (PredicateCompleter.getCompletions(uri, range) ++ KeywordCompleter.getConstraintKeywords(range)).toList
-      case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords(None, range)
+      case SyntacticContext.Exp.Constraint => (PredicateCompleter.getCompletions(uri, range) ++ KeywordCompleter.getConstraintKeywords(range)).toList
+      case SyntacticContext.Exp.OtherExpr => KeywordCompleter.getExprKeywords(None, range)
 
       // Declarations.
       case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords(range)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -140,7 +140,7 @@ object FindReferencesProvider {
     case TypedAst.AssocTypeDef(_, _, _, _, _, loc) => loc.isReal
     case TypedAst.Effect(_, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Op(_, _, loc) => loc.isReal
-    case exp: TypedAst.Expr => exp.loc.isReal
+    case exp: TypedAst.Exp => exp.loc.isReal
     case pat: TypedAst.Pattern => pat.loc.isReal
     case TypedAst.RestrictableChoosePattern.Wild(_, loc) => loc.isReal
     case TypedAst.RestrictableChoosePattern.Var(_, _, loc) => loc.isReal
@@ -230,7 +230,7 @@ object FindReferencesProvider {
     case TypedAst.TypeParam(_, sym, _) => Some(getTypeVarSymOccurs(sym))
     case Type.Var(sym, _) => Some(getTypeVarSymOccurs(sym))
     // Vars
-    case TypedAst.Expr.Var(sym, _, _) => Some(getVarSymOccurs(sym))
+    case TypedAst.Exp.Var(sym, _, _) => Some(getVarSymOccurs(sym))
     case Binder(sym, _) => Some(getVarSymOccurs(sym))
 
     case _ => None
@@ -491,8 +491,8 @@ object FindReferencesProvider {
     object VarSymConsumer extends Consumer {
       override def consumeBinder(bnd: Binder): Unit = consider(bnd.sym, bnd.sym.loc)
 
-      override def consumeExpr(exp: TypedAst.Expr): Unit = exp match {
-        case TypedAst.Expr.Var(varSym, _, loc) => consider(varSym, loc)
+      override def consumeExpr(exp: TypedAst.Exp): Unit = exp match {
+        case TypedAst.Exp.Var(varSym, _, loc) => consider(varSym, loc)
         case _ => ()
       }
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -124,7 +124,7 @@ object GotoProvider {
     // Type Vars
     case Type.Var(sym, loc) => Some(LocationLink.fromTypeVarSym(sym, loc))
     // Vars
-    case TypedAst.Expr.Var(sym, _, loc) => Some(LocationLink.fromVarSym(sym, loc))
+    case TypedAst.Exp.Var(sym, _, loc) => Some(LocationLink.fromVarSym(sym, loc))
     case _ => None
   }
 
@@ -141,7 +141,7 @@ object GotoProvider {
     case TypedAst.AssocTypeDef(_, _, _, _, _, loc) => loc.isReal
     case TypedAst.Effect(_, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Op(_, _, loc) => loc.isReal
-    case exp: TypedAst.Expr => exp.loc.isReal
+    case exp: TypedAst.Exp => exp.loc.isReal
     case pat: TypedAst.Pattern => pat.loc.isReal
     case TypedAst.RestrictableChoosePattern.Wild(_, loc) => loc.isReal
     case TypedAst.RestrictableChoosePattern.Var(_, _, loc) => loc.isReal

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
@@ -37,7 +37,7 @@ object HoverProvider {
   private def hoverAny(x: AnyRef)(implicit root: Root, flix: Flix): Option[Hover] = x match {
     case tpe: Type => hoverKind(tpe.kind, tpe.loc)
     case (varSym: Symbol.VarSym, tpe: Type) => hoverType(tpe, varSym.loc)
-    case exp: Expr => hoverTypeAndEff(exp.tpe, exp.eff, exp.loc)
+    case exp: Exp => hoverTypeAndEff(exp.tpe, exp.eff, exp.loc)
     case Binder(sym, tpe) => hoverType(tpe, sym.loc)
     case DefSymUse(sym, loc) => hoverDef(sym, loc)
     case SigSymUse(sym, loc) => hoverSig(sym, loc)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider
 
 import ca.uwaterloo.flix.api.lsp.acceptors.FileAcceptor
 import ca.uwaterloo.flix.api.lsp.{Consumer, InlayHint, InlayHintKind, Position, Range, Visitor}
-import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, Root}
+import ca.uwaterloo.flix.language.ast.TypedAst.{Exp, Root}
 import ca.uwaterloo.flix.language.ast.shared.SymUse
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
 
@@ -76,9 +76,9 @@ object InlayHintProvider {
   private def getOpSymUses(uri: String)(implicit root: Root): List[(SymUse.OpSymUse, SourceLocation)] = {
     var opSymUses: List[(SymUse.OpSymUse, SourceLocation)] = List.empty
     object opSymUseConsumer extends Consumer {
-      override def consumeExpr(expr: Expr): Unit = {
-        expr match {
-          case Expr.ApplyOp(opSymUse, _, _, _, loc) =>
+      override def consumeExpr(exp: Exp): Unit = {
+        exp match {
+          case Exp.ApplyOp(opSymUse, _, _, _, loc) =>
             opSymUses = (opSymUse, loc) :: opSymUses
           case _ => ()
         }
@@ -94,9 +94,9 @@ object InlayHintProvider {
   private def getDefSymUses(uri: String)(implicit root: Root): List[(SymUse.DefSymUse, SourceLocation)] = {
     var defSymUses: List[(SymUse.DefSymUse, SourceLocation)] = List.empty
     object defSymUseConsumer extends Consumer {
-      override def consumeExpr(expr: Expr): Unit = {
-        expr match {
-          case Expr.ApplyDef(defSymUse, _, _, _, _, _, loc) =>
+      override def consumeExpr(exp: Exp): Unit = {
+        exp match {
+          case Exp.ApplyDef(defSymUse, _, _, _, _, _, loc) =>
             defSymUses = (defSymUse, loc) :: defSymUses
           case _ => ()
         }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
@@ -128,7 +128,7 @@ object RenameProvider {
     case TypedAst.AssocTypeDef(_, _, _, _, _, loc) => loc.isReal
     case TypedAst.Effect(_, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Op(_, _, loc) => loc.isReal
-    case exp: TypedAst.Expr => exp.loc.isReal
+    case exp: TypedAst.Exp => exp.loc.isReal
     case pat: TypedAst.Pattern => pat.loc.isReal
     case TypedAst.RestrictableChoosePattern.Wild(_, loc) => loc.isReal
     case TypedAst.RestrictableChoosePattern.Var(_, _, loc) => loc.isReal
@@ -184,7 +184,7 @@ object RenameProvider {
     case TypedAst.TypeParam(_, sym, _) => Some(getTypeVarSymOccurs(sym))
     case Type.Var(sym, _) => Some(getTypeVarSymOccurs(sym))
     // Vars
-    case TypedAst.Expr.Var(sym, _, _) => Some(getVarOccurs(sym))
+    case TypedAst.Exp.Var(sym, _, _) => Some(getVarOccurs(sym))
     case TypedAst.Binder(sym, _) => Some(getVarOccurs(sym))
 
     case _ => None
@@ -221,8 +221,8 @@ object RenameProvider {
     }
 
     object VarSymConsumer extends Consumer {
-      override def consumeExpr(exp: TypedAst.Expr): Unit = exp match {
-        case TypedAst.Expr.Var(s, _, loc) => consider(s, loc)
+      override def consumeExpr(exp: TypedAst.Exp): Unit = exp match {
+        case TypedAst.Exp.Var(s, _, loc) => consider(s, loc)
         case _ => ()
       }
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SignatureHelpProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SignatureHelpProvider.scala
@@ -28,16 +28,16 @@ object SignatureHelpProvider {
     */
   def provideSignatureHelp(uri: String, pos: Position)(implicit root: Root, flix: Flix): Option[SignatureHelp] = {
     LspUtil.getStack(uri, pos).collectFirst {
-      case TypedAst.Expr.ApplyDef(defnSymUse, exps, _, _, _, _, _) =>
-        // The lookup is guaranteed to succeed because otherwise the expression would be replaced by Expr.Error.
+      case TypedAst.Exp.ApplyDef(defnSymUse, exps, _, _, _, _, _) =>
+        // The lookup is guaranteed to succeed because otherwise the expression would be replaced by Exp.Error.
         mkSignatureHelp(defnSymUse.sym, root.defs(defnSymUse.sym).spec, exps, pos)
-      case TypedAst.Expr.ApplyOp(opSymUse, exps, _, _, _) =>
-        // The lookup is guaranteed to succeed because otherwise the expression would be replaced by Expr.Error.
+      case TypedAst.Exp.ApplyOp(opSymUse, exps, _, _, _) =>
+        // The lookup is guaranteed to succeed because otherwise the expression would be replaced by Exp.Error.
         val ops = root.effects(opSymUse.sym.eff).ops
         val op = ops.find(thatOp => thatOp.sym == opSymUse.sym).get
         mkSignatureHelp(opSymUse.sym, op.spec, exps, pos)
-      case TypedAst.Expr.ApplySig(sigSymUse, exps, _, _, _, _, _, _) =>
-        // The lookup is guaranteed to succeed because otherwise the expression would be replaced by Expr.Error.
+      case TypedAst.Exp.ApplySig(sigSymUse, exps, _, _, _, _, _, _) =>
+        // The lookup is guaranteed to succeed because otherwise the expression would be replaced by Exp.Error.
         mkSignatureHelp(sigSymUse.sym, root.sigs(sigSymUse.sym).spec, exps, pos)
     }
   }
@@ -51,7 +51,7 @@ object SignatureHelpProvider {
     * @param pos  the position of the cursor.
     * @return a SignatureHelp object containing the signature information.
     */
-  private def mkSignatureHelp(sym: Symbol, spec: TypedAst.Spec, exps: List[TypedAst.Expr], pos: Position)(implicit flix: Flix): SignatureHelp = {
+  private def mkSignatureHelp(sym: Symbol, spec: TypedAst.Spec, exps: List[TypedAst.Exp], pos: Position)(implicit flix: Flix): SignatureHelp = {
     // Count the index of the active parameter, which is the first expression that contains the position of the cursor.
     val activeParameter = exps.indexWhere(exp => pos.containedBy(exp.loc))
     val signatureInfo = SignatureInformation.from(sym, spec, activeParameter)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprContext.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprContext.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.{LspUtil, Position}
-import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, Root}
+import ca.uwaterloo.flix.language.ast.TypedAst.{Exp, Root}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.DefSymUse
 import ca.uwaterloo.flix.language.errors.ResolutionError.UndefinedName
 
@@ -60,13 +60,13 @@ object ExprContext {
     val stack = LspUtil.getStack(uri, pos)
     // The stack contains the path of expressions from the leaf to the root.
     stack match {
-      case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyClo(_, _, _, _, _) :: _ =>
+      case Exp.Error(UndefinedName(_, _, _, _), _, _) :: Exp.ApplyClo(_, _, _, _, _) :: _ =>
         // The leaf is an error followed by an ApplyClo expression.
         ExprContext.InsideApply
-      case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.ApplyDef(DefSymUse(sym, _), _, _, _, _, _, _) :: _ if sym.text == "|>" =>
+      case Exp.Error(UndefinedName(_, _, _, _), _, _) :: Exp.ApplyDef(DefSymUse(sym, _), _, _, _, _, _, _) :: _ if sym.text == "|>" =>
         // The leaf is an error followed by an ApplyDef expression with the symbol "|>".
         ExprContext.InsidePipeline
-      case Expr.Error(UndefinedName(_, _, _, _), _, _) :: Expr.RunWith(_, _, _, _, _) :: _ =>
+      case Exp.Error(UndefinedName(_, _, _, _), _, _) :: Exp.RunWith(_, _, _, _, _) :: _ =>
         // The leaf is an error followed by a RunWith expression.
         ExprContext.InsideRunWith
       case _ => ExprContext.Unknown

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/HoleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/HoleCompleter.scala
@@ -37,7 +37,7 @@ object HoleCompleter {
     }
 
     stack.getStack.headOption match {
-      case Some(TypedAst.Expr.HoleWithExp(TypedAst.Expr.Var(sym, sourceType, _), _, targetType, _, loc)) =>
+      case Some(TypedAst.Exp.HoleWithExp(TypedAst.Exp.Var(sym, sourceType, _), _, targetType, _, loc)) =>
         HoleCompleter.candidates(sourceType, targetType, root)
           .map(root.defs(_))
           .filter(_.spec.mod.isPublic)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MagicMatchCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MagicMatchCompleter.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type, TypeConstru
 object MagicMatchCompleter {
 
   /**
-    * Returns a list of Completions for match, triggered by expr.match.
+    * Returns a list of Completions for match, triggered by exp.match.
     *
     * Example-1:
     * Given an identifier `x` of an enum type `Color` with cases `Red`, `Green`, and `Blue`,
@@ -55,7 +55,7 @@ object MagicMatchCompleter {
     } yield {
       val name = s"$baseExp.match"
       val snippet = s"match $baseExp {\n$patternMatchBody}"
-      Completion.MagicMatchCompletion(name, range, Priority.High(0), snippet, "match expr { ... }")
+      Completion.MagicMatchCompletion(name, range, Priority.High(0), snippet, "match exp { ... }")
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TraitCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TraitCompleter.scala
@@ -55,7 +55,7 @@ object TraitCompleter {
   private def getTraitCompletions(trt: TypedAst.Trait, traitUsageKind: TraitUsageKind, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean): List[Completion] = {
     val priority = if (inScope) Priority.High(0) else Priority.Lower(0)
     traitUsageKind match {
-      case TraitUsageKind.Expr =>
+      case TraitUsageKind.Exp =>
         TraitCompletion(trt, range, priority, ap, qualified = qualified, inScope = inScope, withTypeParameter = false) :: Nil
       case TraitUsageKind.Constraint =>
         TraitCompletion(trt, range, priority, ap, qualified = qualified, inScope = inScope, withTypeParameter = true) :: Nil

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -39,11 +39,11 @@ object DesugaredAst {
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: Name.QName, tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], loc: SourceLocation) extends Declaration
 
-    case class Sig(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Option[Expr], tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], loc: SourceLocation)
+    case class Sig(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Option[Exp], tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], loc: SourceLocation)
 
-    case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
+    case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Exp, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
 
-    case class Law(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Type, tconstrs: List[TraitConstraint], loc: SourceLocation) extends Declaration
+    case class Law(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Exp, tpe: Type, eff: Type, tconstrs: List[TraitConstraint], loc: SourceLocation) extends Declaration
 
     case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], derives: Derivations, cases: List[Case], loc: SourceLocation) extends Declaration
 
@@ -73,145 +73,145 @@ object DesugaredAst {
   }
 
 
-  sealed trait Expr {
+  sealed trait Exp {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Ambiguous(qname: Name.QName, loc: SourceLocation) extends Expr
+    case class Ambiguous(qname: Name.QName, loc: SourceLocation) extends Exp
 
-    case class Open(qname: Name.QName, loc: SourceLocation) extends Expr
+    case class Open(qname: Name.QName, loc: SourceLocation) extends Exp
 
-    case class OpenAs(qname: Name.QName, exp: Expr, loc: SourceLocation) extends Expr
+    case class OpenAs(qname: Name.QName, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends Expr
+    case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends Exp
 
-    case class HoleWithExp(exp: Expr, loc: SourceLocation) extends Expr
+    case class HoleWithExp(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Use(uses: List[UseOrImport], exp: Expr, loc: SourceLocation) extends Expr
+    case class Use(uses: List[UseOrImport], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Cst(cst: Constant, loc: SourceLocation) extends Expr
+    case class Cst(cst: Constant, loc: SourceLocation) extends Exp
 
-    case class Apply(exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class Apply(exp: Exp, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class Lambda(fparam: FormalParam, exp: Expr, loc: SourceLocation) extends Expr
+    case class Lambda(fparam: FormalParam, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Unary(sop: SemanticOp.UnaryOp, exp: Expr, loc: SourceLocation) extends Expr
+    case class Unary(sop: SemanticOp.UnaryOp, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Binary(sop: SemanticOp.BinaryOp, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Binary(sop: SemanticOp.BinaryOp, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Discard(exp: Expr, loc: SourceLocation) extends Expr
+    case class Discard(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Let(ident: Name.Ident, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Let(ident: Name.Ident, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class LocalDef(ident: Name.Ident, fparams: List[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(ident: Name.Ident, fparams: List[FormalParam], exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Region(ident: Name.Ident, exp: Expr, loc: SourceLocation) extends Expr
+    case class Region(ident: Name.Ident, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Match(exp: Expr, rules: List[MatchRule], loc: SourceLocation) extends Expr
+    case class Match(exp: Exp, rules: List[MatchRule], loc: SourceLocation) extends Exp
 
-    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], loc: SourceLocation) extends Expr
+    case class TypeMatch(exp: Exp, rules: List[TypeMatchRule], loc: SourceLocation) extends Exp
 
-    case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
+    case class RestrictableChoose(star: Boolean, exp: Exp, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Exp
 
-    case class ExtMatch(exp: Expr, rules: List[ExtMatchRule], loc: SourceLocation) extends Expr
+    case class ExtMatch(exp: Exp, rules: List[ExtMatchRule], loc: SourceLocation) extends Exp
 
-    case class ExtTag(label: Name.Label, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ExtTag(label: Name.Label, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class Tuple(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class Tuple(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class RecordSelect(exp: Expr, label: Name.Label, loc: SourceLocation) extends Expr
+    case class RecordSelect(exp: Exp, label: Name.Label, loc: SourceLocation) extends Exp
 
-    case class RecordExtend(label: Name.Label, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class RecordExtend(label: Name.Label, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class RecordRestrict(label: Name.Label, exp: Expr, loc: SourceLocation) extends Expr
+    case class RecordRestrict(label: Name.Label, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLit(exps: List[Expr], exp: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLit(exps: List[Exp], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayNew(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class ArrayNew(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLoad(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLoad(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLength(exp: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLength(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayStore(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class ArrayStore(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class StructNew(name: Name.QName, exps: List[(Name.Label, Expr)], region: Expr, loc: SourceLocation) extends Expr
+    case class StructNew(name: Name.QName, exps: List[(Name.Label, Exp)], region: Exp, loc: SourceLocation) extends Exp
 
-    case class StructGet(exp: Expr, name: Name.Label, loc: SourceLocation) extends Expr
+    case class StructGet(exp: Exp, name: Name.Label, loc: SourceLocation) extends Exp
 
-    case class StructPut(exp1: Expr, name: Name.Label, exp2: Expr, loc: SourceLocation) extends Expr
+    case class StructPut(exp1: Exp, name: Name.Label, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class VectorLit(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class VectorLit(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class VectorLoad(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class VectorLoad(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class VectorLength(exp: Expr, loc: SourceLocation) extends Expr
+    case class VectorLength(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Ascribe(exp: Expr, expectedType: Option[Type], expectedEff: Option[Type], loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Exp, expectedType: Option[Type], expectedEff: Option[Type], loc: SourceLocation) extends Exp
 
-    case class InstanceOf(exp: Expr, className: Name.Ident, loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Exp, className: Name.Ident, loc: SourceLocation) extends Exp
 
-    case class CheckedCast(cast: CheckedCastType, exp: Expr, loc: SourceLocation) extends Expr
+    case class CheckedCast(cast: CheckedCastType, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class UncheckedCast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], loc: SourceLocation) extends Expr
+    case class UncheckedCast(exp: Exp, declaredType: Option[Type], declaredEff: Option[Type], loc: SourceLocation) extends Exp
 
-    case class Unsafe(exp: Expr, eff: Type, loc: SourceLocation) extends Expr
+    case class Unsafe(exp: Exp, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Without(exp: Expr, eff: Name.QName, loc: SourceLocation) extends Expr
+    case class Without(exp: Exp, eff: Name.QName, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], loc: SourceLocation) extends Exp
 
-    case class Throw(exp: Expr, loc: SourceLocation) extends Expr
+    case class Throw(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Handler(eff: Name.QName, rules: List[HandlerRule], loc: SourceLocation) extends Expr
+    case class Handler(eff: Name.QName, rules: List[HandlerRule], loc: SourceLocation) extends Exp
 
-    case class RunWith(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class RunWith(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class InvokeConstructor(clazzName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeConstructor(clazzName: Name.Ident, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class InvokeMethod(exp: Expr, methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeMethod(exp: Exp, methodName: Name.Ident, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class GetField(exp: Expr, fieldName: Name.Ident, loc: SourceLocation) extends Expr
+    case class GetField(exp: Exp, fieldName: Name.Ident, loc: SourceLocation) extends Exp
 
-    case class NewObject(tpe: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(tpe: Type, methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
-    case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class GetChannel(exp: Expr, loc: SourceLocation) extends Expr
+    case class GetChannel(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class PutChannel(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutChannel(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class SelectChannel(rules: List[SelectChannelRule], exp: Option[Expr], loc: SourceLocation) extends Expr
+    case class SelectChannel(rules: List[SelectChannelRule], exp: Option[Exp], loc: SourceLocation) extends Exp
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
+    case class ParYield(frags: List[ParYieldFragment], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Lazy(exp: Expr, loc: SourceLocation) extends Expr
+    case class Lazy(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Force(exp: Expr, loc: SourceLocation) extends Expr
+    case class Force(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointConstraintSet(cs: List[Constraint], loc: SourceLocation) extends Expr
+    case class FixpointConstraintSet(cs: List[Constraint], loc: SourceLocation) extends Exp
 
-    case class FixpointLambda(pparams: List[PredicateParam], exp: Expr, loc: SourceLocation) extends Expr
+    case class FixpointLambda(pparams: List[PredicateParam], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointMerge(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class FixpointMerge(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Expr
+    case class FixpointQueryWithProvenance(exps: List[Exp], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Exp], queryExp: Exp, selects: List[Exp], from: List[Predicate.Body], where: List[Exp], pred: Name.Pred, loc: SourceLocation) extends Exp
 
-    case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Expr
+    case class FixpointSolveWithProject(exps: List[Exp], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Exp
 
-    case class FixpointInjectInto(exps: List[Expr], predsAndArities: List[PredicateAndArity], loc: SourceLocation) extends Expr
+    case class FixpointInjectInto(exps: List[Exp], predsAndArities: List[PredicateAndArity], loc: SourceLocation) extends Exp
 
-    case class Error(m: CompilationMessage) extends Expr {
+    case class Error(m: CompilationMessage) extends Exp {
       override def loc: SourceLocation = m.loc
     }
 
@@ -299,7 +299,7 @@ object DesugaredAst {
 
     object Head {
 
-      case class Atom(pred: Name.Pred, den: Denotation, exps: List[Expr], loc: SourceLocation) extends Predicate.Head
+      case class Atom(pred: Name.Pred, den: Denotation, exps: List[Exp], loc: SourceLocation) extends Predicate.Head
 
     }
 
@@ -309,9 +309,9 @@ object DesugaredAst {
 
       case class Atom(pred: Name.Pred, den: Denotation, polarity: Polarity, fixity: Fixity, terms: List[Pattern], loc: SourceLocation) extends Predicate.Body
 
-      case class Functional(idents: List[Name.Ident], exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Functional(idents: List[Name.Ident], exp: Exp, loc: SourceLocation) extends Predicate.Body
 
-      case class Guard(exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Guard(exp: Exp, loc: SourceLocation) extends Predicate.Body
 
     }
 
@@ -409,13 +409,13 @@ object DesugaredAst {
 
   }
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, tpe: Type, eff: Option[Type], loc: SourceLocation)
 
-  case class CatchRule(ident: Name.Ident, className: Name.Ident, exp: Expr, loc: SourceLocation)
+  case class CatchRule(ident: Name.Ident, className: Name.Ident, exp: Exp, loc: SourceLocation)
 
-  case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Exp, loc: SourceLocation)
 
-  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
+  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Exp)
 
   case class TraitConstraint(trt: Name.QName, tpe: Type, loc: SourceLocation)
 
@@ -423,13 +423,13 @@ object DesugaredAst {
 
   case class Constraint(head: Predicate.Head, body: List[Predicate.Body], loc: SourceLocation)
 
-  case class MatchRule(pat: Pattern, exp1: Option[Expr], exp2: Expr, loc: SourceLocation)
+  case class MatchRule(pat: Pattern, exp1: Option[Exp], exp2: Exp, loc: SourceLocation)
 
-  case class ExtMatchRule(pat: ExtPattern, exp: Expr, loc: SourceLocation)
+  case class ExtMatchRule(pat: ExtPattern, exp: Exp, loc: SourceLocation)
 
-  case class TypeMatchRule(ident: Name.Ident, tpe: Type, exp: Expr, loc: SourceLocation)
+  case class TypeMatchRule(ident: Name.Ident, tpe: Type, exp: Exp, loc: SourceLocation)
 
-  case class SelectChannelRule(ident: Name.Ident, exp1: Expr, exp2: Expr, loc: SourceLocation)
+  case class SelectChannelRule(ident: Name.Ident, exp1: Exp, exp2: Exp, loc: SourceLocation)
 
   sealed trait TypeParam
 
@@ -441,7 +441,7 @@ object DesugaredAst {
 
   }
 
-  case class ParYieldFragment(pat: Pattern, exp: Expr, loc: SourceLocation)
+  case class ParYieldFragment(pat: Pattern, exp: Exp, loc: SourceLocation)
 
   case class Derivations(traits: List[Name.QName], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -45,9 +45,9 @@ object KindedAst {
 
   case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, symUse: TraitSymUse, tparams: List[TypeParam], tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation)
 
-  case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Expr], loc: SourceLocation)
+  case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Exp], loc: SourceLocation)
 
-  case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
+  case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Exp, loc: SourceLocation)
 
   case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], sc: Scheme, tpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
 
@@ -67,163 +67,163 @@ object KindedAst {
 
   case class Op(sym: Symbol.OpSym, spec: Spec, loc: SourceLocation)
 
-  sealed trait Expr {
+  sealed trait Exp {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends Expr
+    case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends Exp
 
-    case class Hole(sym: Symbol.HoleSym, scp: LocalScope, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class Hole(sym: Symbol.HoleSym, scp: LocalScope, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class HoleWithExp(exp: Expr, scp: LocalScope, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class HoleWithExp(exp: Exp, scp: LocalScope, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class OpenAs(symUse: RestrictableEnumSymUse, exp: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class OpenAs(symUse: RestrictableEnumSymUse, exp: Exp, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class Use(sym: Symbol, alias: Name.Ident, exp: Expr, loc: SourceLocation) extends Expr
+    case class Use(sym: Symbol, alias: Name.Ident, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Cst(cst: Constant, loc: SourceLocation) extends Expr
+    case class Cst(cst: Constant, loc: SourceLocation) extends Exp
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp1: Exp, exp2: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ApplyDef(symUse: DefSymUse, exps: List[Expr], targs: List[Type.Var], itvar: Type, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ApplyDef(symUse: DefSymUse, exps: List[Exp], targs: List[Type.Var], itvar: Type, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ApplyLocalDef(symUse: LocalDefSymUse, exps: List[Expr], arrowTvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ApplyLocalDef(symUse: LocalDefSymUse, exps: List[Exp], arrowTvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ApplyOp(symUse: OpSymUse, exps: List[Expr], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ApplyOp(symUse: OpSymUse, exps: List[Exp], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ApplySig(symUse: SigSymUse, exps: List[Expr], targ: Type.Var, targs: List[Type.Var], itvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ApplySig(symUse: SigSymUse, exps: List[Exp], targ: Type.Var, targs: List[Type.Var], itvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class Lambda(fparam: FormalParam, exp: Expr, allowSubeffecting: Boolean, loc: SourceLocation) extends Expr
+    case class Lambda(fparam: FormalParam, exp: Exp, allowSubeffecting: Boolean, loc: SourceLocation) extends Exp
 
-    case class Unary(sop: SemanticOp.UnaryOp, exp: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class Unary(sop: SemanticOp.UnaryOp, exp: Exp, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class Binary(sop: SemanticOp.BinaryOp, exp1: Expr, exp2: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class Binary(sop: SemanticOp.BinaryOp, exp1: Exp, exp2: Exp, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Discard(exp: Expr, loc: SourceLocation) extends Expr
+    case class Discard(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Let(sym: Symbol.VarSym, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp1: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp1: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class Match(exp: Expr, rules: List[MatchRule], loc: SourceLocation) extends Expr
+    case class Match(exp: Exp, rules: List[MatchRule], loc: SourceLocation) extends Exp
 
-    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], loc: SourceLocation) extends Expr
+    case class TypeMatch(exp: Exp, rules: List[TypeMatchRule], loc: SourceLocation) extends Exp
 
-    case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class RestrictableChoose(star: Boolean, exp: Exp, rules: List[RestrictableChooseRule], tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ExtMatch(exp: Expr, rules: List[ExtMatchRule], loc: SourceLocation) extends Expr
+    case class ExtMatch(exp: Exp, rules: List[ExtMatchRule], loc: SourceLocation) extends Exp
 
-    case class Tag(symUse: CaseSymUse, exps: List[Expr], tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class Tag(symUse: CaseSymUse, exps: List[Exp], tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Expr], isOpen: Boolean, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Exp], isOpen: Boolean, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ExtTag(label: Name.Label, exps: List[Expr], tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class ExtTag(label: Name.Label, exps: List[Exp], tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class Tuple(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class Tuple(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class RecordSelect(exp: Expr, label: Name.Label, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class RecordSelect(exp: Exp, label: Name.Label, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class RecordExtend(label: Name.Label, value: Expr, rest: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class RecordExtend(label: Name.Label, value: Exp, rest: Exp, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class RecordRestrict(label: Name.Label, rest: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class RecordRestrict(label: Name.Label, rest: Exp, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ArrayLit(exps: List[Expr], exp: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ArrayLit(exps: List[Exp], exp: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ArrayNew(exp1: Expr, exp2: Expr, exp3: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ArrayNew(exp1: Exp, exp2: Exp, exp3: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ArrayLoad(base: Expr, index: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ArrayLoad(base: Exp, index: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ArrayStore(base: Expr, index: Expr, elm: Expr, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ArrayStore(base: Exp, index: Exp, elm: Exp, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class ArrayLength(base: Expr, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ArrayLength(base: Exp, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class StructNew(sym: Symbol.StructSym, fields: List[(StructFieldSymUse, Expr)], region: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class StructNew(sym: Symbol.StructSym, fields: List[(StructFieldSymUse, Exp)], region: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class StructGet(exp: Expr, symUse: StructFieldSymUse, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class StructGet(exp: Exp, symUse: StructFieldSymUse, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class StructPut(exp1: Expr, symUse: StructFieldSymUse, exp2: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class StructPut(exp1: Exp, symUse: StructFieldSymUse, exp2: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class VectorLit(exps: List[Expr], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class VectorLit(exps: List[Exp], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class VectorLoad(exp1: Expr, exp2: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class VectorLoad(exp1: Exp, exp2: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class VectorLength(exp: Expr, loc: SourceLocation) extends Expr
+    case class VectorLength(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Ascribe(exp: Expr, expectedType: Option[Type], expectedPur: Option[Type], tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Exp, expectedType: Option[Type], expectedPur: Option[Type], tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Exp, clazz: java.lang.Class[?], loc: SourceLocation) extends Exp
 
-    case class CheckedCast(cast: CheckedCastType, exp: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class CheckedCast(cast: CheckedCastType, exp: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class UncheckedCast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class UncheckedCast(exp: Exp, declaredType: Option[Type], declaredEff: Option[Type], tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class Unsafe(exp: Expr, eff: Type, loc: SourceLocation) extends Expr
+    case class Unsafe(exp: Exp, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Without(exp: Expr, symUse: EffSymUse, loc: SourceLocation) extends Expr
+    case class Without(exp: Exp, symUse: EffSymUse, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], loc: SourceLocation) extends Exp
 
-    case class Throw(exp: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class Throw(exp: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class Handler(symUse: EffSymUse, rules: List[HandlerRule], tvar: Type.Var, evar1: Type.Var, evar2: Type.Var, loc: SourceLocation) extends Expr
+    case class Handler(symUse: EffSymUse, rules: List[HandlerRule], tvar: Type.Var, evar1: Type.Var, evar2: Type.Var, loc: SourceLocation) extends Exp
 
-    case class RunWith(exp1: Expr, exp2: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class RunWith(exp1: Exp, exp2: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class InvokeConstructor(clazz: Class[?], exps: List[Expr], jvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class InvokeConstructor(clazz: Class[?], exps: List[Exp], jvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class InvokeMethod(exp: Expr, methodName: Name.Ident, exps: List[Expr], jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class InvokeMethod(exp: Exp, methodName: Name.Ident, exps: List[Exp], jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class InvokeStaticMethod(clazz: Class[?], methodName: Name.Ident, exps: List[Expr], jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class InvokeStaticMethod(clazz: Class[?], methodName: Name.Ident, exps: List[Exp], jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class GetField(exp: Expr, fieldName: Name.Ident, jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class GetField(exp: Exp, fieldName: Name.Ident, jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class PutField(field: Field, clazz: java.lang.Class[?], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutField(field: Field, clazz: java.lang.Class[?], exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class GetStaticField(field: Field, loc: SourceLocation) extends Expr
+    case class GetStaticField(field: Field, loc: SourceLocation) extends Exp
 
-    case class PutStaticField(field: Field, exp: Expr, loc: SourceLocation) extends Expr
+    case class PutStaticField(field: Field, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[?], methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
-    case class NewChannel(exp: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Exp, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class GetChannel(exp: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class GetChannel(exp: Exp, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class PutChannel(exp1: Expr, exp2: Expr, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class PutChannel(exp1: Exp, exp2: Exp, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class SelectChannel(rules: List[SelectChannelRule], default: Option[Exp], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
+    case class ParYield(frags: List[ParYieldFragment], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Lazy(exp: Expr, loc: SourceLocation) extends Expr
+    case class Lazy(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Force(exp: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class Force(exp: Exp, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class FixpointConstraintSet(cs: List[Constraint], tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class FixpointConstraintSet(cs: List[Constraint], tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class FixpointLambda(pparams: List[PredicateParam], exp: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class FixpointLambda(pparams: List[PredicateParam], exp: Exp, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class FixpointMerge(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class FixpointMerge(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], tvar: Type, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithProvenance(exps: List[Exp], select: Predicate.Head, withh: List[Name.Pred], tvar: Type, loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, tvar: Type, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Exp], queryExp: Exp, selects: List[Exp], from: List[Predicate.Body], where: List[Exp], pred: Name.Pred, tvar: Type, loc: SourceLocation) extends Exp
 
-    case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class FixpointSolveWithProject(exps: List[Exp], optPreds: Option[List[Name.Pred]], mode: SolveMode, tvar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class FixpointInjectInto(exps: List[Expr], predsAndArities: List[PredicateAndArity], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class FixpointInjectInto(exps: List[Exp], predsAndArities: List[PredicateAndArity], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Exp
 
-    case class Error(m: CompilationMessage, tvar: Type.Var, evar: Type.Var) extends Expr {
+    case class Error(m: CompilationMessage, tvar: Type.Var, evar: Type.Var) extends Exp {
       override def loc: SourceLocation = m.loc
     }
 
@@ -310,7 +310,7 @@ object KindedAst {
 
     object Head {
 
-      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Expr], tvar: Type.Var, loc: SourceLocation) extends Predicate.Head
+      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Exp], tvar: Type.Var, loc: SourceLocation) extends Predicate.Head
 
     }
 
@@ -320,9 +320,9 @@ object KindedAst {
 
       case class Atom(pred: Name.Pred, den: Denotation, polarity: Polarity, fixity: Fixity, terms: List[Pattern], tvar: Type.Var, loc: SourceLocation) extends Predicate.Body
 
-      case class Functional(syms: List[Symbol.VarSym], exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Functional(syms: List[Symbol.VarSym], exp: Exp, loc: SourceLocation) extends Predicate.Body
 
-      case class Guard(exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Guard(exp: Exp, loc: SourceLocation) extends Predicate.Body
 
     }
 
@@ -342,24 +342,24 @@ object KindedAst {
 
   case class PredicateParam(pred: Name.Pred, tpe: Type, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, tpe: Type, eff: Type, loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr, loc: SourceLocation)
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Exp, loc: SourceLocation)
 
-  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr, tvar: Type.Var, loc: SourceLocation)
+  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Exp, tvar: Type.Var, loc: SourceLocation)
 
-  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
+  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Exp)
 
-  case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr, loc: SourceLocation)
+  case class MatchRule(pat: Pattern, guard: Option[Exp], exp: Exp, loc: SourceLocation)
 
-  case class ExtMatchRule(pat: ExtPattern, exp: Expr, loc: SourceLocation)
+  case class ExtMatchRule(pat: ExtPattern, exp: Exp, loc: SourceLocation)
 
-  case class TypeMatchRule(sym: Symbol.VarSym, tpe: Type, exp: Expr, loc: SourceLocation)
+  case class TypeMatchRule(sym: Symbol.VarSym, tpe: Type, exp: Exp, loc: SourceLocation)
 
-  case class SelectChannelRule(sym: Symbol.VarSym, chan: Expr, exp: Expr, loc: SourceLocation)
+  case class SelectChannelRule(sym: Symbol.VarSym, chan: Exp, exp: Exp, loc: SourceLocation)
 
   case class TypeParam(name: Name.Ident, sym: Symbol.KindedTypeVarSym, loc: SourceLocation)
 
-  case class ParYieldFragment(pat: Pattern, exp: Expr, loc: SourceLocation)
+  case class ParYieldFragment(pat: Pattern, exp: Exp, loc: SourceLocation)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -32,7 +32,7 @@ object LiftedAst {
                   entryPoints: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], exp: Expr, tpe: SimpleType, loc: SourceLocation)
+  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], exp: Exp, tpe: SimpleType, loc: SourceLocation)
 
   case class Enum(ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], cases: Map[Symbol.CaseSym, Case], loc: SourceLocation)
 
@@ -42,7 +42,7 @@ object LiftedAst {
 
   case class Op(sym: Symbol.OpSym, ann: Annotations, mod: Modifiers, fparams: List[FormalParam], tpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  sealed trait Expr {
+  sealed trait Exp {
     def tpe: SimpleType
 
     def purity: Purity
@@ -50,41 +50,41 @@ object LiftedAst {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Cst(cst: Constant, tpe: SimpleType, loc: SourceLocation) extends Expr {
+    case class Cst(cst: Constant, tpe: SimpleType, loc: SourceLocation) extends Exp {
       def purity: Purity = Pure
     }
 
-    case class Var(sym: Symbol.VarSym, tpe: SimpleType, loc: SourceLocation) extends Expr {
+    case class Var(sym: Symbol.VarSym, tpe: SimpleType, loc: SourceLocation) extends Exp {
       def purity: Purity = Pure
     }
 
-    case class ApplyAtomic(op: AtomicOp, exps: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyAtomic(op: AtomicOp, exps: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp1: Exp, exp2: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyOp(sym: Symbol.OpSym, exps: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyOp(sym: Symbol.OpSym, exps: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Branch(exp: Expr, branches: Map[Symbol.LabelSym, Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Branch(exp: Exp, branches: Map[Symbol.LabelSym, Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class JumpTo(sym: Symbol.LabelSym, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class JumpTo(sym: Symbol.LabelSym, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Let(sym: Symbol.VarSym, exp1: Exp, exp2: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Region(sym: Symbol.VarSym, exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Region(sym: Symbol.VarSym, exp: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class RunWith(exp: Exp, effUse: EffSymUse, rules: List[HandlerRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
   }
 
@@ -94,11 +94,11 @@ object LiftedAst {
   /** [[Type]] is used here because [[Struct]] declarations are not monomorphized. */
   case class StructField(sym: Symbol.StructFieldSym, tpe: Type, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: SimpleType, purity: Purity, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], clo: Exp, retTpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Exp)
 
-  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr)
+  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Exp)
 
   case class FormalParam(sym: Symbol.VarSym, tpe: SimpleType, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -43,9 +43,9 @@ object LoweredAst {
 
   case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tparams: List[TypeParam], tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation)
 
-  case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Expr], loc: SourceLocation)
+  case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Exp], loc: SourceLocation)
 
-  case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
+  case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Exp, loc: SourceLocation)
 
   case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint])
 
@@ -65,7 +65,7 @@ object LoweredAst {
 
   case class Op(sym: Symbol.OpSym, spec: Spec, loc: SourceLocation)
 
-  sealed trait Expr extends Product {
+  sealed trait Exp extends Product {
     def tpe: Type
 
     def eff: Type
@@ -73,71 +73,71 @@ object LoweredAst {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Cst(cst: Constant, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Cst(cst: Constant, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class Lambda(fparam: FormalParam, exp: Expr, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Lambda(fparam: FormalParam, exp: Exp, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class ApplyAtomic(op: AtomicOp, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyAtomic(op: AtomicOp, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Expr], targs: List[Type], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Exp], targs: List[Type], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyLocalDef(sym: Symbol.VarSym, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyLocalDef(sym: Symbol.VarSym, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyOp(sym: Symbol.OpSym, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyOp(sym: Symbol.OpSym, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplySig(sym: Symbol.SigSym, exps: List[Expr], targ: Type, targs: List[Type], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplySig(sym: Symbol.SigSym, exps: List[Exp], targ: Type, targs: List[Type], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Let(sym: Symbol.VarSym, exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Discard(exp: Expr, eff: Type, loc: SourceLocation) extends Expr {
+    case class Discard(exp: Exp, eff: Type, loc: SourceLocation) extends Exp {
       def tpe: Type = Type.mkUnit(loc)
     }
 
-    case class Match(exp: Expr, rules: List[MatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Match(exp: Exp, rules: List[MatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ExtMatch(exp: Expr, rules: List[ExtMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ExtMatch(exp: Exp, rules: List[ExtMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class TypeMatch(exp: Exp, rules: List[TypeMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class VectorLit(exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class VectorLit(exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class VectorLoad(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class VectorLoad(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class VectorLength(exp: Expr, loc: SourceLocation) extends Expr {
+    case class VectorLength(exp: Exp, loc: SourceLocation) extends Exp {
       def eff: Type = exp.eff
 
       def tpe: Type = Type.Int32
     }
 
-    case class Ascribe(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Cast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Cast(exp: Exp, declaredType: Option[Type], declaredEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RunWith(exp: Exp, effUse: EffSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
   }
 
@@ -204,7 +204,7 @@ object LoweredAst {
 
     object Head {
 
-      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Expr], tpe: Type, loc: SourceLocation) extends Predicate.Head
+      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Exp], tpe: Type, loc: SourceLocation) extends Predicate.Head
 
     }
 
@@ -214,9 +214,9 @@ object LoweredAst {
 
       case class Atom(pred: Name.Pred, den: Denotation, polarity: Polarity, fixity: Fixity, terms: List[Pattern], tpe: Type, loc: SourceLocation) extends Predicate.Body
 
-      case class Functional(outVars: List[Symbol.VarSym], exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Functional(outVars: List[Symbol.VarSym], exp: Exp, loc: SourceLocation) extends Predicate.Body
 
-      case class Guard(exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Guard(exp: Exp, loc: SourceLocation) extends Predicate.Body
 
     }
 
@@ -230,22 +230,22 @@ object LoweredAst {
 
   case class PredicateParam(pred: Name.Pred, tpe: Type, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, retTpe: Type, eff: Type, loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Exp)
 
-  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr)
+  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Exp)
 
-  case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr)
+  case class MatchRule(pat: Pattern, guard: Option[Exp], exp: Exp)
 
-  case class TypeMatchRule(sym: Symbol.VarSym, tpe: Type, exp: Expr)
+  case class TypeMatchRule(sym: Symbol.VarSym, tpe: Type, exp: Exp)
 
-  case class ExtMatchRule(pat: ExtPattern, exp: Expr, loc: SourceLocation)
+  case class ExtMatchRule(pat: ExtPattern, exp: Exp, loc: SourceLocation)
 
-  case class SelectChannelRule(sym: Symbol.VarSym, chan: Expr, exp: Expr)
+  case class SelectChannelRule(sym: Symbol.VarSym, chan: Exp, exp: Exp)
 
   case class TypeParam(name: Name.Ident, sym: Symbol.KindedTypeVarSym, loc: SourceLocation)
 
-  case class ParYieldFragment(pat: Pattern, exp: Expr, loc: SourceLocation)
+  case class ParYieldFragment(pat: Pattern, exp: Exp, loc: SourceLocation)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -33,7 +33,7 @@ object MonoAst {
                   entryPoints: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
+  case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Exp, loc: SourceLocation)
 
   case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, fparams: List[FormalParam], functionType: Type, retTpe: Type, eff: Type, defContext: DefContext)
 
@@ -45,7 +45,7 @@ object MonoAst {
 
   case class Struct(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], fields: List[StructField], loc: SourceLocation)
 
-  sealed trait Expr extends Product {
+  sealed trait Exp extends Product {
     def tpe: Type
 
     def eff: Type
@@ -53,65 +53,65 @@ object MonoAst {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Cst(cst: Constant, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Cst(cst: Constant, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class Lambda(fparam: FormalParam, exp: Expr, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Lambda(fparam: FormalParam, exp: Exp, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class ApplyAtomic(op: AtomicOp, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyAtomic(op: AtomicOp, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Expr], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Exp], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyLocalDef(sym: Symbol.VarSym, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyLocalDef(sym: Symbol.VarSym, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyOp(sym: Symbol.OpSym, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyOp(sym: Symbol.OpSym, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, occur: Occur, loc: SourceLocation) extends Expr
+    case class Let(sym: Symbol.VarSym, exp1: Exp, exp2: Exp, tpe: Type, eff: Type, occur: Occur, loc: SourceLocation) extends Exp
 
-    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, tpe: Type, eff: Type, occur: Occur, loc: SourceLocation) extends Expr
+    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Exp, exp2: Exp, tpe: Type, eff: Type, occur: Occur, loc: SourceLocation) extends Exp
 
-    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Discard(exp: Expr, eff: Type, loc: SourceLocation) extends Expr {
+    case class Discard(exp: Exp, eff: Type, loc: SourceLocation) extends Exp {
       def tpe: Type = Type.mkUnit(loc)
     }
 
-    case class Match(exp: Expr, rules: List[MatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Match(exp: Exp, rules: List[MatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ExtMatch(exp: Expr, rules: List[ExtMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ExtMatch(exp: Exp, rules: List[ExtMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class VectorLit(exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class VectorLit(exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class VectorLoad(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class VectorLoad(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class VectorLength(exp: Expr, loc: SourceLocation) extends Expr {
+    case class VectorLength(exp: Exp, loc: SourceLocation) extends Exp {
       def eff: Type = exp.eff
 
       def tpe: Type = Type.Int32
     }
 
-    case class Cast(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Cast(exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RunWith(exp: Exp, effUse: EffSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
   }
 
@@ -174,15 +174,15 @@ object MonoAst {
 
   case class FormalParam(sym: Symbol.VarSym, tpe: Type, occur: Occur, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, retTpe: Type, eff: Type, loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Exp)
 
-  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
+  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Exp)
 
-  case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr)
+  case class MatchRule(pat: Pattern, guard: Option[Exp], exp: Exp)
 
-  case class ExtMatchRule(pat: ExtPattern, exp: Expr, loc: SourceLocation)
+  case class ExtMatchRule(pat: ExtPattern, exp: Exp, loc: SourceLocation)
 
   case class TypeParam(name: Name.Ident, sym: Symbol.KindedTypeVarSym, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -44,9 +44,9 @@ object NamedAst {
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: Name.QName, tparams: List[TypeParam], tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], ns: List[String], loc: SourceLocation) extends Declaration
 
-    case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Expr], loc: SourceLocation) extends Declaration
+    case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Exp], loc: SourceLocation) extends Declaration
 
-    case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation) extends Declaration
+    case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Exp, loc: SourceLocation) extends Declaration
 
     case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: List[Declaration.Case], loc: SourceLocation) extends Declaration
 
@@ -86,145 +86,145 @@ object NamedAst {
     case class Import(name: Name.JavaName, alias: Name.Ident, loc: SourceLocation) extends UseOrImport
   }
 
-  sealed trait Expr {
+  sealed trait Exp {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Ambiguous(qname: Name.QName, loc: SourceLocation) extends Expr
+    case class Ambiguous(qname: Name.QName, loc: SourceLocation) extends Exp
 
-    case class Open(qname: Name.QName, loc: SourceLocation) extends Expr
+    case class Open(qname: Name.QName, loc: SourceLocation) extends Exp
 
-    case class OpenAs(qname: Name.QName, exp: Expr, loc: SourceLocation) extends Expr
+    case class OpenAs(qname: Name.QName, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends Expr
+    case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends Exp
 
-    case class HoleWithExp(exp: Expr, loc: SourceLocation) extends Expr
+    case class HoleWithExp(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Use(use: UseOrImport, exp: Expr, loc: SourceLocation) extends Expr
+    case class Use(use: UseOrImport, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Cst(cst: Constant, loc: SourceLocation) extends Expr
+    case class Cst(cst: Constant, loc: SourceLocation) extends Exp
 
-    case class Apply(exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class Apply(exp: Exp, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class Lambda(fparam: FormalParam, exp: Expr, loc: SourceLocation) extends Expr
+    case class Lambda(fparam: FormalParam, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Unary(sop: SemanticOp.UnaryOp, exp: Expr, loc: SourceLocation) extends Expr
+    case class Unary(sop: SemanticOp.UnaryOp, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Binary(sop: SemanticOp.BinaryOp, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Binary(sop: SemanticOp.BinaryOp, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Discard(exp: Expr, loc: SourceLocation) extends Expr
+    case class Discard(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Let(sym: Symbol.VarSym, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Expr, loc: SourceLocation) extends Expr
+    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Match(exp: Expr, rules: List[MatchRule], loc: SourceLocation) extends Expr
+    case class Match(exp: Exp, rules: List[MatchRule], loc: SourceLocation) extends Exp
 
-    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], loc: SourceLocation) extends Expr
+    case class TypeMatch(exp: Exp, rules: List[TypeMatchRule], loc: SourceLocation) extends Exp
 
-    case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
+    case class RestrictableChoose(star: Boolean, exp: Exp, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Exp
 
-    case class ExtMatch(exp: Expr, rules: List[ExtMatchRule], loc: SourceLocation) extends Expr
+    case class ExtMatch(exp: Exp, rules: List[ExtMatchRule], loc: SourceLocation) extends Exp
 
-    case class ExtTag(label: Name.Label, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ExtTag(label: Name.Label, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class Tuple(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class Tuple(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class RecordSelect(exp: Expr, label: Name.Label, loc: SourceLocation) extends Expr
+    case class RecordSelect(exp: Exp, label: Name.Label, loc: SourceLocation) extends Exp
 
-    case class RecordExtend(label: Name.Label, value: Expr, rest: Expr, loc: SourceLocation) extends Expr
+    case class RecordExtend(label: Name.Label, value: Exp, rest: Exp, loc: SourceLocation) extends Exp
 
-    case class RecordRestrict(label: Name.Label, rest: Expr, loc: SourceLocation) extends Expr
+    case class RecordRestrict(label: Name.Label, rest: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLit(exps: List[Expr], exp: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLit(exps: List[Exp], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayNew(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class ArrayNew(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLoad(base: Expr, index: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLoad(base: Exp, index: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayStore(base: Expr, index: Expr, elm: Expr, loc: SourceLocation) extends Expr
+    case class ArrayStore(base: Exp, index: Exp, elm: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLength(base: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLength(base: Exp, loc: SourceLocation) extends Exp
 
-    case class StructNew(qname: Name.QName, exps: List[(Name.Label, Expr)], region: Expr, loc: SourceLocation) extends Expr
+    case class StructNew(qname: Name.QName, exps: List[(Name.Label, Exp)], region: Exp, loc: SourceLocation) extends Exp
 
-    case class StructGet(exp: Expr, name: Name.Label, loc: SourceLocation) extends Expr
+    case class StructGet(exp: Exp, name: Name.Label, loc: SourceLocation) extends Exp
 
-    case class StructPut(exp1: Expr, name: Name.Label, exp2: Expr, loc: SourceLocation) extends Expr
+    case class StructPut(exp1: Exp, name: Name.Label, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class VectorLit(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class VectorLit(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class VectorLoad(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class VectorLoad(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class VectorLength(exp: Expr, loc: SourceLocation) extends Expr
+    case class VectorLength(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Ascribe(exp: Expr, expectedType: Option[Type], expectedEff: Option[Type], loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Exp, expectedType: Option[Type], expectedEff: Option[Type], loc: SourceLocation) extends Exp
 
-    case class InstanceOf(exp: Expr, className: Name.Ident, loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Exp, className: Name.Ident, loc: SourceLocation) extends Exp
 
-    case class CheckedCast(cast: CheckedCastType, exp: Expr, loc: SourceLocation) extends Expr
+    case class CheckedCast(cast: CheckedCastType, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class UncheckedCast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], loc: SourceLocation) extends Expr
+    case class UncheckedCast(exp: Exp, declaredType: Option[Type], declaredEff: Option[Type], loc: SourceLocation) extends Exp
 
-    case class Unsafe(exp: Expr, eff: Type, loc: SourceLocation) extends Expr
+    case class Unsafe(exp: Exp, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Without(exp: Expr, qname: Name.QName, loc: SourceLocation) extends Expr
+    case class Without(exp: Exp, qname: Name.QName, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], loc: SourceLocation) extends Exp
 
-    case class Throw(exp: Expr, loc: SourceLocation) extends Expr
+    case class Throw(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Handler(qname: Name.QName, rules: List[HandlerRule], loc: SourceLocation) extends Expr
+    case class Handler(qname: Name.QName, rules: List[HandlerRule], loc: SourceLocation) extends Exp
 
-    case class RunWith(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class RunWith(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class InvokeConstructor(clazzName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeConstructor(clazzName: Name.Ident, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class InvokeMethod(exp: Expr, methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeMethod(exp: Exp, methodName: Name.Ident, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class GetField(exp: Expr, fieldName: Name.Ident, loc: SourceLocation) extends Expr
+    case class GetField(exp: Exp, fieldName: Name.Ident, loc: SourceLocation) extends Exp
 
-    case class NewObject(name: String, tpe: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, tpe: Type, methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
-    case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class GetChannel(exp: Expr, loc: SourceLocation) extends Expr
+    case class GetChannel(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class PutChannel(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutChannel(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], loc: SourceLocation) extends Expr
+    case class SelectChannel(rules: List[SelectChannelRule], default: Option[Exp], loc: SourceLocation) extends Exp
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
+    case class ParYield(frags: List[ParYieldFragment], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Lazy(exp: Expr, loc: SourceLocation) extends Expr
+    case class Lazy(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Force(exp: Expr, loc: SourceLocation) extends Expr
+    case class Force(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointConstraintSet(cs: List[Constraint], loc: SourceLocation) extends Expr
+    case class FixpointConstraintSet(cs: List[Constraint], loc: SourceLocation) extends Exp
 
-    case class FixpointLambda(pparams: List[PredicateParam], exp: Expr, loc: SourceLocation) extends Expr
+    case class FixpointLambda(pparams: List[PredicateParam], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointMerge(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class FixpointMerge(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Expr
+    case class FixpointQueryWithProvenance(exps: List[Exp], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Exp], queryExp: Exp, selects: List[Exp], from: List[Predicate.Body], where: List[Exp], pred: Name.Pred, loc: SourceLocation) extends Exp
 
-    case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Expr
+    case class FixpointSolveWithProject(exps: List[Exp], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Exp
 
-    case class FixpointInjectInto(exps: List[Expr], predsAndArities: List[PredicateAndArity], loc: SourceLocation) extends Expr
+    case class FixpointInjectInto(exps: List[Exp], predsAndArities: List[PredicateAndArity], loc: SourceLocation) extends Exp
 
-    case class Error(m: CompilationMessage) extends Expr {
+    case class Error(m: CompilationMessage) extends Exp {
       override def loc: SourceLocation = m.loc
     }
 
@@ -310,7 +310,7 @@ object NamedAst {
 
     object Head {
 
-      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Expr], loc: SourceLocation) extends Predicate.Head
+      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Exp], loc: SourceLocation) extends Predicate.Head
 
     }
 
@@ -320,9 +320,9 @@ object NamedAst {
 
       case class Atom(pred: Name.Pred, den: Denotation, polarity: Polarity, fixity: Fixity, terms: List[Pattern], loc: SourceLocation) extends Predicate.Body
 
-      case class Functional(idents: List[Name.Ident], exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Functional(idents: List[Name.Ident], exp: Exp, loc: SourceLocation) extends Predicate.Body
 
-      case class Guard(exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Guard(exp: Exp, loc: SourceLocation) extends Predicate.Body
 
     }
 
@@ -420,21 +420,21 @@ object NamedAst {
 
   }
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, tpe: Type, eff: Option[Type], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, className: Name.Ident, exp: Expr, loc: SourceLocation)
+  case class CatchRule(sym: Symbol.VarSym, className: Name.Ident, exp: Exp, loc: SourceLocation)
 
-  case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Exp, loc: SourceLocation)
 
-  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
+  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Exp)
 
-  case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr, loc: SourceLocation)
+  case class MatchRule(pat: Pattern, guard: Option[Exp], exp: Exp, loc: SourceLocation)
 
-  case class ExtMatchRule(pat: ExtPattern, exp: Expr, loc: SourceLocation)
+  case class ExtMatchRule(pat: ExtPattern, exp: Exp, loc: SourceLocation)
 
-  case class TypeMatchRule(sym: Symbol.VarSym, tpe: Type, exp: Expr, loc: SourceLocation)
+  case class TypeMatchRule(sym: Symbol.VarSym, tpe: Type, exp: Exp, loc: SourceLocation)
 
-  case class SelectChannelRule(sym: Symbol.VarSym, chan: Expr, exp: Expr, loc: SourceLocation)
+  case class SelectChannelRule(sym: Symbol.VarSym, chan: Exp, exp: Exp, loc: SourceLocation)
 
   sealed trait TypeParam {
     def name: Name.Ident
@@ -458,7 +458,7 @@ object NamedAst {
 
   case class EqualityConstraint(qname: Name.QName, tpe1: Type, tpe2: Type, loc: SourceLocation)
 
-  case class ParYieldFragment(pat: Pattern, exp: Expr, loc: SourceLocation)
+  case class ParYieldFragment(pat: Pattern, exp: Exp, loc: SourceLocation)
 
   case class Derivations(traits: List[Name.QName], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -43,7 +43,7 @@ object ReducedAst {
   /**
     * pcPoints is initialized by [[ca.uwaterloo.flix.language.phase.Reducer]].
     */
-  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], lparams: List[LocalParam], pcPoints: Int, expr: Expr, tpe: SimpleType, unboxedType: UnboxedType, loc: SourceLocation) {
+  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], lparams: List[LocalParam], pcPoints: Int, exp: Exp, tpe: SimpleType, unboxedType: UnboxedType, loc: SourceLocation) {
     val arrowType: SimpleType.Arrow = SimpleType.mkArrow(fparams.map(_.tpe), tpe)
   }
 
@@ -58,7 +58,7 @@ object ReducedAst {
 
   case class Op(sym: Symbol.OpSym, ann: Annotations, mod: Modifiers, fparams: List[FormalParam], tpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  sealed trait Expr {
+  sealed trait Exp {
     def tpe: SimpleType
 
     def purity: Purity
@@ -66,52 +66,52 @@ object ReducedAst {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Cst(cst: Constant, loc: SourceLocation) extends Expr {
+    case class Cst(cst: Constant, loc: SourceLocation) extends Exp {
       def tpe: SimpleType = cst.tpe
       def purity: Purity = Pure
     }
 
-    case class Var(sym: Symbol.VarSym, tpe: SimpleType, loc: SourceLocation) extends Expr {
+    case class Var(sym: Symbol.VarSym, tpe: SimpleType, loc: SourceLocation) extends Exp {
       def purity: Purity = Pure
     }
 
-    case class ApplyAtomic(op: AtomicOp, exps: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyAtomic(op: AtomicOp, exps: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp1: Exp, exp2: Exp, ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Expr], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Exp], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyOp(sym: Symbol.OpSym, exps: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyOp(sym: Symbol.OpSym, exps: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplySelfTail(sym: Symbol.DefnSym, actuals: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplySelfTail(sym: Symbol.DefnSym, actuals: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Branch(exp: Expr, branches: Map[Symbol.LabelSym, Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Branch(exp: Exp, branches: Map[Symbol.LabelSym, Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class JumpTo(sym: Symbol.LabelSym, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class JumpTo(sym: Symbol.LabelSym, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr {
+    case class Let(sym: Symbol.VarSym, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp {
       // Note: We use an implicit representation of type and purity to aid correctness and to save memory.
       def tpe: SimpleType = exp2.tpe
       def purity: Purity = Purity.combine(exp1.purity, exp2.purity)
     }
 
-    case class Stmt(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr {
+    case class Stmt(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp {
       // Note: We use an implicit representation of type and purity to aid correctness and to save memory.
       def tpe: SimpleType = exp2.tpe
       def purity: Purity = Purity.combine(exp1.purity, exp2.purity)
     }
 
-    case class Region(sym: Symbol.VarSym, exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Region(sym: Symbol.VarSym, exp: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class RunWith(exp: Exp, effUse: EffSymUse, rules: List[HandlerRule], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
   }
 
@@ -123,11 +123,11 @@ object ReducedAst {
 
   case class AnonClass(name: String, clazz: java.lang.Class[?], tpe: SimpleType, methods: List[JvmMethod], loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Exp)
 
-  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
+  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Exp)
 
   sealed trait Param {
     def sym: Symbol.VarSym

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -54,9 +54,9 @@ object ResolvedAst {
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, symUse: TraitSymUse, tparams: List[TypeParam], tpe: UnkindedType, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], ns: Name.NName, loc: SourceLocation) extends Declaration
 
-    case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Expr], loc: SourceLocation) extends Declaration
+    case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Exp], loc: SourceLocation) extends Declaration
 
-    case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation) extends Declaration
+    case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Exp, loc: SourceLocation) extends Declaration
 
     case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: List[Declaration.Case], loc: SourceLocation) extends Declaration
 
@@ -83,163 +83,163 @@ object ResolvedAst {
 
   case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], tpe: UnkindedType, eff: Option[UnkindedType], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
 
-  sealed trait Expr {
+  sealed trait Exp {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends Expr
+    case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends Exp
 
-    case class Hole(sym: Symbol.HoleSym, scp: LocalScope, loc: SourceLocation) extends Expr
+    case class Hole(sym: Symbol.HoleSym, scp: LocalScope, loc: SourceLocation) extends Exp
 
-    case class HoleWithExp(exp: Expr, scp: LocalScope, loc: SourceLocation) extends Expr
+    case class HoleWithExp(exp: Exp, scp: LocalScope, loc: SourceLocation) extends Exp
 
-    case class OpenAs(symUse: RestrictableEnumSymUse, exp: Expr, loc: SourceLocation) extends Expr
+    case class OpenAs(symUse: RestrictableEnumSymUse, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Use(sym: Symbol, alias: Name.Ident, exp: Expr, loc: SourceLocation) extends Expr
+    case class Use(sym: Symbol, alias: Name.Ident, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Cst(cst: Constant, loc: SourceLocation) extends Expr
+    case class Cst(cst: Constant, loc: SourceLocation) extends Exp
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ApplyDef(symUse: DefSymUse, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ApplyDef(symUse: DefSymUse, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class ApplyLocalDef(symUse: LocalDefSymUse, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ApplyLocalDef(symUse: LocalDefSymUse, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class ApplyOp(symUse: OpSymUse, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ApplyOp(symUse: OpSymUse, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class ApplySig(symUse: SigSymUse, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ApplySig(symUse: SigSymUse, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class Lambda(fparam: FormalParam, exp: Expr, allowSubeffecting: Boolean, loc: SourceLocation) extends Expr
+    case class Lambda(fparam: FormalParam, exp: Exp, allowSubeffecting: Boolean, loc: SourceLocation) extends Exp
 
-    case class Unary(sop: SemanticOp.UnaryOp, exp: Expr, loc: SourceLocation) extends Expr
+    case class Unary(sop: SemanticOp.UnaryOp, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Binary(sop: SemanticOp.BinaryOp, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Binary(sop: SemanticOp.BinaryOp, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Discard(exp: Expr, loc: SourceLocation) extends Expr
+    case class Discard(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Let(sym: Symbol.VarSym, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Expr, loc: SourceLocation) extends Expr
+    case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Match(exp: Expr, rules: List[MatchRule], loc: SourceLocation) extends Expr
+    case class Match(exp: Exp, rules: List[MatchRule], loc: SourceLocation) extends Exp
 
-    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], loc: SourceLocation) extends Expr
+    case class TypeMatch(exp: Exp, rules: List[TypeMatchRule], loc: SourceLocation) extends Exp
 
-    case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
+    case class RestrictableChoose(star: Boolean, exp: Exp, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Exp
 
-    case class ExtMatch(exp: Expr, rules: List[ExtMatchRule], loc: SourceLocation) extends Expr
+    case class ExtMatch(exp: Exp, rules: List[ExtMatchRule], loc: SourceLocation) extends Exp
 
-    case class Tag(symUse: CaseSymUse, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class Tag(symUse: CaseSymUse, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Expr], isOpen: Boolean, loc: SourceLocation) extends Expr
+    case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Exp], isOpen: Boolean, loc: SourceLocation) extends Exp
 
-    case class ExtTag(label: Name.Label, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ExtTag(label: Name.Label, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class Tuple(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class Tuple(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class RecordSelect(exp: Expr, label: Name.Label, loc: SourceLocation) extends Expr
+    case class RecordSelect(exp: Exp, label: Name.Label, loc: SourceLocation) extends Exp
 
-    case class RecordExtend(label: Name.Label, value: Expr, rest: Expr, loc: SourceLocation) extends Expr
+    case class RecordExtend(label: Name.Label, value: Exp, rest: Exp, loc: SourceLocation) extends Exp
 
-    case class RecordRestrict(label: Name.Label, rest: Expr, loc: SourceLocation) extends Expr
+    case class RecordRestrict(label: Name.Label, rest: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLit(exps: List[Expr], exp: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLit(exps: List[Exp], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayNew(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class ArrayNew(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLoad(base: Expr, index: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLoad(base: Exp, index: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayStore(base: Expr, index: Expr, elm: Expr, loc: SourceLocation) extends Expr
+    case class ArrayStore(base: Exp, index: Exp, elm: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLength(base: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLength(base: Exp, loc: SourceLocation) extends Exp
 
-    case class StructNew(sym: Symbol.StructSym, exps: List[(StructFieldSymUse, Expr)], region: Expr, loc: SourceLocation) extends Expr
+    case class StructNew(sym: Symbol.StructSym, exps: List[(StructFieldSymUse, Exp)], region: Exp, loc: SourceLocation) extends Exp
 
-    case class StructGet(exp: Expr, symUse: StructFieldSymUse, loc: SourceLocation) extends Expr
+    case class StructGet(exp: Exp, symUse: StructFieldSymUse, loc: SourceLocation) extends Exp
 
-    case class StructPut(exp1: Expr, symUse: StructFieldSymUse, exp2: Expr, loc: SourceLocation) extends Expr
+    case class StructPut(exp1: Exp, symUse: StructFieldSymUse, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class VectorLit(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class VectorLit(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class VectorLoad(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class VectorLoad(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class VectorLength(exp: Expr, loc: SourceLocation) extends Expr
+    case class VectorLength(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Ascribe(exp: Expr, expectedType: Option[UnkindedType], expectedEff: Option[UnkindedType], loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Exp, expectedType: Option[UnkindedType], expectedEff: Option[UnkindedType], loc: SourceLocation) extends Exp
 
-    case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Exp, clazz: java.lang.Class[?], loc: SourceLocation) extends Exp
 
-    case class CheckedCast(cast: CheckedCastType, exp: Expr, loc: SourceLocation) extends Expr
+    case class CheckedCast(cast: CheckedCastType, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class UncheckedCast(exp: Expr, declaredType: Option[UnkindedType], declaredEff: Option[UnkindedType], loc: SourceLocation) extends Expr
+    case class UncheckedCast(exp: Exp, declaredType: Option[UnkindedType], declaredEff: Option[UnkindedType], loc: SourceLocation) extends Exp
 
-    case class Unsafe(exp: Expr, eff: UnkindedType, loc: SourceLocation) extends Expr
+    case class Unsafe(exp: Exp, eff: UnkindedType, loc: SourceLocation) extends Exp
 
-    case class Without(exp: Expr, symUse: EffSymUse, loc: SourceLocation) extends Expr
+    case class Without(exp: Exp, symUse: EffSymUse, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], loc: SourceLocation) extends Exp
 
-    case class Throw(exp: Expr, loc: SourceLocation) extends Expr
+    case class Throw(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Handler(symUse: EffSymUse, rules: List[HandlerRule], loc: SourceLocation) extends Expr
+    case class Handler(symUse: EffSymUse, rules: List[HandlerRule], loc: SourceLocation) extends Exp
 
-    case class RunWith(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class RunWith(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class InvokeConstructor(clazz: Class[?], exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeConstructor(clazz: Class[?], exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class InvokeMethod(exp: Expr, methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeMethod(exp: Exp, methodName: Name.Ident, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class InvokeStaticMethod(clazz: Class[?], methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeStaticMethod(clazz: Class[?], methodName: Name.Ident, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class GetField(exp: Expr, fieldName: Name.Ident, loc: SourceLocation) extends Expr
+    case class GetField(exp: Exp, fieldName: Name.Ident, loc: SourceLocation) extends Exp
 
-    case class PutField(field: Field, clazz: java.lang.Class[?], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutField(field: Field, clazz: java.lang.Class[?], exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class GetStaticField(field: Field, loc: SourceLocation) extends Expr
+    case class GetStaticField(field: Field, loc: SourceLocation) extends Exp
 
-    case class PutStaticField(field: Field, exp: Expr, loc: SourceLocation) extends Expr
+    case class PutStaticField(field: Field, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[?], methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
-    case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class GetChannel(exp: Expr, loc: SourceLocation) extends Expr
+    case class GetChannel(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class PutChannel(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutChannel(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], loc: SourceLocation) extends Expr
+    case class SelectChannel(rules: List[SelectChannelRule], default: Option[Exp], loc: SourceLocation) extends Exp
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
+    case class ParYield(frags: List[ParYieldFragment], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Lazy(exp: Expr, loc: SourceLocation) extends Expr
+    case class Lazy(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Force(exp: Expr, loc: SourceLocation) extends Expr
+    case class Force(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointConstraintSet(cs: List[Constraint], loc: SourceLocation) extends Expr
+    case class FixpointConstraintSet(cs: List[Constraint], loc: SourceLocation) extends Exp
 
-    case class FixpointLambda(pparams: List[PredicateParam], exp: Expr, loc: SourceLocation) extends Expr
+    case class FixpointLambda(pparams: List[PredicateParam], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointMerge(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class FixpointMerge(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Expr
+    case class FixpointQueryWithProvenance(exps: List[Exp], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Exp], queryExp: Exp, selects: List[Exp], from: List[Predicate.Body], where: List[Exp], pred: Name.Pred, loc: SourceLocation) extends Exp
 
-    case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Expr
+    case class FixpointSolveWithProject(exps: List[Exp], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Exp
 
-    case class FixpointInjectInto(exps: List[Expr], predsAndArities: List[PredicateAndArity], loc: SourceLocation) extends Expr
+    case class FixpointInjectInto(exps: List[Exp], predsAndArities: List[PredicateAndArity], loc: SourceLocation) extends Exp
 
-    case class Error(m: CompilationMessage) extends Expr {
+    case class Error(m: CompilationMessage) extends Exp {
       override def loc: SourceLocation = m.loc
     }
 
@@ -325,7 +325,7 @@ object ResolvedAst {
 
     object Head {
 
-      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Expr], loc: SourceLocation) extends Predicate.Head
+      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Exp], loc: SourceLocation) extends Predicate.Head
 
     }
 
@@ -335,9 +335,9 @@ object ResolvedAst {
 
       case class Atom(pred: Name.Pred, den: Denotation, polarity: Polarity, fixity: Fixity, terms: List[Pattern], loc: SourceLocation) extends Predicate.Body
 
-      case class Functional(syms: List[Symbol.VarSym], exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Functional(syms: List[Symbol.VarSym], exp: Exp, loc: SourceLocation) extends Predicate.Body
 
-      case class Guard(exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Guard(exp: Exp, loc: SourceLocation) extends Predicate.Body
 
     }
 
@@ -359,21 +359,21 @@ object ResolvedAst {
 
   }
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: UnkindedType, eff: Option[UnkindedType], loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, tpe: UnkindedType, eff: Option[UnkindedType], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr, loc: SourceLocation)
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Exp, loc: SourceLocation)
 
-  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Exp, loc: SourceLocation)
 
-  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
+  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Exp)
 
-  case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr, loc: SourceLocation)
+  case class MatchRule(pat: Pattern, guard: Option[Exp], exp: Exp, loc: SourceLocation)
 
-  case class ExtMatchRule(pat: ExtPattern, exp: Expr, loc: SourceLocation)
+  case class ExtMatchRule(pat: ExtPattern, exp: Exp, loc: SourceLocation)
 
-  case class TypeMatchRule(sym: Symbol.VarSym, tpe: UnkindedType, exp: Expr, loc: SourceLocation)
+  case class TypeMatchRule(sym: Symbol.VarSym, tpe: UnkindedType, exp: Exp, loc: SourceLocation)
 
-  case class SelectChannelRule(sym: Symbol.VarSym, chan: Expr, exp: Expr, loc: SourceLocation)
+  case class SelectChannelRule(sym: Symbol.VarSym, chan: Exp, exp: Exp, loc: SourceLocation)
 
   sealed trait TypeParam {
     val name: Name.Ident
@@ -392,6 +392,6 @@ object ResolvedAst {
 
   case class EqualityConstraint(assocTypeSymUse: AssocTypeSymUse, tpe1: UnkindedType, tpe2: UnkindedType, loc: SourceLocation)
 
-  case class ParYieldFragment(pat: Pattern, exp: Expr, loc: SourceLocation)
+  case class ParYieldFragment(pat: Pattern, exp: Exp, loc: SourceLocation)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -34,7 +34,7 @@ object SimplifiedAst {
                   entryPoints: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
+  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, fparams: List[FormalParam], exp: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation)
 
   case class Enum(ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], cases: Map[Symbol.CaseSym, Case], loc: SourceLocation)
 
@@ -45,7 +45,7 @@ object SimplifiedAst {
   case class Op(sym: Symbol.OpSym, ann: Annotations, mod: Modifiers, fparams: List[FormalParam], tpe: SimpleType, purity: Purity, loc: SourceLocation)
 
 
-  sealed trait Expr {
+  sealed trait Exp {
     def tpe: SimpleType
 
     def purity: Purity
@@ -53,54 +53,54 @@ object SimplifiedAst {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Cst(cst: Constant, tpe: SimpleType, loc: SourceLocation) extends Expr {
+    case class Cst(cst: Constant, tpe: SimpleType, loc: SourceLocation) extends Exp {
       def purity: Purity = Pure
     }
 
-    case class Var(sym: Symbol.VarSym, tpe: SimpleType, loc: SourceLocation) extends Expr {
+    case class Var(sym: Symbol.VarSym, tpe: SimpleType, loc: SourceLocation) extends Exp {
       def purity: Purity = Pure
     }
 
-    case class Lambda(fparams: List[FormalParam], exp: Expr, tpe: SimpleType, loc: SourceLocation) extends Expr {
+    case class Lambda(fparams: List[FormalParam], exp: Exp, tpe: SimpleType, loc: SourceLocation) extends Exp {
       def purity: Purity = Pure
     }
 
     @IntroducedBy(ClosureConv.getClass)
-    case class LambdaClosure(cparams: List[FormalParam], fparams: List[FormalParam], freeVars: List[FreeVar], exp: Expr, tpe: SimpleType, loc: SourceLocation) extends Expr {
+    case class LambdaClosure(cparams: List[FormalParam], fparams: List[FormalParam], freeVars: List[FreeVar], exp: Exp, tpe: SimpleType, loc: SourceLocation) extends Exp {
       def purity: Purity = Pure
     }
 
-    case class ApplyAtomic(op: AtomicOp, exps: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyAtomic(op: AtomicOp, exps: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp1: Exp, exp2: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyLocalDef(sym: Symbol.VarSym, exps: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyLocalDef(sym: Symbol.VarSym, exps: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class ApplyOp(sym: Symbol.OpSym, exps: List[Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyOp(sym: Symbol.OpSym, exps: List[Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Branch(exp: Expr, branches: Map[Symbol.LabelSym, Expr], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Branch(exp: Exp, branches: Map[Symbol.LabelSym, Exp], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class JumpTo(sym: Symbol.LabelSym, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class JumpTo(sym: Symbol.LabelSym, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Let(sym: Symbol.VarSym, exp1: Exp, exp2: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Exp, exp2: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class Region(sym: Symbol.VarSym, exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class Region(sym: Symbol.VarSym, exp: Exp, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class RunWith(exp: Exp, effUse: EffSymUse, rules: List[HandlerRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Exp
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
   }
 
@@ -110,11 +110,11 @@ object SimplifiedAst {
   /** [[Type]] is used here because [[Struct]] declarations are not monomorphized. */
   case class StructField(sym: Symbol.StructFieldSym, tpe: Type, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: SimpleType, purity: Purity, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, retTpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Exp)
 
-  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
+  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Exp)
 
   case class FormalParam(sym: Symbol.VarSym, tpe: SimpleType, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -167,216 +167,216 @@ object SyntaxTree {
     //////////////////////////////////////////////////////////////////////////////////////////
     /// EXPRESSIONS                                                                         //
     //////////////////////////////////////////////////////////////////////////////////////////
-    sealed trait Expr extends TreeKind
+    sealed trait Exp extends TreeKind
 
-    object Expr {
+    object Exp {
 
       /**
         * A marker kind used to wrap nested expressions.
         */
       // For instance on a binary expression "1 + 2" you would do
-      // Expr
+      // Exp
       //   Binary
-      //     Expr
+      //     Exp
       //       LiteralNumber
       //   Operator
-      //     Expr
+      //     Exp
       //       LiteralNumber
-      case object Expr extends Expr
+      case object Exp extends Exp
 
-      case object Apply extends Expr
+      case object Apply extends Exp
 
-      case object Ascribe extends Expr
+      case object Ascribe extends Exp
 
-      case object Binary extends Expr
+      case object Binary extends Exp
 
-      case object Block extends Expr
+      case object Block extends Exp
 
-      case object CheckedEffectCast extends Expr
+      case object CheckedEffectCast extends Exp
 
-      case object CheckedTypeCast extends Expr
+      case object CheckedTypeCast extends Exp
 
-      case object DebugInterpolator extends Expr
+      case object DebugInterpolator extends Exp
 
-      case object ExtMatch extends Expr
+      case object ExtMatch extends Exp
 
-      case object ExtMatchRuleFragment extends Expr
+      case object ExtMatchRuleFragment extends Exp
 
-      case object ExtTag extends Expr
+      case object ExtTag extends Exp
 
-      case object Index extends Expr
+      case object Index extends Exp
 
-      case object IndexMut extends Expr
+      case object IndexMut extends Exp
 
-      case object InvokeConstructor extends Expr
+      case object InvokeConstructor extends Exp
 
-      case object InvokeMethod extends Expr
+      case object InvokeMethod extends Exp
 
-      case object FixpointConstraint extends Expr
+      case object FixpointConstraint extends Exp
 
-      case object FixpointConstraintSet extends Expr
+      case object FixpointConstraintSet extends Exp
 
-      case object FixpointLambda extends Expr
+      case object FixpointLambda extends Exp
 
-      case object FixpointFromFragment extends Expr
+      case object FixpointFromFragment extends Exp
 
-      case object FixpointInject extends Expr
+      case object FixpointInject extends Exp
 
-      case object FixpointQuery extends Expr
+      case object FixpointQuery extends Exp
 
-      case object FixpointQueryWithProvenance extends Expr
+      case object FixpointQueryWithProvenance extends Exp
 
-      case object FixpointSelect extends Expr
+      case object FixpointSelect extends Exp
 
-      case object FixpointSolveWithProject extends Expr
+      case object FixpointSolveWithProject extends Exp
 
-      case object FixpointSolveWithProvenance extends Expr
+      case object FixpointSolveWithProvenance extends Exp
 
-      case object FixpointWhere extends Expr
+      case object FixpointWhere extends Exp
 
-      case object FixpointWith extends Expr
+      case object FixpointWith extends Exp
 
-      case object ForApplicative extends Expr
+      case object ForApplicative extends Exp
 
-      case object Foreach extends Expr
+      case object Foreach extends Exp
 
-      case object ForMonadic extends Expr
+      case object ForMonadic extends Exp
 
-      case object ForFragmentGenerator extends Expr
+      case object ForFragmentGenerator extends Exp
 
-      case object ForFragmentGuard extends Expr
+      case object ForFragmentGuard extends Exp
 
-      case object ForFragmentLet extends Expr
+      case object ForFragmentLet extends Exp
 
-      case object GetField extends Expr
+      case object GetField extends Exp
 
-      case object Handler extends Expr
+      case object Handler extends Exp
 
-      case object Hole extends Expr
+      case object Hole extends Exp
 
-      case object HoleVariable extends Expr
+      case object HoleVariable extends Exp
 
-      case object IfThenElse extends Expr
+      case object IfThenElse extends Exp
 
-      case object InstanceOf extends Expr
+      case object InstanceOf extends Exp
 
-      case object Intrinsic extends Expr
+      case object Intrinsic extends Exp
 
-      case object JvmMethod extends Expr
+      case object JvmMethod extends Exp
 
-      case object Lambda extends Expr
+      case object Lambda extends Exp
 
-      case object LambdaExtMatch extends Expr
+      case object LambdaExtMatch extends Exp
 
-      case object LambdaMatch extends Expr
+      case object LambdaMatch extends Exp
 
-      case object LetMatch extends Expr
+      case object LetMatch extends Exp
 
-      case object Literal extends Expr
+      case object Literal extends Exp
 
-      case object LiteralArray extends Expr
+      case object LiteralArray extends Exp
 
-      case object LiteralList extends Expr
+      case object LiteralList extends Exp
 
-      case object LiteralMap extends Expr
+      case object LiteralMap extends Exp
 
-      case object LiteralMapKeyValueFragment extends Expr
+      case object LiteralMapKeyValueFragment extends Exp
 
-      case object LiteralStructFieldFragment extends Expr
+      case object LiteralStructFieldFragment extends Exp
 
-      case object LiteralSet extends Expr
+      case object LiteralSet extends Exp
 
-      case object LiteralVector extends Expr
+      case object LiteralVector extends Exp
 
-      case object LocalDef extends Expr
+      case object LocalDef extends Exp
 
-      case object Match extends Expr
+      case object Match extends Exp
 
-      case object MatchRuleFragment extends Expr
+      case object MatchRuleFragment extends Exp
 
-      case object NewObject extends Expr
+      case object NewObject extends Exp
 
-      case object NewStruct extends Expr
+      case object NewStruct extends Exp
 
-      case object StructGet extends Expr
+      case object StructGet extends Exp
 
-      case object StructPut extends Expr
+      case object StructPut extends Exp
 
-      case object StructPutRHS extends Expr
+      case object StructPutRHS extends Exp
 
-      case object OpenVariant extends Expr
+      case object OpenVariant extends Exp
 
-      case object OpenVariantAs extends Expr
+      case object OpenVariantAs extends Exp
 
-      case object Paren extends Expr
+      case object Paren extends Exp
 
-      case object ParYield extends Expr
+      case object ParYield extends Exp
 
-      case object ParYieldFragment extends Expr
+      case object ParYieldFragment extends Exp
 
-      case object RecordOperation extends Expr
+      case object RecordOperation extends Exp
 
-      case object RecordOpExtend extends Expr
+      case object RecordOpExtend extends Exp
 
-      case object RecordOpRestrict extends Expr
+      case object RecordOpRestrict extends Exp
 
-      case object RecordOpUpdate extends Expr
+      case object RecordOpUpdate extends Exp
 
-      case object RecordSelect extends Expr
+      case object RecordSelect extends Exp
 
-      case object RestrictableChoose extends Expr
+      case object RestrictableChoose extends Exp
 
-      case object RestrictableChooseStar extends Expr
+      case object RestrictableChooseStar extends Exp
 
-      case object Run extends Expr
+      case object Run extends Exp
 
-      case object Region extends Expr
+      case object Region extends Exp
 
-      case object RegionName extends Expr
+      case object RegionName extends Exp
 
-      case object Select extends Expr
+      case object Select extends Exp
 
-      case object SelectRuleFragment extends Expr
+      case object SelectRuleFragment extends Exp
 
-      case object SelectRuleDefaultFragment extends Expr
+      case object SelectRuleDefaultFragment extends Exp
 
-      case object Spawn extends Expr
+      case object Spawn extends Exp
 
-      case object Statement extends Expr
+      case object Statement extends Exp
 
-      case object Static extends Expr
+      case object Static extends Exp
 
-      case object StringInterpolation extends Expr
+      case object StringInterpolation extends Exp
 
-      case object Try extends Expr
+      case object Try extends Exp
 
-      case object Throw extends Expr
+      case object Throw extends Exp
 
-      case object TryCatchBodyFragment extends Expr
+      case object TryCatchBodyFragment extends Exp
 
-      case object TryCatchRuleFragment extends Expr
+      case object TryCatchRuleFragment extends Exp
 
-      case object RunWithBodyExpr extends Expr
+      case object RunWithBodyExpr extends Exp
 
-      case object RunWithRuleFragment extends Expr
+      case object RunWithRuleFragment extends Exp
 
-      case object Tuple extends Expr
+      case object Tuple extends Exp
 
-      case object TypeMatch extends Expr
+      case object TypeMatch extends Exp
 
-      case object TypeMatchRuleFragment extends Expr
+      case object TypeMatchRuleFragment extends Exp
 
-      case object Unary extends Expr
+      case object Unary extends Exp
 
-      case object UncheckedCast extends Expr
+      case object UncheckedCast extends Exp
 
-      case object Unsafe extends Expr
+      case object Unsafe extends Exp
 
-      case object UnsafeOld extends Expr
+      case object UnsafeOld extends Exp
 
-      case object Use extends Expr
+      case object Use extends Exp
 
-      case object Without extends Expr
+      case object Without extends Exp
 
     }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -60,9 +60,9 @@ object TypedAst {
     override def src: Source = loc.source
   }
 
-  case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Expr], loc: SourceLocation)
+  case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Exp], loc: SourceLocation)
 
-  case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
+  case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Exp, loc: SourceLocation)
 
   case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint]) extends Decl
 
@@ -84,7 +84,7 @@ object TypedAst {
 
   case class Op(sym: Symbol.OpSym, spec: Spec, loc: SourceLocation)
 
-  sealed trait Expr extends Product {
+  sealed trait Exp extends Product {
     def tpe: Type
 
     def eff: Type
@@ -92,191 +92,191 @@ object TypedAst {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Cst(cst: Constant, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Cst(cst: Constant, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class Hole(sym: Symbol.HoleSym, scp: LocalScope, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Hole(sym: Symbol.HoleSym, scp: LocalScope, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class HoleWithExp(exp: Expr, scp: LocalScope, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class HoleWithExp(exp: Exp, scp: LocalScope, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class OpenAs(symUse: RestrictableEnumSymUse, exp: Expr, tpe: Type, loc: SourceLocation) extends Expr {
+    case class OpenAs(symUse: RestrictableEnumSymUse, exp: Exp, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = exp.eff
     }
 
-    case class Use(sym: Symbol, alias: Name.Ident, exp: Expr, loc: SourceLocation) extends Expr {
+    case class Use(sym: Symbol, alias: Name.Ident, exp: Exp, loc: SourceLocation) extends Exp {
       def tpe: Type = exp.tpe
 
       def eff: Type = exp.eff
     }
 
-    case class Lambda(fparam: FormalParam, exp: Expr, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Lambda(fparam: FormalParam, exp: Exp, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyDef(symUse: DefSymUse, exps: List[Expr], targs: List[Type], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyDef(symUse: DefSymUse, exps: List[Exp], targs: List[Type], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyLocalDef(symUse: LocalDefSymUse, exps: List[Expr], arrowTpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyLocalDef(symUse: LocalDefSymUse, exps: List[Exp], arrowTpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplyOp(symUse: OpSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyOp(symUse: OpSymUse, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ApplySig(symUse: SigSymUse, exps: List[Expr], targ: Type, targs: List[Type], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplySig(symUse: SigSymUse, exps: List[Exp], targ: Type, targs: List[Type], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Unary(sop: SemanticOp.UnaryOp, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Unary(sop: SemanticOp.UnaryOp, exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Binary(sop: SemanticOp.BinaryOp, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Binary(sop: SemanticOp.BinaryOp, exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Let(bnd: Binder, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Let(bnd: Binder, exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class LocalDef(bnd: Binder, fparams: List[FormalParam], exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class LocalDef(bnd: Binder, fparams: List[FormalParam], exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Region(bnd: Binder, regSym: Symbol.RegionSym, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Region(bnd: Binder, regSym: Symbol.RegionSym, exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Discard(exp: Expr, eff: Type, loc: SourceLocation) extends Expr {
+    case class Discard(exp: Exp, eff: Type, loc: SourceLocation) extends Exp {
       def tpe: Type = Type.mkUnit(loc)
     }
 
-    case class Match(exp: Expr, rules: List[MatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Match(exp: Exp, rules: List[MatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class TypeMatch(exp: Exp, rules: List[TypeMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RestrictableChoose(star: Boolean, exp: Exp, rules: List[RestrictableChooseRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ExtMatch(exp: Expr, rules: List[ExtMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ExtMatch(exp: Exp, rules: List[ExtMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Tag(symUse: CaseSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Tag(symUse: CaseSymUse, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ExtTag(label: Name.Label, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ExtTag(label: Name.Label, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Tuple(exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Tuple(exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class RecordSelect(exp: Expr, label: Name.Label, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RecordSelect(exp: Exp, label: Name.Label, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class RecordExtend(label: Name.Label, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RecordExtend(label: Name.Label, exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class RecordRestrict(label: Name.Label, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RecordRestrict(label: Name.Label, exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ArrayLit(exps: List[Expr], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ArrayLit(exps: List[Exp], exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ArrayNew(exp1: Expr, exp2: Expr, exp3: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ArrayNew(exp1: Exp, exp2: Exp, exp3: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ArrayLoad(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ArrayLoad(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ArrayLength(exp: Expr, eff: Type, loc: SourceLocation) extends Expr {
+    case class ArrayLength(exp: Exp, eff: Type, loc: SourceLocation) extends Exp {
       def tpe: Type = Type.Int32
     }
 
-    case class ArrayStore(exp1: Expr, exp2: Expr, exp3: Expr, eff: Type, loc: SourceLocation) extends Expr {
+    case class ArrayStore(exp1: Exp, exp2: Exp, exp3: Exp, eff: Type, loc: SourceLocation) extends Exp {
       def tpe: Type = Type.Unit
     }
 
-    case class StructNew(sym: Symbol.StructSym, fields: List[(StructFieldSymUse, Expr)], region: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class StructNew(sym: Symbol.StructSym, fields: List[(StructFieldSymUse, Exp)], region: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class StructGet(exp: Expr, symUse: StructFieldSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class StructGet(exp: Exp, symUse: StructFieldSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class StructPut(exp1: Expr, symUse: StructFieldSymUse, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class StructPut(exp1: Exp, symUse: StructFieldSymUse, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class VectorLit(exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class VectorLit(exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class VectorLoad(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class VectorLoad(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class VectorLength(exp: Expr, loc: SourceLocation) extends Expr {
+    case class VectorLength(exp: Exp, loc: SourceLocation) extends Exp {
       def eff: Type = exp.eff
 
       def tpe: Type = Type.Int32
     }
 
-    case class Ascribe(exp: Expr, expectedType: Option[Type], expectedEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Exp, expectedType: Option[Type], expectedEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr {
+    case class InstanceOf(exp: Exp, clazz: java.lang.Class[?], loc: SourceLocation) extends Exp {
       def eff: Type = exp.eff
 
       def tpe: Type = Type.Bool
     }
 
-    case class CheckedCast(cast: CheckedCastType, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class CheckedCast(cast: CheckedCastType, exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class UncheckedCast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class UncheckedCast(exp: Exp, declaredType: Option[Type], declaredEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Unsafe(exp: Expr, runEff: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Unsafe(exp: Exp, runEff: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Without(exp: Expr, symUse: EffSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Without(exp: Exp, symUse: EffSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Throw(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Throw(exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Handler(symUse: EffSymUse, rules: List[HandlerRule], bodyType: Type, bodyEff: Type, handledEff: Type, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Handler(symUse: EffSymUse, rules: List[HandlerRule], bodyType: Type, bodyEff: Type, handledEff: Type, tpe: Type, loc: SourceLocation) extends Exp {
       override def eff: Type = Type.Pure
     }
 
-    case class RunWith(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RunWith(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class InvokeConstructor(constructor: Constructor[?], exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class InvokeConstructor(constructor: Constructor[?], exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class InvokeMethod(method: Method, exp: Expr, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class InvokeMethod(method: Method, exp: Exp, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class InvokeStaticMethod(method: Method, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class InvokeStaticMethod(method: Method, exps: List[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class GetField(field: Field, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class GetField(field: Field, exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class PutField(field: Field, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class PutField(field: Field, exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class GetStaticField(field: Field, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class GetStaticField(field: Field, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class PutStaticField(field: Field, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class PutStaticField(field: Field, exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
-    case class NewChannel(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class GetChannel(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class GetChannel(exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class PutChannel(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class PutChannel(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class SelectChannel(rules: List[SelectChannelRule], default: Option[Exp], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Spawn(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Spawn(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class ParYield(frags: List[ParYieldFragment], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ParYield(frags: List[ParYieldFragment], exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Lazy(exp: Expr, tpe: Type, loc: SourceLocation) extends Expr {
+    case class Lazy(exp: Exp, tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class Force(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Force(exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class FixpointConstraintSet(cs: List[Constraint], tpe: Type, loc: SourceLocation) extends Expr {
+    case class FixpointConstraintSet(cs: List[Constraint], tpe: Type, loc: SourceLocation) extends Exp {
       def eff: Type = Type.Pure
     }
 
-    case class FixpointLambda(pparams: List[PredicateParam], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class FixpointLambda(pparams: List[PredicateParam], exp: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class FixpointMerge(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class FixpointMerge(exp1: Exp, exp2: Exp, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithProvenance(exps: List[Exp], select: Predicate.Head, withh: List[Name.Pred], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Exp], queryExp: Exp, selects: List[Exp], from: List[Predicate.Body], where: List[Exp], pred: Name.Pred, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class FixpointSolveWithProject(exps: List[Exp], optPreds: Option[List[Name.Pred]], mode: SolveMode, tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class FixpointInjectInto(exps: List[Expr], predsAndArities: List[PredicateAndArity], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class FixpointInjectInto(exps: List[Exp], predsAndArities: List[PredicateAndArity], tpe: Type, eff: Type, loc: SourceLocation) extends Exp
 
-    case class Error(m: CompilationMessage, tpe: Type, eff: Type) extends Expr {
+    case class Error(m: CompilationMessage, tpe: Type, eff: Type) extends Exp {
       override def loc: SourceLocation = m.loc
     }
 
@@ -367,7 +367,7 @@ object TypedAst {
 
     object Head {
 
-      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Expr], tpe: Type, loc: SourceLocation) extends Predicate.Head
+      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Exp], tpe: Type, loc: SourceLocation) extends Predicate.Head
 
     }
 
@@ -377,9 +377,9 @@ object TypedAst {
 
       case class Atom(pred: Name.Pred, den: Denotation, polarity: Polarity, fixity: Fixity, terms: List[Pattern], tpe: Type, loc: SourceLocation) extends Predicate.Body
 
-      case class Functional(outBnds: List[Binder], exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Functional(outBnds: List[Binder], exp: Exp, loc: SourceLocation) extends Predicate.Body
 
-      case class Guard(exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Guard(exp: Exp, loc: SourceLocation) extends Predicate.Body
 
     }
 
@@ -401,24 +401,24 @@ object TypedAst {
 
   case class PredicateParam(pred: Name.Pred, tpe: Type, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, retTpe: Type, eff: Type, loc: SourceLocation)
 
-  case class CatchRule(bnd: Binder, clazz: java.lang.Class[?], exp: Expr, loc: SourceLocation)
+  case class CatchRule(bnd: Binder, clazz: java.lang.Class[?], exp: Exp, loc: SourceLocation)
 
-  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Exp, loc: SourceLocation)
 
-  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
+  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Exp)
 
-  case class ExtMatchRule(pat: ExtPattern, exp: Expr, loc: SourceLocation)
+  case class ExtMatchRule(pat: ExtPattern, exp: Exp, loc: SourceLocation)
 
-  case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr, loc: SourceLocation)
+  case class MatchRule(pat: Pattern, guard: Option[Exp], exp: Exp, loc: SourceLocation)
 
-  case class TypeMatchRule(bnd: Binder, tpe: Type, exp: Expr, loc: SourceLocation)
+  case class TypeMatchRule(bnd: Binder, tpe: Type, exp: Exp, loc: SourceLocation)
 
-  case class SelectChannelRule(bnd: Binder, chan: Expr, exp: Expr, loc: SourceLocation)
+  case class SelectChannelRule(bnd: Binder, chan: Exp, exp: Exp, loc: SourceLocation)
 
   case class TypeParam(name: Name.Ident, sym: Symbol.KindedTypeVarSym, loc: SourceLocation)
 
-  case class ParYieldFragment(pat: Pattern, exp: Expr, loc: SourceLocation)
+  case class ParYieldFragment(pat: Pattern, exp: Exp, loc: SourceLocation)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -41,13 +41,13 @@ object WeededAst {
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, clazz: Name.QName, tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], redefs: List[Declaration.Redef], loc: SourceLocation) extends Declaration
 
-    case class Sig(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Option[Expr], tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], loc: SourceLocation)
+    case class Sig(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Option[Exp], tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], loc: SourceLocation)
 
-    case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
+    case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Exp, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
 
-    case class Redef(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
+    case class Redef(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Exp, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
 
-    case class Law(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Type, tconstrs: List[TraitConstraint], loc: SourceLocation) extends Declaration
+    case class Law(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Exp, tpe: Type, eff: Type, tconstrs: List[TraitConstraint], loc: SourceLocation) extends Declaration
 
     case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], derives: Derivations, cases: List[Case], loc: SourceLocation) extends Declaration
 
@@ -77,171 +77,171 @@ object WeededAst {
   }
 
 
-  sealed trait Expr {
+  sealed trait Exp {
     def loc: SourceLocation
   }
 
-  object Expr {
+  object Exp {
 
-    case class Ambiguous(qname: Name.QName, loc: SourceLocation) extends Expr
+    case class Ambiguous(qname: Name.QName, loc: SourceLocation) extends Exp
 
-    case class Open(qname: Name.QName, loc: SourceLocation) extends Expr
+    case class Open(qname: Name.QName, loc: SourceLocation) extends Exp
 
-    case class OpenAs(qname: Name.QName, exp: Expr, loc: SourceLocation) extends Expr
+    case class OpenAs(qname: Name.QName, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends Expr
+    case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends Exp
 
-    case class HoleWithExp(exp: Expr, loc: SourceLocation) extends Expr
+    case class HoleWithExp(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Use(uses: List[UseOrImport], exp: Expr, loc: SourceLocation) extends Expr
+    case class Use(uses: List[UseOrImport], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Cst(cst: Constant, loc: SourceLocation) extends Expr
+    case class Cst(cst: Constant, loc: SourceLocation) extends Exp
 
-    case class Apply(exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class Apply(exp: Exp, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class Infix(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class Infix(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class Lambda(fparam: FormalParam, exp: Expr, loc: SourceLocation) extends Expr
+    case class Lambda(fparam: FormalParam, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class LambdaExtMatch(pat: ExtPattern, exp: Expr, loc: SourceLocation) extends Expr
+    case class LambdaExtMatch(pat: ExtPattern, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class LambdaMatch(pat: Pattern, exp: Expr, loc: SourceLocation) extends Expr
+    case class LambdaMatch(pat: Pattern, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Unary(sop: SemanticOp.UnaryOp, exp: Expr, loc: SourceLocation) extends Expr
+    case class Unary(sop: SemanticOp.UnaryOp, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Binary(sop: SemanticOp.BinaryOp, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Binary(sop: SemanticOp.BinaryOp, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class Stm(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Stm(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Discard(exp: Expr, loc: SourceLocation) extends Expr
+    case class Discard(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class LocalDef(ident: Name.Ident, fparams: List[FormalParam], declaredTpe: Option[Type], declaredEff: Option[Type], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(ident: Name.Ident, fparams: List[FormalParam], declaredTpe: Option[Type], declaredEff: Option[Type], exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Region(ident: Name.Ident, exp: Expr, loc: SourceLocation) extends Expr
+    case class Region(ident: Name.Ident, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Match(exp: Expr, rules: List[MatchRule], loc: SourceLocation) extends Expr
+    case class Match(exp: Exp, rules: List[MatchRule], loc: SourceLocation) extends Exp
 
-    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], loc: SourceLocation) extends Expr
+    case class TypeMatch(exp: Exp, rules: List[TypeMatchRule], loc: SourceLocation) extends Exp
 
-    case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Expr
+    case class RestrictableChoose(star: Boolean, exp: Exp, rules: List[RestrictableChooseRule], loc: SourceLocation) extends Exp
 
-    case class ExtMatch(exp: Expr, rules: List[ExtMatchRule], loc: SourceLocation) extends Expr
+    case class ExtMatch(exp: Exp, rules: List[ExtMatchRule], loc: SourceLocation) extends Exp
 
-    case class ApplicativeFor(frags: List[ForFragment.Generator], exp: Expr, loc: SourceLocation) extends Expr
+    case class ApplicativeFor(frags: List[ForFragment.Generator], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class ForEach(frags: List[ForFragment], exp: Expr, loc: SourceLocation) extends Expr
+    case class ForEach(frags: List[ForFragment], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class MonadicFor(frags: List[ForFragment], exp: Expr, loc: SourceLocation) extends Expr
+    case class MonadicFor(frags: List[ForFragment], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class LetMatch(pat: Pattern, tpe: Option[Type], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LetMatch(pat: Pattern, tpe: Option[Type], exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ExtTag(label: Name.Label, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ExtTag(label: Name.Label, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class Tuple(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class Tuple(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class RecordSelect(exp: Expr, label: Name.Label, loc: SourceLocation) extends Expr
+    case class RecordSelect(exp: Exp, label: Name.Label, loc: SourceLocation) extends Exp
 
-    case class RecordExtend(label: Name.Label, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class RecordExtend(label: Name.Label, exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class RecordRestrict(label: Name.Label, exp: Expr, loc: SourceLocation) extends Expr
+    case class RecordRestrict(label: Name.Label, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLit(exps: List[Expr], exp: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLit(exps: List[Exp], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayNew(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class ArrayNew(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLoad(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLoad(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayLength(exp: Expr, loc: SourceLocation) extends Expr
+    case class ArrayLength(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class ArrayStore(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class ArrayStore(exp1: Exp, exp2: Exp, exp3: Exp, loc: SourceLocation) extends Exp
 
-    case class StructNew(name: Name.QName, exps: List[(Name.Label, Expr)], region: Expr, loc: SourceLocation) extends Expr
+    case class StructNew(name: Name.QName, exps: List[(Name.Label, Exp)], region: Exp, loc: SourceLocation) extends Exp
 
-    case class VectorLit(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class VectorLit(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class VectorLoad(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class VectorLoad(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class VectorLength(exp: Expr, loc: SourceLocation) extends Expr
+    case class VectorLength(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class FCons(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class FCons(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class FAppend(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class FAppend(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ListLit(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ListLit(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class SetLit(exps: List[Expr], loc: SourceLocation) extends Expr
+    case class SetLit(exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class MapLit(exps: List[(Expr, Expr)], loc: SourceLocation) extends Expr
+    case class MapLit(exps: List[(Exp, Exp)], loc: SourceLocation) extends Exp
 
-    case class Ascribe(exp: Expr, expectedType: Option[Type], expectedEff: Option[Type], loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Exp, expectedType: Option[Type], expectedEff: Option[Type], loc: SourceLocation) extends Exp
 
-    case class InstanceOf(exp: Expr, clazzName: Name.Ident, loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Exp, clazzName: Name.Ident, loc: SourceLocation) extends Exp
 
-    case class CheckedCast(cast: CheckedCastType, exp: Expr, loc: SourceLocation) extends Expr
+    case class CheckedCast(cast: CheckedCastType, exp: Exp, loc: SourceLocation) extends Exp
 
-    case class UncheckedCast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], loc: SourceLocation) extends Expr
+    case class UncheckedCast(exp: Exp, declaredType: Option[Type], declaredEff: Option[Type], loc: SourceLocation) extends Exp
 
-    case class Unsafe(exp: Expr, eff: Type, loc: SourceLocation) extends Expr
+    case class Unsafe(exp: Exp, eff: Type, loc: SourceLocation) extends Exp
 
-    case class UnsafeOld(exp: Expr, loc: SourceLocation) extends Expr
+    case class UnsafeOld(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Without(exp: Expr, eff: Name.QName, loc: SourceLocation) extends Expr
+    case class Without(exp: Exp, eff: Name.QName, loc: SourceLocation) extends Exp
 
-    case class TryCatch(exp: Expr, handlers: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Exp, handlers: List[CatchRule], loc: SourceLocation) extends Exp
 
-    case class Throw(exp: Expr, loc: SourceLocation) extends Expr
+    case class Throw(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Handler(eff: Name.QName, rules: List[HandlerRule], loc: SourceLocation) extends Expr
+    case class Handler(eff: Name.QName, rules: List[HandlerRule], loc: SourceLocation) extends Exp
 
-    case class RunWith(exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class RunWith(exp: Exp, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class InvokeConstructor(clazzName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeConstructor(clazzName: Name.Ident, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class InvokeMethod(exp: Expr, methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeMethod(exp: Exp, methodName: Name.Ident, exps: List[Exp], loc: SourceLocation) extends Exp
 
-    case class GetField(exp: Expr, fieldName: Name.Ident, loc: SourceLocation) extends Expr
+    case class GetField(exp: Exp, fieldName: Name.Ident, loc: SourceLocation) extends Exp
 
-    case class NewObject(tpe: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(tpe: Type, methods: List[JvmMethod], loc: SourceLocation) extends Exp
 
-    case class StructGet(exp: Expr, label: Name.Label, loc: SourceLocation) extends Expr
+    case class StructGet(exp: Exp, label: Name.Label, loc: SourceLocation) extends Exp
 
-    case class StructPut(exp1: Expr, label: Name.Label, exp2: Expr, loc: SourceLocation) extends Expr
+    case class StructPut(exp1: Exp, label: Name.Label, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class Static(loc: SourceLocation) extends Expr
+    case class Static(loc: SourceLocation) extends Exp
 
-    case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class GetChannel(exp: Expr, loc: SourceLocation) extends Expr
+    case class GetChannel(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class PutChannel(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutChannel(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class SelectChannel(rules: List[SelectChannelRule], exp: Option[Expr], loc: SourceLocation) extends Expr
+    case class SelectChannel(rules: List[SelectChannelRule], exp: Option[Exp], loc: SourceLocation) extends Exp
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
+    case class ParYield(frags: List[ParYieldFragment], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Lazy(exp: Expr, loc: SourceLocation) extends Expr
+    case class Lazy(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class Force(exp: Expr, loc: SourceLocation) extends Expr
+    case class Force(exp: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointConstraintSet(cs: List[Constraint], loc: SourceLocation) extends Expr
+    case class FixpointConstraintSet(cs: List[Constraint], loc: SourceLocation) extends Exp
 
-    case class FixpointLambda(pparams: List[PredicateParam], exp: Expr, loc: SourceLocation) extends Expr
+    case class FixpointLambda(pparams: List[PredicateParam], exp: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointMerge(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class FixpointMerge(exp1: Exp, exp2: Exp, loc: SourceLocation) extends Exp
 
-    case class FixpointInjectInto(exps: List[Expr], predsAndArities: List[PredicateAndArity], loc: SourceLocation) extends Expr
+    case class FixpointInjectInto(exps: List[Exp], predsAndArities: List[PredicateAndArity], loc: SourceLocation) extends Exp
 
-    case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Expr
+    case class FixpointSolveWithProject(exps: List[Exp], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Expr
+    case class FixpointQueryWithProvenance(exps: List[Exp], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Exp
 
-    case class FixpointQueryWithSelect(exps: List[Expr], selects: List[Expr], from: List[Predicate.Body], where: List[Expr], loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Exp], selects: List[Exp], from: List[Predicate.Body], where: List[Exp], loc: SourceLocation) extends Exp
 
-    case class Error(m: CompilationMessage) extends Expr {
+    case class Error(m: CompilationMessage) extends Exp {
       override def loc: SourceLocation = m.loc
     }
 
@@ -326,7 +326,7 @@ object WeededAst {
 
     object Head {
 
-      case class Atom(pred: Name.Pred, den: Denotation, exps: List[Expr], loc: SourceLocation) extends Predicate.Head
+      case class Atom(pred: Name.Pred, den: Denotation, exps: List[Exp], loc: SourceLocation) extends Predicate.Head
 
     }
 
@@ -336,9 +336,9 @@ object WeededAst {
 
       case class Atom(pred: Name.Pred, den: Denotation, polarity: Polarity, fixity: Fixity, terms: List[Pattern], loc: SourceLocation) extends Predicate.Body
 
-      case class Functional(idents: List[Name.Ident], exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Functional(idents: List[Name.Ident], exp: Exp, loc: SourceLocation) extends Predicate.Body
 
-      case class Guard(exp: Expr, loc: SourceLocation) extends Predicate.Body
+      case class Guard(exp: Exp, loc: SourceLocation) extends Predicate.Body
 
     }
 
@@ -438,13 +438,13 @@ object WeededAst {
 
   }
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Exp, tpe: Type, eff: Option[Type], loc: SourceLocation)
 
-  case class CatchRule(ident: Name.Ident, className: Name.Ident, exp: Expr, loc: SourceLocation)
+  case class CatchRule(ident: Name.Ident, className: Name.Ident, exp: Exp, loc: SourceLocation)
 
-  case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Exp, loc: SourceLocation)
 
-  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
+  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Exp)
 
   case class TraitConstraint(trt: Name.QName, tpe: Type, loc: SourceLocation)
 
@@ -452,13 +452,13 @@ object WeededAst {
 
   case class Constraint(head: Predicate.Head, body: List[Predicate.Body], loc: SourceLocation)
 
-  case class MatchRule(pat: Pattern, exp1: Option[Expr], exp2: Expr, loc: SourceLocation)
+  case class MatchRule(pat: Pattern, exp1: Option[Exp], exp2: Exp, loc: SourceLocation)
 
-  case class ExtMatchRule(pat: ExtPattern, exp: Expr, loc: SourceLocation)
+  case class ExtMatchRule(pat: ExtPattern, exp: Exp, loc: SourceLocation)
 
-  case class TypeMatchRule(ident: Name.Ident, tpe: Type, exp: Expr, loc: SourceLocation)
+  case class TypeMatchRule(ident: Name.Ident, tpe: Type, exp: Exp, loc: SourceLocation)
 
-  case class SelectChannelRule(ident: Name.Ident, exp1: Expr, exp2: Expr, loc: SourceLocation)
+  case class SelectChannelRule(ident: Name.Ident, exp1: Exp, exp2: Exp, loc: SourceLocation)
 
   sealed trait TypeParam
 
@@ -470,7 +470,7 @@ object WeededAst {
 
   }
 
-  case class ParYieldFragment(pat: Pattern, exp: Expr, loc: SourceLocation)
+  case class ParYieldFragment(pat: Pattern, exp: Exp, loc: SourceLocation)
 
   case class Derivations(traits: List[Name.QName], loc: SourceLocation)
 
@@ -480,11 +480,11 @@ object WeededAst {
 
   object ForFragment {
 
-    case class Generator(pat: Pattern, exp: Expr, loc: SourceLocation) extends ForFragment
+    case class Generator(pat: Pattern, exp: Exp, loc: SourceLocation) extends ForFragment
 
-    case class Guard(exp: Expr, loc: SourceLocation) extends ForFragment
+    case class Guard(exp: Exp, loc: SourceLocation) extends ForFragment
 
-    case class Let(pat: Pattern, exp: Expr, loc: SourceLocation) extends ForFragment
+    case class Let(pat: Pattern, exp: Exp, loc: SourceLocation) extends ForFragment
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -37,83 +37,83 @@ object TypedAstOps {
   /**
     * Creates a set of all the sigs used in the given `exp`.
     */
-  def sigSymsOf(exp0: Expr): Set[Symbol.SigSym] = exp0 match {
-    case Expr.Cst(_, _, _) => Set.empty
-    case Expr.Var(_, _, _) => Set.empty
-    case Expr.Hole(_, _, _, _, _) => Set.empty
-    case Expr.HoleWithExp(exp, _, _, _, _) => sigSymsOf(exp)
-    case Expr.OpenAs(_, exp, _, _) => sigSymsOf(exp)
-    case Expr.Use(_, _, exp, _) => sigSymsOf(exp)
-    case Expr.Lambda(_, exp, _, _) => sigSymsOf(exp)
-    case Expr.ApplyClo(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.ApplyDef(_, exps, _, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
-    case Expr.ApplyLocalDef(_, exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
-    case Expr.ApplyOp(_, exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
-    case Expr.ApplySig(SigSymUse(sym, _), exps, _, _, _, _, _, _) => exps.flatMap(sigSymsOf).toSet + sym
-    case Expr.Unary(_, exp, _, _, _) => sigSymsOf(exp)
-    case Expr.Binary(_, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.Let(_, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.LocalDef(_, _, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.Region(_, _, exp, _, _, _) => sigSymsOf(exp)
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2) ++ sigSymsOf(exp3)
-    case Expr.Stm(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.Discard(exp, _, _) => sigSymsOf(exp)
-    case Expr.Match(exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(rule => sigSymsOf(rule.exp) ++ rule.guard.toList.flatMap(sigSymsOf))
-    case Expr.TypeMatch(exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(rule => sigSymsOf(rule.exp))
-    case Expr.RestrictableChoose(_, exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(rule => sigSymsOf(rule.exp))
-    case Expr.ExtMatch(exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(r => sigSymsOf(r.exp))
-    case Expr.Tag(_, exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
-    case Expr.RestrictableTag(_, exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
-    case Expr.ExtTag(_, exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
-    case Expr.Tuple(elms, _, _, _) => elms.flatMap(sigSymsOf).toSet
-    case Expr.RecordSelect(exp, _, _, _, _) => sigSymsOf(exp)
-    case Expr.RecordExtend(_, value, rest, _, _, _) => sigSymsOf(value) ++ sigSymsOf(rest)
-    case Expr.RecordRestrict(_, rest, _, _, _) => sigSymsOf(rest)
-    case Expr.ArrayLit(exps, exp, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ sigSymsOf(exp)
-    case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2) ++ sigSymsOf(exp3)
-    case Expr.ArrayLoad(base, index, _, _, _) => sigSymsOf(base) ++ sigSymsOf(index)
-    case Expr.ArrayLength(base, _, _) => sigSymsOf(base)
-    case Expr.ArrayStore(base, index, elm, _, _) => sigSymsOf(base) ++ sigSymsOf(index) ++ sigSymsOf(elm)
-    case Expr.StructNew(_, fields, region, _, _, _) => sigSymsOf(region) ++ fields.flatMap { case (_, v) => sigSymsOf(v) }
-    case Expr.StructGet(e, _, _, _, _) => sigSymsOf(e)
-    case Expr.StructPut(e1, _, e2, _, _, _) => sigSymsOf(e1) ++ sigSymsOf(e2)
-    case Expr.VectorLit(exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
-    case Expr.VectorLoad(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.VectorLength(exp, _) => sigSymsOf(exp)
-    case Expr.Ascribe(exp, _, _, _, _, _) => sigSymsOf(exp)
-    case Expr.InstanceOf(exp, _, _) => sigSymsOf(exp)
-    case Expr.CheckedCast(_, exp, _, _, _) => sigSymsOf(exp)
-    case Expr.UncheckedCast(exp, _, _, _, _, _) => sigSymsOf(exp)
-    case Expr.Unsafe(exp, _, _, _, _) => sigSymsOf(exp)
-    case Expr.Without(exp, _, _, _, _) => sigSymsOf(exp)
-    case Expr.TryCatch(exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(rule => sigSymsOf(rule.exp))
-    case Expr.Throw(exp, _, _, _) => sigSymsOf(exp)
-    case Expr.Handler(_, rules, _, _, _, _, _) => rules.flatMap(rule => sigSymsOf(rule.exp)).toSet
-    case Expr.RunWith(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.InvokeConstructor(_, args, _, _, _) => args.flatMap(sigSymsOf).toSet
-    case Expr.InvokeMethod(_, exp, args, _, _, _) => sigSymsOf(exp) ++ args.flatMap(sigSymsOf)
-    case Expr.InvokeStaticMethod(_, args, _, _, _) => args.flatMap(sigSymsOf).toSet
-    case Expr.GetField(_, exp, _, _, _) => sigSymsOf(exp)
-    case Expr.PutField(_, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.GetStaticField(_, _, _, _) => Set.empty
-    case Expr.PutStaticField(_, exp, _, _, _) => sigSymsOf(exp)
-    case Expr.NewObject(_, _, _, _, methods, _) => methods.flatMap(method => sigSymsOf(method.exp)).toSet
-    case Expr.NewChannel(exp, _, _, _) => sigSymsOf(exp)
-    case Expr.GetChannel(exp, _, _, _) => sigSymsOf(exp)
-    case Expr.PutChannel(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.SelectChannel(rules, default, _, _, _) => rules.flatMap(rule => sigSymsOf(rule.chan) ++ sigSymsOf(rule.exp)).toSet ++ default.toSet.flatMap(sigSymsOf)
-    case Expr.Spawn(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.ParYield(frags, exp, _, _, _) => sigSymsOf(exp) ++ frags.flatMap(f => sigSymsOf(f.exp))
-    case Expr.Lazy(exp, _, _) => sigSymsOf(exp)
-    case Expr.Force(exp, _, _, _) => sigSymsOf(exp)
-    case Expr.FixpointConstraintSet(_, _, _) => Set.empty
-    case Expr.FixpointLambda(_, exp, _, _, _) => sigSymsOf(exp)
-    case Expr.FixpointMerge(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
-    case Expr.FixpointQueryWithProvenance(exps, Head.Atom(_, _, terms, _, _), _, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ terms.flatMap(sigSymsOf).toSet
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ sigSymsOf(queryExp) ++ selects.flatMap(sigSymsOf).toSet ++ where.flatMap(sigSymsOf).toSet
-    case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
-    case Expr.FixpointInjectInto(exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
-    case Expr.Error(_, _, _) => Set.empty
+  def sigSymsOf(exp0: Exp): Set[Symbol.SigSym] = exp0 match {
+    case Exp.Cst(_, _, _) => Set.empty
+    case Exp.Var(_, _, _) => Set.empty
+    case Exp.Hole(_, _, _, _, _) => Set.empty
+    case Exp.HoleWithExp(exp, _, _, _, _) => sigSymsOf(exp)
+    case Exp.OpenAs(_, exp, _, _) => sigSymsOf(exp)
+    case Exp.Use(_, _, exp, _) => sigSymsOf(exp)
+    case Exp.Lambda(_, exp, _, _) => sigSymsOf(exp)
+    case Exp.ApplyClo(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.ApplyDef(_, exps, _, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
+    case Exp.ApplyLocalDef(_, exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
+    case Exp.ApplyOp(_, exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
+    case Exp.ApplySig(SigSymUse(sym, _), exps, _, _, _, _, _, _) => exps.flatMap(sigSymsOf).toSet + sym
+    case Exp.Unary(_, exp, _, _, _) => sigSymsOf(exp)
+    case Exp.Binary(_, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.Let(_, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.LocalDef(_, _, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.Region(_, _, exp, _, _, _) => sigSymsOf(exp)
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2) ++ sigSymsOf(exp3)
+    case Exp.Stm(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.Discard(exp, _, _) => sigSymsOf(exp)
+    case Exp.Match(exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(rule => sigSymsOf(rule.exp) ++ rule.guard.toList.flatMap(sigSymsOf))
+    case Exp.TypeMatch(exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(rule => sigSymsOf(rule.exp))
+    case Exp.RestrictableChoose(_, exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(rule => sigSymsOf(rule.exp))
+    case Exp.ExtMatch(exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(r => sigSymsOf(r.exp))
+    case Exp.Tag(_, exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
+    case Exp.RestrictableTag(_, exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
+    case Exp.ExtTag(_, exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
+    case Exp.Tuple(elms, _, _, _) => elms.flatMap(sigSymsOf).toSet
+    case Exp.RecordSelect(exp, _, _, _, _) => sigSymsOf(exp)
+    case Exp.RecordExtend(_, value, rest, _, _, _) => sigSymsOf(value) ++ sigSymsOf(rest)
+    case Exp.RecordRestrict(_, rest, _, _, _) => sigSymsOf(rest)
+    case Exp.ArrayLit(exps, exp, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ sigSymsOf(exp)
+    case Exp.ArrayNew(exp1, exp2, exp3, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2) ++ sigSymsOf(exp3)
+    case Exp.ArrayLoad(base, index, _, _, _) => sigSymsOf(base) ++ sigSymsOf(index)
+    case Exp.ArrayLength(base, _, _) => sigSymsOf(base)
+    case Exp.ArrayStore(base, index, elm, _, _) => sigSymsOf(base) ++ sigSymsOf(index) ++ sigSymsOf(elm)
+    case Exp.StructNew(_, fields, region, _, _, _) => sigSymsOf(region) ++ fields.flatMap { case (_, v) => sigSymsOf(v) }
+    case Exp.StructGet(e, _, _, _, _) => sigSymsOf(e)
+    case Exp.StructPut(e1, _, e2, _, _, _) => sigSymsOf(e1) ++ sigSymsOf(e2)
+    case Exp.VectorLit(exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
+    case Exp.VectorLoad(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.VectorLength(exp, _) => sigSymsOf(exp)
+    case Exp.Ascribe(exp, _, _, _, _, _) => sigSymsOf(exp)
+    case Exp.InstanceOf(exp, _, _) => sigSymsOf(exp)
+    case Exp.CheckedCast(_, exp, _, _, _) => sigSymsOf(exp)
+    case Exp.UncheckedCast(exp, _, _, _, _, _) => sigSymsOf(exp)
+    case Exp.Unsafe(exp, _, _, _, _) => sigSymsOf(exp)
+    case Exp.Without(exp, _, _, _, _) => sigSymsOf(exp)
+    case Exp.TryCatch(exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(rule => sigSymsOf(rule.exp))
+    case Exp.Throw(exp, _, _, _) => sigSymsOf(exp)
+    case Exp.Handler(_, rules, _, _, _, _, _) => rules.flatMap(rule => sigSymsOf(rule.exp)).toSet
+    case Exp.RunWith(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.InvokeConstructor(_, args, _, _, _) => args.flatMap(sigSymsOf).toSet
+    case Exp.InvokeMethod(_, exp, args, _, _, _) => sigSymsOf(exp) ++ args.flatMap(sigSymsOf)
+    case Exp.InvokeStaticMethod(_, args, _, _, _) => args.flatMap(sigSymsOf).toSet
+    case Exp.GetField(_, exp, _, _, _) => sigSymsOf(exp)
+    case Exp.PutField(_, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.GetStaticField(_, _, _, _) => Set.empty
+    case Exp.PutStaticField(_, exp, _, _, _) => sigSymsOf(exp)
+    case Exp.NewObject(_, _, _, _, methods, _) => methods.flatMap(method => sigSymsOf(method.exp)).toSet
+    case Exp.NewChannel(exp, _, _, _) => sigSymsOf(exp)
+    case Exp.GetChannel(exp, _, _, _) => sigSymsOf(exp)
+    case Exp.PutChannel(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.SelectChannel(rules, default, _, _, _) => rules.flatMap(rule => sigSymsOf(rule.chan) ++ sigSymsOf(rule.exp)).toSet ++ default.toSet.flatMap(sigSymsOf)
+    case Exp.Spawn(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.ParYield(frags, exp, _, _, _) => sigSymsOf(exp) ++ frags.flatMap(f => sigSymsOf(f.exp))
+    case Exp.Lazy(exp, _, _) => sigSymsOf(exp)
+    case Exp.Force(exp, _, _, _) => sigSymsOf(exp)
+    case Exp.FixpointConstraintSet(_, _, _) => Set.empty
+    case Exp.FixpointLambda(_, exp, _, _, _) => sigSymsOf(exp)
+    case Exp.FixpointMerge(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Exp.FixpointQueryWithProvenance(exps, Head.Atom(_, _, terms, _, _), _, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ terms.flatMap(sigSymsOf).toSet
+    case Exp.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ sigSymsOf(queryExp) ++ selects.flatMap(sigSymsOf).toSet ++ where.flatMap(sigSymsOf).toSet
+    case Exp.FixpointSolveWithProject(exps, _, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
+    case Exp.FixpointInjectInto(exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
+    case Exp.Error(_, _, _) => Set.empty
   }
 
   /**
@@ -129,284 +129,284 @@ object TypedAstOps {
   /**
     * Returns the free variables in the given expression `exp0`.
     */
-  def freeVars(exp0: Expr): Map[Symbol.VarSym, Type] = exp0 match {
-    case Expr.Cst(_, _, _) => Map.empty
+  def freeVars(exp0: Exp): Map[Symbol.VarSym, Type] = exp0 match {
+    case Exp.Cst(_, _, _) => Map.empty
 
-    case Expr.Var(sym, tpe, _) => Map(sym -> tpe)
+    case Exp.Var(sym, tpe, _) => Map(sym -> tpe)
 
-    case Expr.Hole(_, _, _, _, _) => Map.empty
+    case Exp.Hole(_, _, _, _, _) => Map.empty
 
-    case Expr.HoleWithExp(exp, _, _, _, _) =>
+    case Exp.HoleWithExp(exp, _, _, _, _) =>
       freeVars(exp)
 
-    case Expr.OpenAs(_, exp, _, _) =>
+    case Exp.OpenAs(_, exp, _, _) =>
       freeVars(exp)
 
-    case Expr.Use(_, _, exp, _) =>
+    case Exp.Use(_, _, exp, _) =>
       freeVars(exp)
 
-    case Expr.Lambda(fparam, exp, _, _) =>
+    case Exp.Lambda(fparam, exp, _, _) =>
       freeVars(exp) - fparam.bnd.sym
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
+    case Exp.ApplyClo(exp1, exp2, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)
 
-    case Expr.ApplyDef(_, exps, _, _, _, _, _) =>
+    case Exp.ApplyDef(_, exps, _, _, _, _, _) =>
       exps.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, exp) => freeVars(exp) ++ acc
       }
 
-    case Expr.ApplyLocalDef(_, exps, _, _, _, _) =>
+    case Exp.ApplyLocalDef(_, exps, _, _, _, _) =>
       exps.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, exp) => freeVars(exp) ++ acc
       }
 
-    case Expr.ApplyOp(_, exps, _, _, _) =>
+    case Exp.ApplyOp(_, exps, _, _, _) =>
       exps.flatMap(freeVars).toMap
 
-    case Expr.ApplySig(_, exps, _, _, _, _, _, _) =>
+    case Exp.ApplySig(_, exps, _, _, _, _, _, _) =>
       exps.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, exp) => freeVars(exp) ++ acc
       }
 
-    case Expr.Unary(_, exp, _, _, _) =>
+    case Exp.Unary(_, exp, _, _, _) =>
       freeVars(exp)
 
-    case Expr.Binary(_, exp1, exp2, _, _, _) =>
+    case Exp.Binary(_, exp1, exp2, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)
 
-    case Expr.Let(bnd, exp1, exp2, _, _, _) =>
+    case Exp.Let(bnd, exp1, exp2, _, _, _) =>
       (freeVars(exp1) ++ freeVars(exp2)) - bnd.sym
 
-    case Expr.LocalDef(TypedAst.Binder(sym, _), fparams, exp1, exp2, _, _, _) =>
+    case Exp.LocalDef(TypedAst.Binder(sym, _), fparams, exp1, exp2, _, _, _) =>
       val bound = sym :: fparams.map(_.bnd.sym)
       (freeVars(exp1) -- bound) ++ (freeVars(exp2) - sym)
 
-    case Expr.Region(Binder(sym, _), _, exp, _, _, _) =>
+    case Exp.Region(Binder(sym, _), _, exp, _, _, _) =>
       freeVars(exp) - sym
 
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2) ++ freeVars(exp3)
 
-    case Expr.Stm(exp1, exp2, _, _, _) =>
+    case Exp.Stm(exp1, exp2, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)
 
-    case Expr.Discard(exp, _, _) =>
+    case Exp.Discard(exp, _, _) =>
       freeVars(exp)
 
-    case Expr.Match(exp, rules, _, _, _) =>
+    case Exp.Match(exp, rules, _, _, _) =>
       rules.foldLeft(freeVars(exp)) {
         case (acc, MatchRule(pat, guard, body, _)) =>
           acc ++ ((guard.map(freeVars).getOrElse(Map.empty) ++ freeVars(body)) -- freeVars(pat).keys)
       }
 
-    case Expr.TypeMatch(exp, rules, _, _, _) =>
+    case Exp.TypeMatch(exp, rules, _, _, _) =>
       rules.foldLeft(freeVars(exp)) {
         case (acc, TypeMatchRule(bnd, _, body, _)) => acc ++ (freeVars(body) - bnd.sym)
       }
 
-    case Expr.RestrictableChoose(_, exp, rules, _, _, _) =>
+    case Exp.RestrictableChoose(_, exp, rules, _, _, _) =>
       val e = freeVars(exp)
       val rs = rules.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, RestrictableChooseRule(pat, body)) => acc ++ (freeVars(body) -- freeVars(pat).toList)
       }
       e ++ rs
 
-    case Expr.ExtMatch(exp, rules, _, _, _) =>
+    case Exp.ExtMatch(exp, rules, _, _, _) =>
       rules.foldLeft(freeVars(exp)) {
         case (acc, ExtMatchRule(pat, exp1, _)) =>
           acc ++ freeVars(exp1) -- freeVars(pat)
       }
 
-    case Expr.Tag(_, exps, _, _, _) =>
+    case Exp.Tag(_, exps, _, _, _) =>
       exps.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, exp) => freeVars(exp) ++ acc
       }
 
-    case Expr.RestrictableTag(_, exps, _, _, _) =>
+    case Exp.RestrictableTag(_, exps, _, _, _) =>
       exps.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, exp) => freeVars(exp) ++ acc
       }
 
-    case Expr.ExtTag(_, exps, _, _, _) =>
+    case Exp.ExtTag(_, exps, _, _, _) =>
       exps.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, exp) => freeVars(exp) ++ acc
       }
 
-    case Expr.Tuple(elms, _, _, _) =>
+    case Exp.Tuple(elms, _, _, _) =>
       elms.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, exp) => acc ++ freeVars(exp)
       }
 
-    case Expr.RecordSelect(exp, _, _, _, _) =>
+    case Exp.RecordSelect(exp, _, _, _, _) =>
       freeVars(exp)
 
-    case Expr.RecordExtend(_, value, rest, _, _, _) =>
+    case Exp.RecordExtend(_, value, rest, _, _, _) =>
       freeVars(value) ++ freeVars(rest)
 
-    case Expr.RecordRestrict(_, rest, _, _, _) =>
+    case Exp.RecordRestrict(_, rest, _, _, _) =>
       freeVars(rest)
 
-    case Expr.ArrayLit(elms, exp, _, _, _) =>
+    case Exp.ArrayLit(elms, exp, _, _, _) =>
       elms.foldLeft(freeVars(exp)) {
         case (acc, e) => acc ++ freeVars(e)
       }
 
-    case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) =>
+    case Exp.ArrayNew(exp1, exp2, exp3, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2) ++ freeVars(exp3)
 
-    case Expr.ArrayLoad(base, index, _, _, _) =>
+    case Exp.ArrayLoad(base, index, _, _, _) =>
       freeVars(base) ++ freeVars(index)
 
-    case Expr.ArrayLength(base, _, _) =>
+    case Exp.ArrayLength(base, _, _) =>
       freeVars(base)
 
-    case Expr.ArrayStore(base, index, elm, _, _) =>
+    case Exp.ArrayStore(base, index, elm, _, _) =>
       freeVars(base) ++ freeVars(index) ++ freeVars(elm)
 
-    case Expr.StructNew(_, fields, region, _, _, _) =>
+    case Exp.StructNew(_, fields, region, _, _, _) =>
       freeVars(region) ++ fields.flatMap { case (_, v) => freeVars(v) }
 
-    case Expr.StructGet(e, _, _, _, _) =>
+    case Exp.StructGet(e, _, _, _, _) =>
       freeVars(e)
 
-    case Expr.StructPut(e1, _, e2, _, _, _) =>
+    case Exp.StructPut(e1, _, e2, _, _, _) =>
       freeVars(e1) ++ freeVars(e2)
 
-    case Expr.VectorLit(elms, _, _, _) =>
+    case Exp.VectorLit(elms, _, _, _) =>
       elms.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, e) => acc ++ freeVars(e)
       }
 
-    case Expr.VectorLoad(exp1, exp2, _, _, _) =>
+    case Exp.VectorLoad(exp1, exp2, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)
 
-    case Expr.VectorLength(exp, _) =>
+    case Exp.VectorLength(exp, _) =>
       freeVars(exp)
 
-    case Expr.Ascribe(exp, _, _, _, _, _) =>
+    case Exp.Ascribe(exp, _, _, _, _, _) =>
       freeVars(exp)
 
-    case Expr.Without(exp, _, _, _, _) =>
+    case Exp.Without(exp, _, _, _, _) =>
       freeVars(exp)
 
-    case Expr.InstanceOf(exp, _, _) =>
+    case Exp.InstanceOf(exp, _, _) =>
       freeVars(exp)
 
-    case Expr.CheckedCast(_, exp, _, _, _) =>
+    case Exp.CheckedCast(_, exp, _, _, _) =>
       freeVars(exp)
 
-    case Expr.UncheckedCast(exp, _, _, _, _, _) =>
+    case Exp.UncheckedCast(exp, _, _, _, _, _) =>
       freeVars(exp)
 
-    case Expr.Unsafe(exp, _, _, _, _) =>
+    case Exp.Unsafe(exp, _, _, _, _) =>
       freeVars(exp)
 
-    case Expr.TryCatch(exp, rules, _, _, _) =>
+    case Exp.TryCatch(exp, rules, _, _, _) =>
       rules.foldLeft(freeVars(exp)) {
         case (acc, CatchRule(bnd, _, body, _)) => acc ++ freeVars(body) - bnd.sym
       }
 
-    case Expr.Throw(exp, _, _, _) => freeVars(exp)
+    case Exp.Throw(exp, _, _, _) => freeVars(exp)
 
-    case Expr.Handler(_, rules, _, _, _, _, _) =>
+    case Exp.Handler(_, rules, _, _, _, _, _) =>
       rules.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, HandlerRule(_, fparams, exp, _)) => acc ++ freeVars(exp) -- fparams.map(_.bnd.sym)
       }
 
-    case Expr.RunWith(exp1, exp2, _, _, _) =>
+    case Exp.RunWith(exp1, exp2, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)
 
-    case Expr.InvokeConstructor(_, args, _, _, _) =>
+    case Exp.InvokeConstructor(_, args, _, _, _) =>
       args.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, exp) => acc ++ freeVars(exp)
       }
 
-    case Expr.InvokeMethod(_, exp, args, _, _, _) =>
+    case Exp.InvokeMethod(_, exp, args, _, _, _) =>
       args.foldLeft(freeVars(exp)) {
         case (acc, obj) => acc ++ freeVars(obj)
       }
 
-    case Expr.InvokeStaticMethod(_, args, _, _, _) =>
+    case Exp.InvokeStaticMethod(_, args, _, _, _) =>
       args.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, exp) => acc ++ freeVars(exp)
       }
 
-    case Expr.GetField(_, exp, _, _, _) =>
+    case Exp.GetField(_, exp, _, _, _) =>
       freeVars(exp)
 
-    case Expr.PutField(_, exp1, exp2, _, _, _) =>
+    case Exp.PutField(_, exp1, exp2, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)
 
-    case Expr.GetStaticField(_, _, _, _) =>
+    case Exp.GetStaticField(_, _, _, _) =>
       Map.empty
 
-    case Expr.PutStaticField(_, exp, _, _, _) =>
+    case Exp.PutStaticField(_, exp, _, _, _) =>
       freeVars(exp)
 
-    case Expr.NewObject(_, _, _, _, methods, _) =>
+    case Exp.NewObject(_, _, _, _, methods, _) =>
       methods.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, JvmMethod(_, fparams, exp, _, _, _)) => acc ++ freeVars(exp) -- fparams.map(_.bnd.sym)
       }
 
-    case Expr.NewChannel(exp, _, _, _) =>
+    case Exp.NewChannel(exp, _, _, _) =>
       freeVars(exp)
 
-    case Expr.GetChannel(exp, _, _, _) =>
+    case Exp.GetChannel(exp, _, _, _) =>
       freeVars(exp)
 
-    case Expr.PutChannel(exp1, exp2, _, _, _) =>
+    case Exp.PutChannel(exp1, exp2, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)
 
-    case Expr.SelectChannel(rules, default, _, _, _) =>
+    case Exp.SelectChannel(rules, default, _, _, _) =>
       val d = default.map(freeVars).getOrElse(Map.empty)
       rules.foldLeft(d) {
         case (acc, SelectChannelRule(Binder(sym, _), chan, exp, _)) => acc ++ ((freeVars(chan) ++ freeVars(exp)) - sym)
       }
 
-    case Expr.Spawn(exp1, exp2, _, _, _) =>
+    case Exp.Spawn(exp1, exp2, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)
 
-    case Expr.ParYield(frags, exp, _, _, _) =>
+    case Exp.ParYield(frags, exp, _, _, _) =>
       val freeFragVars = frags.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, ParYieldFragment(p, e, _)) => acc ++ freeVars(p) ++ freeVars(e)
       }
       freeVars(exp) -- freeFragVars.keys
 
-    case Expr.Lazy(exp, _, _) =>
+    case Exp.Lazy(exp, _, _) =>
       freeVars(exp)
 
-    case Expr.Force(exp, _, _, _) =>
+    case Exp.Force(exp, _, _, _) =>
       freeVars(exp)
 
-    case Expr.FixpointConstraintSet(cs, _, _) =>
+    case Exp.FixpointConstraintSet(cs, _, _) =>
       cs.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         case (acc, c) => acc ++ freeVars(c)
       }
 
-    case Expr.FixpointLambda(_, exp, _, _, _) =>
+    case Exp.FixpointLambda(_, exp, _, _, _) =>
       freeVars(exp)
 
-    case Expr.FixpointMerge(exp1, exp2, _, _, _) =>
+    case Exp.FixpointMerge(exp1, exp2, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)
 
-    case Expr.FixpointQueryWithProvenance(exps, select, _, _, _, _) =>
+    case Exp.FixpointQueryWithProvenance(exps, select, _, _, _, _) =>
       freeVars(exps) ++ freeVars(select)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
+    case Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
       freeVars(exps) ++ freeVars(queryExp) ++ freeVars(selects) ++ from.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         (acc, b) => acc ++ freeVars(b)
       } ++ freeVars(where)
 
-    case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
+    case Exp.FixpointSolveWithProject(exps, _, _, _, _, _) =>
       exps.foldLeft(Map.empty[Symbol.VarSym, Type]) {
         (acc, exp) => acc ++ freeVars(exp)
       }
 
-    case Expr.FixpointInjectInto(exps, _, _, _, _) =>
+    case Exp.FixpointInjectInto(exps, _, _, _, _) =>
       freeVars(exps)
 
-    case Expr.Error(_, _, _) =>
+    case Exp.Error(_, _, _) =>
       Map.empty
 
   }
@@ -505,7 +505,7 @@ object TypedAstOps {
   /**
     * Returns the free variables in the given list of expressions `exp0`.
     */
-  private def freeVars(exps0: List[Expr]): Map[Symbol.VarSym, Type] =
+  private def freeVars(exps0: List[Exp]): Map[Symbol.VarSym, Type] =
     exps0.foldLeft(Map.empty[Symbol.VarSym, Type]) {
       case (acc, exp) => acc ++ freeVars(exp)
     }

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
@@ -42,12 +42,12 @@ object SyntacticContext {
     case object Type extends Decl
   }
 
-  sealed trait Expr extends SyntacticContext
+  sealed trait Exp extends SyntacticContext
 
-  object Expr {
-    case object Constraint extends Expr
+  object Exp {
+    case object Constraint extends Exp
 
-    case object OtherExpr extends Expr
+    case object OtherExpr extends Exp
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/TraitUsageKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/TraitUsageKind.scala
@@ -27,7 +27,7 @@ object TraitUsageKind {
     * Represents a trait use in an expression
     * e.g. let res = E...
     */
-  case object Expr extends TraitUsageKind
+  case object Exp extends TraitUsageKind
 
   /**
     * Represents a trait use in a constraint

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -26,7 +26,7 @@ sealed trait DocAst
 
 object DocAst {
 
-  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, parameters: List[Expr.AscriptionTpe], resType: Type, effect: Type, body: Expr)
+  case class Def(ann: Annotations, mod: Modifiers, sym: Symbol.DefnSym, parameters: List[Exp.AscriptionTpe], resType: Type, effect: Type, body: Exp)
 
   case class Enum(ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], cases: List[Case])
 
@@ -35,20 +35,20 @@ object DocAst {
   case class TypeParam(sym: Symbol.KindedTypeVarSym)
 
   /** `misc` is used for printing non-structured asts like [[ca.uwaterloo.flix.language.ast.SyntaxTree]] */
-  case class Program(enums: List[Enum], defs: List[Def], misc: List[(String, Expr)])
+  case class Program(enums: List[Enum], defs: List[Def], misc: List[(String, Exp)])
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[Expr.AscriptionTpe], clo: Expr, tpe: Type)
+  case class JvmMethod(ident: Name.Ident, fparams: List[Exp.AscriptionTpe], clo: Exp, tpe: Type)
 
 
-  sealed trait Expr
+  sealed trait Exp
 
-  object Expr {
+  object Exp {
 
-    /** A [[Expr]] atom that doesn't need parenthesis */
-    sealed trait Atom extends Expr
+    /** A [[Exp]] atom that doesn't need parenthesis */
+    sealed trait Atom extends Exp
 
-    /** A [[Expr]] that sometimes needs parenthesis */
-    sealed trait Composite extends Expr
+    /** A [[Exp]] that sometimes needs parenthesis */
+    sealed trait Composite extends Exp
 
     sealed trait LetBinder extends Atom
 
@@ -56,9 +56,9 @@ object DocAst {
 
     case object Unit extends Atom
 
-    case class Tuple(elms: List[Expr]) extends Atom
+    case class Tuple(elms: List[Exp]) extends Atom
 
-    case class Tag(sym: Sym, args: List[Expr]) extends Atom
+    case class Tag(sym: Sym, args: List[Exp]) extends Atom
 
     /** inserted string printed as-is (assumed not to require parenthesis) */
     case class AsIs(s: String) extends Atom
@@ -68,285 +68,285 @@ object DocAst {
 
     case object RecordEmpty extends Atom
 
-    case class RecordExtend(label: Name.Label, value: Expr, rest: Expr) extends RecordOp
+    case class RecordExtend(label: Name.Label, value: Exp, rest: Exp) extends RecordOp
 
-    case class RecordRestrict(label: Name.Label, value: Expr) extends RecordOp
+    case class RecordRestrict(label: Name.Label, value: Exp) extends RecordOp
 
-    case class Keyword(word: String, d: Expr) extends Composite
+    case class Keyword(word: String, d: Exp) extends Composite
 
-    case class DoubleKeyword(word1: String, d1: Expr, word2: String, d2: Either[Expr, Type]) extends Composite
+    case class DoubleKeyword(word1: String, d1: Exp, word2: String, d2: Either[Exp, Type]) extends Composite
 
-    case class DoubleKeywordPost(d1: Expr, word1: String, d2: Type, word3: String, d3: Type) extends Composite
+    case class DoubleKeywordPost(d1: Exp, word1: String, d2: Type, word3: String, d3: Type) extends Composite
 
-    case class InfixKeyword(d1: Expr, word: String, d2: Type) extends Composite
+    case class InfixKeyword(d1: Exp, word: String, d2: Type) extends Composite
 
-    case class Unary(op: String, d: Expr) extends Composite
+    case class Unary(op: String, d: Exp) extends Composite
 
     /** e.g. `arr?` */
-    case class UnaryRightAfter(d: Expr, op: String) extends Atom
+    case class UnaryRightAfter(d: Exp, op: String) extends Atom
 
-    case class Binary(d1: Expr, op: String, d2: Expr) extends Composite
+    case class Binary(d1: Exp, op: String, d2: Exp) extends Composite
 
-    case class IfThenElse(cond: Expr, thn: Expr, els: Expr) extends Composite
+    case class IfThenElse(cond: Exp, thn: Exp, els: Exp) extends Composite
 
-    case class Branch(d: Expr, branches: Map[Symbol.LabelSym, Expr]) extends Atom
+    case class Branch(d: Exp, branches: Map[Symbol.LabelSym, Exp]) extends Atom
 
-    case class Match(d: Expr, branches: List[(Expr, Option[Expr], Expr)]) extends Atom
+    case class Match(d: Exp, branches: List[(Exp, Option[Exp], Exp)]) extends Atom
 
-    case class ExtMatch(d: Expr, branches: List[(Expr, Expr)]) extends Atom
+    case class ExtMatch(d: Exp, branches: List[(Exp, Exp)]) extends Atom
 
-    case class TypeMatch(d: Expr, branches: List[(Expr, Type, Expr)]) extends Atom
+    case class TypeMatch(d: Exp, branches: List[(Exp, Type, Exp)]) extends Atom
 
     /** e.g. `r.x` */
-    case class Dot(d1: Expr, d2: Expr) extends Atom
+    case class Dot(d1: Exp, d2: Exp) extends Atom
 
     /** e.g. `r..toString()`. It is used for java "dots" */
-    case class DoubleDot(d1: Expr, d2: Expr) extends Atom
+    case class DoubleDot(d1: Exp, d2: Exp) extends Atom
 
     /**
       * e.g. `r#x` for [[RecordSelect]].
       */
-    case class Hash(d1: Expr, d2: Expr) extends Atom
+    case class Hash(d1: Exp, d2: Exp) extends Atom
 
-    case class TryCatch(d: Expr, rules: List[(Symbol.VarSym, Class[?], Expr)]) extends Atom
+    case class TryCatch(d: Exp, rules: List[(Symbol.VarSym, Class[?], Exp)]) extends Atom
 
-    case class Handler(eff: Symbol.EffSym, rules: List[(Symbol.OpSym, List[AscriptionTpe], Expr)]) extends Composite
+    case class Handler(eff: Symbol.EffSym, rules: List[(Symbol.OpSym, List[AscriptionTpe], Exp)]) extends Composite
 
-    case class Stm(d1: Expr, d2: Expr) extends LetBinder
+    case class Stm(d1: Exp, d2: Exp) extends LetBinder
 
-    case class Let(v: Expr, tpe: Option[Type], bind: Expr, body: Expr) extends LetBinder
+    case class Let(v: Exp, tpe: Option[Type], bind: Exp, body: Exp) extends LetBinder
 
-    case class LocalDef(sym: Expr, parameters: List[Expr.AscriptionTpe], resType: Option[Type], effect: Option[Type], body: Expr, next: Expr) extends LetBinder
+    case class LocalDef(sym: Exp, parameters: List[Exp.AscriptionTpe], resType: Option[Type], effect: Option[Type], body: Exp, next: Exp) extends LetBinder
 
-    case class Region(v: Expr, d: Expr) extends Atom
+    case class Region(v: Exp, d: Exp) extends Atom
 
-    case class AppWithTail(f: Expr, args: List[Expr], ct: Option[ExpPosition]) extends Atom
+    case class AppWithTail(f: Exp, args: List[Exp], ct: Option[ExpPosition]) extends Atom
 
-    case class SquareApp(f: Expr, args: List[Expr]) extends Atom
+    case class SquareApp(f: Exp, args: List[Exp]) extends Atom
 
-    case class DoubleSquareApp(f: Expr, args: List[Expr]) extends Atom
+    case class DoubleSquareApp(f: Exp, args: List[Exp]) extends Atom
 
-    case class Assign(d1: Expr, d2: Expr) extends Composite
+    case class Assign(d1: Exp, d2: Exp) extends Composite
 
-    case class AscriptionTpe(v: Expr, tpe: Type) extends Composite
+    case class AscriptionTpe(v: Exp, tpe: Type) extends Composite
 
-    case class AscriptionEff(v: Expr, tpe: Option[Type], eff: Option[Type]) extends Composite
+    case class AscriptionEff(v: Exp, tpe: Option[Type], eff: Option[Type]) extends Composite
 
-    case class Unsafe(d: Expr, tpe: Type) extends Composite
+    case class Unsafe(d: Exp, tpe: Type) extends Composite
 
     case class NewObject(name: String, clazz: Class[?], tpe: Type, methods: List[JvmMethod]) extends Composite
 
-    case class Lambda(fparams: List[Expr.AscriptionTpe], body: Expr) extends Composite
+    case class Lambda(fparams: List[Exp.AscriptionTpe], body: Exp) extends Composite
 
     case class Native(clazz: Class[?]) extends Atom
 
-    val Unknown: Expr =
+    val Unknown: Exp =
       Meta("unknown exp")
 
-    def Var(sym: Symbol.VarSym): Expr =
+    def Var(sym: Symbol.VarSym): Exp =
       AsIs(sym.toString)
 
-    val Wild: Expr =
+    val Wild: Exp =
       AsIs("_")
 
-    def Hole(sym: Symbol.HoleSym): Expr =
+    def Hole(sym: Symbol.HoleSym): Exp =
       AsIs("?" + sym.toString)
 
-    def HoleWithExp(exp: Expr): Expr =
+    def HoleWithExp(exp: Exp): Exp =
       UnaryRightAfter(exp, "?")
 
-    def HoleError(sym: Symbol.HoleSym): Expr =
+    def HoleError(sym: Symbol.HoleSym): Exp =
       AsIs(sym.toString)
 
-    val MatchError: Expr =
+    val MatchError: Exp =
       AsIs("?matchError")
 
-    val CastError: Expr =
+    val CastError: Exp =
       AsIs("?castError")
 
     /** represents the error ast node when compiling partial programs */
-    val Error: Expr =
+    val Error: Exp =
       AsIs("?astError")
 
-    def Tag(sym: Symbol.CaseSym, exprs: List[Expr]): Expr =
+    def Tag(sym: Symbol.CaseSym, exprs: List[Exp]): Exp =
       Tag(Sym(sym), exprs)
 
-    def ExtTag(label: Name.Label, exprs: List[Expr]): Expr =
+    def ExtTag(label: Name.Label, exprs: List[Exp]): Exp =
       Keyword("xvar", Tag(Sym(label), exprs))
 
-    def Untag(d: Expr, idx: Int): Expr =
+    def Untag(d: Exp, idx: Int): Exp =
       Keyword("untag_" + idx, d)
 
-    def Is(sym: Symbol.CaseSym, d: Expr): Expr =
+    def Is(sym: Symbol.CaseSym, d: Exp): Exp =
       Binary(d, "is", AsIs(sym.toString))
 
-    def Discard(d: Expr): Expr =
+    def Discard(d: Exp): Exp =
       Keyword("discard", d)
 
-    def Def(sym: Symbol.DefnSym): Expr =
+    def Def(sym: Symbol.DefnSym): Exp =
       AsIs(sym.toString)
 
-    def Sig(sym: Symbol.SigSym): Expr =
+    def Sig(sym: Symbol.SigSym): Exp =
       AsIs(sym.toString)
 
     /** e.g. `something @ rc` */
-    def InRegion(d1: Expr, d2: Expr): Expr =
+    def InRegion(d1: Exp, d2: Exp): Exp =
       Binary(d1, "@", d2)
 
-    def ArrayNew(d1: Expr, d2: Expr): Expr =
+    def ArrayNew(d1: Exp, d2: Exp): Exp =
       SquareApp(AsIs(""), List(Binary(d1, ";", d2)))
 
-    def ArrayLit(ds: List[Expr]): Expr =
+    def ArrayLit(ds: List[Exp]): Exp =
       SquareApp(AsIs(""), ds)
 
-    def ArrayLength(d: Expr): Expr =
+    def ArrayLength(d: Exp): Exp =
       DoubleDot(d, AsIs("length"))
 
-    def ArrayLoad(d1: Expr, index: Expr): Expr =
+    def ArrayLoad(d1: Exp, index: Exp): Exp =
       SquareApp(d1, List(index))
 
-    def ArrayStore(d1: Expr, index: Expr, d2: Expr): Expr =
+    def ArrayStore(d1: Exp, index: Exp, d2: Exp): Exp =
       Assign(SquareApp(d1, List(index)), d2)
 
-    def StructNew(sym: Symbol.StructSym, exps: List[(Symbol.StructFieldSym, Expr)], d2: Expr): Expr = {
+    def StructNew(sym: Symbol.StructSym, exps: List[(Symbol.StructFieldSym, Exp)], d2: Exp): Exp = {
       val beforeRecord = "new " + sym.toString
       val name = Name.Label(sym.name, sym.loc)
-      val record = exps.foldRight(RecordEmpty: Expr) { case (cur, acc) => RecordExtend(name, cur._2, acc) }
+      val record = exps.foldRight(RecordEmpty: Exp) { case (cur, acc) => RecordExtend(name, cur._2, acc) }
       DoubleKeyword(beforeRecord, record, "@", Left(d2))
     }
 
-    def StructGet(d1: Expr, field: Symbol.StructFieldSym): Expr =
+    def StructGet(d1: Exp, field: Symbol.StructFieldSym): Exp =
       Dot(d1, AsIs(field.name))
 
-    def StructPut(d1: Expr, field: Symbol.StructFieldSym, d2: Expr): Expr =
+    def StructPut(d1: Exp, field: Symbol.StructFieldSym, d2: Exp): Exp =
       Assign(Dot(d1, AsIs(field.name)), d2)
 
-    def VectorLit(ds: List[Expr]): Expr =
+    def VectorLit(ds: List[Exp]): Exp =
       DoubleSquareApp(AsIs(""), ds)
 
-    def VectorLoad(d1: Expr, index: Expr): Expr =
+    def VectorLoad(d1: Exp, index: Exp): Exp =
       DoubleSquareApp(d1, List(index))
 
-    def VectorLength(d: Expr): Expr =
+    def VectorLength(d: Exp): Exp =
       DoubleDot(d, AsIs("length"))
 
-    def Lazy(d: Expr): Expr =
+    def Lazy(d: Exp): Exp =
       Keyword("lazy", d)
 
-    def Force(d: Expr): Expr =
+    def Force(d: Exp): Exp =
       Keyword("force", d)
 
-    def Throw(d: Expr): Expr =
+    def Throw(d: Exp): Exp =
       Keyword("throw", d)
 
-    def Index(idx: Int, d: Expr): Expr =
+    def Index(idx: Int, d: Exp): Exp =
       Dot(d, AsIs(s"_$idx"))
 
-    def InstanceOf(d: Expr, clazz: Class[?]): Expr =
+    def InstanceOf(d: Exp, clazz: Class[?]): Exp =
       Binary(d, "instanceof", Native(clazz))
 
-    def ClosureLifted(sym: Symbol.DefnSym, ds: List[Expr]): Expr = {
+    def ClosureLifted(sym: Symbol.DefnSym, ds: List[Exp]): Exp = {
       val defName = AsIs(sym.toString)
       if (ds.isEmpty) defName else App(defName, ds)
     }
 
-    def RunWith(d1: Expr, d2: Expr): Expr =
+    def RunWith(d1: Exp, d2: Exp): Exp =
       DoubleKeyword("run", d1, "with", Left(d2))
 
-    def RunWithHandler(d: Expr, eff: Symbol.EffSym, rules: List[(Symbol.OpSym, List[AscriptionTpe], Expr)]): Expr =
+    def RunWithHandler(d: Exp, eff: Symbol.EffSym, rules: List[(Symbol.OpSym, List[AscriptionTpe], Exp)]): Exp =
       RunWith(d, Handler(eff, rules))
 
-    def Spawn(d1: Expr, d2: Expr): Expr =
+    def Spawn(d1: Exp, d2: Exp): Exp =
       InRegion(Keyword("spawn", d1), d2)
 
-    def Cast(d: Expr, tpe: Type): Expr =
+    def Cast(d: Exp, tpe: Type): Exp =
       DoubleKeyword("cast", d, "as", Right(tpe))
 
-    def UncheckedCast(d: Expr, tpe0: Option[Type], eff0: Option[Type]): Expr = (tpe0, eff0) match {
+    def UncheckedCast(d: Exp, tpe0: Option[Type], eff0: Option[Type]): Exp = (tpe0, eff0) match {
       case (Some(tpe), Some(eff)) => App(AsIs("unchecked_cast"), List(DoubleKeywordPost(d, "as", tpe, "\\", eff)))
       case (Some(tpe), None) => App(AsIs("unchecked_cast"), List(InfixKeyword(d, "as", tpe)))
       case (None, Some(eff)) => App(AsIs("unchecked_cast"), List(DoubleKeywordPost(d, "as", Type.Wild, "\\", eff)))
       case (None, None) => d
     }
 
-    def CheckedCast(cast: CheckedCastType, d: Expr): Expr = cast match {
+    def CheckedCast(cast: CheckedCastType, d: Exp): Exp = cast match {
       case CheckedCastType.TypeCast => Keyword("checked_cast", d)
       case CheckedCastType.EffectCast => Keyword("checked_ecast", d)
     }
 
-    def Unbox(d: Expr, tpe: Type): Expr =
+    def Unbox(d: Exp, tpe: Type): Exp =
       DoubleKeyword("unbox", d, "as", Right(tpe))
 
-    def Box(d: Expr): Expr =
+    def Box(d: Exp): Exp =
       Keyword("box", d)
 
-    def Without(d: Expr, sym: Symbol.EffSym): Expr =
+    def Without(d: Exp, sym: Symbol.EffSym): Exp =
       Binary(d, "without", AsIs(sym.toString))
 
-    def Cst(cst: Constant): Expr =
+    def Cst(cst: Constant): Exp =
       printer.ConstantPrinter.print(cst)
 
-    def App(f: Expr, args: List[Expr]): Expr =
+    def App(f: Exp, args: List[Exp]): Exp =
       AppWithTail(f, args, None)
 
-    def ApplyClo(d: Expr, ds: List[Expr]): Expr =
+    def ApplyClo(d: Exp, ds: List[Exp]): Exp =
       App(d, ds)
 
-    def ApplyCloWithTail(d: Expr, ds: List[Expr], ct: ExpPosition): Expr =
+    def ApplyCloWithTail(d: Exp, ds: List[Exp], ct: ExpPosition): Exp =
       AppWithTail(d, ds, Some(ct))
 
-    def ApplySelfTail(sym: Symbol.DefnSym, ds: List[Expr]): Expr =
+    def ApplySelfTail(sym: Symbol.DefnSym, ds: List[Exp]): Exp =
       AppWithTail(AsIs(sym.toString), ds, Some(ExpPosition.Tail))
 
-    def ApplyDef(sym: Symbol.DefnSym, ds: List[Expr]): Expr =
+    def ApplyDef(sym: Symbol.DefnSym, ds: List[Exp]): Exp =
       App(AsIs(sym.toString), ds)
 
-    def ApplyLocalDef(sym: Symbol.VarSym, ds: List[Expr]): Expr =
+    def ApplyLocalDef(sym: Symbol.VarSym, ds: List[Exp]): Exp =
       App(AsIs(sym.toString), ds)
 
-    def ApplyDefWithTail(sym: Symbol.DefnSym, ds: List[Expr], ct: ExpPosition): Expr =
+    def ApplyDefWithTail(sym: Symbol.DefnSym, ds: List[Exp], ct: ExpPosition): Exp =
       AppWithTail(AsIs(sym.toString), ds, Some(ct))
 
-    def ApplyOp(sym: Symbol.OpSym, ds: List[Expr]): Expr =
+    def ApplyOp(sym: Symbol.OpSym, ds: List[Exp]): Exp =
       Keyword("do", App(AsIs(sym.toString), ds))
 
-    def JavaInvokeMethod(d: Expr, methodName: Name.Ident, ds: List[Expr]): Expr =
+    def JavaInvokeMethod(d: Exp, methodName: Name.Ident, ds: List[Exp]): Exp =
       App(DoubleDot(d, AsIs(methodName.name)), ds)
 
-    def JavaInvokeMethod(m: Method, d: Expr, ds: List[Expr]): Expr =
+    def JavaInvokeMethod(m: Method, d: Exp, ds: List[Exp]): Exp =
       App(DoubleDot(d, AsIs(m.getName)), ds)
 
-    def JavaInvokeStaticMethod(m: Method, ds: List[Expr]): Expr = {
+    def JavaInvokeStaticMethod(m: Method, ds: List[Exp]): Exp = {
       App(Dot(Native(m.getDeclaringClass), AsIs(m.getName)), ds)
     }
 
-    def JavaGetStaticField(f: Field): Expr = {
+    def JavaGetStaticField(f: Field): Exp = {
       Dot(Native(f.getDeclaringClass), AsIs(f.getName))
     }
 
-    def JavaInvokeConstructor(c: Constructor[?], ds: List[Expr]): Expr = {
+    def JavaInvokeConstructor(c: Constructor[?], ds: List[Exp]): Exp = {
       App(Native(c.getDeclaringClass), ds)
     }
 
-    def JavaGetField(f: Field, d: Expr): Expr =
+    def JavaGetField(f: Field, d: Exp): Exp =
       DoubleDot(d, AsIs(f.getName))
 
-    def JavaPutField(f: Field, d1: Expr, d2: Expr): Expr =
+    def JavaPutField(f: Field, d1: Exp, d2: Exp): Exp =
       Assign(DoubleDot(d1, AsIs(f.getName)), d2)
 
-    def JavaPutStaticField(f: Field, d: Expr): Expr =
+    def JavaPutStaticField(f: Field, d: Exp): Exp =
       Assign(Dot(Native(f.getDeclaringClass), AsIs(f.getName)), d)
 
-    def JumpTo(sym: Symbol.LabelSym): Expr =
+    def JumpTo(sym: Symbol.LabelSym): Exp =
       Keyword("goto", AsIs(sym.toString))
 
-    def RecordSelect(label: Name.Label, d: Expr): Expr =
+    def RecordSelect(label: Name.Label, d: Exp): Exp =
       Hash(d, AsIs(label.name))
 
-    def Regex(p: java.util.regex.Pattern): Expr =
+    def Regex(p: java.util.regex.Pattern): Exp =
       App(AsIs("Regex"), List(AsIs(s""""${p.toString}"""")))
 
-    val Absent: Expr =
+    val Absent: Exp =
       AsIs("Absent")
 
   }
@@ -502,11 +502,11 @@ object DocAst {
 
   object Pattern {
 
-    def ExtTag(label: Name.Label, exprs: List[Expr]): Expr =
-      Expr.Tag(Sym(label), exprs)
+    def ExtTag(label: Name.Label, exprs: List[Exp]): Exp =
+      Exp.Tag(Sym(label), exprs)
 
-    def Default: Expr =
-      Expr.Wild
+    def Default: Exp =
+      Exp.Wild
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.dbg
 import ca.uwaterloo.flix.language.ast.shared.{ExpPosition, VarText}
 import ca.uwaterloo.flix.language.dbg.Doc.*
 import ca.uwaterloo.flix.language.dbg.DocAst.*
-import ca.uwaterloo.flix.language.dbg.DocAst.Expr.*
+import ca.uwaterloo.flix.language.dbg.DocAst.Exp.*
 
 import scala.annotation.tailrec
 
@@ -59,18 +59,18 @@ object DocAstFormatter {
         ((sym.namespace: Seq[String], sym.name), d)
     }
     val misc = misc0.map {
-      case (name, expr) =>
+      case (name, exp) =>
         val intro = text("/*") +: sep(breakWith(" "), name.split(" ").toList.map(text)) +: text("*/")
-        val e = format(expr)
+        val e = format(exp)
         intro +: e
     }
     (enums ++ defs).sortBy(_._1).map(_._2) ++ misc
   }
 
-  def format(d: Expr)(implicit i: Indent): Doc =
+  def format(d: Exp)(implicit i: Indent): Doc =
     aux(d, paren = false, inBlock = true)
 
-  private def aux(d0: Expr, paren: Boolean = true, inBlock: Boolean = false)(implicit i: Indent): Doc = {
+  private def aux(d0: Exp, paren: Boolean = true, inBlock: Boolean = false)(implicit i: Indent): Doc = {
     val doc = d0 match {
       case Unit =>
         text("()")
@@ -302,9 +302,9 @@ object DocAstFormatter {
   private def formatAscription(tpe: Option[Type])(implicit i: Indent): Doc =
     tpe.map(t => text(":") +: formatType(t)).getOrElse(empty)
 
-  private def collectLetBinders(d: Expr): (List[LetBinder], Expr) = {
+  private def collectLetBinders(d: Exp): (List[LetBinder], Exp) = {
     @tailrec
-    def chase(d0: Expr, acc: List[LetBinder]): (List[LetBinder], Expr) = {
+    def chase(d0: Exp, acc: List[LetBinder]): (List[LetBinder], Exp) = {
       d0 match {
         case s@Stm(_, d2) =>
           chase(d2, s :: acc)
@@ -319,9 +319,9 @@ object DocAstFormatter {
     chase(d, List())
   }
 
-  private def collectRecordOps(d: Expr): (List[RecordOp], Option[Expr]) = {
+  private def collectRecordOps(d: Exp): (List[RecordOp], Option[Exp]) = {
     @tailrec
-    def chase(d0: Expr, acc: List[RecordOp]): (List[RecordOp], Option[Expr]) = {
+    def chase(d0: Exp, acc: List[RecordOp]): (List[RecordOp], Option[Exp]) = {
       d0 match {
         case re@RecordExtend(_, _, rest) =>
           chase(rest, re :: acc)

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ConstantPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ConstantPrinter.scala
@@ -17,30 +17,30 @@
 package ca.uwaterloo.flix.language.dbg.printer
 
 import ca.uwaterloo.flix.language.ast.shared.Constant
-import ca.uwaterloo.flix.language.dbg.DocAst.Expr
+import ca.uwaterloo.flix.language.dbg.DocAst.Exp
 
 object ConstantPrinter {
 
   /**
-    * Returns the [[Expr]] representation of `cst`.
+    * Returns the [[Exp]] representation of `cst`.
     */
-  def print(cst: Constant): Expr = cst match {
-    case Constant.Unit => Expr.Unit
-    case Constant.Null => Expr.AsIs("null")
-    case Constant.Bool(lit) => Expr.AsIs(lit.toString)
-    case Constant.Char(lit) => Expr.AsIs("'''" + lit.toString + "'''")
-    case Constant.Float32(lit) => Expr.AsIs(s"${lit}f32")
-    case Constant.Float64(lit) => Expr.AsIs(s"${lit}f64")
-    case Constant.BigDecimal(lit) => Expr.AsIs(s"${lit}ff")
-    case Constant.Int8(lit) => Expr.AsIs(s"${lit}i8")
-    case Constant.Int16(lit) => Expr.AsIs(s"${lit}i16")
-    case Constant.Int32(lit) => Expr.AsIs(s"${lit}i32")
-    case Constant.Int64(lit) => Expr.AsIs(s"${lit}i64")
-    case Constant.BigInt(lit) => Expr.AsIs(s"${lit}ii")
-    case Constant.Str(lit) => Expr.AsIs("\"\"\"" + lit + "\"\"\"")
-    case Constant.Regex(lit) => Expr.Regex(lit)
-    case Constant.RecordEmpty => Expr.RecordEmpty
-    case Constant.Static => Expr.AsIs("Static")
+  def print(cst: Constant): Exp = cst match {
+    case Constant.Unit => Exp.Unit
+    case Constant.Null => Exp.AsIs("null")
+    case Constant.Bool(lit) => Exp.AsIs(lit.toString)
+    case Constant.Char(lit) => Exp.AsIs("'''" + lit.toString + "'''")
+    case Constant.Float32(lit) => Exp.AsIs(s"${lit}f32")
+    case Constant.Float64(lit) => Exp.AsIs(s"${lit}f64")
+    case Constant.BigDecimal(lit) => Exp.AsIs(s"${lit}ff")
+    case Constant.Int8(lit) => Exp.AsIs(s"${lit}i8")
+    case Constant.Int16(lit) => Exp.AsIs(s"${lit}i16")
+    case Constant.Int32(lit) => Exp.AsIs(s"${lit}i32")
+    case Constant.Int64(lit) => Exp.AsIs(s"${lit}i64")
+    case Constant.BigInt(lit) => Exp.AsIs(s"${lit}ii")
+    case Constant.Str(lit) => Exp.AsIs("\"\"\"" + lit + "\"\"\"")
+    case Constant.Regex(lit) => Exp.Regex(lit)
+    case Constant.RecordEmpty => Exp.RecordEmpty
+    case Constant.Static => Exp.AsIs("Static")
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -16,7 +16,7 @@
 
 package ca.uwaterloo.flix.language.dbg.printer
 
-import ca.uwaterloo.flix.language.ast.LiftedAst.Expr.*
+import ca.uwaterloo.flix.language.ast.LiftedAst.Exp.*
 import ca.uwaterloo.flix.language.ast.{LiftedAst, Symbol}
 import ca.uwaterloo.flix.language.dbg.DocAst
 import ca.uwaterloo.flix.util.collection.MapOps
@@ -43,46 +43,46 @@ object LiftedAstPrinter {
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `e`.
+    * Returns the [[DocAst.Exp]] representation of `e`.
     */
-  def print(e: LiftedAst.Expr): DocAst.Expr = e match {
+  def print(e: LiftedAst.Exp): DocAst.Exp = e match {
     case Cst(cst, _, _) => ConstantPrinter.print(cst)
     case Var(sym, _, _) => printVarSym(sym)
     case ApplyAtomic(op, exps, tpe, purity, _) => OpPrinter.print(op, exps.map(print), SimpleTypePrinter.print(tpe), PurityPrinter.print(purity))
-    case ApplyClo(exp1, exp2, _, _, _) => DocAst.Expr.ApplyClo(print(exp1), List(print(exp2)))
-    case ApplyDef(sym, args, _, _, _) => DocAst.Expr.ApplyDef(sym, args.map(print))
-    case ApplyOp(sym, exps, _, _, _) => DocAst.Expr.ApplyOp(sym, exps.map(print))
-    case IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Expr.IfThenElse(print(exp1), print(exp2), print(exp3))
-    case Branch(exp, branches, _, _, _) => DocAst.Expr.Branch(print(exp), MapOps.mapValues(branches)(print))
-    case JumpTo(sym, _, _, _) => DocAst.Expr.JumpTo(sym)
-    case Let(sym, exp1, exp2, _, _, _) => DocAst.Expr.Let(printVarSym(sym), Some(SimpleTypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
-    case Stm(exp1, exp2, _, _, _) => DocAst.Expr.Stm(print(exp1), print(exp2))
-    case Region(sym, exp, _, _, _) => DocAst.Expr.Region(printVarSym(sym), print(exp))
-    case TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
+    case ApplyClo(exp1, exp2, _, _, _) => DocAst.Exp.ApplyClo(print(exp1), List(print(exp2)))
+    case ApplyDef(sym, args, _, _, _) => DocAst.Exp.ApplyDef(sym, args.map(print))
+    case ApplyOp(sym, exps, _, _, _) => DocAst.Exp.ApplyOp(sym, exps.map(print))
+    case IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Exp.IfThenElse(print(exp1), print(exp2), print(exp3))
+    case Branch(exp, branches, _, _, _) => DocAst.Exp.Branch(print(exp), MapOps.mapValues(branches)(print))
+    case JumpTo(sym, _, _, _) => DocAst.Exp.JumpTo(sym)
+    case Let(sym, exp1, exp2, _, _, _) => DocAst.Exp.Let(printVarSym(sym), Some(SimpleTypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
+    case Stm(exp1, exp2, _, _, _) => DocAst.Exp.Stm(print(exp1), print(exp2))
+    case Region(sym, exp, _, _, _) => DocAst.Exp.Region(printVarSym(sym), print(exp))
+    case TryCatch(exp, rules, _, _, _) => DocAst.Exp.TryCatch(print(exp), rules.map {
       case LiftedAst.CatchRule(sym, clazz, rexp) => (sym, clazz, print(rexp))
     })
-    case RunWith(exp, effUse, rules, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map {
+    case RunWith(exp, effUse, rules, _, _, _) => DocAst.Exp.RunWithHandler(print(exp), effUse.sym, rules.map {
       case LiftedAst.HandlerRule(symUse, fparams, body) =>
         (symUse.sym, fparams.map(printFormalParam), print(body))
     })
-    case NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expr.NewObject(name, clazz, SimpleTypePrinter.print(tpe), methods.map {
+    case NewObject(name, clazz, tpe, _, methods, _) => DocAst.Exp.NewObject(name, clazz, SimpleTypePrinter.print(tpe), methods.map {
       case LiftedAst.JvmMethod(ident, fparams, clo, retTpe, _, _) =>
         DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(clo), SimpleTypePrinter.print(retTpe))
     })
   }
 
   /**
-    * Returns the [[DocAst.Expr.AscriptionTpe]] representation of `fp`.
+    * Returns the [[DocAst.Exp.AscriptionTpe]] representation of `fp`.
     */
-  private def printFormalParam(fp: LiftedAst.FormalParam): DocAst.Expr.AscriptionTpe = {
+  private def printFormalParam(fp: LiftedAst.FormalParam): DocAst.Exp.AscriptionTpe = {
     val LiftedAst.FormalParam(sym, tpe, _) = fp
-    DocAst.Expr.AscriptionTpe(printVarSym(sym), SimpleTypePrinter.print(tpe))
+    DocAst.Exp.AscriptionTpe(printVarSym(sym), SimpleTypePrinter.print(tpe))
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `sym`.
+    * Returns the [[DocAst.Exp]] representation of `sym`.
     */
-  private def printVarSym(sym: Symbol.VarSym): DocAst.Expr =
-    DocAst.Expr.Var(sym)
+  private def printVarSym(sym: Symbol.VarSym): DocAst.Exp =
+    DocAst.Exp.Var(sym)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.dbg.printer
 
 import ca.uwaterloo.flix.language.ast.{LoweredAst, Symbol}
-import ca.uwaterloo.flix.language.ast.LoweredAst.{Expr, ExtPattern, ExtTagPattern, Pattern}
+import ca.uwaterloo.flix.language.ast.LoweredAst.{Exp, ExtPattern, ExtTagPattern, Pattern}
 import ca.uwaterloo.flix.language.dbg.DocAst
 
 object LoweredAstPrinter {
@@ -49,25 +49,25 @@ object LoweredAstPrinter {
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `e`.
+    * Returns the [[DocAst.Exp]] representation of `e`.
     */
-  def print(e: LoweredAst.Expr): DocAst.Expr = e match {
-    case Expr.Cst(cst, _, _) => ConstantPrinter.print(cst)
-    case Expr.Var(sym, _, _) => DocAst.Expr.Var(sym)
-    case Expr.Lambda(fparam, exp, _, _) => DocAst.Expr.Lambda(List(printFormalParam(fparam)), print(exp))
-    case Expr.ApplyClo(exp1, exp2, _, _, _) => DocAst.Expr.ApplyClo(print(exp1), List(print(exp2)))
-    case Expr.ApplyDef(sym, exps, _, _, _, _, _) => DocAst.Expr.ApplyDef(sym, exps.map(print))
-    case Expr.ApplyLocalDef(sym, exps, _, _, _) => DocAst.Expr.ApplyClo(DocAst.Expr.Var(sym), exps.map(print))
-    case Expr.ApplyOp(op, exps, _, _, _) => DocAst.Expr.ApplyOp(op, exps.map(print))
-    case Expr.ApplySig(sym, exps, _, _, _, _, _, _) => DocAst.Expr.ApplyClo(DocAst.Expr.Sig(sym), exps.map(print))
-    case Expr.ApplyAtomic(op, exps, tpe, eff, _) => OpPrinter.print(op, exps.map(print), TypePrinter.print(tpe), TypePrinter.print(eff))
-    case Expr.Let(sym, exp1, exp2, _, _, _) => DocAst.Expr.Let(DocAst.Expr.Var(sym), None, print(exp1), print(exp2))
-    case Expr.LocalDef(sym, fparams, exp1, exp2, tpe, eff, _) => DocAst.Expr.LocalDef(DocAst.Expr.Var(sym), fparams.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
-    case Expr.Region(sym, _, exp, _, _, _) => DocAst.Expr.Region(DocAst.Expr.Var(sym), print(exp))
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Expr.IfThenElse(print(exp1), print(exp2), print(exp3))
-    case Expr.Stm(exp1, exp2, _, _, _) => DocAst.Expr.Stm(print(exp1), print(exp2))
-    case Expr.Discard(exp, _, _) => DocAst.Expr.Discard(print(exp))
-    case Expr.Match(exp, rules, _, _, _) =>
+  def print(e: LoweredAst.Exp): DocAst.Exp = e match {
+    case Exp.Cst(cst, _, _) => ConstantPrinter.print(cst)
+    case Exp.Var(sym, _, _) => DocAst.Exp.Var(sym)
+    case Exp.Lambda(fparam, exp, _, _) => DocAst.Exp.Lambda(List(printFormalParam(fparam)), print(exp))
+    case Exp.ApplyClo(exp1, exp2, _, _, _) => DocAst.Exp.ApplyClo(print(exp1), List(print(exp2)))
+    case Exp.ApplyDef(sym, exps, _, _, _, _, _) => DocAst.Exp.ApplyDef(sym, exps.map(print))
+    case Exp.ApplyLocalDef(sym, exps, _, _, _) => DocAst.Exp.ApplyClo(DocAst.Exp.Var(sym), exps.map(print))
+    case Exp.ApplyOp(op, exps, _, _, _) => DocAst.Exp.ApplyOp(op, exps.map(print))
+    case Exp.ApplySig(sym, exps, _, _, _, _, _, _) => DocAst.Exp.ApplyClo(DocAst.Exp.Sig(sym), exps.map(print))
+    case Exp.ApplyAtomic(op, exps, tpe, eff, _) => OpPrinter.print(op, exps.map(print), TypePrinter.print(tpe), TypePrinter.print(eff))
+    case Exp.Let(sym, exp1, exp2, _, _, _) => DocAst.Exp.Let(DocAst.Exp.Var(sym), None, print(exp1), print(exp2))
+    case Exp.LocalDef(sym, fparams, exp1, exp2, tpe, eff, _) => DocAst.Exp.LocalDef(DocAst.Exp.Var(sym), fparams.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
+    case Exp.Region(sym, _, exp, _, _, _) => DocAst.Exp.Region(DocAst.Exp.Var(sym), print(exp))
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Exp.IfThenElse(print(exp1), print(exp2), print(exp3))
+    case Exp.Stm(exp1, exp2, _, _, _) => DocAst.Exp.Stm(print(exp1), print(exp2))
+    case Exp.Discard(exp, _, _) => DocAst.Exp.Discard(print(exp))
+    case Exp.Match(exp, rules, _, _, _) =>
       val expD = print(exp)
       val rulesD = rules.map {
         case LoweredAst.MatchRule(pat, guard, body) =>
@@ -76,99 +76,99 @@ object LoweredAstPrinter {
           val bodyD = print(body)
           (patD, guardD, bodyD)
       }
-      DocAst.Expr.Match(expD, rulesD)
-    case Expr.ExtMatch(exp, rules, _, _, _) => DocAst.Expr.ExtMatch(print(exp), rules.map(printExtMatchRule))
-    case Expr.TypeMatch(exp, rules, _, _, _) =>
+      DocAst.Exp.Match(expD, rulesD)
+    case Exp.ExtMatch(exp, rules, _, _, _) => DocAst.Exp.ExtMatch(print(exp), rules.map(printExtMatchRule))
+    case Exp.TypeMatch(exp, rules, _, _, _) =>
       val expD = print(exp)
       val rulesD = rules.map {
         case LoweredAst.TypeMatchRule(sym, tpe, body) =>
-          val patD = DocAst.Expr.Var(sym)
+          val patD = DocAst.Exp.Var(sym)
           val tpeD = TypePrinter.print(tpe)
           val bodyD = print(body)
           (patD, tpeD, bodyD)
       }
-      DocAst.Expr.TypeMatch(expD, rulesD)
-    case Expr.VectorLit(exps, _, _, _) => DocAst.Expr.VectorLit(exps.map(print))
-    case Expr.VectorLoad(exp1, exp2, _, _, _) => DocAst.Expr.VectorLoad(print(exp1), print(exp2))
-    case Expr.VectorLength(exp, _) => DocAst.Expr.ArrayLength(print(exp))
-    case Expr.Ascribe(exp, tpe, _, _) => DocAst.Expr.AscriptionTpe(print(exp), TypePrinter.print(tpe))
-    case Expr.Cast(exp, declaredType, _, _, _, _) => declaredType match {
+      DocAst.Exp.TypeMatch(expD, rulesD)
+    case Exp.VectorLit(exps, _, _, _) => DocAst.Exp.VectorLit(exps.map(print))
+    case Exp.VectorLoad(exp1, exp2, _, _, _) => DocAst.Exp.VectorLoad(print(exp1), print(exp2))
+    case Exp.VectorLength(exp, _) => DocAst.Exp.ArrayLength(print(exp))
+    case Exp.Ascribe(exp, tpe, _, _) => DocAst.Exp.AscriptionTpe(print(exp), TypePrinter.print(tpe))
+    case Exp.Cast(exp, declaredType, _, _, _, _) => declaredType match {
       case None => print(exp) // TODO needs eff
-      case Some(t) => DocAst.Expr.Cast(print(exp), TypePrinter.print(t))
+      case Some(t) => DocAst.Exp.Cast(print(exp), TypePrinter.print(t))
     }
-    case Expr.TryCatch(exp, rules, _, _, _) =>
+    case Exp.TryCatch(exp, rules, _, _, _) =>
       val expD = print(exp)
       val rulesD = rules.map {
         case LoweredAst.CatchRule(sym, clazz, body) => (sym, clazz, print(body))
       }
-      DocAst.Expr.TryCatch(expD, rulesD)
-    case Expr.RunWith(exp, effSymUse, rules, _, _, _) =>
+      DocAst.Exp.TryCatch(expD, rulesD)
+    case Exp.RunWith(exp, effSymUse, rules, _, _, _) =>
       val expD = print(exp)
       val effD = effSymUse.sym
       val rulesD = rules.map {
         case LoweredAst.HandlerRule(opSymUse, fparams, body) => (opSymUse.sym, fparams.map(printFormalParam), print(body))
       }
-      DocAst.Expr.RunWithHandler(expD, effD, rulesD)
-    case Expr.NewObject(name, clazz, tpe, _, methods, _) =>
+      DocAst.Exp.RunWithHandler(expD, effD, rulesD)
+    case Exp.NewObject(name, clazz, tpe, _, methods, _) =>
       val methodsD = methods.map {
         case LoweredAst.JvmMethod(ident, fparams, exp, retTpe, _, _) => DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
       }
-      DocAst.Expr.NewObject(name, clazz, TypePrinter.print(tpe), methodsD)
+      DocAst.Exp.NewObject(name, clazz, TypePrinter.print(tpe), methodsD)
   }
 
   /**
     * Returns the [[DocAst]] representation of `rule`.
     */
-  private def printExtMatchRule(rule: LoweredAst.ExtMatchRule): (DocAst.Expr, DocAst.Expr) = rule match {
+  private def printExtMatchRule(rule: LoweredAst.ExtMatchRule): (DocAst.Exp, DocAst.Exp) = rule match {
     case LoweredAst.ExtMatchRule(pat, exp, _) =>
       (printExtPattern(pat), print(exp))
   }
 
   /**
-    * Converts the given pattern into a [[DocAst.Expr]].
+    * Converts the given pattern into a [[DocAst.Exp]].
     */
-  private def printPattern(pat: LoweredAst.Pattern): DocAst.Expr = pat match {
-    case Pattern.Wild(_, _) => DocAst.Expr.Wild
-    case Pattern.Var(sym, _, _) => DocAst.Expr.Var(sym)
-    case Pattern.Cst(cst, _, _) => DocAst.Expr.Cst(cst)
-    case Pattern.Tag(symUse, pats, _, _) => DocAst.Expr.Tag(symUse.sym, pats.map(printPattern))
-    case Pattern.Tuple(elms, _, _) => DocAst.Expr.Tuple(elms.map(printPattern).toList)
+  private def printPattern(pat: LoweredAst.Pattern): DocAst.Exp = pat match {
+    case Pattern.Wild(_, _) => DocAst.Exp.Wild
+    case Pattern.Var(sym, _, _) => DocAst.Exp.Var(sym)
+    case Pattern.Cst(cst, _, _) => DocAst.Exp.Cst(cst)
+    case Pattern.Tag(symUse, pats, _, _) => DocAst.Exp.Tag(symUse.sym, pats.map(printPattern))
+    case Pattern.Tuple(elms, _, _) => DocAst.Exp.Tuple(elms.map(printPattern).toList)
     case Pattern.Record(pats, rest, _, _) => printRecordPattern(pats, rest)
   }
 
   /**
-    * Converts the record pattern into a [[DocAst.Expr]] by adding a series of [[DocAst.Expr.RecordExtend]] expressions.
+    * Converts the record pattern into a [[DocAst.Exp]] by adding a series of [[DocAst.Exp.RecordExtend]] expressions.
     */
-  private def printRecordPattern(pats: List[LoweredAst.Pattern.Record.RecordLabelPattern], pat: LoweredAst.Pattern): DocAst.Expr = {
+  private def printRecordPattern(pats: List[LoweredAst.Pattern.Record.RecordLabelPattern], pat: LoweredAst.Pattern): DocAst.Exp = {
     pats.foldRight(printPattern(pat)) {
       case (LoweredAst.Pattern.Record.RecordLabelPattern(label, p, _, _), acc) =>
-        DocAst.Expr.RecordExtend(label, printPattern(p), acc)
+        DocAst.Exp.RecordExtend(label, printPattern(p), acc)
     }
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pattern`.
+    * Returns the [[DocAst.Exp]] representation of `pattern`.
     */
-  private def printExtPattern(pattern: LoweredAst.ExtPattern): DocAst.Expr = pattern match {
+  private def printExtPattern(pattern: LoweredAst.ExtPattern): DocAst.Exp = pattern match {
     case ExtPattern.Default(_) => DocAst.Pattern.Default
     case ExtPattern.Tag(label, pats, _) => DocAst.Pattern.ExtTag(label, pats.map(printExtTagPattern))
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pattern`.
+    * Returns the [[DocAst.Exp]] representation of `pattern`.
     */
-  private def printExtTagPattern(pattern: LoweredAst.ExtTagPattern): DocAst.Expr = pattern match {
-    case ExtTagPattern.Wild(_, _) => DocAst.Expr.Wild
-    case ExtTagPattern.Var(sym, _, _) => DocAst.Expr.Var(sym)
-    case ExtTagPattern.Unit(_, _) => DocAst.Expr.Unit
+  private def printExtTagPattern(pattern: LoweredAst.ExtTagPattern): DocAst.Exp = pattern match {
+    case ExtTagPattern.Wild(_, _) => DocAst.Exp.Wild
+    case ExtTagPattern.Var(sym, _, _) => DocAst.Exp.Var(sym)
+    case ExtTagPattern.Unit(_, _) => DocAst.Exp.Unit
   }
 
   /**
-    * Returns the [[DocAst.Expr.AscriptionTpe]] representation of `fp`.
+    * Returns the [[DocAst.Exp.AscriptionTpe]] representation of `fp`.
     */
-  private def printFormalParam(fp: LoweredAst.FormalParam): DocAst.Expr.AscriptionTpe = {
+  private def printFormalParam(fp: LoweredAst.FormalParam): DocAst.Exp.AscriptionTpe = {
     val LoweredAst.FormalParam(sym, tpe, _) = fp
-    DocAst.Expr.AscriptionTpe(DocAst.Expr.Var(sym), TypePrinter.print(tpe))
+    DocAst.Exp.AscriptionTpe(DocAst.Exp.Var(sym), TypePrinter.print(tpe))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -1,7 +1,7 @@
 package ca.uwaterloo.flix.language.dbg.printer
 
 import ca.uwaterloo.flix.language.ast.{MonoAst, Symbol}
-import ca.uwaterloo.flix.language.ast.MonoAst.{Expr, ExtPattern, ExtTagPattern, Pattern}
+import ca.uwaterloo.flix.language.ast.MonoAst.{Exp, ExtPattern, ExtTagPattern, Pattern}
 import ca.uwaterloo.flix.language.dbg.DocAst
 
 object MonoAstPrinter {
@@ -23,30 +23,30 @@ object MonoAstPrinter {
     DocAst.Program(enums, defs, Nil)
   }
 
-  private def print(e: MonoAst.Expr): DocAst.Expr = e match {
-    case Expr.Cst(cst, _, _) => ConstantPrinter.print(cst)
-    case Expr.Var(sym, _, _) => printVar(sym)
-    case Expr.Lambda(fparam, exp, _, _) => DocAst.Expr.Lambda(List(printFormalParam(fparam)), print(exp))
-    case Expr.ApplyAtomic(op, exps, tpe, eff, _) => OpPrinter.print(op, exps.map(print), TypePrinter.print(tpe), TypePrinter.print(eff))
-    case Expr.ApplyClo(exp1, exp2, _, _, _) => DocAst.Expr.App(print(exp1), List(print(exp2)))
-    case Expr.ApplyDef(sym, exps, _, _, _, _) => DocAst.Expr.ApplyDef(sym, exps.map(print))
-    case Expr.ApplyLocalDef(sym, exps, _, _, _) => DocAst.Expr.ApplyLocalDef(sym, exps.map(print))
-    case Expr.ApplyOp(sym, exps, _, _, _) => DocAst.Expr.ApplyOp(sym, exps.map(print))
-    case Expr.Let(sym, exp1, exp2, _, _, _, _) => DocAst.Expr.Let(printVar(sym), Some(TypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
-    case Expr.LocalDef(sym, fparams, exp1, exp2, tpe, eff, _, _) => DocAst.Expr.LocalDef(printVar(sym), fparams.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
-    case Expr.Region(sym, _, exp, _, _, _) => DocAst.Expr.Region(printVar(sym), print(exp))
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Expr.IfThenElse(print(exp1), print(exp2), print(exp3))
-    case Expr.Stm(exp1, exp2, _, _, _) => DocAst.Expr.Stm(print(exp1), print(exp2))
-    case Expr.Discard(exp, _, _) => DocAst.Expr.Discard(print(exp))
-    case Expr.Match(exp, rules, _, _, _) => DocAst.Expr.Match(print(exp), rules.map(printMatchRule))
-    case Expr.ExtMatch(exp, rules, _, _, _) => DocAst.Expr.ExtMatch(print(exp), rules.map(printExtMatchRule))
-    case Expr.VectorLit(exps, _, _, _) => DocAst.Expr.VectorLit(exps.map(print))
-    case Expr.VectorLoad(exp1, exp2, _, _, _) => DocAst.Expr.VectorLoad(print(exp1), print(exp2))
-    case Expr.VectorLength(exp, _) => DocAst.Expr.VectorLength(print(exp))
-    case Expr.Cast(exp, tpe, eff, _) => DocAst.Expr.UncheckedCast(print(exp), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)))
-    case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule))
-    case Expr.RunWith(exp, effUse, rules, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map(printHandlerRule))
-    case Expr.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expr.NewObject(name, clazz, TypePrinter.print(tpe), methods.map(printJvmMethod))
+  private def print(e: MonoAst.Exp): DocAst.Exp = e match {
+    case Exp.Cst(cst, _, _) => ConstantPrinter.print(cst)
+    case Exp.Var(sym, _, _) => printVar(sym)
+    case Exp.Lambda(fparam, exp, _, _) => DocAst.Exp.Lambda(List(printFormalParam(fparam)), print(exp))
+    case Exp.ApplyAtomic(op, exps, tpe, eff, _) => OpPrinter.print(op, exps.map(print), TypePrinter.print(tpe), TypePrinter.print(eff))
+    case Exp.ApplyClo(exp1, exp2, _, _, _) => DocAst.Exp.App(print(exp1), List(print(exp2)))
+    case Exp.ApplyDef(sym, exps, _, _, _, _) => DocAst.Exp.ApplyDef(sym, exps.map(print))
+    case Exp.ApplyLocalDef(sym, exps, _, _, _) => DocAst.Exp.ApplyLocalDef(sym, exps.map(print))
+    case Exp.ApplyOp(sym, exps, _, _, _) => DocAst.Exp.ApplyOp(sym, exps.map(print))
+    case Exp.Let(sym, exp1, exp2, _, _, _, _) => DocAst.Exp.Let(printVar(sym), Some(TypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
+    case Exp.LocalDef(sym, fparams, exp1, exp2, tpe, eff, _, _) => DocAst.Exp.LocalDef(printVar(sym), fparams.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
+    case Exp.Region(sym, _, exp, _, _, _) => DocAst.Exp.Region(printVar(sym), print(exp))
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Exp.IfThenElse(print(exp1), print(exp2), print(exp3))
+    case Exp.Stm(exp1, exp2, _, _, _) => DocAst.Exp.Stm(print(exp1), print(exp2))
+    case Exp.Discard(exp, _, _) => DocAst.Exp.Discard(print(exp))
+    case Exp.Match(exp, rules, _, _, _) => DocAst.Exp.Match(print(exp), rules.map(printMatchRule))
+    case Exp.ExtMatch(exp, rules, _, _, _) => DocAst.Exp.ExtMatch(print(exp), rules.map(printExtMatchRule))
+    case Exp.VectorLit(exps, _, _, _) => DocAst.Exp.VectorLit(exps.map(print))
+    case Exp.VectorLoad(exp1, exp2, _, _, _) => DocAst.Exp.VectorLoad(print(exp1), print(exp2))
+    case Exp.VectorLength(exp, _) => DocAst.Exp.VectorLength(print(exp))
+    case Exp.Cast(exp, tpe, eff, _) => DocAst.Exp.UncheckedCast(print(exp), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)))
+    case Exp.TryCatch(exp, rules, _, _, _) => DocAst.Exp.TryCatch(print(exp), rules.map(printCatchRule))
+    case Exp.RunWith(exp, effUse, rules, _, _, _) => DocAst.Exp.RunWithHandler(print(exp), effUse.sym, rules.map(printHandlerRule))
+    case Exp.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Exp.NewObject(name, clazz, TypePrinter.print(tpe), methods.map(printJvmMethod))
   }
 
   /** Returns the [[DocAst.JvmMethod]] representation of `method`. */
@@ -56,71 +56,71 @@ object MonoAstPrinter {
   }
 
   /** Returns the [[DocAst]] representation of `rule`. */
-  private def printHandlerRule(rule: MonoAst.HandlerRule): (Symbol.OpSym, List[DocAst.Expr.AscriptionTpe], DocAst.Expr) = rule match {
+  private def printHandlerRule(rule: MonoAst.HandlerRule): (Symbol.OpSym, List[DocAst.Exp.AscriptionTpe], DocAst.Exp) = rule match {
     case MonoAst.HandlerRule(op, fparams, exp) => (op.sym, fparams.map(printFormalParam), print(exp))
   }
 
   /** Returns the [[DocAst]] representation of `rule`. */
-  private def printCatchRule(rule: MonoAst.CatchRule): (Symbol.VarSym, Class[?], DocAst.Expr) = rule match {
+  private def printCatchRule(rule: MonoAst.CatchRule): (Symbol.VarSym, Class[?], DocAst.Exp) = rule match {
     case MonoAst.CatchRule(sym, clazz, exp) => (sym, clazz, print(exp))
   }
 
   /** Returns the [[DocAst]] representation of `rule`. */
-  private def printMatchRule(rule: MonoAst.MatchRule): (DocAst.Expr, Option[DocAst.Expr], DocAst.Expr) = rule match {
+  private def printMatchRule(rule: MonoAst.MatchRule): (DocAst.Exp, Option[DocAst.Exp], DocAst.Exp) = rule match {
     case MonoAst.MatchRule(pat, guard, exp) => (printPattern(pat), guard.map(print), print(exp))
   }
 
   /**
     * Returns the [[DocAst]] representation of `rule`.
     */
-  private def printExtMatchRule(rule: MonoAst.ExtMatchRule): (DocAst.Expr, DocAst.Expr) = rule match {
+  private def printExtMatchRule(rule: MonoAst.ExtMatchRule): (DocAst.Exp, DocAst.Exp) = rule match {
     case MonoAst.ExtMatchRule(pat, exp, _) =>
       (printExtPattern(pat), print(exp))
   }
 
-  /** Returns the [[DocAst.Expr]] representation of `pattern`. */
-  private def printPattern(pattern: MonoAst.Pattern): DocAst.Expr = pattern match {
-    case Pattern.Wild(_, _) => DocAst.Expr.Wild
+  /** Returns the [[DocAst.Exp]] representation of `pattern`. */
+  private def printPattern(pattern: MonoAst.Pattern): DocAst.Exp = pattern match {
+    case Pattern.Wild(_, _) => DocAst.Exp.Wild
     case Pattern.Var(sym, _, _, _) => printVar(sym)
     case Pattern.Cst(cst, _, _) => ConstantPrinter.print(cst)
-    case Pattern.Tag(symUse, pats, _, _) => DocAst.Expr.Tag(symUse.sym, pats.map(printPattern))
-    case Pattern.Tuple(elms, _, _) => DocAst.Expr.Tuple(elms.map(printPattern).toList)
+    case Pattern.Tag(symUse, pats, _, _) => DocAst.Exp.Tag(symUse.sym, pats.map(printPattern))
+    case Pattern.Tuple(elms, _, _) => DocAst.Exp.Tuple(elms.map(printPattern).toList)
     case Pattern.Record(pats, pat, _, _) => printRecordPattern(pats, pat)
   }
 
-  /** Returns the [[DocAst.Expr]] representation of `pats`. */
-  private def printRecordPattern(pats: List[Pattern.Record.RecordLabelPattern], pat: Pattern): DocAst.Expr = {
+  /** Returns the [[DocAst.Exp]] representation of `pats`. */
+  private def printRecordPattern(pats: List[Pattern.Record.RecordLabelPattern], pat: Pattern): DocAst.Exp = {
     pats.foldRight(printPattern(pat)) {
       case (MonoAst.Pattern.Record.RecordLabelPattern(label, recordPat, _, _), acc) =>
-        DocAst.Expr.RecordExtend(label, printPattern(recordPat), acc)
+        DocAst.Exp.RecordExtend(label, printPattern(recordPat), acc)
     }
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pattern`.
+    * Returns the [[DocAst.Exp]] representation of `pattern`.
     */
-  private def printExtPattern(pattern: MonoAst.ExtPattern): DocAst.Expr = pattern match {
+  private def printExtPattern(pattern: MonoAst.ExtPattern): DocAst.Exp = pattern match {
     case ExtPattern.Default(_) => DocAst.Pattern.Default
     case ExtPattern.Tag(label, pats, _) => DocAst.Pattern.ExtTag(label, pats.map(printExtTagPattern))
     }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pattern`.
+    * Returns the [[DocAst.Exp]] representation of `pattern`.
     */
-  private def printExtTagPattern(pattern: MonoAst.ExtTagPattern): DocAst.Expr = pattern match {
-    case ExtTagPattern.Wild(_, _) => DocAst.Expr.Wild
-    case ExtTagPattern.Var(sym, _, _, _) => DocAst.Expr.Var(sym)
-    case ExtTagPattern.Unit(_, _) => DocAst.Expr.Unit
+  private def printExtTagPattern(pattern: MonoAst.ExtTagPattern): DocAst.Exp = pattern match {
+    case ExtTagPattern.Wild(_, _) => DocAst.Exp.Wild
+    case ExtTagPattern.Var(sym, _, _, _) => DocAst.Exp.Var(sym)
+    case ExtTagPattern.Unit(_, _) => DocAst.Exp.Unit
   }
 
-  /** Returns the [[DocAst.Expr]] representation of `sym`. */
-  private def printVar(sym: Symbol.VarSym): DocAst.Expr =
-    DocAst.Expr.Var(sym)
+  /** Returns the [[DocAst.Exp]] representation of `sym`. */
+  private def printVar(sym: Symbol.VarSym): DocAst.Exp =
+    DocAst.Exp.Var(sym)
 
-  /** Returns the [[DocAst.Expr.AscriptionTpe]] representation of `fp`. */
-  private def printFormalParam(fp: MonoAst.FormalParam): DocAst.Expr.AscriptionTpe = {
+  /** Returns the [[DocAst.Exp.AscriptionTpe]] representation of `fp`. */
+  private def printFormalParam(fp: MonoAst.FormalParam): DocAst.Exp.AscriptionTpe = {
     val MonoAst.FormalParam(sym, tpe, _, _) = fp
-    DocAst.Expr.AscriptionTpe(DocAst.Expr.Var(sym), TypePrinter.print(tpe))
+    DocAst.Exp.AscriptionTpe(DocAst.Exp.Var(sym), TypePrinter.print(tpe))
   }
 
   /** Returns the [[DocAst.Case]] representation of `caze`. */

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
@@ -19,8 +19,8 @@ package ca.uwaterloo.flix.language.dbg.printer
 import ca.uwaterloo.flix.language.ast.SemanticOp.*
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.dbg.DocAst
-import ca.uwaterloo.flix.language.dbg.DocAst.Expr
-import ca.uwaterloo.flix.language.dbg.DocAst.Expr.*
+import ca.uwaterloo.flix.language.dbg.DocAst.Exp
+import ca.uwaterloo.flix.language.dbg.DocAst.Exp.*
 import ca.uwaterloo.flix.util.collection.ListOps
 
 object OpPrinter {
@@ -164,9 +164,9 @@ object OpPrinter {
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `op`.
+    * Returns the [[DocAst.Exp]] representation of `op`.
     */
-  def print(op: AtomicOp, ds: List[Expr], tpe: DocAst.Type, eff: DocAst.Type): Expr = (op, ds) match {
+  def print(op: AtomicOp, ds: List[Exp], tpe: DocAst.Type, eff: DocAst.Type): Exp = (op, ds) match {
     case (AtomicOp.GetStaticField(field), Nil) => JavaGetStaticField(field)
     case (AtomicOp.HoleError(sym), Nil) => HoleError(sym)
     case (AtomicOp.MatchError, Nil) => MatchError
@@ -186,11 +186,11 @@ object OpPrinter {
     case (AtomicOp.ArrayLength, List(d)) => ArrayLength(d)
     case (AtomicOp.StructNew(sym, fields), d :: rs) =>
       ListOps.zipOption(fields, rs) match {
-        case None => Expr.Unknown
-        case Some(fs) => Expr.StructNew(sym, fs, d)
+        case None => Exp.Unknown
+        case Some(fs) => Exp.StructNew(sym, fs, d)
       }
-    case (AtomicOp.StructGet(field), List(d)) => Expr.StructGet(d, field)
-    case (AtomicOp.StructPut(field), List(d1, d2)) => Expr.StructPut(d1, field, d2)
+    case (AtomicOp.StructGet(field), List(d)) => Exp.StructGet(d, field)
+    case (AtomicOp.StructPut(field), List(d1, d2)) => Exp.StructPut(d1, field, d2)
     case (AtomicOp.Lazy, List(d)) => Lazy(d)
     case (AtomicOp.Force, List(d)) => Force(d)
     case (AtomicOp.GetField(field), List(d)) => JavaGetField(field, d)

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -16,7 +16,7 @@
 
 package ca.uwaterloo.flix.language.dbg.printer
 
-import ca.uwaterloo.flix.language.ast.ReducedAst.Expr
+import ca.uwaterloo.flix.language.ast.ReducedAst.Exp
 import ca.uwaterloo.flix.language.ast.{ReducedAst, Symbol}
 import ca.uwaterloo.flix.language.dbg.DocAst
 import ca.uwaterloo.flix.util.collection.MapOps
@@ -43,45 +43,45 @@ object ReducedAstPrinter {
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `e`.
+    * Returns the [[DocAst.Exp]] representation of `e`.
     */
-  def print(e: ReducedAst.Expr): DocAst.Expr = e match {
-    case Expr.Cst(cst, _) => ConstantPrinter.print(cst)
-    case Expr.Var(sym, _, _) => printVarSym(sym)
-    case Expr.ApplyAtomic(op, exps, tpe, purity, _) => OpPrinter.print(op, exps.map(print), SimpleTypePrinter.print(tpe), PurityPrinter.print(purity))
-    case Expr.ApplyClo(exp1, exp2, ct, _, _, _) => DocAst.Expr.ApplyCloWithTail(print(exp1), List(print(exp2)), ct)
-    case Expr.ApplyDef(sym, exps, ct, _, _, _) => DocAst.Expr.ApplyDefWithTail(sym, exps.map(print), ct)
-    case Expr.ApplyOp(sym, exps, _, _, _) => DocAst.Expr.ApplyOp(sym, exps.map(print))
-    case Expr.ApplySelfTail(sym, actuals, _, _, _) => DocAst.Expr.ApplySelfTail(sym, actuals.map(print))
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Expr.IfThenElse(print(exp1), print(exp2), print(exp3))
-    case Expr.Branch(exp, branches, _, _, _) => DocAst.Expr.Branch(print(exp), MapOps.mapValues(branches)(print))
-    case Expr.JumpTo(sym, _, _, _) => DocAst.Expr.JumpTo(sym)
-    case Expr.Let(sym, exp1, exp2, _) => DocAst.Expr.Let(printVarSym(sym), Some(SimpleTypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
-    case Expr.Stmt(exp1, exp2, _) => DocAst.Expr.Stm(print(exp1), print(exp2))
-    case Expr.Region(sym, exp, _, _, _) => DocAst.Expr.Region(printVarSym(sym), print(exp))
-    case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
+  def print(e: ReducedAst.Exp): DocAst.Exp = e match {
+    case Exp.Cst(cst, _) => ConstantPrinter.print(cst)
+    case Exp.Var(sym, _, _) => printVarSym(sym)
+    case Exp.ApplyAtomic(op, exps, tpe, purity, _) => OpPrinter.print(op, exps.map(print), SimpleTypePrinter.print(tpe), PurityPrinter.print(purity))
+    case Exp.ApplyClo(exp1, exp2, ct, _, _, _) => DocAst.Exp.ApplyCloWithTail(print(exp1), List(print(exp2)), ct)
+    case Exp.ApplyDef(sym, exps, ct, _, _, _) => DocAst.Exp.ApplyDefWithTail(sym, exps.map(print), ct)
+    case Exp.ApplyOp(sym, exps, _, _, _) => DocAst.Exp.ApplyOp(sym, exps.map(print))
+    case Exp.ApplySelfTail(sym, actuals, _, _, _) => DocAst.Exp.ApplySelfTail(sym, actuals.map(print))
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Exp.IfThenElse(print(exp1), print(exp2), print(exp3))
+    case Exp.Branch(exp, branches, _, _, _) => DocAst.Exp.Branch(print(exp), MapOps.mapValues(branches)(print))
+    case Exp.JumpTo(sym, _, _, _) => DocAst.Exp.JumpTo(sym)
+    case Exp.Let(sym, exp1, exp2, _) => DocAst.Exp.Let(printVarSym(sym), Some(SimpleTypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
+    case Exp.Stmt(exp1, exp2, _) => DocAst.Exp.Stm(print(exp1), print(exp2))
+    case Exp.Region(sym, exp, _, _, _) => DocAst.Exp.Region(printVarSym(sym), print(exp))
+    case Exp.TryCatch(exp, rules, _, _, _) => DocAst.Exp.TryCatch(print(exp), rules.map {
       case ReducedAst.CatchRule(sym, clazz, body) => (sym, clazz, print(body))
     })
-    case Expr.RunWith(exp, effUse, rules, _, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map {
+    case Exp.RunWith(exp, effUse, rules, _, _, _, _) => DocAst.Exp.RunWithHandler(print(exp), effUse.sym, rules.map {
       case ReducedAst.HandlerRule(op, fparams, body) =>
         (op.sym, fparams.map(printFormalParam), print(body))
     })
-    case Expr.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expr.NewObject(name, clazz, SimpleTypePrinter.print(tpe), methods.map(printJvmMethod))
+    case Exp.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Exp.NewObject(name, clazz, SimpleTypePrinter.print(tpe), methods.map(printJvmMethod))
   }
 
   /**
-    * Returns the [[DocAst.Expr.AscriptionTpe]] representation of `fp`.
+    * Returns the [[DocAst.Exp.AscriptionTpe]] representation of `fp`.
     */
-  private def printFormalParam(fp: ReducedAst.FormalParam): DocAst.Expr.AscriptionTpe = {
+  private def printFormalParam(fp: ReducedAst.FormalParam): DocAst.Exp.AscriptionTpe = {
     val ReducedAst.FormalParam(sym, tpe) = fp
-    DocAst.Expr.AscriptionTpe(printVarSym(sym), SimpleTypePrinter.print(tpe))
+    DocAst.Exp.AscriptionTpe(printVarSym(sym), SimpleTypePrinter.print(tpe))
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `sym`.
+    * Returns the [[DocAst.Exp]] representation of `sym`.
     */
-  private def printVarSym(sym: Symbol.VarSym): DocAst.Expr =
-    DocAst.Expr.Var(sym)
+  private def printVarSym(sym: Symbol.VarSym): DocAst.Exp =
+    DocAst.Exp.Var(sym)
 
   /**
     * Returns the [[DocAst.JvmMethod]] representation of `method`.

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -16,7 +16,7 @@
 
 package ca.uwaterloo.flix.language.dbg.printer
 
-import ca.uwaterloo.flix.language.ast.ResolvedAst.{Expr, ExtPattern, ExtTagPattern, Pattern}
+import ca.uwaterloo.flix.language.ast.ResolvedAst.{Exp, ExtPattern, ExtTagPattern, Pattern}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{DefSymUse, LocalDefSymUse, SigSymUse}
 import ca.uwaterloo.flix.language.ast.{ResolvedAst, Symbol}
 import ca.uwaterloo.flix.language.dbg.DocAst
@@ -41,145 +41,145 @@ object ResolvedAstPrinter {
     DocAst.Program(Nil, defs, Nil)
   }
 
-  /** Returns the [[DocAst.Expr]] representation of `exp`. */
-  private def print(exp0: ResolvedAst.Expr): DocAst.Expr = exp0 match {
-    case Expr.Var(sym, _) => printVarSym(sym)
-    case Expr.Hole(sym, _, _) => DocAst.Expr.Hole(sym)
-    case Expr.HoleWithExp(exp, _, _) => DocAst.Expr.HoleWithExp(print(exp))
-    case Expr.OpenAs(_, _, _) => DocAst.Expr.Unknown
-    case Expr.Use(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.Cst(cst, _) => ConstantPrinter.print(cst)
-    case Expr.ApplyClo(exp1, exp2, _) => DocAst.Expr.App(print(exp1), List(print(exp2)))
-    case Expr.ApplyDef(DefSymUse(sym, _), exps, _) => DocAst.Expr.ApplyDef(sym, exps.map(print))
-    case Expr.ApplyLocalDef(LocalDefSymUse(sym, _), exps, _) => DocAst.Expr.App(printVarSym(sym), exps.map(print))
-    case Expr.ApplyOp(symUse, exps, _) => DocAst.Expr.ApplyOp(symUse.sym, exps.map(print))
-    case Expr.ApplySig(SigSymUse(sym, _), exps, _) => DocAst.Expr.App(DocAst.Expr.AsIs(sym.name), exps.map(print))
-    case Expr.Lambda(fparam, exp, _, _) => DocAst.Expr.Lambda(List(printFormalParam(fparam)), print(exp))
-    case Expr.Unary(sop, exp, _) => DocAst.Expr.Unary(OpPrinter.print(sop), print(exp))
-    case Expr.Binary(sop, exp1, exp2, _) => DocAst.Expr.Binary(print(exp1), OpPrinter.print(sop), print(exp2))
-    case Expr.IfThenElse(exp1, exp2, exp3, _) => DocAst.Expr.IfThenElse(print(exp1), print(exp2), print(exp3))
-    case Expr.Stm(exp1, exp2, _) => DocAst.Expr.Stm(print(exp1), print(exp2))
-    case Expr.Discard(exp, _) => DocAst.Expr.Discard(print(exp))
-    case Expr.Let(sym, exp1, exp2, _) => DocAst.Expr.Let(printVarSym(sym), None, print(exp1), print(exp2))
-    case Expr.LocalDef(sym, fparams, exp1, exp2, _) => DocAst.Expr.LocalDef(DocAst.Expr.Var(sym), fparams.map(printFormalParam), None, None, print(exp1), print(exp2))
-    case Expr.Region(sym, _, exp, _) => DocAst.Expr.Region(printVarSym(sym), print(exp))
-    case Expr.Match(exp, rules, _) => DocAst.Expr.Match(print(exp), rules.map {
+  /** Returns the [[DocAst.Exp]] representation of `exp`. */
+  private def print(exp0: ResolvedAst.Exp): DocAst.Exp = exp0 match {
+    case Exp.Var(sym, _) => printVarSym(sym)
+    case Exp.Hole(sym, _, _) => DocAst.Exp.Hole(sym)
+    case Exp.HoleWithExp(exp, _, _) => DocAst.Exp.HoleWithExp(print(exp))
+    case Exp.OpenAs(_, _, _) => DocAst.Exp.Unknown
+    case Exp.Use(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.Cst(cst, _) => ConstantPrinter.print(cst)
+    case Exp.ApplyClo(exp1, exp2, _) => DocAst.Exp.App(print(exp1), List(print(exp2)))
+    case Exp.ApplyDef(DefSymUse(sym, _), exps, _) => DocAst.Exp.ApplyDef(sym, exps.map(print))
+    case Exp.ApplyLocalDef(LocalDefSymUse(sym, _), exps, _) => DocAst.Exp.App(printVarSym(sym), exps.map(print))
+    case Exp.ApplyOp(symUse, exps, _) => DocAst.Exp.ApplyOp(symUse.sym, exps.map(print))
+    case Exp.ApplySig(SigSymUse(sym, _), exps, _) => DocAst.Exp.App(DocAst.Exp.AsIs(sym.name), exps.map(print))
+    case Exp.Lambda(fparam, exp, _, _) => DocAst.Exp.Lambda(List(printFormalParam(fparam)), print(exp))
+    case Exp.Unary(sop, exp, _) => DocAst.Exp.Unary(OpPrinter.print(sop), print(exp))
+    case Exp.Binary(sop, exp1, exp2, _) => DocAst.Exp.Binary(print(exp1), OpPrinter.print(sop), print(exp2))
+    case Exp.IfThenElse(exp1, exp2, exp3, _) => DocAst.Exp.IfThenElse(print(exp1), print(exp2), print(exp3))
+    case Exp.Stm(exp1, exp2, _) => DocAst.Exp.Stm(print(exp1), print(exp2))
+    case Exp.Discard(exp, _) => DocAst.Exp.Discard(print(exp))
+    case Exp.Let(sym, exp1, exp2, _) => DocAst.Exp.Let(printVarSym(sym), None, print(exp1), print(exp2))
+    case Exp.LocalDef(sym, fparams, exp1, exp2, _) => DocAst.Exp.LocalDef(DocAst.Exp.Var(sym), fparams.map(printFormalParam), None, None, print(exp1), print(exp2))
+    case Exp.Region(sym, _, exp, _) => DocAst.Exp.Region(printVarSym(sym), print(exp))
+    case Exp.Match(exp, rules, _) => DocAst.Exp.Match(print(exp), rules.map {
       case ResolvedAst.MatchRule(pat, guard, body, _) => (printPattern(pat), guard.map(print), print(body))
     })
-    case Expr.TypeMatch(exp, rules, _) => DocAst.Expr.TypeMatch(print(exp), rules.map {
+    case Exp.TypeMatch(exp, rules, _) => DocAst.Exp.TypeMatch(print(exp), rules.map {
       case ResolvedAst.TypeMatchRule(sym, tpe, body, _) => (printVarSym(sym), UnkindedTypePrinter.print(tpe), print(body))
     })
-    case Expr.RestrictableChoose(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.ExtMatch(exp, rules, _) => DocAst.Expr.ExtMatch(print(exp), rules.map(printExtMatchRule))
-    case Expr.Tag(symUse, exps, _) => DocAst.Expr.Tag(symUse.sym, exps.map(print))
-    case Expr.RestrictableTag(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.ExtTag(label, exps, _) => DocAst.Expr.ExtTag(label, exps.map(print))
-    case Expr.Tuple(exps, _) => DocAst.Expr.Tuple(exps.map(print))
-    case Expr.RecordSelect(exp, label, _) => DocAst.Expr.RecordSelect(label, print(exp))
-    case Expr.RecordExtend(label, value, rest, _) => DocAst.Expr.RecordExtend(label, print(value), print(rest))
-    case Expr.RecordRestrict(label, rest, _) => DocAst.Expr.RecordRestrict(label, print(rest))
-    case Expr.ArrayLit(exps, exp, _) => DocAst.Expr.InRegion(DocAst.Expr.ArrayLit(exps.map(print)), print(exp))
-    case Expr.ArrayNew(exp1, exp2, exp3, _) => DocAst.Expr.InRegion(DocAst.Expr.ArrayNew(print(exp1), print(exp2)), print(exp3))
-    case Expr.ArrayLoad(base, index, _) => DocAst.Expr.ArrayLoad(print(base), print(index))
-    case Expr.ArrayStore(base, index, elm, _) => DocAst.Expr.ArrayStore(print(base), print(index), print(elm))
-    case Expr.ArrayLength(base, _) => DocAst.Expr.ArrayLength(print(base))
-    case Expr.StructNew(sym, exps, region, _) => DocAst.Expr.StructNew(sym, exps.map {
+    case Exp.RestrictableChoose(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.ExtMatch(exp, rules, _) => DocAst.Exp.ExtMatch(print(exp), rules.map(printExtMatchRule))
+    case Exp.Tag(symUse, exps, _) => DocAst.Exp.Tag(symUse.sym, exps.map(print))
+    case Exp.RestrictableTag(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.ExtTag(label, exps, _) => DocAst.Exp.ExtTag(label, exps.map(print))
+    case Exp.Tuple(exps, _) => DocAst.Exp.Tuple(exps.map(print))
+    case Exp.RecordSelect(exp, label, _) => DocAst.Exp.RecordSelect(label, print(exp))
+    case Exp.RecordExtend(label, value, rest, _) => DocAst.Exp.RecordExtend(label, print(value), print(rest))
+    case Exp.RecordRestrict(label, rest, _) => DocAst.Exp.RecordRestrict(label, print(rest))
+    case Exp.ArrayLit(exps, exp, _) => DocAst.Exp.InRegion(DocAst.Exp.ArrayLit(exps.map(print)), print(exp))
+    case Exp.ArrayNew(exp1, exp2, exp3, _) => DocAst.Exp.InRegion(DocAst.Exp.ArrayNew(print(exp1), print(exp2)), print(exp3))
+    case Exp.ArrayLoad(base, index, _) => DocAst.Exp.ArrayLoad(print(base), print(index))
+    case Exp.ArrayStore(base, index, elm, _) => DocAst.Exp.ArrayStore(print(base), print(index), print(elm))
+    case Exp.ArrayLength(base, _) => DocAst.Exp.ArrayLength(print(base))
+    case Exp.StructNew(sym, exps, region, _) => DocAst.Exp.StructNew(sym, exps.map {
       case (symUse, exp) => (symUse.sym, print(exp))
     }, print(region))
-    case Expr.StructGet(exp, symUse, _) => DocAst.Expr.StructGet(print(exp), symUse.sym)
-    case Expr.StructPut(exp1, symUse, exp2, _) => DocAst.Expr.StructPut(print(exp1), symUse.sym, print(exp2))
-    case Expr.VectorLit(exps, _) => DocAst.Expr.VectorLit(exps.map(print))
-    case Expr.VectorLoad(exp1, exp2, _) => DocAst.Expr.VectorLoad(print(exp1), print(exp2))
-    case Expr.VectorLength(exp, _) => DocAst.Expr.VectorLength(print(exp))
-    case Expr.Ascribe(exp, tpe, eff, _) => DocAst.Expr.AscriptionEff(print(exp), tpe.map(UnkindedTypePrinter.print), eff.map(UnkindedTypePrinter.print))
-    case Expr.InstanceOf(exp, clazz, _) => DocAst.Expr.InstanceOf(print(exp), clazz)
-    case Expr.CheckedCast(cast, exp, _) => DocAst.Expr.CheckedCast(cast, print(exp))
-    case Expr.UncheckedCast(exp, tpe, eff, _) => DocAst.Expr.UncheckedCast(print(exp), tpe.map(UnkindedTypePrinter.print), eff.map(UnkindedTypePrinter.print))
-    case Expr.Unsafe(exp, runEff, _) => DocAst.Expr.Unsafe(print(exp), UnkindedTypePrinter.print(runEff))
-    case Expr.Without(exp, symUse, _) => DocAst.Expr.Without(print(exp), symUse.sym)
-    case Expr.TryCatch(exp, rules, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
+    case Exp.StructGet(exp, symUse, _) => DocAst.Exp.StructGet(print(exp), symUse.sym)
+    case Exp.StructPut(exp1, symUse, exp2, _) => DocAst.Exp.StructPut(print(exp1), symUse.sym, print(exp2))
+    case Exp.VectorLit(exps, _) => DocAst.Exp.VectorLit(exps.map(print))
+    case Exp.VectorLoad(exp1, exp2, _) => DocAst.Exp.VectorLoad(print(exp1), print(exp2))
+    case Exp.VectorLength(exp, _) => DocAst.Exp.VectorLength(print(exp))
+    case Exp.Ascribe(exp, tpe, eff, _) => DocAst.Exp.AscriptionEff(print(exp), tpe.map(UnkindedTypePrinter.print), eff.map(UnkindedTypePrinter.print))
+    case Exp.InstanceOf(exp, clazz, _) => DocAst.Exp.InstanceOf(print(exp), clazz)
+    case Exp.CheckedCast(cast, exp, _) => DocAst.Exp.CheckedCast(cast, print(exp))
+    case Exp.UncheckedCast(exp, tpe, eff, _) => DocAst.Exp.UncheckedCast(print(exp), tpe.map(UnkindedTypePrinter.print), eff.map(UnkindedTypePrinter.print))
+    case Exp.Unsafe(exp, runEff, _) => DocAst.Exp.Unsafe(print(exp), UnkindedTypePrinter.print(runEff))
+    case Exp.Without(exp, symUse, _) => DocAst.Exp.Without(print(exp), symUse.sym)
+    case Exp.TryCatch(exp, rules, _) => DocAst.Exp.TryCatch(print(exp), rules.map {
       case ResolvedAst.CatchRule(sym, clazz, body, _) => (sym, clazz, print(body))
     })
-    case Expr.Throw(exp, _) => DocAst.Expr.Throw(print(exp))
-    case Expr.Handler(symUse, rules, _) => DocAst.Expr.Handler(symUse.sym, rules.map {
+    case Exp.Throw(exp, _) => DocAst.Exp.Throw(print(exp))
+    case Exp.Handler(symUse, rules, _) => DocAst.Exp.Handler(symUse.sym, rules.map {
       case ResolvedAst.HandlerRule(opSymUse, fparams, exp, _) => (opSymUse.sym, fparams.map(printFormalParam), print(exp))
     })
-    case Expr.RunWith(exp1, exp2, _) => DocAst.Expr.RunWith(print(exp1), print(exp2))
-    case Expr.InvokeConstructor(_, _, _) => DocAst.Expr.Unknown
-    case Expr.InvokeMethod(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.InvokeStaticMethod(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.GetField(_, _, _) => DocAst.Expr.Unknown
-    case Expr.PutField(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.GetStaticField(_, _) => DocAst.Expr.Unknown
-    case Expr.PutStaticField(_, _, _) => DocAst.Expr.Unknown
-    case Expr.NewObject(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.NewChannel(_, _) => DocAst.Expr.Unknown
-    case Expr.GetChannel(_, _) => DocAst.Expr.Unknown
-    case Expr.PutChannel(_, _, _) => DocAst.Expr.Unknown
-    case Expr.SelectChannel(_, _, _) => DocAst.Expr.Unknown
-    case Expr.Spawn(_, _, _) => DocAst.Expr.Unknown
-    case Expr.ParYield(_, _, _) => DocAst.Expr.Unknown
-    case Expr.Lazy(_, _) => DocAst.Expr.Unknown
-    case Expr.Force(_, _) => DocAst.Expr.Unknown
-    case Expr.FixpointConstraintSet(_, _) => DocAst.Expr.Unknown
-    case Expr.FixpointLambda(_, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointMerge(_, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointQueryWithProvenance(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointQueryWithSelect(_, _, _, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointSolveWithProject(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointInjectInto(_, _, _) => DocAst.Expr.Unknown
-    case Expr.Error(_) => DocAst.Expr.Error
+    case Exp.RunWith(exp1, exp2, _) => DocAst.Exp.RunWith(print(exp1), print(exp2))
+    case Exp.InvokeConstructor(_, _, _) => DocAst.Exp.Unknown
+    case Exp.InvokeMethod(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.InvokeStaticMethod(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.GetField(_, _, _) => DocAst.Exp.Unknown
+    case Exp.PutField(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.GetStaticField(_, _) => DocAst.Exp.Unknown
+    case Exp.PutStaticField(_, _, _) => DocAst.Exp.Unknown
+    case Exp.NewObject(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.NewChannel(_, _) => DocAst.Exp.Unknown
+    case Exp.GetChannel(_, _) => DocAst.Exp.Unknown
+    case Exp.PutChannel(_, _, _) => DocAst.Exp.Unknown
+    case Exp.SelectChannel(_, _, _) => DocAst.Exp.Unknown
+    case Exp.Spawn(_, _, _) => DocAst.Exp.Unknown
+    case Exp.ParYield(_, _, _) => DocAst.Exp.Unknown
+    case Exp.Lazy(_, _) => DocAst.Exp.Unknown
+    case Exp.Force(_, _) => DocAst.Exp.Unknown
+    case Exp.FixpointConstraintSet(_, _) => DocAst.Exp.Unknown
+    case Exp.FixpointLambda(_, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointMerge(_, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointQueryWithProvenance(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointQueryWithSelect(_, _, _, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointSolveWithProject(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointInjectInto(_, _, _) => DocAst.Exp.Unknown
+    case Exp.Error(_) => DocAst.Exp.Error
   }
 
   /**
     * Returns the [[DocAst]] representation of `rule`.
     */
-  private def printExtMatchRule(rule: ResolvedAst.ExtMatchRule): (DocAst.Expr, DocAst.Expr) = rule match {
+  private def printExtMatchRule(rule: ResolvedAst.ExtMatchRule): (DocAst.Exp, DocAst.Exp) = rule match {
     case ResolvedAst.ExtMatchRule(pat, exp, _) =>
       (printExtPattern(pat), print(exp))
   }
 
-  /** Returns the [[DocAst.Expr]] representation of `pat`. */
-  private def printPattern(pat: ResolvedAst.Pattern): DocAst.Expr = pat match {
-    case Pattern.Wild(_) => DocAst.Expr.Wild
+  /** Returns the [[DocAst.Exp]] representation of `pat`. */
+  private def printPattern(pat: ResolvedAst.Pattern): DocAst.Exp = pat match {
+    case Pattern.Wild(_) => DocAst.Exp.Wild
     case Pattern.Var(sym, _) => printVarSym(sym)
     case Pattern.Cst(cst, _) => ConstantPrinter.print(cst)
-    case Pattern.Tag(symUse, pats, _) => DocAst.Expr.Tag(symUse.sym, pats.map(printPattern))
-    case Pattern.Tuple(pats, _) => DocAst.Expr.Tuple(pats.map(printPattern).toList)
-    case Pattern.Record(_, _, _) => DocAst.Expr.Unknown
-    case Pattern.Error(_) => DocAst.Expr.Error
+    case Pattern.Tag(symUse, pats, _) => DocAst.Exp.Tag(symUse.sym, pats.map(printPattern))
+    case Pattern.Tuple(pats, _) => DocAst.Exp.Tuple(pats.map(printPattern).toList)
+    case Pattern.Record(_, _, _) => DocAst.Exp.Unknown
+    case Pattern.Error(_) => DocAst.Exp.Error
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pat`.
+    * Returns the [[DocAst.Exp]] representation of `pat`.
     */
-  private def printExtPattern(pat: ResolvedAst.ExtPattern): DocAst.Expr = pat match {
-    case ExtPattern.Default(_) => DocAst.Expr.Wild
+  private def printExtPattern(pat: ResolvedAst.ExtPattern): DocAst.Exp = pat match {
+    case ExtPattern.Default(_) => DocAst.Exp.Wild
     case ExtPattern.Tag(label, pats, _) => DocAst.Pattern.ExtTag(label, pats.map(printExtTagPattern))
-    case ExtPattern.Error(_) => DocAst.Expr.Error
+    case ExtPattern.Error(_) => DocAst.Exp.Error
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pat`.
+    * Returns the [[DocAst.Exp]] representation of `pat`.
     */
-  private def printExtTagPattern(pat: ResolvedAst.ExtTagPattern): DocAst.Expr = pat match {
-    case ExtTagPattern.Wild(_) => DocAst.Expr.Wild
-    case ExtTagPattern.Var(sym, _) => DocAst.Expr.Var(sym)
-    case ExtTagPattern.Unit(_) => DocAst.Expr.Unit
-    case ExtTagPattern.Error(_) => DocAst.Expr.Error
+  private def printExtTagPattern(pat: ResolvedAst.ExtTagPattern): DocAst.Exp = pat match {
+    case ExtTagPattern.Wild(_) => DocAst.Exp.Wild
+    case ExtTagPattern.Var(sym, _) => DocAst.Exp.Var(sym)
+    case ExtTagPattern.Unit(_) => DocAst.Exp.Unit
+    case ExtTagPattern.Error(_) => DocAst.Exp.Error
   }
 
-  /** Returns the [[DocAst.Expr.AscriptionTpe]] representation of `fp`. */
-  private def printFormalParam(fp: ResolvedAst.FormalParam): DocAst.Expr.AscriptionTpe = fp match {
+  /** Returns the [[DocAst.Exp.AscriptionTpe]] representation of `fp`. */
+  private def printFormalParam(fp: ResolvedAst.FormalParam): DocAst.Exp.AscriptionTpe = fp match {
     case ResolvedAst.FormalParam(sym, Some(tpe), _) =>
-      DocAst.Expr.AscriptionTpe(printVarSym(sym), UnkindedTypePrinter.print(tpe))
+      DocAst.Exp.AscriptionTpe(printVarSym(sym), UnkindedTypePrinter.print(tpe))
     case ResolvedAst.FormalParam(sym, None, _) =>
-      DocAst.Expr.AscriptionTpe(printVarSym(sym), DocAst.Type.Wild)
+      DocAst.Exp.AscriptionTpe(printVarSym(sym), DocAst.Type.Wild)
   }
 
-  /** Returns the [[DocAst.Expr]] representation of `sym`. */
-  private def printVarSym(sym: Symbol.VarSym): DocAst.Expr =
-    DocAst.Expr.Var(sym)
+  /** Returns the [[DocAst.Exp]] representation of `sym`. */
+  private def printVarSym(sym: Symbol.VarSym): DocAst.Exp =
+    DocAst.Exp.Var(sym)
 
 
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -16,7 +16,7 @@
 
 package ca.uwaterloo.flix.language.dbg.printer
 
-import ca.uwaterloo.flix.language.ast.SimplifiedAst.Expr.*
+import ca.uwaterloo.flix.language.ast.SimplifiedAst.Exp.*
 import ca.uwaterloo.flix.language.ast.{SimplifiedAst, Symbol}
 import ca.uwaterloo.flix.language.dbg.DocAst
 import ca.uwaterloo.flix.util.collection.MapOps
@@ -43,51 +43,51 @@ object SimplifiedAstPrinter {
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `e`.
+    * Returns the [[DocAst.Exp]] representation of `e`.
     */
-  def print(e: SimplifiedAst.Expr): DocAst.Expr = e match {
+  def print(e: SimplifiedAst.Exp): DocAst.Exp = e match {
     case Cst(cst, _, _) => ConstantPrinter.print(cst)
     case Var(sym, _, _) => printVarSym(sym)
-    case Lambda(fparams, exp, _, _) => DocAst.Expr.Lambda(fparams.map(printFormalParam), print(exp))
-    case LambdaClosure(cparams, fparams, _, exp, _, _) => DocAst.Expr.Lambda((cparams ++ fparams).map(printFormalParam), print(exp))
+    case Lambda(fparams, exp, _, _) => DocAst.Exp.Lambda(fparams.map(printFormalParam), print(exp))
+    case LambdaClosure(cparams, fparams, _, exp, _, _) => DocAst.Exp.Lambda((cparams ++ fparams).map(printFormalParam), print(exp))
     case ApplyAtomic(op, exps, tpe, purity, _) => OpPrinter.print(op, exps.map(print), SimpleTypePrinter.print(tpe), PurityPrinter.print(purity))
-    case ApplyClo(exp1, exp2, _, _, _) => DocAst.Expr.ApplyClo(print(exp1), List(print(exp2)))
-    case ApplyDef(sym, exps, _, _, _) => DocAst.Expr.ApplyDef(sym, exps.map(print))
-    case ApplyOp(sym, exps, _, _, _) => DocAst.Expr.ApplyOp(sym, exps.map(print))
-    case ApplyLocalDef(sym, exps, _, _, _) => DocAst.Expr.ApplyClo(printVarSym(sym), exps.map(print))
-    case IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Expr.IfThenElse(print(exp1), print(exp2), print(exp3))
-    case Stm(exp1, exp2, _, _, _) => DocAst.Expr.Stm(print(exp1), print(exp2))
-    case Branch(exp, branches, _, _, _) => DocAst.Expr.Branch(print(exp), MapOps.mapValues(branches)(print))
-    case JumpTo(sym, _, _, _) => DocAst.Expr.JumpTo(sym)
-    case Let(sym, exp1, exp2, _, _, _) => DocAst.Expr.Let(printVarSym(sym), Some(SimpleTypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
-    case LocalDef(sym, fparams, exp1, exp2, tpe, eff, _) => DocAst.Expr.LocalDef(printVarSym(sym), fparams.map(printFormalParam), Some(SimpleTypePrinter.print(tpe)), Some(PurityPrinter.print(eff)), print(exp1), print(exp2))
-    case Region(sym, exp, _, _, _) => DocAst.Expr.Region(printVarSym(sym), print(exp))
-    case TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
+    case ApplyClo(exp1, exp2, _, _, _) => DocAst.Exp.ApplyClo(print(exp1), List(print(exp2)))
+    case ApplyDef(sym, exps, _, _, _) => DocAst.Exp.ApplyDef(sym, exps.map(print))
+    case ApplyOp(sym, exps, _, _, _) => DocAst.Exp.ApplyOp(sym, exps.map(print))
+    case ApplyLocalDef(sym, exps, _, _, _) => DocAst.Exp.ApplyClo(printVarSym(sym), exps.map(print))
+    case IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Exp.IfThenElse(print(exp1), print(exp2), print(exp3))
+    case Stm(exp1, exp2, _, _, _) => DocAst.Exp.Stm(print(exp1), print(exp2))
+    case Branch(exp, branches, _, _, _) => DocAst.Exp.Branch(print(exp), MapOps.mapValues(branches)(print))
+    case JumpTo(sym, _, _, _) => DocAst.Exp.JumpTo(sym)
+    case Let(sym, exp1, exp2, _, _, _) => DocAst.Exp.Let(printVarSym(sym), Some(SimpleTypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
+    case LocalDef(sym, fparams, exp1, exp2, tpe, eff, _) => DocAst.Exp.LocalDef(printVarSym(sym), fparams.map(printFormalParam), Some(SimpleTypePrinter.print(tpe)), Some(PurityPrinter.print(eff)), print(exp1), print(exp2))
+    case Region(sym, exp, _, _, _) => DocAst.Exp.Region(printVarSym(sym), print(exp))
+    case TryCatch(exp, rules, _, _, _) => DocAst.Exp.TryCatch(print(exp), rules.map {
       case SimplifiedAst.CatchRule(sym, clazz, body) =>
         (sym, clazz, print(body))
     })
-    case RunWith(exp, effUse, rules, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map {
+    case RunWith(exp, effUse, rules, _, _, _) => DocAst.Exp.RunWithHandler(print(exp), effUse.sym, rules.map {
       case SimplifiedAst.HandlerRule(op, fparams, body) =>
         (op.sym, fparams.map(printFormalParam), print(body))
     })
-    case NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expr.NewObject(name, clazz, SimpleTypePrinter.print(tpe), methods.map {
+    case NewObject(name, clazz, tpe, _, methods, _) => DocAst.Exp.NewObject(name, clazz, SimpleTypePrinter.print(tpe), methods.map {
       case SimplifiedAst.JvmMethod(ident, fparams, exp, retTpe, _, _) =>
         DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(exp), SimpleTypePrinter.print(retTpe))
     })
   }
 
   /**
-    * Returns the [[DocAst.Expr.AscriptionTpe]] representation of `fp`.
+    * Returns the [[DocAst.Exp.AscriptionTpe]] representation of `fp`.
     */
-  private def printFormalParam(fp: SimplifiedAst.FormalParam): DocAst.Expr.AscriptionTpe = {
+  private def printFormalParam(fp: SimplifiedAst.FormalParam): DocAst.Exp.AscriptionTpe = {
     val SimplifiedAst.FormalParam(sym, tpe, _) = fp
-    DocAst.Expr.AscriptionTpe(printVarSym(sym), SimpleTypePrinter.print(tpe))
+    DocAst.Exp.AscriptionTpe(printVarSym(sym), SimpleTypePrinter.print(tpe))
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `sym`.
+    * Returns the [[DocAst.Exp]] representation of `sym`.
     */
-  private def printVarSym(sym: Symbol.VarSym): DocAst.Expr =
-    DocAst.Expr.Var(sym)
+  private def printVarSym(sym: Symbol.VarSym): DocAst.Exp =
+    DocAst.Exp.Var(sym)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SyntaxTreePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SyntaxTreePrinter.scala
@@ -14,29 +14,29 @@ object SyntaxTreePrinter {
     DocAst.Program(Nil, Nil, units)
   }
 
-  private def print(tree: SyntaxTree.Tree): DocAst.Expr = {
+  private def print(tree: SyntaxTree.Tree): DocAst.Exp = {
     val SyntaxTree.Tree(kind, children, _) = tree
     kind match {
       // ErrorTree is not a case object, so we can't rely on the generated `toString`.
       case TreeKind.ErrorTree(_) =>
-        DocAst.Expr.App(DocAst.Expr.AsIs("ErrorTree"), children.iterator.map(print).toList)
+        DocAst.Exp.App(DocAst.Exp.AsIs("ErrorTree"), children.iterator.map(print).toList)
       case other =>
-        DocAst.Expr.App(DocAst.Expr.AsIs(other.toString), children.iterator.map(print).toList)
+        DocAst.Exp.App(DocAst.Exp.AsIs(other.toString), children.iterator.map(print).toList)
     }
   }
 
-  private def print(token: Token): DocAst.Expr = token.kind match {
+  private def print(token: Token): DocAst.Exp = token.kind match {
     // Err is not a case object, so we can't rely on the generated `toString`.
     case TokenKind.Err(_) =>
-      DocAst.Expr.SquareApp(DocAst.Expr.AsIs("Err"), List(DocAst.Expr.AsIs(s"\"${token.text}\"")))
+      DocAst.Exp.SquareApp(DocAst.Exp.AsIs("Err"), List(DocAst.Exp.AsIs(s"\"${token.text}\"")))
     case other =>
-      DocAst.Expr.SquareApp(DocAst.Expr.AsIs(other.toString), List(DocAst.Expr.AsIs(s"\"${token.text}\"")))
+      DocAst.Exp.SquareApp(DocAst.Exp.AsIs(other.toString), List(DocAst.Exp.AsIs(s"\"${token.text}\"")))
   }
 
-  private def print(child: SyntaxTree.Child): DocAst.Expr = child match {
+  private def print(child: SyntaxTree.Child): DocAst.Exp = child match {
     case token: Token => print(token)
     case tree: SyntaxTree.Tree => print(tree)
-    case _ => DocAst.Expr.Unknown
+    case _ => DocAst.Exp.Unknown
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TokenPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TokenPrinter.scala
@@ -27,15 +27,15 @@ object TokenPrinter {
     DocAst.Program(Nil, Nil, files)
   }
 
-  private def print(tokens: Array[Token]): DocAst.Expr = {
+  private def print(tokens: Array[Token]): DocAst.Exp = {
     val printedTokens = tokens.iterator.map(print).toList
-    DocAst.Expr.App(DocAst.Expr.AsIs("Tokens"), printedTokens)
+    DocAst.Exp.App(DocAst.Exp.AsIs("Tokens"), printedTokens)
   }
 
-  private def print(token: Token): DocAst.Expr = {
+  private def print(token: Token): DocAst.Exp = {
     val kindString = token.kind.getClass.getSimpleName.replace("$", "")
     val contentString = printContent(token)
-    DocAst.Expr.AsIs(s"$kindString($contentString)")
+    DocAst.Exp.AsIs(s"$kindString($contentString)")
   }
 
   private def printContent(token: Token): String = {

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -1,7 +1,7 @@
 package ca.uwaterloo.flix.language.dbg.printer
 
 import ca.uwaterloo.flix.language.ast.TypedAst.Pattern.Record
-import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, ExtPattern, ExtTagPattern, Pattern}
+import ca.uwaterloo.flix.language.ast.TypedAst.{Exp, ExtPattern, ExtTagPattern, Pattern}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{DefSymUse, LocalDefSymUse, SigSymUse}
 import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
 import ca.uwaterloo.flix.language.dbg.DocAst
@@ -24,85 +24,85 @@ object TypedAstPrinter {
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `e`.
+    * Returns the [[DocAst.Exp]] representation of `e`.
     */
-  private def print(e: TypedAst.Expr): DocAst.Expr = e match {
-    case Expr.Cst(cst, _, _) => ConstantPrinter.print(cst)
-    case Expr.Var(sym, _, _) => printVar(sym)
-    case Expr.Hole(sym, _, _, _, _) => DocAst.Expr.Hole(sym)
-    case Expr.HoleWithExp(exp, _, _, _, _) => DocAst.Expr.HoleWithExp(print(exp))
-    case Expr.OpenAs(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.Use(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.Lambda(fparam, exp, _, _) => DocAst.Expr.Lambda(List(printFormalParam(fparam)), print(exp))
-    case Expr.ApplyClo(exp1, exp2, _, _, _) => DocAst.Expr.App(print(exp1), List(print(exp2)))
-    case Expr.ApplyDef(DefSymUse(sym, _), exps, _, _, _, _, _) => DocAst.Expr.ApplyDef(sym, exps.map(print))
-    case Expr.ApplyLocalDef(LocalDefSymUse(sym, _), exps, _, _, _, _) => DocAst.Expr.App(DocAst.Expr.Var(sym), exps.map(print))
-    case Expr.ApplyOp(op, exps, _, _, _) => DocAst.Expr.ApplyOp(op.sym, exps.map(print))
-    case Expr.ApplySig(SigSymUse(sym, _), exps, _, _, _, _, _, _) => DocAst.Expr.App(DocAst.Expr.AsIs(sym.name), exps.map(print))
-    case Expr.Unary(sop, exp, _, _, _) => DocAst.Expr.Unary(OpPrinter.print(sop), print(exp))
-    case Expr.Binary(sop, exp1, exp2, _, _, _) => DocAst.Expr.Binary(print(exp1), OpPrinter.print(sop), print(exp2))
-    case Expr.Let(bnd, exp1, exp2, _, _, _) => DocAst.Expr.Let(printVar(bnd.sym), Some(TypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
-    case Expr.LocalDef(TypedAst.Binder(sym, _), fparams, exp1, exp2, tpe, eff, _) => DocAst.Expr.LocalDef(printVar(sym), fparams.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
-    case Expr.Region(TypedAst.Binder(sym, _), _, exp, _, _, _) => DocAst.Expr.Region(printVar(sym), print(exp))
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Expr.IfThenElse(print(exp1), print(exp2), print(exp3))
-    case Expr.Stm(exp1, exp2, _, _, _) => DocAst.Expr.Stm(print(exp1), print(exp2))
-    case Expr.Discard(exp, _, _) => DocAst.Expr.Discard(print(exp))
-    case Expr.Match(exp, rules, _, _, _) => DocAst.Expr.Match(print(exp), rules.map(printMatchRule))
-    case Expr.TypeMatch(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.RestrictableChoose(_, _, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.ExtMatch(exp, rules, _, _, _) => DocAst.Expr.ExtMatch(print(exp), rules.map(printExtMatchRule))
-    case Expr.Tag(symUse, exps, _, _, _) => DocAst.Expr.Tag(symUse.sym, exps.map(print))
-    case Expr.RestrictableTag(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.ExtTag(label, exps, _, _, _) => DocAst.Expr.ExtTag(label, exps.map(print))
-    case Expr.Tuple(elms, _, _, _) => DocAst.Expr.Tuple(elms.map(print))
-    case Expr.RecordSelect(exp, label, _, _, _) => DocAst.Expr.RecordSelect(label, print(exp))
-    case Expr.RecordExtend(label, exp1, exp2, _, _, _) => DocAst.Expr.RecordExtend(label, print(exp1), print(exp2))
-    case Expr.RecordRestrict(label, exp, _, _, _) => DocAst.Expr.RecordRestrict(label, print(exp))
-    case Expr.ArrayLit(exps, exp, _, _, _) => DocAst.Expr.InRegion(DocAst.Expr.ArrayLit(exps.map(print)), print(exp))
-    case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) => DocAst.Expr.InRegion(DocAst.Expr.ArrayNew(print(exp1), print(exp2)), print(exp3))
-    case Expr.ArrayLoad(exp1, exp2, _, _, _) => DocAst.Expr.ArrayLoad(print(exp1), print(exp2))
-    case Expr.ArrayLength(exp, _, _) => DocAst.Expr.ArrayLength(print(exp))
-    case Expr.ArrayStore(exp1, exp2, exp3, _, _) => DocAst.Expr.ArrayStore(print(exp1), print(exp2), print(exp3))
-    case Expr.StructNew(sym, fields, region, _, _, _) => DocAst.Expr.StructNew(sym, fields.map { case (k, v) => (k.sym, print(v)) }, print(region))
-    case Expr.StructGet(exp, field, _, _, _) => DocAst.Expr.StructGet(print(exp), field.sym)
-    case Expr.StructPut(exp1, field, exp2, _, _, _) => DocAst.Expr.StructPut(print(exp1), field.sym, print(exp2))
-    case Expr.VectorLit(exps, _, _, _) => DocAst.Expr.VectorLit(exps.map(print))
-    case Expr.VectorLoad(exp1, exp2, _, _, _) => DocAst.Expr.VectorLoad(print(exp1), print(exp2))
-    case Expr.VectorLength(exp, _) => DocAst.Expr.VectorLength(print(exp))
-    case Expr.Ascribe(exp, _, _, tpe, _, _) => DocAst.Expr.AscriptionTpe(print(exp), TypePrinter.print(tpe))
-    case Expr.InstanceOf(exp, clazz, _) => DocAst.Expr.InstanceOf(print(exp), clazz)
-    case Expr.CheckedCast(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.UncheckedCast(_, _, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.Unsafe(exp, runEff, _, _, _) => DocAst.Expr.Unsafe(print(exp), TypePrinter.print(runEff))
-    case Expr.Without(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule))
-    case Expr.Throw(exp, _, _, _) => DocAst.Expr.Throw(print(exp))
-    case Expr.Handler(symUse, rules, _, _, _, _, _) => DocAst.Expr.Handler(symUse.sym, rules.map(printHandlerRule))
-    case Expr.RunWith(exp1, exp2, _, _, _) => DocAst.Expr.RunWith(print(exp1), print(exp2))
-    case Expr.InvokeConstructor(constructor, exps, _, _, _) => DocAst.Expr.JavaInvokeConstructor(constructor, exps.map(print))
-    case Expr.InvokeMethod(method, exp, exps, _, _, _) => DocAst.Expr.JavaInvokeMethod(method, print(exp), exps.map(print))
-    case Expr.InvokeStaticMethod(method, exps, _, _, _) => DocAst.Expr.JavaInvokeStaticMethod(method, exps.map(print))
-    case Expr.GetField(field, exp, _, _, _) => DocAst.Expr.JavaGetField(field, print(exp))
-    case Expr.PutField(field, exp1, exp2, _, _, _) => DocAst.Expr.JavaPutField(field, print(exp1), print(exp2))
-    case Expr.GetStaticField(field, _, _, _) => DocAst.Expr.JavaGetStaticField(field)
-    case Expr.PutStaticField(field, exp, _, _, _) => DocAst.Expr.JavaPutStaticField(field, print(exp))
-    case Expr.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expr.NewObject(name, clazz, TypePrinter.print(tpe), methods.map(printJvmMethod))
-    case Expr.NewChannel(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.GetChannel(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.PutChannel(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.SelectChannel(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.Spawn(exp1, exp2, _, _, _) => DocAst.Expr.Spawn(print(exp1), print(exp2))
-    case Expr.ParYield(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.Lazy(exp, _, _) => DocAst.Expr.Lazy(print(exp))
-    case Expr.Force(exp, _, _, _) => DocAst.Expr.Force(print(exp))
-    case Expr.FixpointConstraintSet(_, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointLambda(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointMerge(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointQueryWithProvenance(_, _, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointQueryWithSelect(_, _, _, _, _, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointSolveWithProject(_, _, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointInjectInto(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.Error(_, _, _) => DocAst.Expr.Error
+  private def print(e: TypedAst.Exp): DocAst.Exp = e match {
+    case Exp.Cst(cst, _, _) => ConstantPrinter.print(cst)
+    case Exp.Var(sym, _, _) => printVar(sym)
+    case Exp.Hole(sym, _, _, _, _) => DocAst.Exp.Hole(sym)
+    case Exp.HoleWithExp(exp, _, _, _, _) => DocAst.Exp.HoleWithExp(print(exp))
+    case Exp.OpenAs(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.Use(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.Lambda(fparam, exp, _, _) => DocAst.Exp.Lambda(List(printFormalParam(fparam)), print(exp))
+    case Exp.ApplyClo(exp1, exp2, _, _, _) => DocAst.Exp.App(print(exp1), List(print(exp2)))
+    case Exp.ApplyDef(DefSymUse(sym, _), exps, _, _, _, _, _) => DocAst.Exp.ApplyDef(sym, exps.map(print))
+    case Exp.ApplyLocalDef(LocalDefSymUse(sym, _), exps, _, _, _, _) => DocAst.Exp.App(DocAst.Exp.Var(sym), exps.map(print))
+    case Exp.ApplyOp(op, exps, _, _, _) => DocAst.Exp.ApplyOp(op.sym, exps.map(print))
+    case Exp.ApplySig(SigSymUse(sym, _), exps, _, _, _, _, _, _) => DocAst.Exp.App(DocAst.Exp.AsIs(sym.name), exps.map(print))
+    case Exp.Unary(sop, exp, _, _, _) => DocAst.Exp.Unary(OpPrinter.print(sop), print(exp))
+    case Exp.Binary(sop, exp1, exp2, _, _, _) => DocAst.Exp.Binary(print(exp1), OpPrinter.print(sop), print(exp2))
+    case Exp.Let(bnd, exp1, exp2, _, _, _) => DocAst.Exp.Let(printVar(bnd.sym), Some(TypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
+    case Exp.LocalDef(TypedAst.Binder(sym, _), fparams, exp1, exp2, tpe, eff, _) => DocAst.Exp.LocalDef(printVar(sym), fparams.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
+    case Exp.Region(TypedAst.Binder(sym, _), _, exp, _, _, _) => DocAst.Exp.Region(printVar(sym), print(exp))
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Exp.IfThenElse(print(exp1), print(exp2), print(exp3))
+    case Exp.Stm(exp1, exp2, _, _, _) => DocAst.Exp.Stm(print(exp1), print(exp2))
+    case Exp.Discard(exp, _, _) => DocAst.Exp.Discard(print(exp))
+    case Exp.Match(exp, rules, _, _, _) => DocAst.Exp.Match(print(exp), rules.map(printMatchRule))
+    case Exp.TypeMatch(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.RestrictableChoose(_, _, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.ExtMatch(exp, rules, _, _, _) => DocAst.Exp.ExtMatch(print(exp), rules.map(printExtMatchRule))
+    case Exp.Tag(symUse, exps, _, _, _) => DocAst.Exp.Tag(symUse.sym, exps.map(print))
+    case Exp.RestrictableTag(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.ExtTag(label, exps, _, _, _) => DocAst.Exp.ExtTag(label, exps.map(print))
+    case Exp.Tuple(elms, _, _, _) => DocAst.Exp.Tuple(elms.map(print))
+    case Exp.RecordSelect(exp, label, _, _, _) => DocAst.Exp.RecordSelect(label, print(exp))
+    case Exp.RecordExtend(label, exp1, exp2, _, _, _) => DocAst.Exp.RecordExtend(label, print(exp1), print(exp2))
+    case Exp.RecordRestrict(label, exp, _, _, _) => DocAst.Exp.RecordRestrict(label, print(exp))
+    case Exp.ArrayLit(exps, exp, _, _, _) => DocAst.Exp.InRegion(DocAst.Exp.ArrayLit(exps.map(print)), print(exp))
+    case Exp.ArrayNew(exp1, exp2, exp3, _, _, _) => DocAst.Exp.InRegion(DocAst.Exp.ArrayNew(print(exp1), print(exp2)), print(exp3))
+    case Exp.ArrayLoad(exp1, exp2, _, _, _) => DocAst.Exp.ArrayLoad(print(exp1), print(exp2))
+    case Exp.ArrayLength(exp, _, _) => DocAst.Exp.ArrayLength(print(exp))
+    case Exp.ArrayStore(exp1, exp2, exp3, _, _) => DocAst.Exp.ArrayStore(print(exp1), print(exp2), print(exp3))
+    case Exp.StructNew(sym, fields, region, _, _, _) => DocAst.Exp.StructNew(sym, fields.map { case (k, v) => (k.sym, print(v)) }, print(region))
+    case Exp.StructGet(exp, field, _, _, _) => DocAst.Exp.StructGet(print(exp), field.sym)
+    case Exp.StructPut(exp1, field, exp2, _, _, _) => DocAst.Exp.StructPut(print(exp1), field.sym, print(exp2))
+    case Exp.VectorLit(exps, _, _, _) => DocAst.Exp.VectorLit(exps.map(print))
+    case Exp.VectorLoad(exp1, exp2, _, _, _) => DocAst.Exp.VectorLoad(print(exp1), print(exp2))
+    case Exp.VectorLength(exp, _) => DocAst.Exp.VectorLength(print(exp))
+    case Exp.Ascribe(exp, _, _, tpe, _, _) => DocAst.Exp.AscriptionTpe(print(exp), TypePrinter.print(tpe))
+    case Exp.InstanceOf(exp, clazz, _) => DocAst.Exp.InstanceOf(print(exp), clazz)
+    case Exp.CheckedCast(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.UncheckedCast(_, _, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.Unsafe(exp, runEff, _, _, _) => DocAst.Exp.Unsafe(print(exp), TypePrinter.print(runEff))
+    case Exp.Without(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.TryCatch(exp, rules, _, _, _) => DocAst.Exp.TryCatch(print(exp), rules.map(printCatchRule))
+    case Exp.Throw(exp, _, _, _) => DocAst.Exp.Throw(print(exp))
+    case Exp.Handler(symUse, rules, _, _, _, _, _) => DocAst.Exp.Handler(symUse.sym, rules.map(printHandlerRule))
+    case Exp.RunWith(exp1, exp2, _, _, _) => DocAst.Exp.RunWith(print(exp1), print(exp2))
+    case Exp.InvokeConstructor(constructor, exps, _, _, _) => DocAst.Exp.JavaInvokeConstructor(constructor, exps.map(print))
+    case Exp.InvokeMethod(method, exp, exps, _, _, _) => DocAst.Exp.JavaInvokeMethod(method, print(exp), exps.map(print))
+    case Exp.InvokeStaticMethod(method, exps, _, _, _) => DocAst.Exp.JavaInvokeStaticMethod(method, exps.map(print))
+    case Exp.GetField(field, exp, _, _, _) => DocAst.Exp.JavaGetField(field, print(exp))
+    case Exp.PutField(field, exp1, exp2, _, _, _) => DocAst.Exp.JavaPutField(field, print(exp1), print(exp2))
+    case Exp.GetStaticField(field, _, _, _) => DocAst.Exp.JavaGetStaticField(field)
+    case Exp.PutStaticField(field, exp, _, _, _) => DocAst.Exp.JavaPutStaticField(field, print(exp))
+    case Exp.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Exp.NewObject(name, clazz, TypePrinter.print(tpe), methods.map(printJvmMethod))
+    case Exp.NewChannel(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.GetChannel(_, _, _, _) => DocAst.Exp.Unknown
+    case Exp.PutChannel(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.SelectChannel(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.Spawn(exp1, exp2, _, _, _) => DocAst.Exp.Spawn(print(exp1), print(exp2))
+    case Exp.ParYield(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.Lazy(exp, _, _) => DocAst.Exp.Lazy(print(exp))
+    case Exp.Force(exp, _, _, _) => DocAst.Exp.Force(print(exp))
+    case Exp.FixpointConstraintSet(_, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointLambda(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointMerge(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointQueryWithProvenance(_, _, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointQueryWithSelect(_, _, _, _, _, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointSolveWithProject(_, _, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.FixpointInjectInto(_, _, _, _, _) => DocAst.Exp.Unknown
+    case Exp.Error(_, _, _) => DocAst.Exp.Error
   }
 
   /**
@@ -116,89 +116,89 @@ object TypedAstPrinter {
   /**
     * Returns the [[DocAst]] representation of `rule`.
     */
-  private def printHandlerRule(rule: TypedAst.HandlerRule): (Symbol.OpSym, List[DocAst.Expr.AscriptionTpe], DocAst.Expr) = rule match {
+  private def printHandlerRule(rule: TypedAst.HandlerRule): (Symbol.OpSym, List[DocAst.Exp.AscriptionTpe], DocAst.Exp) = rule match {
     case TypedAst.HandlerRule(op, fparams, exp, _) => (op.sym, fparams.map(printFormalParam), print(exp))
   }
 
   /**
     * Returns the [[DocAst]] representation of `rule`.
     */
-  private def printCatchRule(rule: TypedAst.CatchRule): (Symbol.VarSym, Class[?], DocAst.Expr) = rule match {
+  private def printCatchRule(rule: TypedAst.CatchRule): (Symbol.VarSym, Class[?], DocAst.Exp) = rule match {
     case TypedAst.CatchRule(bnd, clazz, exp, _) => (bnd.sym, clazz, print(exp))
   }
 
   /**
     * Returns the [[DocAst]] representation of `rule`.
     */
-  private def printMatchRule(rule: TypedAst.MatchRule): (DocAst.Expr, Option[DocAst.Expr], DocAst.Expr) = rule match {
+  private def printMatchRule(rule: TypedAst.MatchRule): (DocAst.Exp, Option[DocAst.Exp], DocAst.Exp) = rule match {
     case TypedAst.MatchRule(pat, guard, exp, _) => (printPattern(pat), guard.map(print), print(exp))
   }
 
   /**
     * Returns the [[DocAst]] representation of `rule`.
     */
-  private def printExtMatchRule(rule: TypedAst.ExtMatchRule): (DocAst.Expr, DocAst.Expr) = rule match {
+  private def printExtMatchRule(rule: TypedAst.ExtMatchRule): (DocAst.Exp, DocAst.Exp) = rule match {
     case TypedAst.ExtMatchRule(pat, exp, _) =>
       (printExtPattern(pat), print(exp))
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pattern`.
+    * Returns the [[DocAst.Exp]] representation of `pattern`.
     */
-  private def printPattern(pattern: TypedAst.Pattern): DocAst.Expr = pattern match {
-    case Pattern.Wild(_, _) => DocAst.Expr.Wild
+  private def printPattern(pattern: TypedAst.Pattern): DocAst.Exp = pattern match {
+    case Pattern.Wild(_, _) => DocAst.Exp.Wild
     case Pattern.Var(TypedAst.Binder(sym, _), _, _) => printVar(sym)
     case Pattern.Cst(cst, _, _) => ConstantPrinter.print(cst)
-    case Pattern.Tag(symUse, pats, _, _) => DocAst.Expr.Tag(symUse.sym, pats.map(printPattern))
-    case Pattern.Tuple(elms, _, _) => DocAst.Expr.Tuple(elms.map(printPattern).toList)
+    case Pattern.Tag(symUse, pats, _, _) => DocAst.Exp.Tag(symUse.sym, pats.map(printPattern))
+    case Pattern.Tuple(elms, _, _) => DocAst.Exp.Tuple(elms.map(printPattern).toList)
     case Pattern.Record(pats, pat, _, _) => printRecordPattern(pats, pat)
-    case Pattern.Error(_, _) => DocAst.Expr.Error
+    case Pattern.Error(_, _) => DocAst.Exp.Error
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pats`.
+    * Returns the [[DocAst.Exp]] representation of `pats`.
     */
-  private def printRecordPattern(pats: List[Record.RecordLabelPattern], pat: Pattern): DocAst.Expr = {
+  private def printRecordPattern(pats: List[Record.RecordLabelPattern], pat: Pattern): DocAst.Exp = {
     pats.foldRight(printPattern(pat)) {
       case (TypedAst.Pattern.Record.RecordLabelPattern(label, rest, _, _), acc) =>
-        DocAst.Expr.RecordExtend(label, printPattern(rest), acc)
+        DocAst.Exp.RecordExtend(label, printPattern(rest), acc)
     }
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pattern`.
+    * Returns the [[DocAst.Exp]] representation of `pattern`.
     */
-  private def printExtPattern(pattern: TypedAst.ExtPattern): DocAst.Expr = {
+  private def printExtPattern(pattern: TypedAst.ExtPattern): DocAst.Exp = {
     pattern match {
-      case ExtPattern.Default(_) => DocAst.Expr.Wild
+      case ExtPattern.Default(_) => DocAst.Exp.Wild
       case ExtPattern.Tag(label, pats, _) => DocAst.Pattern.ExtTag(label, pats.map(printExtTagPattern))
-      case ExtPattern.Error(_) => DocAst.Expr.Error
+      case ExtPattern.Error(_) => DocAst.Exp.Error
     }
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `pattern`.
+    * Returns the [[DocAst.Exp]] representation of `pattern`.
     */
-  private def printExtTagPattern(pattern: TypedAst.ExtTagPattern): DocAst.Expr = pattern match {
-    case ExtTagPattern.Wild(_, _) => DocAst.Expr.Wild
-    case ExtTagPattern.Var(TypedAst.Binder(sym, _), _, _) => DocAst.Expr.Var(sym)
-    case ExtTagPattern.Unit(_, _) => DocAst.Expr.Unit
-    case ExtTagPattern.Error(_, _) => DocAst.Expr.Error
+  private def printExtTagPattern(pattern: TypedAst.ExtTagPattern): DocAst.Exp = pattern match {
+    case ExtTagPattern.Wild(_, _) => DocAst.Exp.Wild
+    case ExtTagPattern.Var(TypedAst.Binder(sym, _), _, _) => DocAst.Exp.Var(sym)
+    case ExtTagPattern.Unit(_, _) => DocAst.Exp.Unit
+    case ExtTagPattern.Error(_, _) => DocAst.Exp.Error
   }
 
   /**
-    * Returns the [[DocAst.Expr]] representation of `sym`.
+    * Returns the [[DocAst.Exp]] representation of `sym`.
     */
-  private def printVar(sym: Symbol.VarSym): DocAst.Expr = {
-    DocAst.Expr.Var(sym)
+  private def printVar(sym: Symbol.VarSym): DocAst.Exp = {
+    DocAst.Exp.Var(sym)
   }
 
   /**
-    * Returns the [[DocAst.Expr.AscriptionTpe]] representation of `fp`.
+    * Returns the [[DocAst.Exp.AscriptionTpe]] representation of `fp`.
     */
-  private def printFormalParam(fp: TypedAst.FormalParam): DocAst.Expr.AscriptionTpe = {
+  private def printFormalParam(fp: TypedAst.FormalParam): DocAst.Exp.AscriptionTpe = {
     val TypedAst.FormalParam(bnd, tpe, _, _) = fp
-    DocAst.Expr.AscriptionTpe(DocAst.Expr.Var(bnd.sym), TypePrinter.print(tpe))
+    DocAst.Exp.AscriptionTpe(DocAst.Exp.Var(bnd.sym), TypePrinter.print(tpe))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.TypedAst.Pattern.Record
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
-import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, ExtMatchRule, ExtPattern, ExtTagPattern, Pattern, RestrictableChoosePattern, Root}
+import ca.uwaterloo.flix.language.ast.TypedAst.{Exp, ExtMatchRule, ExtPattern, ExtTagPattern, Pattern, RestrictableChoosePattern, Root}
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
@@ -109,87 +109,87 @@ object Dependencies {
     typeAlias
   }
 
-  private def visitExp(exp0: Expr)(implicit sctx: SharedContext): Unit = exp0 match {
-    case Expr.Cst(_, tpe, _) =>
+  private def visitExp(exp0: Exp)(implicit sctx: SharedContext): Unit = exp0 match {
+    case Exp.Cst(_, tpe, _) =>
       visitType(tpe)
 
-    case Expr.Var(_, tpe, _) =>
+    case Exp.Var(_, tpe, _) =>
       visitType(tpe)
 
-    case Expr.Hole(_, _, tpe, eff, _) =>
+    case Exp.Hole(_, _, tpe, eff, _) =>
       visitType(tpe)
       visitType(eff)
 
-    case Expr.HoleWithExp(exp, _, tpe, eff, _) =>
+    case Exp.HoleWithExp(exp, _, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.OpenAs(symUse, exp, tpe, _) =>
+    case Exp.OpenAs(symUse, exp, tpe, _) =>
       visitSymUse(symUse)
       visitExp(exp)
       visitType(tpe)
 
-    case Expr.Use(_, _, exp, _) =>
+    case Exp.Use(_, _, exp, _) =>
       visitExp(exp)
 
-    case Expr.Lambda(fparam, exp, tpe, _) =>
+    case Exp.Lambda(fparam, exp, tpe, _) =>
       visitFormalParam(fparam)
       visitExp(exp)
       visitType(tpe)
 
-    case Expr.ApplyClo(exp1, exp2, tpe, eff, _) =>
+    case Exp.ApplyClo(exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ApplyDef(symUse, exps, _, itpe, tpe, eff, _) =>
+    case Exp.ApplyDef(symUse, exps, _, itpe, tpe, eff, _) =>
       visitSymUse(symUse)
       exps.foreach(visitExp)
       visitType(itpe)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ApplyLocalDef(symUse, exps, arrowTpe, tpe, eff, _) =>
+    case Exp.ApplyLocalDef(symUse, exps, arrowTpe, tpe, eff, _) =>
       visitSymUse(symUse)
       exps.foreach(visitExp)
       visitType(arrowTpe)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ApplyOp(op, exps, tpe, eff, _) =>
+    case Exp.ApplyOp(op, exps, tpe, eff, _) =>
       visitSymUse(op)
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ApplySig(symUse, exps, _, _, itpe, tpe, eff, _) =>
+    case Exp.ApplySig(symUse, exps, _, _, itpe, tpe, eff, _) =>
       visitSymUse(symUse)
       exps.foreach(visitExp)
       visitType(itpe)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Unary(_, exp, tpe, eff, _) =>
+    case Exp.Unary(_, exp, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Binary(_, exp1, exp2, tpe, eff, _) =>
+    case Exp.Binary(_, exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Let(bnd, exp1, exp2, tpe, eff, _) =>
+    case Exp.Let(bnd, exp1, exp2, tpe, eff, _) =>
       visitBinder(bnd)
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.LocalDef(bnd, fparams, exp1, exp2, tpe, eff, _) =>
+    case Exp.LocalDef(bnd, fparams, exp1, exp2, tpe, eff, _) =>
       visitBinder(bnd)
       fparams.foreach(visitFormalParam)
       visitExp(exp1)
@@ -197,121 +197,121 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Region(bnd, _, exp, tpe, eff, _) =>
+    case Exp.Region(bnd, _, exp, tpe, eff, _) =>
       visitBinder(bnd)
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.IfThenElse(exp1, exp2, exp3, tpe, eff, _) =>
+    case Exp.IfThenElse(exp1, exp2, exp3, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Stm(exp1, exp2, tpe, eff, _) =>
+    case Exp.Stm(exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Discard(exp, eff, _) =>
+    case Exp.Discard(exp, eff, _) =>
       visitExp(exp)
       visitType(eff)
 
-    case Expr.Match(exp, rules, tpe, eff, _) =>
+    case Exp.Match(exp, rules, tpe, eff, _) =>
       visitExp(exp)
       rules.foreach(visitMatchRule)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.TypeMatch(exp, rules, tpe, eff, _) =>
+    case Exp.TypeMatch(exp, rules, tpe, eff, _) =>
       visitExp(exp)
       rules.foreach(visitTypeMatchRule)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.RestrictableChoose(_, exp, rules, tpe, eff, _) =>
+    case Exp.RestrictableChoose(_, exp, rules, tpe, eff, _) =>
       visitExp(exp)
       rules.foreach(visitRestrictableChooseRule)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ExtMatch(exp, rules, tpe, eff, _) =>
+    case Exp.ExtMatch(exp, rules, tpe, eff, _) =>
       visitExp(exp)
       rules.foreach(visitExtMatchRule)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Tag(symUse, exps, tpe, eff, _) =>
+    case Exp.Tag(symUse, exps, tpe, eff, _) =>
       visitSymUse(symUse)
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.RestrictableTag(symUse, exps, tpe, eff, _) =>
+    case Exp.RestrictableTag(symUse, exps, tpe, eff, _) =>
       visitSymUse(symUse)
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ExtTag(_, exps, tpe, eff, _) =>
+    case Exp.ExtTag(_, exps, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Tuple(exps, tpe, eff, _) =>
+    case Exp.Tuple(exps, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.RecordSelect(exp, _, tpe, eff, _) =>
+    case Exp.RecordSelect(exp, _, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.RecordExtend(_, exp1, exp2, tpe, eff, _) =>
+    case Exp.RecordExtend(_, exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.RecordRestrict(_, exp, tpe, eff, _) =>
+    case Exp.RecordRestrict(_, exp, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ArrayLit(exps, exp, tpe, eff, _) =>
+    case Exp.ArrayLit(exps, exp, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ArrayNew(exp1, exp2, exp3, tpe, eff, _) =>
+    case Exp.ArrayNew(exp1, exp2, exp3, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ArrayLoad(exp1, exp2, tpe, eff, _) =>
+    case Exp.ArrayLoad(exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ArrayLength(exp, eff, _) =>
+    case Exp.ArrayLength(exp, eff, _) =>
       visitExp(exp)
       visitType(eff)
 
-    case Expr.ArrayStore(exp1, exp2, exp3, eff, _) =>
+    case Exp.ArrayStore(exp1, exp2, exp3, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
       visitType(eff)
 
-    case Expr.StructNew(_, fields, region, tpe, eff, _) =>
+    case Exp.StructNew(_, fields, region, tpe, eff, _) =>
       fields.foreach{ field =>
         visitSymUse(field._1)
         visitExp(field._2)
@@ -320,77 +320,77 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.StructGet(exp, symUse, tpe, eff, _) =>
+    case Exp.StructGet(exp, symUse, tpe, eff, _) =>
       visitExp(exp)
       visitSymUse(symUse)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.StructPut(exp1, symUse, exp2, tpe, eff, _) =>
+    case Exp.StructPut(exp1, symUse, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitSymUse(symUse)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.VectorLit(exps, tpe, eff, _) =>
+    case Exp.VectorLit(exps, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.VectorLoad(exp1, exp2, tpe, eff, _) =>
+    case Exp.VectorLoad(exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.VectorLength(exp, _) =>
+    case Exp.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, _, _, tpe, eff, _) =>
-      visitExp(exp)
-      visitType(tpe)
-      visitType(eff)
-
-    case Expr.InstanceOf(exp, _, _) =>
-      visitExp(exp)
-
-    case Expr.CheckedCast(_, exp, tpe, eff, _) =>
+    case Exp.Ascribe(exp, _, _, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.UncheckedCast(exp, declaredType, declaredEff, tpe, eff, _) =>
+    case Exp.InstanceOf(exp, _, _) =>
+      visitExp(exp)
+
+    case Exp.CheckedCast(_, exp, tpe, eff, _) =>
+      visitExp(exp)
+      visitType(tpe)
+      visitType(eff)
+
+    case Exp.UncheckedCast(exp, declaredType, declaredEff, tpe, eff, _) =>
       visitExp(exp)
       declaredType.toList.foreach(visitType)
       declaredEff.toList.foreach(visitType)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Unsafe(exp, runEff, tpe, eff, _) =>
+    case Exp.Unsafe(exp, runEff, tpe, eff, _) =>
       visitExp(exp)
       visitType(runEff)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Without(exp, symUse, tpe, eff, _) =>
+    case Exp.Without(exp, symUse, tpe, eff, _) =>
       visitExp(exp)
       visitSymUse(symUse)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.TryCatch(exp, rules, tpe, eff, _) =>
+    case Exp.TryCatch(exp, rules, tpe, eff, _) =>
       visitExp(exp)
       rules.foreach(visitCatchRule)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Throw(exp, tpe, eff, _) =>
+    case Exp.Throw(exp, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Handler(symUse, rules, bodyType, bodyEff, handledEff, tpe, _) =>
+    case Exp.Handler(symUse, rules, bodyType, bodyEff, handledEff, tpe, _) =>
       visitSymUse(symUse)
       rules.foreach(visitHandlerRule)
       visitType(bodyType)
@@ -398,114 +398,114 @@ object Dependencies {
       visitType(handledEff)
       visitType(tpe)
 
-    case Expr.RunWith(exp1, exp2, tpe, eff, _) =>
+    case Exp.RunWith(exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.InvokeConstructor(_, exps, tpe, eff, _) =>
+    case Exp.InvokeConstructor(_, exps, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.InvokeMethod(_, exp, exps, tpe, eff, _) =>
+    case Exp.InvokeMethod(_, exp, exps, tpe, eff, _) =>
       visitExp(exp)
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.InvokeStaticMethod(_, exps, tpe, eff, _) =>
+    case Exp.InvokeStaticMethod(_, exps, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.GetField(_, exp, tpe, eff, _) =>
+    case Exp.GetField(_, exp, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.PutField(_, exp1, exp2, tpe, eff, _) =>
+    case Exp.PutField(_, exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.GetStaticField(_, tpe, eff, _) =>
+    case Exp.GetStaticField(_, tpe, eff, _) =>
       visitType(tpe)
       visitType(eff)
 
-    case Expr.PutStaticField(_, exp, tpe, eff, _) =>
+    case Exp.PutStaticField(_, exp, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.NewObject(_, _, tpe, eff, methods, _) =>
+    case Exp.NewObject(_, _, tpe, eff, methods, _) =>
       visitType(tpe)
       visitType(eff)
       methods.foreach(visitJvmMethod)
 
-    case Expr.NewChannel(exp, tpe, eff, _) =>
+    case Exp.NewChannel(exp, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.PutChannel(exp1, exp2, tpe, eff, _) =>
+    case Exp.PutChannel(exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.SelectChannel(rules, default, tpe, eff, _) =>
+    case Exp.SelectChannel(rules, default, tpe, eff, _) =>
       rules.foreach(visitSelectChannelRule)
       default.toList.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Spawn(exp1, exp2, tpe, eff, _) =>
+    case Exp.Spawn(exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.ParYield(frags, exp, tpe, eff, _) =>
+    case Exp.ParYield(frags, exp, tpe, eff, _) =>
       frags.foreach(visitParYieldFragment)
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Lazy(exp, tpe, _) =>
+    case Exp.Lazy(exp, tpe, _) =>
       visitExp(exp)
       visitType(tpe)
 
-    case Expr.Force(exp, tpe, eff, _) =>
+    case Exp.Force(exp, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.FixpointConstraintSet(cs, tpe, _) =>
+    case Exp.FixpointConstraintSet(cs, tpe, _) =>
       cs.foreach(visitConstrait)
       visitType(tpe)
 
-    case Expr.FixpointLambda(pparams, exp, tpe, eff, _) =>
+    case Exp.FixpointLambda(pparams, exp, tpe, eff, _) =>
       pparams.foreach(visitPParam)
       visitExp(exp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.FixpointMerge(exp1, exp2, tpe, eff, _) =>
+    case Exp.FixpointMerge(exp1, exp2, tpe, eff, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.FixpointQueryWithProvenance(exps, select, _, tpe, eff, _) =>
+    case Exp.FixpointQueryWithProvenance(exps, select, _, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitHead(select)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, tpe, eff, _) =>
+    case Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitExp(queryExp)
       selects.foreach(visitExp)
@@ -514,21 +514,21 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.FixpointSolveWithProject(exps, _, _, tpe, eff, _) =>
+    case Exp.FixpointSolveWithProject(exps, _, _, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.FixpointInjectInto(exps, _, tpe, eff, _) =>
+    case Exp.FixpointInjectInto(exps, _, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Error(_, tpe, eff) =>
+    case Exp.Error(_, tpe, eff) =>
       visitType(tpe)
       visitType(eff)
 
-    case Expr.GetChannel(exp, tpe, eff, _) =>
+    case Exp.GetChannel(exp, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.*
-import ca.uwaterloo.flix.language.ast.DesugaredAst.Expr
+import ca.uwaterloo.flix.language.ast.DesugaredAst.Exp
 import ca.uwaterloo.flix.language.ast.WeededAst.Predicate
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugDesugaredAst
@@ -473,362 +473,362 @@ object Desugar {
   }
 
   /**
-    * Desugars the given [[WeededAst.Expr]] `exp0`.
+    * Desugars the given [[WeededAst.Exp]] `exp0`.
     */
-  private def visitExp(exp0: WeededAst.Expr)(implicit flix: Flix): DesugaredAst.Expr = exp0 match {
-    case WeededAst.Expr.Ambiguous(qname, loc) =>
-      Expr.Ambiguous(qname, loc)
+  private def visitExp(exp0: WeededAst.Exp)(implicit flix: Flix): DesugaredAst.Exp = exp0 match {
+    case WeededAst.Exp.Ambiguous(qname, loc) =>
+      Exp.Ambiguous(qname, loc)
 
-    case WeededAst.Expr.Open(qname, loc) =>
-      Expr.Open(qname, loc)
+    case WeededAst.Exp.Open(qname, loc) =>
+      Exp.Open(qname, loc)
 
-    case WeededAst.Expr.OpenAs(qname, exp, loc) =>
+    case WeededAst.Exp.OpenAs(qname, exp, loc) =>
       val e = visitExp(exp)
-      Expr.OpenAs(qname, e, loc)
+      Exp.OpenAs(qname, e, loc)
 
-    case WeededAst.Expr.Hole(name, loc) =>
-      Expr.Hole(name, loc)
+    case WeededAst.Exp.Hole(name, loc) =>
+      Exp.Hole(name, loc)
 
-    case WeededAst.Expr.HoleWithExp(exp, loc) =>
+    case WeededAst.Exp.HoleWithExp(exp, loc) =>
       val e = visitExp(exp)
-      Expr.HoleWithExp(e, loc)
+      Exp.HoleWithExp(e, loc)
 
-    case WeededAst.Expr.Use(uses, exp, loc) =>
+    case WeededAst.Exp.Use(uses, exp, loc) =>
       val u1 = uses.map(visitUseOrImport)
       val e = visitExp(exp)
-      Expr.Use(u1, e, loc)
+      Exp.Use(u1, e, loc)
 
-    case WeededAst.Expr.Cst(cst, loc) =>
-      Expr.Cst(cst, loc)
+    case WeededAst.Exp.Cst(cst, loc) =>
+      Exp.Cst(cst, loc)
 
-    case WeededAst.Expr.Apply(exp, exps, loc) =>
+    case WeededAst.Exp.Apply(exp, exps, loc) =>
       val e = visitExp(exp)
       val es = visitExps(exps)
-      Expr.Apply(e, es, loc)
+      Exp.Apply(e, es, loc)
 
-    case WeededAst.Expr.Infix(exp1, exp2, exp3, loc) =>
+    case WeededAst.Exp.Infix(exp1, exp2, exp3, loc) =>
       desugarInfix(exp1, exp2, exp3, loc)
 
-    case WeededAst.Expr.Lambda(fparam, exp, loc) =>
+    case WeededAst.Exp.Lambda(fparam, exp, loc) =>
       val fparam1 = visitFormalParam(fparam)
       val e = visitExp(exp)
-      Expr.Lambda(fparam1, e, loc)
+      Exp.Lambda(fparam1, e, loc)
 
-    case WeededAst.Expr.LambdaExtMatch(pat, exp, loc) =>
+    case WeededAst.Exp.LambdaExtMatch(pat, exp, loc) =>
       val p = visitExtPattern(pat)
       val e = visitExp(exp)
       desugarLambdaExtMatch(p, e, loc)
 
-    case WeededAst.Expr.LambdaMatch(pat, exp, loc) =>
+    case WeededAst.Exp.LambdaMatch(pat, exp, loc) =>
       val p = visitPattern(pat)
       val e = visitExp(exp)
       desugarLambdaMatch(p, e, loc)
 
-    case WeededAst.Expr.Unary(sop, exp, loc) =>
+    case WeededAst.Exp.Unary(sop, exp, loc) =>
       val e = visitExp(exp)
-      Expr.Unary(sop, e, loc)
+      Exp.Unary(sop, e, loc)
 
-    case WeededAst.Expr.Binary(sop, exp1, exp2, loc) =>
+    case WeededAst.Exp.Binary(sop, exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.Binary(sop, e1, e2, loc)
+      Exp.Binary(sop, e1, e2, loc)
 
-    case WeededAst.Expr.IfThenElse(exp1, exp2, exp3, loc) =>
+    case WeededAst.Exp.IfThenElse(exp1, exp2, exp3, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      Expr.IfThenElse(e1, e2, e3, loc)
+      Exp.IfThenElse(e1, e2, e3, loc)
 
-    case WeededAst.Expr.Stm(exp1, exp2, loc) =>
+    case WeededAst.Exp.Stm(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.Stm(e1, e2, loc)
+      Exp.Stm(e1, e2, loc)
 
-    case WeededAst.Expr.Discard(exp, loc) =>
+    case WeededAst.Exp.Discard(exp, loc) =>
       val e = visitExp(exp)
-      Expr.Discard(e, loc)
+      Exp.Discard(e, loc)
 
-    case WeededAst.Expr.LocalDef(ident, fparams, dtpe, deff, exp1, exp2, loc) =>
+    case WeededAst.Exp.LocalDef(ident, fparams, dtpe, deff, exp1, exp2, loc) =>
       val fps = visitFormalParams(fparams)
       val t = dtpe.map(visitType)
       val ef = deff.map(visitType)
       val e10 = visitExp(exp1)
       // Ascribe has an invariant that at least t or ef must be defined
-      val e1 = if (t.isDefined || ef.isDefined) Expr.Ascribe(e10, t, ef, e10.loc) else e10
+      val e1 = if (t.isDefined || ef.isDefined) Exp.Ascribe(e10, t, ef, e10.loc) else e10
       val e2 = visitExp(exp2)
-      Expr.LocalDef(ident, fps, e1, e2, loc)
+      Exp.LocalDef(ident, fps, e1, e2, loc)
 
-    case WeededAst.Expr.Region(ident, exp, loc) =>
+    case WeededAst.Exp.Region(ident, exp, loc) =>
       val e = visitExp(exp)
-      Expr.Region(ident, e, loc)
+      Exp.Region(ident, e, loc)
 
-    case WeededAst.Expr.Match(exp, rules, loc) =>
+    case WeededAst.Exp.Match(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitMatchRule)
-      Expr.Match(e, rs, loc)
+      Exp.Match(e, rs, loc)
 
-    case WeededAst.Expr.TypeMatch(exp, rules, loc) =>
+    case WeededAst.Exp.TypeMatch(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitTypeMatchRule)
-      Expr.TypeMatch(e, rs, loc)
+      Exp.TypeMatch(e, rs, loc)
 
-    case WeededAst.Expr.RestrictableChoose(star, exp, rules, loc) =>
+    case WeededAst.Exp.RestrictableChoose(star, exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitRestrictableChooseRule)
-      Expr.RestrictableChoose(star, e, rs, loc)
+      Exp.RestrictableChoose(star, e, rs, loc)
 
-    case WeededAst.Expr.ExtMatch(exp, rules, loc) =>
+    case WeededAst.Exp.ExtMatch(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitExtMatchRule)
-      Expr.ExtMatch(e, rs, loc)
+      Exp.ExtMatch(e, rs, loc)
 
-    case WeededAst.Expr.ApplicativeFor(frags, exp, loc) =>
+    case WeededAst.Exp.ApplicativeFor(frags, exp, loc) =>
       desugarApplicativeFor(frags, exp, loc)
 
-    case WeededAst.Expr.ForEach(frags, exp, _) =>
+    case WeededAst.Exp.ForEach(frags, exp, _) =>
       desugarForEach(frags, exp)
 
-    case WeededAst.Expr.MonadicFor(frags, exp, loc) =>
+    case WeededAst.Exp.MonadicFor(frags, exp, loc) =>
       desugarMonadicFor(frags, exp, loc)
 
-    case WeededAst.Expr.LetMatch(pat, tpe, exp1, exp2, loc) =>
+    case WeededAst.Exp.LetMatch(pat, tpe, exp1, exp2, loc) =>
       desugarLetMatch(pat, tpe, exp1, exp2, loc)
 
-    case WeededAst.Expr.ExtTag(label, exps, loc) =>
+    case WeededAst.Exp.ExtTag(label, exps, loc) =>
       val es = visitExps(exps)
-      Expr.ExtTag(label, es, loc)
+      Exp.ExtTag(label, es, loc)
 
-    case WeededAst.Expr.Tuple(exps, loc) =>
+    case WeededAst.Exp.Tuple(exps, loc) =>
       desugarTuple(exps, loc)
 
-    case WeededAst.Expr.RecordSelect(exp, label, loc) =>
+    case WeededAst.Exp.RecordSelect(exp, label, loc) =>
       val e = visitExp(exp)
-      Expr.RecordSelect(e, label, loc)
+      Exp.RecordSelect(e, label, loc)
 
-    case WeededAst.Expr.RecordExtend(label, exp1, exp2, loc) =>
+    case WeededAst.Exp.RecordExtend(label, exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.RecordExtend(label, e1, e2, loc)
+      Exp.RecordExtend(label, e1, e2, loc)
 
-    case WeededAst.Expr.RecordRestrict(label, exp, loc) =>
+    case WeededAst.Exp.RecordRestrict(label, exp, loc) =>
       val e = visitExp(exp)
-      Expr.RecordRestrict(label, e, loc)
+      Exp.RecordRestrict(label, e, loc)
 
-    case WeededAst.Expr.ArrayLit(exps, exp, loc) =>
+    case WeededAst.Exp.ArrayLit(exps, exp, loc) =>
       val es = visitExps(exps)
       val e = visitExp(exp)
-      Expr.ArrayLit(es, e, loc)
+      Exp.ArrayLit(es, e, loc)
 
-    case WeededAst.Expr.ArrayNew(exp1, exp2, exp3, loc) =>
+    case WeededAst.Exp.ArrayNew(exp1, exp2, exp3, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      Expr.ArrayNew(e1, e2, e3, loc)
+      Exp.ArrayNew(e1, e2, e3, loc)
 
-    case WeededAst.Expr.ArrayLoad(exp1, exp2, loc) =>
+    case WeededAst.Exp.ArrayLoad(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.ArrayLoad(e1, e2, loc)
+      Exp.ArrayLoad(e1, e2, loc)
 
-    case WeededAst.Expr.ArrayLength(exp, loc) =>
+    case WeededAst.Exp.ArrayLength(exp, loc) =>
       val e = visitExp(exp)
-      Expr.ArrayLength(e, loc)
+      Exp.ArrayLength(e, loc)
 
-    case WeededAst.Expr.ArrayStore(exp1, exp2, exp3, loc) =>
+    case WeededAst.Exp.ArrayStore(exp1, exp2, exp3, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      Expr.ArrayStore(e1, e2, e3, loc)
+      Exp.ArrayStore(e1, e2, e3, loc)
 
-    case WeededAst.Expr.StructNew(name, fields0, region0, loc) =>
+    case WeededAst.Exp.StructNew(name, fields0, region0, loc) =>
       val fields = fields0.map(field => (field._1, visitExp(field._2)))
       val region = visitExp(region0)
-      Expr.StructNew(name, fields, region, loc)
+      Exp.StructNew(name, fields, region, loc)
 
-    case WeededAst.Expr.StructGet(e, name, loc) =>
-      Expr.StructGet(visitExp(e), name, loc)
+    case WeededAst.Exp.StructGet(e, name, loc) =>
+      Exp.StructGet(visitExp(e), name, loc)
 
-    case WeededAst.Expr.StructPut(e1, name, e2, loc) =>
-      Expr.StructPut(visitExp(e1), name, visitExp(e2), loc)
+    case WeededAst.Exp.StructPut(e1, name, e2, loc) =>
+      Exp.StructPut(visitExp(e1), name, visitExp(e2), loc)
 
-    case WeededAst.Expr.VectorLit(exps, loc) =>
+    case WeededAst.Exp.VectorLit(exps, loc) =>
       val e = visitExps(exps)
-      Expr.VectorLit(e, loc)
+      Exp.VectorLit(e, loc)
 
-    case WeededAst.Expr.VectorLoad(exp1, exp2, loc) =>
+    case WeededAst.Exp.VectorLoad(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.VectorLoad(e1, e2, loc)
+      Exp.VectorLoad(e1, e2, loc)
 
-    case WeededAst.Expr.VectorLength(exp, loc) =>
+    case WeededAst.Exp.VectorLength(exp, loc) =>
       val e = visitExp(exp)
-      Expr.VectorLength(e, loc)
+      Exp.VectorLength(e, loc)
 
-    case WeededAst.Expr.FCons(exp1, exp2, loc) =>
+    case WeededAst.Exp.FCons(exp1, exp2, loc) =>
       desugarFCons(exp1, exp2, loc)
 
-    case WeededAst.Expr.FAppend(exp1, exp2, loc) =>
+    case WeededAst.Exp.FAppend(exp1, exp2, loc) =>
       desugarFAppend(exp1, exp2, loc)
 
-    case WeededAst.Expr.ListLit(exps, loc) =>
+    case WeededAst.Exp.ListLit(exps, loc) =>
       desugarListLit(exps, loc)
 
-    case WeededAst.Expr.SetLit(exps, loc) =>
+    case WeededAst.Exp.SetLit(exps, loc) =>
       desugarSetLit(exps, loc)
 
-    case WeededAst.Expr.MapLit(exps, loc) =>
+    case WeededAst.Exp.MapLit(exps, loc) =>
       desugarMapLit(exps, loc)
 
-    case WeededAst.Expr.Ascribe(exp, expectedType, expectedEff, loc) =>
+    case WeededAst.Exp.Ascribe(exp, expectedType, expectedEff, loc) =>
       val e = visitExp(exp)
       val ts = expectedType.map(visitType)
       val effs = expectedEff.map(visitType)
-      Expr.Ascribe(e, ts, effs, loc)
+      Exp.Ascribe(e, ts, effs, loc)
 
-    case WeededAst.Expr.InstanceOf(exp, className, loc) =>
+    case WeededAst.Exp.InstanceOf(exp, className, loc) =>
       val e = visitExp(exp)
-      Expr.InstanceOf(e, className, loc)
+      Exp.InstanceOf(e, className, loc)
 
-    case WeededAst.Expr.CheckedCast(cast, exp, loc) =>
+    case WeededAst.Exp.CheckedCast(cast, exp, loc) =>
       val e = visitExp(exp)
-      Expr.CheckedCast(cast, e, loc)
+      Exp.CheckedCast(cast, e, loc)
 
-    case WeededAst.Expr.UncheckedCast(exp, declaredType, declaredEff, loc) =>
+    case WeededAst.Exp.UncheckedCast(exp, declaredType, declaredEff, loc) =>
       val e = visitExp(exp)
       val t = declaredType.map(visitType)
       val eff = declaredEff.map(visitType)
-      Expr.UncheckedCast(e, t, eff, loc)
+      Exp.UncheckedCast(e, t, eff, loc)
 
-    case WeededAst.Expr.Unsafe(exp, eff0, loc) =>
+    case WeededAst.Exp.Unsafe(exp, eff0, loc) =>
       val e = visitExp(exp)
       val eff = visitType(eff0)
-      Expr.Unsafe(e, eff, loc)
+      Exp.Unsafe(e, eff, loc)
 
-    case WeededAst.Expr.UnsafeOld(exp, loc) =>
+    case WeededAst.Exp.UnsafeOld(exp, loc) =>
       // We desugar an unsafe expression to an unchecked cast to pure.
       val e = visitExp(exp)
       val declaredType = None
       val declaredEff = Some(DesugaredAst.Type.Pure(loc.asSynthetic))
-      Expr.UncheckedCast(e, declaredType, declaredEff, loc)
+      Exp.UncheckedCast(e, declaredType, declaredEff, loc)
 
-    case WeededAst.Expr.Without(exp, eff, loc) =>
+    case WeededAst.Exp.Without(exp, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Without(e, eff, loc)
+      Exp.Without(e, eff, loc)
 
-    case WeededAst.Expr.TryCatch(exp, rules, loc) =>
+    case WeededAst.Exp.TryCatch(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitCatchRule)
-      Expr.TryCatch(e, rs, loc)
+      Exp.TryCatch(e, rs, loc)
 
-    case WeededAst.Expr.Throw(exp, loc) =>
+    case WeededAst.Exp.Throw(exp, loc) =>
       val e = visitExp(exp)
-      Expr.Throw(e, loc)
+      Exp.Throw(e, loc)
 
-    case WeededAst.Expr.Handler(eff, rules, loc) =>
+    case WeededAst.Exp.Handler(eff, rules, loc) =>
       val rs = rules.map(visitHandlerRule)
-      Expr.Handler(eff, rs, loc)
+      Exp.Handler(eff, rs, loc)
 
-    case WeededAst.Expr.RunWith(exp, exps, loc) =>
+    case WeededAst.Exp.RunWith(exp, exps, loc) =>
       val e = visitExp(exp)
       exps.foldLeft(e) {
-        case (acc, e2) => Expr.RunWith(acc, visitExp(e2), loc)
+        case (acc, e2) => Exp.RunWith(acc, visitExp(e2), loc)
       }
 
-    case WeededAst.Expr.InvokeConstructor(className, exps, loc) =>
+    case WeededAst.Exp.InvokeConstructor(className, exps, loc) =>
       val es = visitExps(exps)
-      Expr.InvokeConstructor(className, es, loc)
+      Exp.InvokeConstructor(className, es, loc)
 
-    case WeededAst.Expr.InvokeMethod(exp, name, exps, loc) =>
+    case WeededAst.Exp.InvokeMethod(exp, name, exps, loc) =>
       val e = visitExp(exp)
       val es = visitExps(exps)
-      Expr.InvokeMethod(e, name, es, loc)
+      Exp.InvokeMethod(e, name, es, loc)
 
-    case WeededAst.Expr.GetField(exp, name, loc) =>
+    case WeededAst.Exp.GetField(exp, name, loc) =>
       val e = visitExp(exp)
-      Expr.GetField(e, name, loc)
+      Exp.GetField(e, name, loc)
 
-    case WeededAst.Expr.NewObject(tpe, methods, loc) =>
+    case WeededAst.Exp.NewObject(tpe, methods, loc) =>
       val t = visitType(tpe)
       val ms = methods.map(visitJvmMethod)
-      Expr.NewObject(t, ms, loc)
+      Exp.NewObject(t, ms, loc)
 
-    case WeededAst.Expr.Static(loc) =>
-      DesugaredAst.Expr.Cst(Constant.Static, loc)
+    case WeededAst.Exp.Static(loc) =>
+      DesugaredAst.Exp.Cst(Constant.Static, loc)
 
-    case WeededAst.Expr.NewChannel(exp, loc) =>
+    case WeededAst.Exp.NewChannel(exp, loc) =>
       val e = visitExp(exp)
-      Expr.NewChannel(e, loc)
+      Exp.NewChannel(e, loc)
 
-    case WeededAst.Expr.GetChannel(exp, loc) =>
+    case WeededAst.Exp.GetChannel(exp, loc) =>
       val e = visitExp(exp)
-      Expr.GetChannel(e, loc)
+      Exp.GetChannel(e, loc)
 
-    case WeededAst.Expr.PutChannel(exp1, exp2, loc) =>
+    case WeededAst.Exp.PutChannel(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.PutChannel(e1, e2, loc)
+      Exp.PutChannel(e1, e2, loc)
 
-    case WeededAst.Expr.SelectChannel(rules, exp, loc) =>
+    case WeededAst.Exp.SelectChannel(rules, exp, loc) =>
       val rs = rules.map(visitSelectChannelRule)
       val es = exp.map(visitExp)
-      Expr.SelectChannel(rs, es, loc)
+      Exp.SelectChannel(rs, es, loc)
 
-    case WeededAst.Expr.Spawn(exp1, exp2, loc) =>
+    case WeededAst.Exp.Spawn(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.Spawn(e1, e2, loc)
+      Exp.Spawn(e1, e2, loc)
 
-    case WeededAst.Expr.ParYield(frags, exp, loc) =>
+    case WeededAst.Exp.ParYield(frags, exp, loc) =>
       val fs = frags.map(visitParYieldFragment)
       val e = visitExp(exp)
-      Expr.ParYield(fs, e, loc)
+      Exp.ParYield(fs, e, loc)
 
-    case WeededAst.Expr.Lazy(exp, loc) =>
+    case WeededAst.Exp.Lazy(exp, loc) =>
       val e = visitExp(exp)
-      Expr.Lazy(e, loc)
+      Exp.Lazy(e, loc)
 
-    case WeededAst.Expr.Force(exp, loc) =>
+    case WeededAst.Exp.Force(exp, loc) =>
       val e = visitExp(exp)
-      Expr.Force(e, loc)
+      Exp.Force(e, loc)
 
-    case WeededAst.Expr.FixpointConstraintSet(cs, loc) =>
+    case WeededAst.Exp.FixpointConstraintSet(cs, loc) =>
       val cs1 = cs.map(visitConstraint)
-      Expr.FixpointConstraintSet(cs1, loc)
+      Exp.FixpointConstraintSet(cs1, loc)
 
-    case WeededAst.Expr.FixpointLambda(pparams, exp, loc) =>
+    case WeededAst.Exp.FixpointLambda(pparams, exp, loc) =>
       val ps = pparams.map(visitPredicateParam)
       val e = visitExp(exp)
-      Expr.FixpointLambda(ps, e, loc)
+      Exp.FixpointLambda(ps, e, loc)
 
-    case WeededAst.Expr.FixpointMerge(exp1, exp2, loc) =>
+    case WeededAst.Exp.FixpointMerge(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.FixpointMerge(e1, e2, loc)
+      Exp.FixpointMerge(e1, e2, loc)
 
-    case WeededAst.Expr.FixpointInjectInto(exps, predsAndArities, loc) =>
+    case WeededAst.Exp.FixpointInjectInto(exps, predsAndArities, loc) =>
       val es = visitExps(exps)
-      DesugaredAst.Expr.FixpointInjectInto(es, predsAndArities, loc)
+      DesugaredAst.Exp.FixpointInjectInto(es, predsAndArities, loc)
 
-    case WeededAst.Expr.FixpointSolveWithProject(exps, optPreds, mode, loc) =>
+    case WeededAst.Exp.FixpointSolveWithProject(exps, optPreds, mode, loc) =>
       val es = visitExps(exps)
-      DesugaredAst.Expr.FixpointSolveWithProject(es, optPreds, mode, loc)
+      DesugaredAst.Exp.FixpointSolveWithProject(es, optPreds, mode, loc)
 
-    case WeededAst.Expr.FixpointQueryWithProvenance(exps, select, withh, loc) =>
+    case WeededAst.Exp.FixpointQueryWithProvenance(exps, select, withh, loc) =>
       val es = visitExps(exps)
       val s = visitHead(select)
-      DesugaredAst.Expr.FixpointQueryWithProvenance(es, s, withh, loc)
+      DesugaredAst.Exp.FixpointQueryWithProvenance(es, s, withh, loc)
 
-    case WeededAst.Expr.FixpointQueryWithSelect(exps, selects, from, where, loc) =>
+    case WeededAst.Exp.FixpointQueryWithSelect(exps, selects, from, where, loc) =>
       desugarFixpointQueryWithSelect(exps, selects, from, where ,loc)
 
-    case WeededAst.Expr.Error(m) =>
-      DesugaredAst.Expr.Error(m)
+    case WeededAst.Exp.Error(m) =>
+      DesugaredAst.Exp.Error(m)
   }
 
   /**
-    * Desugars the given list of [[WeededAst.Expr]] `exps0`.
+    * Desugars the given list of [[WeededAst.Exp]] `exps0`.
     */
-  private def visitExps(exps0: List[WeededAst.Expr])(implicit flix: Flix): List[DesugaredAst.Expr] =
+  private def visitExps(exps0: List[WeededAst.Exp])(implicit flix: Flix): List[DesugaredAst.Exp] =
     exps0.map(visitExp)
 
   /**
@@ -1079,11 +1079,11 @@ object Desugar {
     *   f(a, b)
     * }}}
     */
-  private def desugarInfix(exp1: WeededAst.Expr, exp2: WeededAst.Expr, exp3: WeededAst.Expr, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr.Apply = {
+  private def desugarInfix(exp1: WeededAst.Exp, exp2: WeededAst.Exp, exp3: WeededAst.Exp, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp.Apply = {
     val e1 = visitExp(exp1)
     val e2 = visitExp(exp2)
     val e3 = visitExp(exp3)
-    Expr.Apply(e2, List(e1, e3), loc0)
+    Exp.Apply(e2, List(e1, e3), loc0)
   }
 
   /**
@@ -1101,7 +1101,7 @@ object Desugar {
     * }}}
     *
     */
-  private def desugarApplicativeFor(frags0: List[WeededAst.ForFragment.Generator], exp0: WeededAst.Expr, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarApplicativeFor(frags0: List[WeededAst.ForFragment.Generator], exp0: WeededAst.Exp, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp = {
     val fqnAp = "Applicative.ap"
     val fqnMap = "Functor.map"
     val yieldExp = visitExp(exp0)
@@ -1139,7 +1139,7 @@ object Desugar {
     *   ForEach.foreach(x -> if (x > 0) ForEach.foreach(y -> println(x + y), ys) else (), xs)
     * }}}
     */
-  private def desugarForEach(frags0: List[WeededAst.ForFragment], exp0: WeededAst.Expr)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarForEach(frags0: List[WeededAst.ForFragment], exp0: WeededAst.Exp)(implicit flix: Flix): DesugaredAst.Exp = {
     val fqnForEach = "ForEach.forEach"
 
     frags0.foldRight(visitExp(exp0)) {
@@ -1152,14 +1152,14 @@ object Desugar {
 
       case (WeededAst.ForFragment.Guard(exp1, loc1), acc) =>
         val e1 = visitExp(exp1)
-        DesugaredAst.Expr.IfThenElse(e1, acc, DesugaredAst.Expr.Cst(Constant.Unit, loc1.asSynthetic), loc1.asSynthetic)
+        DesugaredAst.Exp.IfThenElse(e1, acc, DesugaredAst.Exp.Cst(Constant.Unit, loc1.asSynthetic), loc1.asSynthetic)
 
       case (WeededAst.ForFragment.Let(pat1, exp1, loc1), acc) =>
         // Rewrite to pattern match
         val p1 = visitPattern(pat1)
         val e1 = visitExp(exp1)
         val matchRule = DesugaredAst.MatchRule(p1, None, acc, loc1.asSynthetic)
-        DesugaredAst.Expr.Match(e1, List(matchRule), loc1.asSynthetic)
+        DesugaredAst.Exp.Match(e1, List(matchRule), loc1.asSynthetic)
     }
   }
 
@@ -1177,7 +1177,7 @@ object Desugar {
     *   Monad.flatMap(x -> if (x > 0) Monad.flatMap(y -> Applicative.point(x + y), ys) else MonadZero.empty(), xs)
     * }}}
     */
-  private def desugarMonadicFor(frags0: List[WeededAst.ForFragment], exp0: WeededAst.Expr, loc0: SourceLocation)(implicit flix: Flix): Expr = {
+  private def desugarMonadicFor(frags0: List[WeededAst.ForFragment], exp0: WeededAst.Exp, loc0: SourceLocation)(implicit flix: Flix): Exp = {
     val fqnFlatMap = "Monad.flatMap"
     val fqnPoint = "Applicative.point"
     val fqnZero = "MonadZero.empty"
@@ -1193,22 +1193,22 @@ object Desugar {
 
       case (WeededAst.ForFragment.Guard(exp1, loc1), acc) =>
         val e1 = visitExp(exp1)
-        val zero = mkApplyFqn(fqnZero, List(DesugaredAst.Expr.Cst(Constant.Unit, loc1.asSynthetic)), loc1.asSynthetic)
-        DesugaredAst.Expr.IfThenElse(e1, acc, zero, loc1.asSynthetic)
+        val zero = mkApplyFqn(fqnZero, List(DesugaredAst.Exp.Cst(Constant.Unit, loc1.asSynthetic)), loc1.asSynthetic)
+        DesugaredAst.Exp.IfThenElse(e1, acc, zero, loc1.asSynthetic)
 
       case (WeededAst.ForFragment.Let(pat1, exp1, loc1), acc) =>
         // Rewrite to pattern match
         val p1 = visitPattern(pat1)
         val e1 = visitExp(exp1)
         val matchRule = DesugaredAst.MatchRule(p1, None, acc, loc1.asSynthetic)
-        DesugaredAst.Expr.Match(e1, List(matchRule), loc1.asSynthetic)
+        DesugaredAst.Exp.Match(e1, List(matchRule), loc1.asSynthetic)
     }
   }
 
   /**
     * Rewrites a let-match to a regular let-binding or a full pattern match.
     */
-  private def desugarLetMatch(pat0: WeededAst.Pattern, tpe0: Option[WeededAst.Type], exp1: WeededAst.Expr, exp2: WeededAst.Expr, loc0: SourceLocation)(implicit flix: Flix): Expr = {
+  private def desugarLetMatch(pat0: WeededAst.Pattern, tpe0: Option[WeededAst.Type], exp1: WeededAst.Exp, exp2: WeededAst.Exp, loc0: SourceLocation)(implicit flix: Flix): Exp = {
     val p = visitPattern(pat0)
     val t = tpe0.map(visitType)
     val e1 = visitExp(exp1)
@@ -1216,28 +1216,28 @@ object Desugar {
     p match {
       case DesugaredAst.Pattern.Var(ident, _) =>
         // No pattern match
-        DesugaredAst.Expr.Let(ident, withAscription(e1, t), e2, loc0)
+        DesugaredAst.Exp.Let(ident, withAscription(e1, t), e2, loc0)
       case _ =>
         // Full pattern match
         val rule = DesugaredAst.MatchRule(p, None, e2, loc0)
-        DesugaredAst.Expr.Match(withAscription(e1, t), List(rule), loc0)
+        DesugaredAst.Exp.Match(withAscription(e1, t), List(rule), loc0)
     }
   }
 
   /**
     * Rewrites empty tuples to [[Constant.Unit]] and eliminate single-element tuples.
     */
-  private def desugarTuple(exps0: List[WeededAst.Expr], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarTuple(exps0: List[WeededAst.Exp], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp = {
     val es = visitExps(exps0)
     es match {
-      case Nil => DesugaredAst.Expr.Cst(Constant.Unit, loc0)
+      case Nil => DesugaredAst.Exp.Cst(Constant.Unit, loc0)
       case x :: Nil => x
-      case xs => DesugaredAst.Expr.Tuple(xs, loc0)
+      case xs => DesugaredAst.Exp.Tuple(xs, loc0)
     }
   }
 
   /**
-    * Rewrites [[WeededAst.Expr.FCons]] (`x :: xs`) into a call to `List.Cons(x, xs)`.
+    * Rewrites [[WeededAst.Exp.FCons]] (`x :: xs`) into a call to `List.Cons(x, xs)`.
     * If there are over 20 literals we translate it to `Vector.toList(Vector#{1, 2, ...})`.
     *
     * Additionally, if there are over 20 literals and the FCons sequence does not end with the literal `Nil`,
@@ -1245,7 +1245,7 @@ object Desugar {
     *
     * E.g., `1 :: 2 :: 3 :: ... :: 25 :: xs` is translated to `List.append(Vector.toList(Vector#{1, 2, 3, ..., 25}), xs)`.
     */
-  private def desugarFCons(exp1: WeededAst.Expr, exp2: WeededAst.Expr, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarFCons(exp1: WeededAst.Exp, exp2: WeededAst.Exp, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp = {
     val (flattened, rest) = flattenFCons(exp1, exp2)
     if (flattened.length > 20) {
       val desugaredFCons = desugarListLit(flattened, loc0)
@@ -1280,12 +1280,12 @@ object Desugar {
     * This function terminates when it encounters anything that is not an FCons expression.
     *
     */
-  private def flattenFCons(exp1: WeededAst.Expr, exp2: WeededAst.Expr): (List[WeededAst.Expr], Option[WeededAst.Expr]) = {
+  private def flattenFCons(exp1: WeededAst.Exp, exp2: WeededAst.Exp): (List[WeededAst.Exp], Option[WeededAst.Exp]) = {
     @tailrec
-    def flatten(exp: WeededAst.Expr, acc: List[WeededAst.Expr]): (List[WeededAst.Expr], Option[WeededAst.Expr]) = exp match {
-      case WeededAst.Expr.FCons(e1, e2, _) => flatten(e2, e1 :: acc)
-      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _), _) if nname.idents == "List" :: Nil => (acc.reverse, None)
-      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _), _) if nname.idents.isEmpty => (acc.reverse, None)
+    def flatten(exp: WeededAst.Exp, acc: List[WeededAst.Exp]): (List[WeededAst.Exp], Option[WeededAst.Exp]) = exp match {
+      case WeededAst.Exp.FCons(e1, e2, _) => flatten(e2, e1 :: acc)
+      case WeededAst.Exp.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _), _) if nname.idents == "List" :: Nil => (acc.reverse, None)
+      case WeededAst.Exp.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _), _) if nname.idents.isEmpty => (acc.reverse, None)
       case _ => (acc.reverse, Some(exp))
     }
 
@@ -1293,9 +1293,9 @@ object Desugar {
   }
 
   /**
-    * Rewrites  [[WeededAst.Expr.FAppend]] (`xs ++ ys`) into a call to `List.append`.
+    * Rewrites  [[WeededAst.Exp.FAppend]] (`xs ++ ys`) into a call to `List.append`.
     */
-  private def desugarFAppend(exp1: WeededAst.Expr, exp2: WeededAst.Expr, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarFAppend(exp1: WeededAst.Exp, exp2: WeededAst.Exp, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp = {
     // NB: We painstakingly construct the qualified name
     // to ensure that source locations are available.
     val e1 = visitExp(exp1)
@@ -1304,21 +1304,21 @@ object Desugar {
   }
 
   /**
-    * Rewrites [[WeededAst.Expr.ListLit]] (`List#{1, 2, 3}`) expression into `Vector.toList(Vector#{1, 2, 3})`.
+    * Rewrites [[WeededAst.Exp.ListLit]] (`List#{1, 2, 3}`) expression into `Vector.toList(Vector#{1, 2, 3})`.
     */
-  private def desugarListLit(exps0: List[WeededAst.Expr], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarListLit(exps0: List[WeededAst.Exp], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp = {
     desugarCollectionLitToVec("Vector.toList", exps0, loc0)
   }
 
   /**
-    * Rewrites [[WeededAst.Expr.SetLit]] (`Set#{1, 2}`) into `Vector.toSet(Vector#{1, 2})`.
+    * Rewrites [[WeededAst.Exp.SetLit]] (`Set#{1, 2}`) into `Vector.toSet(Vector#{1, 2})`.
     */
-  private def desugarSetLit(exps0: List[WeededAst.Expr], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarSetLit(exps0: List[WeededAst.Exp], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp = {
     if (exps0.isEmpty) {
       // Vector.toSet requires an instance of Order[a]
       // which we do not have for an empty literal
       // so we construct the empty set directly.
-      val unit = DesugaredAst.Expr.Cst(Constant.Unit, loc0)
+      val unit = DesugaredAst.Exp.Cst(Constant.Unit, loc0)
       mkApplyFqn("Set.empty", List(unit), loc0)
     } else {
       desugarCollectionLitToVec("Vector.toSet", exps0, loc0)
@@ -1326,17 +1326,17 @@ object Desugar {
   }
 
   /**
-    * Rewrites [[WeededAst.Expr.MapLit]] (`Map#{1 => 2, 2 => 3}`) into `Vector.toMap(Vector#{(1, 2), (2, 3)})`.
+    * Rewrites [[WeededAst.Exp.MapLit]] (`Map#{1 => 2, 2 => 3}`) into `Vector.toMap(Vector#{(1, 2), (2, 3)})`.
     */
-  private def desugarMapLit(exps0: List[(WeededAst.Expr, WeededAst.Expr)], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarMapLit(exps0: List[(WeededAst.Exp, WeededAst.Exp)], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp = {
     if (exps0.isEmpty) {
       // Vector.toMap requires an instance of Order[a]
       // which we do not have for an empty literal
       // so we construct the empty map directly.
-      val unit = DesugaredAst.Expr.Cst(Constant.Unit, loc0)
+      val unit = DesugaredAst.Exp.Cst(Constant.Unit, loc0)
       mkApplyFqn("Map.empty", List(unit), loc0)
     } else {
-      val es = exps0.map { case (k, v) => WeededAst.Expr.Tuple(List(k, v), k.loc) }
+      val es = exps0.map { case (k, v) => WeededAst.Exp.Tuple(List(k, v), k.loc) }
       desugarCollectionLitToVec("Vector.toMap", es, loc0)
     }
   }
@@ -1346,14 +1346,14 @@ object Desugar {
     *
     * Conceptually, it returns (in Flix): `fqn(Vector#{exps})`.
     */
-  private def desugarCollectionLitToVec(fqn: String, exps0: List[WeededAst.Expr], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarCollectionLitToVec(fqn: String, exps0: List[WeededAst.Exp], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp = {
     val es = visitExps(exps0)
-    val vectorLit = DesugaredAst.Expr.VectorLit(es, loc0)
+    val vectorLit = DesugaredAst.Exp.VectorLit(es, loc0)
     mkApplyFqn(fqn, List(vectorLit), loc0)
   }
 
   /**
-    * Rewrites a [[WeededAst.Expr.FixpointQueryWithSelect]] to include a #Result relation to store the query result.
+    * Rewrites a [[WeededAst.Exp.FixpointQueryWithSelect]] to include a #Result relation to store the query result.
     *
     * E.g.,
     * {{{
@@ -1364,7 +1364,7 @@ object Desugar {
     *   query e1, e2, e3, #{ #Result(x, y, z) :- A(x, y), B(y) if x > 0 } select (x, y, z) from A(x, y), B(z) where x > 0
     * }}}
     */
-  private def desugarFixpointQueryWithSelect(exps0: List[WeededAst.Expr], selects0: List[WeededAst.Expr], from0: List[Predicate.Body], where0: List[WeededAst.Expr], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr = {
+  private def desugarFixpointQueryWithSelect(exps0: List[WeededAst.Exp], selects0: List[WeededAst.Exp], from0: List[Predicate.Body], where0: List[WeededAst.Exp], loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp = {
     val exps = visitExps(exps0)
     val selects = visitExps(selects0)
     val from = visitPredicateBodies(from0)
@@ -1391,13 +1391,13 @@ object Desugar {
     val pseudoConstraint = DesugaredAst.Constraint(head, body, loc0)
 
     // Construct a constraint set that contains the single pseudo constraint.
-    val queryExp = DesugaredAst.Expr.FixpointConstraintSet(List(pseudoConstraint), loc0)
+    val queryExp = DesugaredAst.Exp.FixpointConstraintSet(List(pseudoConstraint), loc0)
 
-    DesugaredAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc0)
+    DesugaredAst.Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc0)
   }
 
   /**
-    * Desugars a [[WeededAst.Expr.LambdaExtMatch]] into a lambda with an extensible pattern match on its argument.
+    * Desugars a [[WeededAst.Exp.LambdaExtMatch]] into a lambda with an extensible pattern match on its argument.
     *
     * {{{
     *   (ematch A(x, y) -> exp)
@@ -1415,21 +1415,21 @@ object Desugar {
     * @param exp0 the body of the lambda.
     * @param loc0 the location of the entire lambda.
     */
-  private def desugarLambdaExtMatch(pat0: DesugaredAst.ExtPattern, exp0: DesugaredAst.Expr, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr.Lambda = {
+  private def desugarLambdaExtMatch(pat0: DesugaredAst.ExtPattern, exp0: DesugaredAst.Exp, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp.Lambda = {
     // The name of the lambda parameter.
     val ident = Name.Ident("matchVar" + Flix.Delimiter + flix.genSym.freshId(), loc0.asSynthetic)
 
     // Construct the body of the lambda expression.
-    val paramVarExpr = DesugaredAst.Expr.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), loc0.asSynthetic)
+    val paramVarExpr = DesugaredAst.Exp.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), loc0.asSynthetic)
     val rule = DesugaredAst.ExtMatchRule(pat0, exp0, loc0.asSynthetic)
 
     val fparam = DesugaredAst.FormalParam(ident, None, loc0.asSynthetic)
-    val body = DesugaredAst.Expr.ExtMatch(paramVarExpr, List(rule), loc0.asSynthetic)
-    DesugaredAst.Expr.Lambda(fparam, body, loc0.asSynthetic)
+    val body = DesugaredAst.Exp.ExtMatch(paramVarExpr, List(rule), loc0.asSynthetic)
+    DesugaredAst.Exp.Lambda(fparam, body, loc0.asSynthetic)
   }
 
   /**
-    * Desugars a [[WeededAst.Expr.LambdaMatch]] into a lambda with a pattern match on its argument.
+    * Desugars a [[WeededAst.Exp.LambdaMatch]] into a lambda with a pattern match on its argument.
     *
     * {{{
     *   (match A(x, y) -> exp)
@@ -1447,36 +1447,36 @@ object Desugar {
     * @param exp0 the body of the lambda.
     * @param loc0 the location of the entire lambda.
     */
-  private def desugarLambdaMatch(pat0: DesugaredAst.Pattern, exp0: DesugaredAst.Expr, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Expr.Lambda = {
+  private def desugarLambdaMatch(pat0: DesugaredAst.Pattern, exp0: DesugaredAst.Exp, loc0: SourceLocation)(implicit flix: Flix): DesugaredAst.Exp.Lambda = {
     // The name of the lambda parameter.
     val ident = Name.Ident("matchVar" + Flix.Delimiter + flix.genSym.freshId(), loc0.asSynthetic)
 
     // Construct the body of the lambda expression.
-    val paramVarExpr = DesugaredAst.Expr.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), loc0.asSynthetic)
+    val paramVarExpr = DesugaredAst.Exp.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), loc0.asSynthetic)
     val rule = DesugaredAst.MatchRule(pat0, None, exp0, loc0.asSynthetic)
 
     val fparam = DesugaredAst.FormalParam(ident, None, loc0.asSynthetic)
-    val body = DesugaredAst.Expr.Match(paramVarExpr, List(rule), loc0.asSynthetic)
-    DesugaredAst.Expr.Lambda(fparam, body, loc0.asSynthetic)
+    val body = DesugaredAst.Exp.Match(paramVarExpr, List(rule), loc0.asSynthetic)
+    DesugaredAst.Exp.Lambda(fparam, body, loc0.asSynthetic)
   }
 
   /**
     * Returns an apply expression for the given fully-qualified name `fqn` and the given arguments `args0`.
     */
-  private def mkApplyFqn(fqn0: String, args0: List[DesugaredAst.Expr], loc0: SourceLocation): DesugaredAst.Expr = {
+  private def mkApplyFqn(fqn0: String, args0: List[DesugaredAst.Exp], loc0: SourceLocation): DesugaredAst.Exp = {
     val l = loc0.asSynthetic
-    val lambda = DesugaredAst.Expr.Ambiguous(Name.mkQName(fqn0), l)
-    DesugaredAst.Expr.Apply(lambda, args0, l)
+    val lambda = DesugaredAst.Exp.Ambiguous(Name.mkQName(fqn0), l)
+    DesugaredAst.Exp.Apply(lambda, args0, l)
   }
 
   /**
     * Returns the given expression `exp0` optionally wrapped in a type ascription if `tpe0` is `Some`.
     */
-  private def withAscription(exp0: DesugaredAst.Expr, tpe0: Option[DesugaredAst.Type]): DesugaredAst.Expr = {
+  private def withAscription(exp0: DesugaredAst.Exp, tpe0: Option[DesugaredAst.Type]): DesugaredAst.Exp = {
     val l = exp0.loc.asSynthetic
     tpe0 match {
       case None => exp0
-      case Some(t) => DesugaredAst.Expr.Ascribe(exp0, Some(t), None, l)
+      case Some(t) => DesugaredAst.Exp.Ascribe(exp0, Some(t), None, l)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -62,9 +62,9 @@ object EffectBinder {
 
   private sealed trait Binder
 
-  private case class LetBinder(sym: VarSym, exp: ReducedAst.Expr, loc: SourceLocation) extends Binder
+  private case class LetBinder(sym: VarSym, exp: ReducedAst.Exp, loc: SourceLocation) extends Binder
 
-  private case class NonBinder(exp: ReducedAst.Expr, loc: SourceLocation) extends Binder
+  private case class NonBinder(exp: ReducedAst.Exp, loc: SourceLocation) extends Binder
 
   /**
     * Transforms the [[LiftedAst.Def]] such that effect operations will be run without an
@@ -128,81 +128,81 @@ object EffectBinder {
   }
 
   /**
-    * Transforms the [[LiftedAst.Expr]] such that effect operations will be run without an
-    * operand stack - binding necessary expressions in the returned [[ReducedAst.Expr]].
+    * Transforms the [[LiftedAst.Exp]] such that effect operations will be run without an
+    * operand stack - binding necessary expressions in the returned [[ReducedAst.Exp]].
     */
-  private def visitExpr(exp0: LiftedAst.Expr)(implicit flix: Flix): ReducedAst.Expr = exp0 match {
-    case LiftedAst.Expr.Cst(_, _, _) =>
+  private def visitExpr(exp0: LiftedAst.Exp)(implicit flix: Flix): ReducedAst.Exp = exp0 match {
+    case LiftedAst.Exp.Cst(_, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp0)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.Var(_, _, _) =>
+    case LiftedAst.Exp.Var(_, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp0)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.ApplyAtomic(_, _, _, _, _) =>
+    case LiftedAst.Exp.ApplyAtomic(_, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp0)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.ApplyClo(_, _, _, _, _) =>
+    case LiftedAst.Exp.ApplyClo(_, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp0)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.ApplyDef(_, _, _, _, _) =>
+    case LiftedAst.Exp.ApplyDef(_, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp0)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.ApplyOp(_, _, _, _, _) =>
+    case LiftedAst.Exp.ApplyOp(_, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp0)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.IfThenElse(_, _, _, _, _, _) =>
+    case LiftedAst.Exp.IfThenElse(_, _, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp0)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.Branch(exp, branches0, tpe, purity, loc) =>
+    case LiftedAst.Exp.Branch(exp, branches0, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val branches = MapOps.mapValues(branches0)(visitExpr)
-      ReducedAst.Expr.Branch(e, branches, tpe, purity, loc)
+      ReducedAst.Exp.Branch(e, branches, tpe, purity, loc)
 
-    case LiftedAst.Expr.JumpTo(_, _, _, _) =>
+    case LiftedAst.Exp.JumpTo(_, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp0)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.Let(sym, exp1, exp2, _, _, loc) =>
+    case LiftedAst.Exp.Let(sym, exp1, exp2, _, _, loc) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       val e2 = visitExpr(exp2)
-      val e = ReducedAst.Expr.Let(sym, e1, e2, loc)
+      val e = ReducedAst.Exp.Let(sym, e1, e2, loc)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.Stm(exp1, exp2, _, _, loc) =>
+    case LiftedAst.Exp.Stm(exp1, exp2, _, _, loc) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       val e2 = visitExpr(exp2)
-      val e = ReducedAst.Expr.Stmt(e1, e2, loc)
+      val e = ReducedAst.Exp.Stmt(e1, e2, loc)
       bindBinders(binders, e)
 
-    case LiftedAst.Expr.Region(sym, exp, tpe, purity, loc) =>
+    case LiftedAst.Exp.Region(sym, exp, tpe, purity, loc) =>
       val e = visitExpr(exp)
-      ReducedAst.Expr.Region(sym, e, tpe, purity, loc)
+      ReducedAst.Exp.Region(sym, e, tpe, purity, loc)
 
-    case LiftedAst.Expr.TryCatch(exp, rules, tpe, purity, loc) =>
+    case LiftedAst.Exp.TryCatch(exp, rules, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val rules1 = rules.map {
         case cr => ReducedAst.CatchRule(cr.sym, cr.clazz, visitExpr(cr.exp))
       }
-      ReducedAst.Expr.TryCatch(e, rules1, tpe, purity, loc)
+      ReducedAst.Exp.TryCatch(e, rules1, tpe, purity, loc)
 
-    case LiftedAst.Expr.RunWith(exp, effUse, rules, tpe, purity, loc) =>
+    case LiftedAst.Exp.RunWith(exp, effUse, rules, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val rules1 = rules.map {
         case LiftedAst.HandlerRule(symUse, fparams0, body) =>
@@ -210,84 +210,84 @@ object EffectBinder {
           val b = visitExpr(body)
           ReducedAst.HandlerRule(symUse, fparams, b)
       }
-      ReducedAst.Expr.RunWith(e, effUse, rules1, ExpPosition.NonTail, tpe, purity, loc)
+      ReducedAst.Exp.RunWith(e, effUse, rules1, ExpPosition.NonTail, tpe, purity, loc)
 
-    case LiftedAst.Expr.NewObject(_, _, _, _, _, _) =>
+    case LiftedAst.Exp.NewObject(_, _, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp0)
       bindBinders(binders, e)
   }
 
   /**
-    * Transforms the [[LiftedAst.Expr]] such that effect operations will be run without an
+    * Transforms the [[LiftedAst.Exp]] such that effect operations will be run without an
     * operand stack. The outer-most expression IS NOT let-bound but all
     * sub-expressions will be. `do E(x, y, z)` might be returned.
     *
     * Necessary bindings are added to binders, where the first binder is the
     * outermost one.
     */
-  private def visitExprInnerWithBinders(binders: mutable.ArrayBuffer[Binder])(exp0: LiftedAst.Expr)(implicit flix: Flix): ReducedAst.Expr = exp0 match {
-    case LiftedAst.Expr.Cst(cst, tpe, loc) =>
-      ReducedAst.Expr.Cst(cst, loc)
+  private def visitExprInnerWithBinders(binders: mutable.ArrayBuffer[Binder])(exp0: LiftedAst.Exp)(implicit flix: Flix): ReducedAst.Exp = exp0 match {
+    case LiftedAst.Exp.Cst(cst, tpe, loc) =>
+      ReducedAst.Exp.Cst(cst, loc)
 
-    case LiftedAst.Expr.Var(sym, tpe, loc) =>
-      ReducedAst.Expr.Var(sym, tpe, loc)
+    case LiftedAst.Exp.Var(sym, tpe, loc) =>
+      ReducedAst.Exp.Var(sym, tpe, loc)
 
-    case LiftedAst.Expr.ApplyAtomic(op@AtomicOp.Binary(SemanticOp.BoolOp.And | SemanticOp.BoolOp.Or), exps, tpe, purity, loc) =>
+    case LiftedAst.Exp.ApplyAtomic(op@AtomicOp.Binary(SemanticOp.BoolOp.And | SemanticOp.BoolOp.Or), exps, tpe, purity, loc) =>
       // And and Or does not leave the first argument on the stack in genExpression.
       val List(exp1, exp2) = exps
       val e1 = visitExprWithBinders(binders)(exp1)
       val e2 = visitExpr(exp2)
-      ReducedAst.Expr.ApplyAtomic(op, List(e1, e2), tpe, purity, loc)
+      ReducedAst.Exp.ApplyAtomic(op, List(e1, e2), tpe, purity, loc)
 
-    case LiftedAst.Expr.ApplyAtomic(op, exps, tpe, purity, loc) =>
+    case LiftedAst.Exp.ApplyAtomic(op, exps, tpe, purity, loc) =>
       val es = exps.map(visitExprWithBinders(binders))
-      ReducedAst.Expr.ApplyAtomic(op, es, tpe, purity, loc)
+      ReducedAst.Exp.ApplyAtomic(op, es, tpe, purity, loc)
 
-    case LiftedAst.Expr.ApplyClo(exp1, exp2, tpe, purity, loc) =>
+    case LiftedAst.Exp.ApplyClo(exp1, exp2, tpe, purity, loc) =>
       val e1 = visitExprWithBinders(binders)(exp1)
       val e2 = visitExprWithBinders(binders)(exp2)
-      ReducedAst.Expr.ApplyClo(e1, e2, ExpPosition.NonTail, tpe, purity, loc)
+      ReducedAst.Exp.ApplyClo(e1, e2, ExpPosition.NonTail, tpe, purity, loc)
 
-    case LiftedAst.Expr.ApplyDef(sym, exps, tpe, purity, loc) =>
+    case LiftedAst.Exp.ApplyDef(sym, exps, tpe, purity, loc) =>
       val es = exps.map(visitExprWithBinders(binders))
-      ReducedAst.Expr.ApplyDef(sym, es, ExpPosition.NonTail, tpe, purity, loc)
+      ReducedAst.Exp.ApplyDef(sym, es, ExpPosition.NonTail, tpe, purity, loc)
 
-    case LiftedAst.Expr.ApplyOp(sym, exps, tpe, purity, loc) =>
+    case LiftedAst.Exp.ApplyOp(sym, exps, tpe, purity, loc) =>
       val es = exps.map(visitExprWithBinders(binders))
-      ReducedAst.Expr.ApplyOp(sym, es, tpe, purity, loc)
+      ReducedAst.Exp.ApplyOp(sym, es, tpe, purity, loc)
 
-    case LiftedAst.Expr.IfThenElse(exp1, exp2, exp3, tpe, purity, loc) =>
+    case LiftedAst.Exp.IfThenElse(exp1, exp2, exp3, tpe, purity, loc) =>
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       val e2 = visitExpr(exp2)
       val e3 = visitExpr(exp3)
-      ReducedAst.Expr.IfThenElse(e1, e2, e3, tpe, purity, loc)
+      ReducedAst.Exp.IfThenElse(e1, e2, e3, tpe, purity, loc)
 
-    case LiftedAst.Expr.Branch(exp, branches, tpe, purity, loc) =>
+    case LiftedAst.Exp.Branch(exp, branches, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val bs = branches.map {
         case (sym, branchExp) => (sym, visitExpr(branchExp))
       }
-      ReducedAst.Expr.Branch(e, bs, tpe, purity, loc)
+      ReducedAst.Exp.Branch(e, bs, tpe, purity, loc)
 
-    case LiftedAst.Expr.JumpTo(sym, tpe, purity, loc) =>
-      ReducedAst.Expr.JumpTo(sym, tpe, purity, loc)
+    case LiftedAst.Exp.JumpTo(sym, tpe, purity, loc) =>
+      ReducedAst.Exp.JumpTo(sym, tpe, purity, loc)
 
-    case LiftedAst.Expr.Let(sym, exp1, exp2, _, _, loc) =>
+    case LiftedAst.Exp.Let(sym, exp1, exp2, _, _, loc) =>
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       binders.addOne(LetBinder(sym, e1, loc))
       visitExprInnerWithBinders(binders)(exp2)
 
-    case LiftedAst.Expr.Stm(exp1, exp2, _, _, loc) =>
+    case LiftedAst.Exp.Stm(exp1, exp2, _, _, loc) =>
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       binders.addOne(NonBinder(e1, loc))
       visitExprInnerWithBinders(binders)(exp2)
 
-    case LiftedAst.Expr.Region(sym, exp, tpe, purity, loc) =>
+    case LiftedAst.Exp.Region(sym, exp, tpe, purity, loc) =>
       val e = visitExpr(exp)
-      ReducedAst.Expr.Region(sym, e, tpe, purity, loc)
+      ReducedAst.Exp.Region(sym, e, tpe, purity, loc)
 
-    case LiftedAst.Expr.TryCatch(exp, rules0, tpe, purity, loc) =>
+    case LiftedAst.Exp.TryCatch(exp, rules0, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val rules = rules0.map {
         case LiftedAst.CatchRule(sym, clazz, body) =>
@@ -295,9 +295,9 @@ object EffectBinder {
           val b = visitExpr(body)
           ReducedAst.CatchRule(sym, clazz, b)
       }
-      ReducedAst.Expr.TryCatch(e, rules, tpe, purity, loc)
+      ReducedAst.Exp.TryCatch(e, rules, tpe, purity, loc)
 
-    case LiftedAst.Expr.RunWith(exp, effUse, rules, tpe, purity, loc) =>
+    case LiftedAst.Exp.RunWith(exp, effUse, rules, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val rs = rules.map {
         case LiftedAst.HandlerRule(symUse, fparams0, body) =>
@@ -305,76 +305,76 @@ object EffectBinder {
           val b = visitExpr(body)
           ReducedAst.HandlerRule(symUse, fparams, b)
       }
-      ReducedAst.Expr.RunWith(e, effUse, rs, ExpPosition.NonTail, tpe, purity, loc)
+      ReducedAst.Exp.RunWith(e, effUse, rs, ExpPosition.NonTail, tpe, purity, loc)
 
-    case LiftedAst.Expr.NewObject(name, clazz, tpe, purity, methods, loc) =>
+    case LiftedAst.Exp.NewObject(name, clazz, tpe, purity, methods, loc) =>
       val ms = methods.map(visitJvmMethod)
-      ReducedAst.Expr.NewObject(name, clazz, tpe, purity, ms, loc)
+      ReducedAst.Exp.NewObject(name, clazz, tpe, purity, ms, loc)
   }
 
   /**
-    * Transforms the [[LiftedAst.Expr]] such that effect operations will be run without an
+    * Transforms the [[LiftedAst.Exp]] such that effect operations will be run without an
     * operand stack. The outer-most expression IS let-bound along with all
     * sub-expressions. A variable or a constant is always returned.
     *
     * Necessary bindings are added to binders, where the first binder is the
     * outermost one.
     */
-  private def visitExprWithBinders(binders: mutable.ArrayBuffer[Binder])(exp: LiftedAst.Expr)(implicit flix: Flix): ReducedAst.Expr = {
+  private def visitExprWithBinders(binders: mutable.ArrayBuffer[Binder])(exp: LiftedAst.Exp)(implicit flix: Flix): ReducedAst.Exp = {
     /**
       * Let-binds the given expression, unless its a variable or constant.
       * If the given argument is a binder, then the structure is flattened.
       */
     @tailrec
-    def bind(e: ReducedAst.Expr): ReducedAst.Expr = e match {
+    def bind(e: ReducedAst.Exp): ReducedAst.Exp = e match {
       // trivial expressions
-      case ReducedAst.Expr.Cst(_, _) => e
-      case ReducedAst.Expr.Var(_, _, _) => e
-      case ReducedAst.Expr.JumpTo(_, _, _, _) => e
-      case ReducedAst.Expr.ApplyAtomic(_, _, _, _, _) => e
+      case ReducedAst.Exp.Cst(_, _) => e
+      case ReducedAst.Exp.Var(_, _, _) => e
+      case ReducedAst.Exp.JumpTo(_, _, _, _) => e
+      case ReducedAst.Exp.ApplyAtomic(_, _, _, _, _) => e
       // non-trivial expressions
-      case ReducedAst.Expr.ApplyClo(_, _, _, _, _, _) => letBindExpr(binders)(e)
-      case ReducedAst.Expr.ApplyDef(_, _, _, _, _, _) => letBindExpr(binders)(e)
-      case ReducedAst.Expr.ApplyOp(_, _, _, _, _) => letBindExpr(binders)(e)
-      case ReducedAst.Expr.ApplySelfTail(_, _, _, _, _) => letBindExpr(binders)(e)
-      case ReducedAst.Expr.IfThenElse(_, _, _, _, _, _) => letBindExpr(binders)(e)
-      case ReducedAst.Expr.Branch(_, _, _, _, _) => letBindExpr(binders)(e)
-      case ReducedAst.Expr.Let(sym, exp1, exp2, loc) =>
+      case ReducedAst.Exp.ApplyClo(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.ApplyDef(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.ApplyOp(_, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.ApplySelfTail(_, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.IfThenElse(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.Branch(_, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.Let(sym, exp1, exp2, loc) =>
         binders.addOne(LetBinder(sym, exp1, loc))
         bind(exp2)
-      case ReducedAst.Expr.Stmt(exp1, exp2, loc) =>
+      case ReducedAst.Exp.Stmt(exp1, exp2, loc) =>
         binders.addOne(NonBinder(exp1, loc))
         bind(exp2)
-      case ReducedAst.Expr.Region(_, _, _, _, _) => letBindExpr(binders)(e)
-      case ReducedAst.Expr.TryCatch(_, _, _, _, _) => letBindExpr(binders)(e)
-      case ReducedAst.Expr.RunWith(_, _, _, _, _, _, _) => letBindExpr(binders)(e)
-      case ReducedAst.Expr.NewObject(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.Region(_, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.TryCatch(_, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.RunWith(_, _, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Exp.NewObject(_, _, _, _, _, _) => letBindExpr(binders)(e)
     }
 
     bind(visitExprInnerWithBinders(binders)(exp))
   }
 
   /**
-    * Simply let-binds the given expression, adding a [[ReducedAst.Expr.Let]] to binders.
+    * Simply let-binds the given expression, adding a [[ReducedAst.Exp.Let]] to binders.
     * The local params of [[LocalContext]] is updated with this new binder.
     */
-  private def letBindExpr(binders: mutable.ArrayBuffer[Binder])(e: ReducedAst.Expr)(implicit flix: Flix): ReducedAst.Expr.Var = {
+  private def letBindExpr(binders: mutable.ArrayBuffer[Binder])(e: ReducedAst.Exp)(implicit flix: Flix): ReducedAst.Exp.Var = {
     val loc = e.loc.asSynthetic
     val sym = Symbol.freshVarSym("anf", BoundBy.Let, loc)
     binders.addOne(LetBinder(sym, e, loc))
-    ReducedAst.Expr.Var(sym, e.tpe, loc)
+    ReducedAst.Exp.Var(sym, e.tpe, loc)
   }
 
   /**
-    * Returns an [[ReducedAst.Expr]] where the given binders is a chained [[ReducedAst.Expr.Let]]
+    * Returns an [[ReducedAst.Exp]] where the given binders is a chained [[ReducedAst.Exp.Let]]
     * expression. The first binder will be the outer-most one.
     */
-  private def bindBinders(binders: mutable.ArrayBuffer[Binder], exp: ReducedAst.Expr): ReducedAst.Expr = {
+  private def bindBinders(binders: mutable.ArrayBuffer[Binder], exp: ReducedAst.Exp): ReducedAst.Exp = {
     binders.foldRight(exp) {
       case (LetBinder(sym, exp1, loc), acc) =>
-        ReducedAst.Expr.Let(sym, exp1, acc, loc)
+        ReducedAst.Exp.Let(sym, exp1, acc, loc)
       case (NonBinder(exp1, loc), acc) =>
-        ReducedAst.Expr.Stmt(exp1, acc, loc)
+        ReducedAst.Exp.Stmt(exp1, acc, loc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -550,11 +550,11 @@ object EntryPoints {
       val mainArrowType = oldEntryPoint.spec.declaredScheme.base
       val mainSym = DefSymUse(oldEntryPoint.sym, SourceLocation.Unknown)
       val mainArgType = Type.Unit
-      val mainArg = TypedAst.Expr.Cst(Constant.Unit, mainArgType, SourceLocation.Unknown)
+      val mainArg = TypedAst.Exp.Cst(Constant.Unit, mainArgType, SourceLocation.Unknown)
       val mainReturnType = mainArrowType.arrowResultType
       val mainEffect = mainArrowType.arrowEffectType
       // `mainFunc()`.
-      val mainCall = TypedAst.Expr.ApplyDef(mainSym, List(mainArg), List.empty, mainArrowType, mainReturnType, mainEffect, SourceLocation.Unknown)
+      val mainCall = TypedAst.Exp.ApplyDef(mainSym, List(mainArg), List.empty, mainArrowType, mainReturnType, mainEffect, SourceLocation.Unknown)
 
       // `println(mainFunc())`.
       val printSym = DefSymUse(root.defs(new Symbol.DefnSym(None, Nil, "println", SourceLocation.Unknown)).sym, SourceLocation.Unknown)
@@ -564,7 +564,7 @@ object EntryPoints {
       val printEffect = Type.IO
       val printArrowType = Type.mkArrowWithEffect(printArgType, printEffect, printReturnType, SourceLocation.Unknown)
       val printCallEffect = Type.mkUnion(printEffect, printArg.eff, SourceLocation.Unknown)
-      val printCall = TypedAst.Expr.ApplyDef(printSym, List(printArg), List(printArgType), printArrowType, printReturnType, printCallEffect, SourceLocation.Unknown)
+      val printCall = TypedAst.Exp.ApplyDef(printSym, List(printArg), List(printArgType), printArrowType, printReturnType, printCallEffect, SourceLocation.Unknown)
 
       val sym = new Symbol.DefnSym(None, Nil, "main" + Flix.Delimiter, SourceLocation.Unknown)
 
@@ -624,7 +624,7 @@ object EntryPoints {
       val runWithIODef = root.defs(RunWithIOSym)
       val runWithIOSymUse = DefSymUse(runWithIODef.sym, runWithIODef.loc)
       // Create _ -> exp.
-      val innerLambda = TypedAst.Expr.Lambda(TypedAst.FormalParam(
+      val innerLambda = TypedAst.Exp.Lambda(TypedAst.FormalParam(
         TypedAst.Binder(Symbol.freshVarSym("_", FormalParam, syntheticExpLocation), Type.Unit),
         Type.Unit,
         TypeSource.Inferred,
@@ -637,7 +637,7 @@ object EntryPoints {
       // Create the instantiated type of runWithIO.
       val runWithIOArrowType = Type.mkArrowWithEffect(innerLambda.tpe, eff, currentDef.spec.retTpe, syntheticExpLocation)
       // Create Assert.runWithIO(_ -> exp).
-      val runWithIOCall = TypedAst.Expr.ApplyDef(runWithIOSymUse, List(innerLambda), List(innerLambda.tpe), runWithIOArrowType, currentDef.spec.retTpe, eff, syntheticExpLocation)
+      val runWithIOCall = TypedAst.Exp.ApplyDef(runWithIOSymUse, List(innerLambda), List(innerLambda.tpe), runWithIOArrowType, currentDef.spec.retTpe, eff, syntheticExpLocation)
 
       currentDef.copy(spec = spec, exp = runWithIOCall)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -3,7 +3,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.SimpleType.erase
 import ca.uwaterloo.flix.language.ast.ReducedAst.*
-import ca.uwaterloo.flix.language.ast.ReducedAst.Expr.*
+import ca.uwaterloo.flix.language.ast.ReducedAst.Exp.*
 import ca.uwaterloo.flix.language.ast.{AtomicOp, SimpleType, Purity, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugReducedAst
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
@@ -49,7 +49,7 @@ object Eraser {
   private def visitDef(defn: Def): Def = defn match {
     case Def(ann, mod, sym, cparams, fparams, lparams, pcPoints, exp, tpe, originalTpe, loc) =>
       val eNew = visitExp(exp)
-      val e = Expr.ApplyAtomic(AtomicOp.Box, List(eNew), box(tpe), exp.purity, loc)
+      val e = Exp.ApplyAtomic(AtomicOp.Box, List(eNew), box(tpe), exp.purity, loc)
       Def(ann, mod, sym, cparams.map(visitParam), fparams.map(visitParam), lparams.map(visitLocalParam), pcPoints, e, box(tpe), UnboxedType(erase(originalTpe.tpe)), loc)
   }
 
@@ -85,7 +85,7 @@ object Eraser {
       StructField(sym, polymorphicErasure(tpe), loc)
   }
 
-  private def visitBranch(branch: (Symbol.LabelSym, Expr)): (Symbol.LabelSym, Expr) = branch match {
+  private def visitBranch(branch: (Symbol.LabelSym, Exp)): (Symbol.LabelSym, Exp) = branch match {
     case (sym, exp) =>
       (sym, visitExp(exp))
   }
@@ -106,7 +106,7 @@ object Eraser {
       JvmMethod(ident, fparams.map(visitParam), visitExp(clo), visitType(retTpe), purity, loc)
   }
 
-  private def visitExp(exp0: Expr): Expr = exp0 match {
+  private def visitExp(exp0: Exp): Exp = exp0 match {
     case Cst(cst, loc) =>
       Cst(cst, loc)
     case Var(sym, tpe, loc) =>
@@ -191,12 +191,12 @@ object Eraser {
       NewObject(name, clazz, visitType(tpe), purity, methods.map(visitJvmMethod), loc)
   }
 
-  private def castExp(exp: Expr, t: SimpleType, purity: Purity, loc: SourceLocation): Expr = {
-    Expr.ApplyAtomic(AtomicOp.Cast, List(exp), t, purity, loc.asSynthetic)
+  private def castExp(exp: Exp, t: SimpleType, purity: Purity, loc: SourceLocation): Exp = {
+    Exp.ApplyAtomic(AtomicOp.Cast, List(exp), t, purity, loc.asSynthetic)
   }
 
-  private def unboxExp(exp: Expr, t: SimpleType, purity: Purity, loc: SourceLocation): Expr = {
-    Expr.ApplyAtomic(AtomicOp.Unbox, List(exp), t, purity, loc.asSynthetic)
+  private def unboxExp(exp: Exp, t: SimpleType, purity: Purity, loc: SourceLocation): Exp = {
+    Exp.ApplyAtomic(AtomicOp.Unbox, List(exp), t, purity, loc.asSynthetic)
   }
 
   private def visitEffect(eff: Effect): Effect = eff match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -377,42 +377,42 @@ object Kinder {
   /**
     * Performs kinding on the given expression under the given kind environment.
     */
-  private def visitExp(exp00: ResolvedAst.Expr, kenv0: KindEnv, root: ResolvedAst.Root)(implicit scope: Scope, renv: RootEnv, sctx: SharedContext, flix: Flix): KindedAst.Expr = {
+  private def visitExp(exp00: ResolvedAst.Exp, kenv0: KindEnv, root: ResolvedAst.Root)(implicit scope: Scope, renv: RootEnv, sctx: SharedContext, flix: Flix): KindedAst.Exp = {
     exp00 match {
-      case ResolvedAst.Expr.Var(sym, loc) =>
-        KindedAst.Expr.Var(sym, loc)
+      case ResolvedAst.Exp.Var(sym, loc) =>
+        KindedAst.Exp.Var(sym, loc)
 
-      case ResolvedAst.Expr.Hole(sym, env, loc) =>
+      case ResolvedAst.Exp.Hole(sym, env, loc) =>
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshEffSlackVar(loc.asSynthetic)
-        KindedAst.Expr.Hole(sym, env, tvar, evar, loc)
+        KindedAst.Exp.Hole(sym, env, tvar, evar, loc)
 
-      case ResolvedAst.Expr.HoleWithExp(exp0, env, loc) =>
+      case ResolvedAst.Exp.HoleWithExp(exp0, env, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshEffSlackVar(loc.asSynthetic)
-        KindedAst.Expr.HoleWithExp(exp, env, tvar, evar, loc)
+        KindedAst.Exp.HoleWithExp(exp, env, tvar, evar, loc)
 
-      case ResolvedAst.Expr.OpenAs(symUse, exp0, loc) =>
+      case ResolvedAst.Exp.OpenAs(symUse, exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.OpenAs(symUse, exp, tvar, loc)
+        KindedAst.Exp.OpenAs(symUse, exp, tvar, loc)
 
-      case ResolvedAst.Expr.Use(sym, alias, exp0, loc) =>
+      case ResolvedAst.Exp.Use(sym, alias, exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
-        KindedAst.Expr.Use(sym, alias, exp, loc)
+        KindedAst.Exp.Use(sym, alias, exp, loc)
 
-      case ResolvedAst.Expr.Cst(cst, loc) =>
-        KindedAst.Expr.Cst(cst, loc)
+      case ResolvedAst.Exp.Cst(cst, loc) =>
+        KindedAst.Exp.Cst(cst, loc)
 
-      case ResolvedAst.Expr.ApplyClo(exp10, exp20, loc) =>
+      case ResolvedAst.Exp.ApplyClo(exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.ApplyClo(exp1, exp2, tvar, evar, loc)
+        KindedAst.Exp.ApplyClo(exp1, exp2, tvar, evar, loc)
 
-      case ResolvedAst.Expr.ApplyDef(DefSymUse(sym, loc1), exps0, loc2) =>
+      case ResolvedAst.Exp.ApplyDef(DefSymUse(sym, loc1), exps0, loc2) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val targs = renv.defSpecs(sym).tparams.map {
           tparam => Type.freshVar(tparam.sym.kind, tparam.sym.loc)
@@ -420,22 +420,22 @@ object Kinder {
         val itvar = Type.freshVar(Kind.Star, loc1.asSynthetic)
         val tvar = Type.freshVar(Kind.Star, loc2.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc2.asSynthetic)
-        KindedAst.Expr.ApplyDef(DefSymUse(sym, loc1), exps, targs, itvar, tvar, evar, loc2)
+        KindedAst.Exp.ApplyDef(DefSymUse(sym, loc1), exps, targs, itvar, tvar, evar, loc2)
 
-      case ResolvedAst.Expr.ApplyLocalDef(symUse, exps0, loc) =>
+      case ResolvedAst.Exp.ApplyLocalDef(symUse, exps0, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val arrowTvar = Type.freshVar(Kind.Star, loc.asSynthetic) // use loc of symuse
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, evar, loc)
+        KindedAst.Exp.ApplyLocalDef(symUse, exps, arrowTvar, tvar, evar, loc)
 
-      case ResolvedAst.Expr.ApplyOp(symUse, exps0, loc) =>
+      case ResolvedAst.Exp.ApplyOp(symUse, exps0, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc)
         val evar = Type.freshVar(Kind.Eff, loc)
-        KindedAst.Expr.ApplyOp(symUse, exps, tvar, evar, loc)
+        KindedAst.Exp.ApplyOp(symUse, exps, tvar, evar, loc)
 
-      case ResolvedAst.Expr.ApplySig(SigSymUse(sym, loc1), exps0, loc2) =>
+      case ResolvedAst.Exp.ApplySig(SigSymUse(sym, loc1), exps0, loc2) =>
         val traitKind = getTraitKind(root.traits(sym.trt))
         val targ = Type.freshVar(traitKind, loc1.asSynthetic)
         val targs = renv.sigSpecs(sym).tparams.map {
@@ -445,45 +445,45 @@ object Kinder {
         val itvar = Type.freshVar(Kind.Star, loc1.asSynthetic)
         val tvar = Type.freshVar(Kind.Star, loc2.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc2.asSynthetic)
-        KindedAst.Expr.ApplySig(SigSymUse(sym, loc1), exps, targ, targs, itvar, tvar, evar, loc2)
+        KindedAst.Exp.ApplySig(SigSymUse(sym, loc1), exps, targ, targs, itvar, tvar, evar, loc2)
 
-      case ResolvedAst.Expr.Lambda(fparam0, exp0, allowSubeffecting, loc) =>
+      case ResolvedAst.Exp.Lambda(fparam0, exp0, allowSubeffecting, loc) =>
         val fparam = visitFormalParam(fparam0, kenv0, root)
         val exp = visitExp(exp0, kenv0, root)
-        KindedAst.Expr.Lambda(fparam, exp, allowSubeffecting, loc)
+        KindedAst.Exp.Lambda(fparam, exp, allowSubeffecting, loc)
 
-      case ResolvedAst.Expr.Unary(sop, exp0, loc) =>
+      case ResolvedAst.Exp.Unary(sop, exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.Unary(sop, exp, tvar, loc)
+        KindedAst.Exp.Unary(sop, exp, tvar, loc)
 
-      case ResolvedAst.Expr.Binary(sop, exp10, exp20, loc) =>
+      case ResolvedAst.Exp.Binary(sop, exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.Binary(sop, exp1, exp2, tvar, loc)
+        KindedAst.Exp.Binary(sop, exp1, exp2, tvar, loc)
 
-      case ResolvedAst.Expr.IfThenElse(exp10, exp20, exp30, loc) =>
+      case ResolvedAst.Exp.IfThenElse(exp10, exp20, exp30, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
         val exp3 = visitExp(exp30, kenv0, root)
-        KindedAst.Expr.IfThenElse(exp1, exp2, exp3, loc)
+        KindedAst.Exp.IfThenElse(exp1, exp2, exp3, loc)
 
-      case ResolvedAst.Expr.Stm(exp10, exp20, loc) =>
+      case ResolvedAst.Exp.Stm(exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
-        KindedAst.Expr.Stm(exp1, exp2, loc)
+        KindedAst.Exp.Stm(exp1, exp2, loc)
 
-      case ResolvedAst.Expr.Discard(exp0, loc) =>
+      case ResolvedAst.Exp.Discard(exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
-        KindedAst.Expr.Discard(exp, loc)
+        KindedAst.Exp.Discard(exp, loc)
 
-      case ResolvedAst.Expr.Let(sym, exp10, exp20, loc) =>
+      case ResolvedAst.Exp.Let(sym, exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
-        KindedAst.Expr.Let(sym, exp1, exp2, loc)
+        KindedAst.Exp.Let(sym, exp1, exp2, loc)
 
-      case ResolvedAst.Expr.LocalDef(sym, fparams0, exp10, exp20, loc) =>
+      case ResolvedAst.Exp.LocalDef(sym, fparams0, exp10, exp20, loc) =>
         // we must infer the formal parameters because the may contain wildcard types
         // which would not appear in the function's kenv
         val fparamKenvs = fparams0.map(inferFormalParam(_, kenv0, root))
@@ -492,109 +492,109 @@ object Kinder {
         val exp1 = visitExp(exp10, kenv1, root)
         // We visit exp2 outside the new kenv since it's not in the def's scope
         val exp2 = visitExp(exp20, kenv0, root)
-        KindedAst.Expr.LocalDef(sym, fparams, exp1, exp2, loc)
+        KindedAst.Exp.LocalDef(sym, fparams, exp1, exp2, loc)
 
-      case ResolvedAst.Expr.Region(sym, regSym, exp0, loc) =>
+      case ResolvedAst.Exp.Region(sym, regSym, exp0, loc) =>
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
         // Record that we enter the new scope.
         val newScope = scope.enter(regSym)
         val exp = visitExp(exp0, kenv0, root)(newScope, renv, sctx, flix)
-        KindedAst.Expr.Region(sym, regSym, exp, tvar, evar, loc)
+        KindedAst.Exp.Region(sym, regSym, exp, tvar, evar, loc)
 
-      case ResolvedAst.Expr.Match(exp0, rules0, loc) =>
+      case ResolvedAst.Exp.Match(exp0, rules0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val rules = rules0.map(visitMatchRule(_, kenv0, root))
-        KindedAst.Expr.Match(exp, rules, loc)
+        KindedAst.Exp.Match(exp, rules, loc)
 
-      case ResolvedAst.Expr.TypeMatch(exp0, rules0, loc) =>
+      case ResolvedAst.Exp.TypeMatch(exp0, rules0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val rules = rules0.map(visitTypeMatchRule(_, kenv0, root))
-        KindedAst.Expr.TypeMatch(exp, rules, loc)
+        KindedAst.Exp.TypeMatch(exp, rules, loc)
 
-      case ResolvedAst.Expr.RestrictableChoose(star, exp0, rules0, loc) =>
+      case ResolvedAst.Exp.RestrictableChoose(star, exp0, rules0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val rules = rules0.map(visitRestrictableChooseRule(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.RestrictableChoose(star, exp, rules, tvar, loc)
+        KindedAst.Exp.RestrictableChoose(star, exp, rules, tvar, loc)
 
-      case ResolvedAst.Expr.ExtMatch(exp, rules, loc) =>
+      case ResolvedAst.Exp.ExtMatch(exp, rules, loc) =>
         val e = visitExp(exp, kenv0, root)
         val rs = rules.map(visitExtMatchRule(_, kenv0, root))
 
-        KindedAst.Expr.ExtMatch(e, rs, loc)
+        KindedAst.Exp.ExtMatch(e, rs, loc)
 
-      case ResolvedAst.Expr.Tag(symUse, exps0, loc) =>
+      case ResolvedAst.Exp.Tag(symUse, exps0, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.Tag(symUse, exps, tvar, loc)
+        KindedAst.Exp.Tag(symUse, exps, tvar, loc)
 
-      case ResolvedAst.Expr.RestrictableTag(symUse, exps0, isOpen, loc) =>
+      case ResolvedAst.Exp.RestrictableTag(symUse, exps0, isOpen, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.RestrictableTag(symUse, exps, isOpen, tvar, evar, loc)
+        KindedAst.Exp.RestrictableTag(symUse, exps, isOpen, tvar, evar, loc)
 
-      case ResolvedAst.Expr.ExtTag(label, exps0, loc) =>
+      case ResolvedAst.Exp.ExtTag(label, exps0, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.ExtTag(label, exps, tvar, loc)
+        KindedAst.Exp.ExtTag(label, exps, tvar, loc)
 
-      case ResolvedAst.Expr.Tuple(exps0, loc) =>
+      case ResolvedAst.Exp.Tuple(exps0, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
-        KindedAst.Expr.Tuple(exps, loc)
+        KindedAst.Exp.Tuple(exps, loc)
 
-      case ResolvedAst.Expr.RecordSelect(exp0, label, loc) =>
+      case ResolvedAst.Exp.RecordSelect(exp0, label, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.RecordSelect(exp, label, tvar, loc)
+        KindedAst.Exp.RecordSelect(exp, label, tvar, loc)
 
-      case ResolvedAst.Expr.RecordExtend(label, exp10, exp20, loc) =>
+      case ResolvedAst.Exp.RecordExtend(label, exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.RecordExtend(label, exp1, exp2, tvar, loc)
+        KindedAst.Exp.RecordExtend(label, exp1, exp2, tvar, loc)
 
-      case ResolvedAst.Expr.RecordRestrict(label, exp0, loc) =>
+      case ResolvedAst.Exp.RecordRestrict(label, exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.RecordRestrict(label, exp, tvar, loc)
+        KindedAst.Exp.RecordRestrict(label, exp, tvar, loc)
 
-      case ResolvedAst.Expr.ArrayLit(exps0, exp0, loc) =>
+      case ResolvedAst.Exp.ArrayLit(exps0, exp0, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.ArrayLit(exps, exp, tvar, evar, loc)
+        KindedAst.Exp.ArrayLit(exps, exp, tvar, evar, loc)
 
-      case ResolvedAst.Expr.ArrayNew(exp10, exp20, exp30, loc) =>
-        val exp1 = visitExp(exp10, kenv0, root)
-        val exp2 = visitExp(exp20, kenv0, root)
-        val exp3 = visitExp(exp30, kenv0, root)
-        val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.ArrayNew(exp1, exp2, exp3, tvar, evar, loc)
-
-      case ResolvedAst.Expr.ArrayLoad(exp10, exp20, loc) =>
-        val exp1 = visitExp(exp10, kenv0, root)
-        val exp2 = visitExp(exp20, kenv0, root)
-        val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.ArrayLoad(exp1, exp2, tvar, evar, loc)
-
-      case ResolvedAst.Expr.ArrayStore(exp10, exp20, exp30, loc) =>
+      case ResolvedAst.Exp.ArrayNew(exp10, exp20, exp30, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
         val exp3 = visitExp(exp30, kenv0, root)
+        val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.ArrayStore(exp1, exp2, exp3, evar, loc)
+        KindedAst.Exp.ArrayNew(exp1, exp2, exp3, tvar, evar, loc)
 
-      case ResolvedAst.Expr.ArrayLength(exp0, loc) =>
+      case ResolvedAst.Exp.ArrayLoad(exp10, exp20, loc) =>
+        val exp1 = visitExp(exp10, kenv0, root)
+        val exp2 = visitExp(exp20, kenv0, root)
+        val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
+        val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
+        KindedAst.Exp.ArrayLoad(exp1, exp2, tvar, evar, loc)
+
+      case ResolvedAst.Exp.ArrayStore(exp10, exp20, exp30, loc) =>
+        val exp1 = visitExp(exp10, kenv0, root)
+        val exp2 = visitExp(exp20, kenv0, root)
+        val exp3 = visitExp(exp30, kenv0, root)
+        val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
+        KindedAst.Exp.ArrayStore(exp1, exp2, exp3, evar, loc)
+
+      case ResolvedAst.Exp.ArrayLength(exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.ArrayLength(exp, evar, loc)
+        KindedAst.Exp.ArrayLength(exp, evar, loc)
 
-      case ResolvedAst.Expr.StructNew(sym, exps0, region0, loc) =>
+      case ResolvedAst.Exp.StructNew(sym, exps0, region0, loc) =>
         val fields = exps0.map {
           case (symUse, fieldExp0) =>
             val exp = visitExp(fieldExp0, kenv0, root)
@@ -603,39 +603,39 @@ object Kinder {
         val region = visitExp(region0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.StructNew(sym, fields, region, tvar, evar, loc)
+        KindedAst.Exp.StructNew(sym, fields, region, tvar, evar, loc)
 
-      case ResolvedAst.Expr.StructGet(exp0, symUse, loc) =>
+      case ResolvedAst.Exp.StructGet(exp0, symUse, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.StructGet(exp, symUse, tvar, evar, loc)
+        KindedAst.Exp.StructGet(exp, symUse, tvar, evar, loc)
 
-      case ResolvedAst.Expr.StructPut(exp10, symUse, exp20, loc) =>
+      case ResolvedAst.Exp.StructPut(exp10, symUse, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.StructPut(exp1, symUse, exp2, tvar, evar, loc)
+        KindedAst.Exp.StructPut(exp1, symUse, exp2, tvar, evar, loc)
 
-      case ResolvedAst.Expr.VectorLit(exps0, loc) =>
+      case ResolvedAst.Exp.VectorLit(exps0, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.VectorLit(exps, tvar, evar, loc)
+        KindedAst.Exp.VectorLit(exps, tvar, evar, loc)
 
-      case ResolvedAst.Expr.VectorLoad(exp10, exp20, loc) =>
+      case ResolvedAst.Exp.VectorLoad(exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.VectorLoad(exp1, exp2, tvar, evar, loc)
+        KindedAst.Exp.VectorLoad(exp1, exp2, tvar, evar, loc)
 
-      case ResolvedAst.Expr.VectorLength(exp, loc) =>
+      case ResolvedAst.Exp.VectorLength(exp, loc) =>
         val e = visitExp(exp, kenv0, root)
-        KindedAst.Expr.VectorLength(e, loc)
+        KindedAst.Exp.VectorLength(e, loc)
 
-      case ResolvedAst.Expr.Ascribe(exp0, expectedType0, expectedEff0, loc) =>
+      case ResolvedAst.Exp.Ascribe(exp0, expectedType0, expectedEff0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
 
         // We must infer for the ascriptions because they may have wildcard types,
@@ -646,134 +646,134 @@ object Kinder {
         val expectedType = expectedType0.map(visitType(_, Kind.Star, kenv, root))
         val expectedEff = expectedEff0.map(visitType(_, Kind.Eff, kenv, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.Ascribe(exp, expectedType, expectedEff, tvar, loc)
+        KindedAst.Exp.Ascribe(exp, expectedType, expectedEff, tvar, loc)
 
-      case ResolvedAst.Expr.InstanceOf(exp0, clazz, loc) =>
+      case ResolvedAst.Exp.InstanceOf(exp0, clazz, loc) =>
         val exp = visitExp(exp0, kenv0, root)
-        KindedAst.Expr.InstanceOf(exp, clazz, loc)
+        KindedAst.Exp.InstanceOf(exp, clazz, loc)
 
-      case ResolvedAst.Expr.CheckedCast(cast, exp0, loc) =>
+      case ResolvedAst.Exp.CheckedCast(cast, exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc)
         val evar = Type.freshVar(Kind.Eff, loc)
-        KindedAst.Expr.CheckedCast(cast, exp, tvar, evar, loc)
+        KindedAst.Exp.CheckedCast(cast, exp, tvar, evar, loc)
 
-      case ResolvedAst.Expr.UncheckedCast(exp0, declaredType0, declaredEff0, loc) =>
+      case ResolvedAst.Exp.UncheckedCast(exp0, declaredType0, declaredEff0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val declaredType = declaredType0.map(visitType(_, Kind.Star, kenv0, root))
         val declaredEff = declaredEff0.map(visitType(_, Kind.Eff, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.UncheckedCast(exp, declaredType, declaredEff, tvar, loc)
+        KindedAst.Exp.UncheckedCast(exp, declaredType, declaredEff, tvar, loc)
 
-      case ResolvedAst.Expr.Unsafe(exp0, eff0, loc) =>
+      case ResolvedAst.Exp.Unsafe(exp0, eff0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val eff = visitType(eff0, Kind.Eff, kenv0, root)
-        KindedAst.Expr.Unsafe(exp, eff, loc)
+        KindedAst.Exp.Unsafe(exp, eff, loc)
 
-      case ResolvedAst.Expr.Without(exp0, symUse, loc) =>
+      case ResolvedAst.Exp.Without(exp0, symUse, loc) =>
         val exp = visitExp(exp0, kenv0, root)
-        KindedAst.Expr.Without(exp, symUse, loc)
+        KindedAst.Exp.Without(exp, symUse, loc)
 
-      case ResolvedAst.Expr.TryCatch(exp0, rules0, loc) =>
+      case ResolvedAst.Exp.TryCatch(exp0, rules0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val rules = rules0.map(visitCatchRule(_, kenv0, root))
-        KindedAst.Expr.TryCatch(exp, rules, loc)
+        KindedAst.Exp.TryCatch(exp, rules, loc)
 
-      case ResolvedAst.Expr.Throw(exp0, loc) =>
+      case ResolvedAst.Exp.Throw(exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc)
         val evar = Type.freshVar(Kind.Eff, loc)
-        KindedAst.Expr.Throw(exp, tvar, evar, loc)
+        KindedAst.Exp.Throw(exp, tvar, evar, loc)
 
-      case ResolvedAst.Expr.Handler(symUse, rules0, loc) =>
+      case ResolvedAst.Exp.Handler(symUse, rules0, loc) =>
         val tvar = Type.freshVar(Kind.Star, loc)
         val evar1 = Type.freshVar(Kind.Eff, loc)
         val evar2 = Type.freshVar(Kind.Eff, loc)
         val rules = rules0.map(visitHandlerRule(_, kenv0, root))
-        KindedAst.Expr.Handler(symUse, rules, tvar, evar1, evar2, loc)
+        KindedAst.Exp.Handler(symUse, rules, tvar, evar1, evar2, loc)
 
-      case ResolvedAst.Expr.RunWith(exp10, exp20, loc) =>
+      case ResolvedAst.Exp.RunWith(exp10, exp20, loc) =>
         val tvar = Type.freshVar(Kind.Star, loc)
         val evar = Type.freshVar(Kind.Eff, loc)
 
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
-        KindedAst.Expr.RunWith(exp1, exp2, tvar, evar, loc)
+        KindedAst.Exp.RunWith(exp1, exp2, tvar, evar, loc)
 
-      case ResolvedAst.Expr.InvokeConstructor(clazz, exps0, loc) =>
+      case ResolvedAst.Exp.InvokeConstructor(clazz, exps0, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val jvar = Type.freshVar(Kind.Jvm, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.InvokeConstructor(clazz, exps, jvar, evar, loc)
+        KindedAst.Exp.InvokeConstructor(clazz, exps, jvar, evar, loc)
 
-      case ResolvedAst.Expr.InvokeMethod(exp0, methodName, exps0, loc) =>
+      case ResolvedAst.Exp.InvokeMethod(exp0, methodName, exps0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val exps = exps0.map(visitExp(_, kenv0, root))
         val jvar = Type.freshVar(Kind.Jvm, loc.asSynthetic)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.InvokeMethod(exp, methodName, exps, jvar, tvar, evar, loc)
+        KindedAst.Exp.InvokeMethod(exp, methodName, exps, jvar, tvar, evar, loc)
 
-      case ResolvedAst.Expr.InvokeStaticMethod(clazz, methodName, exps0, loc) =>
+      case ResolvedAst.Exp.InvokeStaticMethod(clazz, methodName, exps0, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val jvar = Type.freshVar(Kind.Jvm, loc.asSynthetic)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.InvokeStaticMethod(clazz, methodName, exps, jvar, tvar, evar, loc)
+        KindedAst.Exp.InvokeStaticMethod(clazz, methodName, exps, jvar, tvar, evar, loc)
 
-      case ResolvedAst.Expr.GetField(exp0, fieldName, loc) =>
+      case ResolvedAst.Exp.GetField(exp0, fieldName, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val jvar = Type.freshVar(Kind.Jvm, loc.asSynthetic)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.GetField(exp, fieldName, jvar, tvar, evar, loc)
+        KindedAst.Exp.GetField(exp, fieldName, jvar, tvar, evar, loc)
 
-      case ResolvedAst.Expr.PutField(field, clazz, exp10, exp20, loc) =>
+      case ResolvedAst.Exp.PutField(field, clazz, exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
-        KindedAst.Expr.PutField(field, clazz, exp1, exp2, loc)
+        KindedAst.Exp.PutField(field, clazz, exp1, exp2, loc)
 
-      case ResolvedAst.Expr.GetStaticField(field, loc) =>
-        KindedAst.Expr.GetStaticField(field, loc)
+      case ResolvedAst.Exp.GetStaticField(field, loc) =>
+        KindedAst.Exp.GetStaticField(field, loc)
 
-      case ResolvedAst.Expr.PutStaticField(field, exp0, loc) =>
+      case ResolvedAst.Exp.PutStaticField(field, exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
-        KindedAst.Expr.PutStaticField(field, exp, loc)
+        KindedAst.Exp.PutStaticField(field, exp, loc)
 
-      case ResolvedAst.Expr.NewObject(name, clazz, methods0, loc) =>
+      case ResolvedAst.Exp.NewObject(name, clazz, methods0, loc) =>
         val methods = methods0.map(visitJvmMethod(_, kenv0, root))
-        KindedAst.Expr.NewObject(name, clazz, methods, loc)
+        KindedAst.Exp.NewObject(name, clazz, methods, loc)
 
-      case ResolvedAst.Expr.NewChannel(exp0, loc) =>
+      case ResolvedAst.Exp.NewChannel(exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.NewChannel(exp, tvar, loc)
+        KindedAst.Exp.NewChannel(exp, tvar, loc)
 
-      case ResolvedAst.Expr.GetChannel(exp0, loc) =>
+      case ResolvedAst.Exp.GetChannel(exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.GetChannel(exp, tvar, evar, loc)
+        KindedAst.Exp.GetChannel(exp, tvar, evar, loc)
 
-      case ResolvedAst.Expr.PutChannel(exp10, exp20, loc) =>
+      case ResolvedAst.Exp.PutChannel(exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.PutChannel(exp1, exp2, evar, loc)
+        KindedAst.Exp.PutChannel(exp1, exp2, evar, loc)
 
-      case ResolvedAst.Expr.SelectChannel(rules0, exp0, loc) =>
+      case ResolvedAst.Exp.SelectChannel(rules0, exp0, loc) =>
         val rules = rules0.map(visitSelectChannelRule(_, kenv0, root))
         val exp = exp0.map(visitExp(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.SelectChannel(rules, exp, tvar, evar, loc)
+        KindedAst.Exp.SelectChannel(rules, exp, tvar, evar, loc)
 
-      case ResolvedAst.Expr.Spawn(exp10, exp20, loc) =>
+      case ResolvedAst.Exp.Spawn(exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
-        KindedAst.Expr.Spawn(exp1, exp2, loc)
+        KindedAst.Exp.Spawn(exp1, exp2, loc)
 
-      case ResolvedAst.Expr.ParYield(frags0, exp0, loc) =>
+      case ResolvedAst.Exp.ParYield(frags0, exp0, loc) =>
         val frags = frags0.map {
           case ResolvedAst.ParYieldFragment(pat1, exp1, l0) =>
             val pat = visitPattern(pat1, kenv0, root)
@@ -781,61 +781,61 @@ object Kinder {
             KindedAst.ParYieldFragment(pat, exp, l0)
         }
         val exp = visitExp(exp0, kenv0, root)
-        KindedAst.Expr.ParYield(frags, exp, loc)
+        KindedAst.Exp.ParYield(frags, exp, loc)
 
-      case ResolvedAst.Expr.Lazy(exp0, loc) =>
+      case ResolvedAst.Exp.Lazy(exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
-        KindedAst.Expr.Lazy(exp, loc)
+        KindedAst.Exp.Lazy(exp, loc)
 
-      case ResolvedAst.Expr.Force(exp0, loc) =>
+      case ResolvedAst.Exp.Force(exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.Force(exp, tvar, loc)
+        KindedAst.Exp.Force(exp, tvar, loc)
 
-      case ResolvedAst.Expr.FixpointConstraintSet(cs0, loc) =>
+      case ResolvedAst.Exp.FixpointConstraintSet(cs0, loc) =>
         val cs = cs0.map(visitConstraint(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.FixpointConstraintSet(cs, tvar, loc)
+        KindedAst.Exp.FixpointConstraintSet(cs, tvar, loc)
 
-      case ResolvedAst.Expr.FixpointLambda(pparams0, exp0, loc) =>
+      case ResolvedAst.Exp.FixpointLambda(pparams0, exp0, loc) =>
         val pparams = pparams0.map(visitPredicateParam(_, kenv0, root))
         val exp = visitExp(exp0, kenv0, root)
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.FixpointLambda(pparams, exp, tvar, loc)
+        KindedAst.Exp.FixpointLambda(pparams, exp, tvar, loc)
 
-      case ResolvedAst.Expr.FixpointMerge(exp10, exp20, loc) =>
+      case ResolvedAst.Exp.FixpointMerge(exp10, exp20, loc) =>
         val exp1 = visitExp(exp10, kenv0, root)
         val exp2 = visitExp(exp20, kenv0, root)
-        KindedAst.Expr.FixpointMerge(exp1, exp2, loc)
+        KindedAst.Exp.FixpointMerge(exp1, exp2, loc)
 
-      case ResolvedAst.Expr.FixpointQueryWithProvenance(exps, select, withh, loc) =>
+      case ResolvedAst.Exp.FixpointQueryWithProvenance(exps, select, withh, loc) =>
         val es = exps.map(visitExp(_, kenv0, root))
         val s = visitHeadPredicate(select, kenv0, root)
-        KindedAst.Expr.FixpointQueryWithProvenance(es, s, withh, Type.freshVar(Kind.Star, loc), loc)
+        KindedAst.Exp.FixpointQueryWithProvenance(es, s, withh, Type.freshVar(Kind.Star, loc), loc)
 
-      case ResolvedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
+      case ResolvedAst.Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
         val es = exps.map(visitExp(_, kenv0, root))
         val qe = visitExp(queryExp, kenv0, root)
         val ss = selects.map(visitExp(_, kenv0, root))
         val f = from.map(visitBodyPredicate(_, kenv0, root))
         val w = where.map(visitExp(_, kenv0, root))
-        KindedAst.Expr.FixpointQueryWithSelect(es, qe, ss, f, w, pred, Type.freshVar(Kind.Star, loc), loc)
+        KindedAst.Exp.FixpointQueryWithSelect(es, qe, ss, f, w, pred, Type.freshVar(Kind.Star, loc), loc)
 
-      case ResolvedAst.Expr.FixpointSolveWithProject(exps, optPreds, mode, loc) =>
+      case ResolvedAst.Exp.FixpointSolveWithProject(exps, optPreds, mode, loc) =>
         val es = exps.map(visitExp(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.FixpointSolveWithProject(es, optPreds, mode, tvar, loc)
+        KindedAst.Exp.FixpointSolveWithProject(es, optPreds, mode, tvar, loc)
 
-      case ResolvedAst.Expr.FixpointInjectInto(exps0, predsAndArities, loc) =>
+      case ResolvedAst.Exp.FixpointInjectInto(exps0, predsAndArities, loc) =>
         val exps = exps0.map(visitExp(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
         val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-        KindedAst.Expr.FixpointInjectInto(exps, predsAndArities, tvar, evar, loc)
+        KindedAst.Exp.FixpointInjectInto(exps, predsAndArities, tvar, evar, loc)
 
-      case ResolvedAst.Expr.Error(m) =>
+      case ResolvedAst.Exp.Error(m) =>
         val tvar = Type.freshVar(Kind.Star, m.loc)
         val evar = Type.freshEffSlackVar(m.loc)
-        KindedAst.Expr.Error(m, tvar, evar)
+        KindedAst.Exp.Error(m, tvar, evar)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -369,276 +369,276 @@ object Lowering {
   /**
     * Lowers the given expression `exp0`.
     */
-  private def visitExp(exp0: TypedAst.Expr)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Expr = exp0 match {
-    case TypedAst.Expr.Cst(cst, tpe, loc) =>
+  private def visitExp(exp0: TypedAst.Exp)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Exp = exp0 match {
+    case TypedAst.Exp.Cst(cst, tpe, loc) =>
       val t = visitType(tpe)
-      LoweredAst.Expr.Cst(cst, t, loc)
+      LoweredAst.Exp.Cst(cst, t, loc)
 
-    case TypedAst.Expr.Var(sym, tpe, loc) =>
+    case TypedAst.Exp.Var(sym, tpe, loc) =>
       val t = visitType(tpe)
-      LoweredAst.Expr.Var(sym, t, loc)
+      LoweredAst.Exp.Var(sym, t, loc)
 
-    case TypedAst.Expr.Hole(sym, _, tpe, eff, loc) =>
+    case TypedAst.Exp.Hole(sym, _, tpe, eff, loc) =>
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.HoleError(sym), List.empty, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.HoleError(sym), List.empty, t, eff, loc)
 
-    case TypedAst.Expr.HoleWithExp(_, _, tpe, _, loc) =>
+    case TypedAst.Exp.HoleWithExp(_, _, tpe, _, loc) =>
       val sym = Symbol.freshHoleSym(loc)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.HoleError(sym), List.empty, t, Type.Pure, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.HoleError(sym), List.empty, t, Type.Pure, loc)
 
-    case TypedAst.Expr.OpenAs(_, exp, _, _) =>
+    case TypedAst.Exp.OpenAs(_, exp, _, _) =>
       visitExp(exp) // TODO RESTR-VARS maybe add to loweredAST
 
-    case TypedAst.Expr.Use(_, _, exp, _) =>
+    case TypedAst.Exp.Use(_, _, exp, _) =>
       visitExp(exp)
 
-    case TypedAst.Expr.Lambda(fparam, exp, tpe, loc) =>
+    case TypedAst.Exp.Lambda(fparam, exp, tpe, loc) =>
       val p = visitFormalParam(fparam)
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.Lambda(p, e, t, loc)
+      LoweredAst.Exp.Lambda(p, e, t, loc)
 
-    case TypedAst.Expr.ApplyClo(exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.ApplyClo(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyClo(e1, e2, t, eff, loc)
+      LoweredAst.Exp.ApplyClo(e1, e2, t, eff, loc)
 
-    case TypedAst.Expr.ApplyDef(DefSymUse(sym, _), exps, targs, itpe, tpe, eff, loc) =>
+    case TypedAst.Exp.ApplyDef(DefSymUse(sym, _), exps, targs, itpe, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val tas = targs.map(visitType)
       val it = visitType(itpe)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyDef(sym, es, tas, it, t, eff, loc)
+      LoweredAst.Exp.ApplyDef(sym, es, tas, it, t, eff, loc)
 
-    case TypedAst.Expr.ApplyLocalDef(LocalDefSymUse(sym, _), exps, _, tpe, eff, loc) =>
+    case TypedAst.Exp.ApplyLocalDef(LocalDefSymUse(sym, _), exps, _, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyLocalDef(sym, es, t, eff, loc)
+      LoweredAst.Exp.ApplyLocalDef(sym, es, t, eff, loc)
 
-    case TypedAst.Expr.ApplyOp(OpSymUse(sym, _), exps, tpe, eff, loc) =>
+    case TypedAst.Exp.ApplyOp(OpSymUse(sym, _), exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      LoweredAst.Expr.ApplyOp(sym, es, tpe, eff, loc)
+      LoweredAst.Exp.ApplyOp(sym, es, tpe, eff, loc)
 
-    case TypedAst.Expr.ApplySig(SigSymUse(sym, _), exps, targ, targs, itpe, tpe, eff, loc) =>
+    case TypedAst.Exp.ApplySig(SigSymUse(sym, _), exps, targ, targs, itpe, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val ta = visitType(targ)
       val tas = targs.map(visitType)
       val it = visitType(itpe)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplySig(sym, es, ta, tas, it, t, eff, loc)
+      LoweredAst.Exp.ApplySig(sym, es, ta, tas, it, t, eff, loc)
 
-    case TypedAst.Expr.Unary(sop, exp, tpe, eff, loc) =>
+    case TypedAst.Exp.Unary(sop, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Unary(sop), List(e), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.Unary(sop), List(e), t, eff, loc)
 
-    case TypedAst.Expr.Binary(sop, exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.Binary(sop, exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Binary(sop), List(e1, e2), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.Binary(sop), List(e1, e2), t, eff, loc)
 
-    case TypedAst.Expr.Let(bnd, exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.Let(bnd, exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
-      LoweredAst.Expr.Let(bnd.sym, e1, e2, t, eff, loc)
+      LoweredAst.Exp.Let(bnd.sym, e1, e2, t, eff, loc)
 
-    case TypedAst.Expr.LocalDef(TypedAst.Binder(sym, _), fparams, exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.LocalDef(TypedAst.Binder(sym, _), fparams, exp1, exp2, tpe, eff, loc) =>
       val fps = fparams.map(visitFormalParam)
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
-      LoweredAst.Expr.LocalDef(sym, fps, e1, e2, t, eff, loc)
+      LoweredAst.Exp.LocalDef(sym, fps, e1, e2, t, eff, loc)
 
-    case TypedAst.Expr.Region(TypedAst.Binder(sym, _), regionVar, exp, tpe, eff, loc) =>
+    case TypedAst.Exp.Region(TypedAst.Binder(sym, _), regionVar, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.Region(sym, regionVar, e, t, eff, loc)
+      LoweredAst.Exp.Region(sym, regionVar, e, t, eff, loc)
 
-    case TypedAst.Expr.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
+    case TypedAst.Exp.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
       val t = visitType(tpe)
-      LoweredAst.Expr.IfThenElse(e1, e2, e3, t, eff, loc)
+      LoweredAst.Exp.IfThenElse(e1, e2, e3, t, eff, loc)
 
-    case TypedAst.Expr.Stm(exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.Stm(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
-      LoweredAst.Expr.Stm(e1, e2, t, eff, loc)
+      LoweredAst.Exp.Stm(e1, e2, t, eff, loc)
 
-    case TypedAst.Expr.Discard(exp, eff, loc) =>
+    case TypedAst.Exp.Discard(exp, eff, loc) =>
       val e = visitExp(exp)
-      LoweredAst.Expr.Discard(e, eff, loc)
+      LoweredAst.Exp.Discard(e, eff, loc)
 
-    case TypedAst.Expr.Match(exp, rules, tpe, eff, loc) =>
+    case TypedAst.Exp.Match(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitMatchRule)
       val t = visitType(tpe)
-      LoweredAst.Expr.Match(e, rs, t, eff, loc)
+      LoweredAst.Exp.Match(e, rs, t, eff, loc)
 
-    case TypedAst.Expr.TypeMatch(exp, rules, tpe, eff, loc) =>
+    case TypedAst.Exp.TypeMatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitTypeMatchRule)
       val t = visitType(tpe)
-      LoweredAst.Expr.TypeMatch(e, rs, t, eff, loc)
+      LoweredAst.Exp.TypeMatch(e, rs, t, eff, loc)
 
-    case TypedAst.Expr.RestrictableChoose(_, exp, rules, tpe, eff, loc) =>
+    case TypedAst.Exp.RestrictableChoose(_, exp, rules, tpe, eff, loc) =>
       // lower into an ordinary match
       val e = visitExp(exp)
       val rs = rules.map(visitRestrictableChooseRule)
       val t = visitType(tpe)
-      LoweredAst.Expr.Match(e, rs, t, eff, loc)
+      LoweredAst.Exp.Match(e, rs, t, eff, loc)
 
-    case TypedAst.Expr.ExtMatch(exp, rules, tpe, eff, loc) =>
+    case TypedAst.Exp.ExtMatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitExtMatchRule)
       val t = visitType(tpe)
-      LoweredAst.Expr.ExtMatch(e, rs, t, eff, loc)
+      LoweredAst.Exp.ExtMatch(e, rs, t, eff, loc)
 
-    case TypedAst.Expr.Tag(symUse, exps, tpe, eff, loc) =>
+    case TypedAst.Exp.Tag(symUse, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Tag(symUse.sym), es, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.Tag(symUse.sym), es, t, eff, loc)
 
-    case TypedAst.Expr.RestrictableTag(symUse, exps, tpe, eff, loc) =>
+    case TypedAst.Exp.RestrictableTag(symUse, exps, tpe, eff, loc) =>
       // Lower a restrictable tag into a normal tag.
       val caseSym = visitRestrictableCaseSym(symUse.sym)
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Tag(caseSym), es, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.Tag(caseSym), es, t, eff, loc)
 
-    case TypedAst.Expr.ExtTag(label, exps, tpe, eff, loc) =>
+    case TypedAst.Exp.ExtTag(label, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.ExtTag(label), es, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.ExtTag(label), es, t, eff, loc)
 
-    case TypedAst.Expr.Tuple(exps, tpe, eff, loc) =>
+    case TypedAst.Exp.Tuple(exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Tuple, es, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.Tuple, es, t, eff, loc)
 
-    case TypedAst.Expr.RecordSelect(exp, label, tpe, eff, loc) =>
+    case TypedAst.Exp.RecordSelect(exp, label, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.RecordSelect(label), List(e), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.RecordSelect(label), List(e), t, eff, loc)
 
-    case TypedAst.Expr.RecordExtend(label, exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.RecordExtend(label, exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.RecordExtend(label), List(e1, e2), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.RecordExtend(label), List(e1, e2), t, eff, loc)
 
-    case TypedAst.Expr.RecordRestrict(label, exp, tpe, eff, loc) =>
+    case TypedAst.Exp.RecordRestrict(label, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.RecordRestrict(label), List(e), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.RecordRestrict(label), List(e), t, eff, loc)
 
-    case TypedAst.Expr.ArrayLit(exps, exp, tpe, eff, loc) =>
+    case TypedAst.Exp.ArrayLit(exps, exp, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.ArrayLit, e :: es, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.ArrayLit, e :: es, t, eff, loc)
 
-    case TypedAst.Expr.ArrayNew(exp1, exp2, exp3, tpe, eff, loc) =>
+    case TypedAst.Exp.ArrayNew(exp1, exp2, exp3, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.ArrayNew, List(e1, e2, e3), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.ArrayNew, List(e1, e2, e3), t, eff, loc)
 
-    case TypedAst.Expr.ArrayLoad(exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.ArrayLoad(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.ArrayLoad, List(e1, e2), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.ArrayLoad, List(e1, e2), t, eff, loc)
 
-    case TypedAst.Expr.ArrayLength(exp, eff, loc) =>
+    case TypedAst.Exp.ArrayLength(exp, eff, loc) =>
       val e = visitExp(exp)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.ArrayLength, List(e), Type.Int32, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.ArrayLength, List(e), Type.Int32, eff, loc)
 
-    case TypedAst.Expr.ArrayStore(exp1, exp2, exp3, eff, loc) =>
+    case TypedAst.Exp.ArrayStore(exp1, exp2, exp3, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.ArrayStore, List(e1, e2, e3), Type.Unit, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.ArrayStore, List(e1, e2, e3), Type.Unit, eff, loc)
 
-    case TypedAst.Expr.StructNew(sym, fields0, region0, tpe, eff, loc) =>
+    case TypedAst.Exp.StructNew(sym, fields0, region0, tpe, eff, loc) =>
       val fields = fields0.map { case (k, v) => (k, visitExp(v)) }
       val region = visitExp(region0)
       val (names0, es) = fields.unzip
       val names = names0.map(_.sym)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.StructNew(sym, names), region :: es, tpe, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.StructNew(sym, names), region :: es, tpe, eff, loc)
 
-    case TypedAst.Expr.StructGet(exp, field, tpe, eff, loc) =>
+    case TypedAst.Exp.StructGet(exp, field, tpe, eff, loc) =>
       val e = visitExp(exp)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.StructGet(field.sym), List(e), tpe, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.StructGet(field.sym), List(e), tpe, eff, loc)
 
-    case TypedAst.Expr.StructPut(exp, field, exp1, tpe, eff, loc) =>
+    case TypedAst.Exp.StructPut(exp, field, exp1, tpe, eff, loc) =>
       val struct = visitExp(exp)
       val rhs = visitExp(exp1)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.StructPut(field.sym), List(struct, rhs), tpe, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.StructPut(field.sym), List(struct, rhs), tpe, eff, loc)
 
-    case TypedAst.Expr.VectorLit(exps, tpe, eff, loc) =>
+    case TypedAst.Exp.VectorLit(exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.VectorLit(es, t, eff, loc)
+      LoweredAst.Exp.VectorLit(es, t, eff, loc)
 
-    case TypedAst.Expr.VectorLoad(base, index, tpe, eff, loc) =>
+    case TypedAst.Exp.VectorLoad(base, index, tpe, eff, loc) =>
       val b = visitExp(base)
       val i = visitExp(index)
       val t = visitType(tpe)
-      LoweredAst.Expr.VectorLoad(b, i, t, eff, loc)
+      LoweredAst.Exp.VectorLoad(b, i, t, eff, loc)
 
-    case TypedAst.Expr.VectorLength(base, loc) =>
+    case TypedAst.Exp.VectorLength(base, loc) =>
       val b = visitExp(base)
-      LoweredAst.Expr.VectorLength(b, loc)
+      LoweredAst.Exp.VectorLength(b, loc)
 
-    case TypedAst.Expr.Ascribe(exp, _, _, tpe, eff, loc) =>
+    case TypedAst.Exp.Ascribe(exp, _, _, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.Ascribe(e, t, eff, loc)
+      LoweredAst.Exp.Ascribe(e, t, eff, loc)
 
-    case TypedAst.Expr.InstanceOf(exp, clazz, loc) =>
+    case TypedAst.Exp.InstanceOf(exp, clazz, loc) =>
       val e = visitExp(exp)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(clazz), List(e), Type.Bool, e.eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.InstanceOf(clazz), List(e), Type.Bool, e.eff, loc)
 
-    case TypedAst.Expr.CheckedCast(_, exp, tpe, eff, loc) =>
+    case TypedAst.Exp.CheckedCast(_, exp, tpe, eff, loc) =>
       // Note: We do *NOT* erase checked (i.e. safe) casts.
       // In Java, `String` is a subtype of `Object`, but the Flix IR makes this upcast _explicit_.
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.Cast(e, Some(t), None, t, eff, loc)
+      LoweredAst.Exp.Cast(e, Some(t), None, t, eff, loc)
 
-    case TypedAst.Expr.UncheckedCast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+    case TypedAst.Exp.UncheckedCast(exp, declaredType, declaredEff, tpe, eff, loc) =>
       val e = visitExp(exp)
       val dt = declaredType.map(visitType)
       val t = visitType(tpe)
-      LoweredAst.Expr.Cast(e, dt, declaredEff, t, eff, loc)
+      LoweredAst.Exp.Cast(e, dt, declaredEff, t, eff, loc)
 
-    case TypedAst.Expr.Unsafe(exp, _, tpe, eff, loc) =>
+    case TypedAst.Exp.Unsafe(exp, _, tpe, eff, loc) =>
       val e = visitExp(exp)
-      LoweredAst.Expr.Cast(e, None, Some(eff), tpe, eff, loc)
+      LoweredAst.Exp.Cast(e, None, Some(eff), tpe, eff, loc)
 
-    case TypedAst.Expr.Without(exp, _, _, _, _) =>
+    case TypedAst.Exp.Without(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case TypedAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>
+    case TypedAst.Exp.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitCatchRule)
       val t = visitType(tpe)
-      LoweredAst.Expr.TryCatch(e, rs, t, eff, loc)
+      LoweredAst.Exp.TryCatch(e, rs, t, eff, loc)
 
-    case TypedAst.Expr.Throw(exp, tpe, eff, loc) =>
+    case TypedAst.Exp.Throw(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Throw, List(e), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.Throw, List(e), t, eff, loc)
 
-    case TypedAst.Expr.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
+    case TypedAst.Exp.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
       // handler sym { rules }
       // is lowered to
       // handlerBody -> try handlerBody() with sym { rules }
@@ -647,68 +647,68 @@ object Lowering {
       val bt = visitType(bodyTpe)
       val t = visitType(tpe)
       val bodyThunkType = Type.mkArrowWithEffect(Type.Unit, bodyEff, bt, loc.asSynthetic)
-      val bodyVar = LoweredAst.Expr.Var(bodySym, bodyThunkType, loc.asSynthetic)
-      val body = LoweredAst.Expr.ApplyClo(bodyVar, LoweredAst.Expr.Cst(Constant.Unit, Type.Unit, loc.asSynthetic), bt, bodyEff, loc.asSynthetic)
-      val RunWith = LoweredAst.Expr.RunWith(body, symUse, rs, bt, handledEff, loc)
+      val bodyVar = LoweredAst.Exp.Var(bodySym, bodyThunkType, loc.asSynthetic)
+      val body = LoweredAst.Exp.ApplyClo(bodyVar, LoweredAst.Exp.Cst(Constant.Unit, Type.Unit, loc.asSynthetic), bt, bodyEff, loc.asSynthetic)
+      val RunWith = LoweredAst.Exp.RunWith(body, symUse, rs, bt, handledEff, loc)
       val param = LoweredAst.FormalParam(bodySym, bodyThunkType, loc.asSynthetic)
-      LoweredAst.Expr.Lambda(param, RunWith, t, loc)
+      LoweredAst.Exp.Lambda(param, RunWith, t, loc)
 
-    case TypedAst.Expr.RunWith(exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.RunWith(exp1, exp2, tpe, eff, loc) =>
       // run exp1 with exp2
       // is lowered to
       // exp2(_runWith -> exp1)
       val unitParam = LoweredAst.FormalParam(Symbol.freshVarSym("_runWith", BoundBy.FormalParam, loc.asSynthetic), Type.Unit, loc.asSynthetic)
       val thunkType = Type.mkArrowWithEffect(Type.Unit, exp1.eff, exp1.tpe, loc.asSynthetic)
-      val thunk = LoweredAst.Expr.Lambda(unitParam, visitExp(exp1), thunkType, loc.asSynthetic)
-      LoweredAst.Expr.ApplyClo(visitExp(exp2), thunk, tpe, eff, loc)
+      val thunk = LoweredAst.Exp.Lambda(unitParam, visitExp(exp1), thunkType, loc.asSynthetic)
+      LoweredAst.Exp.ApplyClo(visitExp(exp2), thunk, tpe, eff, loc)
 
-    case TypedAst.Expr.InvokeConstructor(constructor, exps, tpe, eff, loc) =>
+    case TypedAst.Exp.InvokeConstructor(constructor, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.InvokeConstructor(constructor), es, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.InvokeConstructor(constructor), es, t, eff, loc)
 
-    case TypedAst.Expr.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
+    case TypedAst.Exp.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
       val e = visitExp(exp)
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.InvokeMethod(method), e :: es, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.InvokeMethod(method), e :: es, t, eff, loc)
 
-    case TypedAst.Expr.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
+    case TypedAst.Exp.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.InvokeStaticMethod(method), es, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.InvokeStaticMethod(method), es, t, eff, loc)
 
-    case TypedAst.Expr.GetField(field, exp, tpe, eff, loc) =>
+    case TypedAst.Exp.GetField(field, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.GetField(field), List(e), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.GetField(field), List(e), t, eff, loc)
 
-    case TypedAst.Expr.PutField(field, exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.PutField(field, exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.PutField(field), List(e1, e2), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.PutField(field), List(e1, e2), t, eff, loc)
 
-    case TypedAst.Expr.GetStaticField(field, tpe, eff, loc) =>
+    case TypedAst.Exp.GetStaticField(field, tpe, eff, loc) =>
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.GetStaticField(field), List.empty, t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.GetStaticField(field), List.empty, t, eff, loc)
 
-    case TypedAst.Expr.PutStaticField(field, exp, tpe, eff, loc) =>
+    case TypedAst.Exp.PutStaticField(field, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.PutStaticField(field), List(e), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.PutStaticField(field), List(e), t, eff, loc)
 
-    case TypedAst.Expr.NewObject(name, clazz, tpe, eff, methods, loc) =>
+    case TypedAst.Exp.NewObject(name, clazz, tpe, eff, methods, loc) =>
       val t = visitType(tpe)
       val ms = methods.map(visitJvmMethod)
-      LoweredAst.Expr.NewObject(name, clazz, t, eff, ms, loc)
+      LoweredAst.Exp.NewObject(name, clazz, t, eff, ms, loc)
 
     // New channel expressions are rewritten as follows:
     //     %%CHANNEL_NEW%%(m)
     // becomes a call to the standard library function:
     //     Concurrent/Channel.newChannel(10)
     //
-    case TypedAst.Expr.NewChannel(exp, tpe, eff, loc) =>
+    case TypedAst.Exp.NewChannel(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
       mkNewChannelTuple(e, t, eff, loc)
@@ -718,7 +718,7 @@ object Lowering {
     // becomes a call to the standard library function:
     //     Concurrent/Channel.get(c)
     //
-    case TypedAst.Expr.GetChannel(exp, tpe, eff, loc) =>
+    case TypedAst.Exp.GetChannel(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
       mkGetChannel(e, t, eff, loc)
@@ -728,7 +728,7 @@ object Lowering {
     // becomes a call to the standard library function:
     //     Concurrent/Channel.put(42, c)
     //
-    case TypedAst.Expr.PutChannel(exp1, exp2, _, eff, loc) =>
+    case TypedAst.Exp.PutChannel(exp1, exp2, _, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       mkPutChannel(e1, e2, eff, loc)
@@ -754,7 +754,7 @@ object Lowering {
     //     }
     // Note: match is not exhaustive: we're relying on the simplifier to handle this for us
     //
-    case TypedAst.Expr.SelectChannel(rules, default, tpe, eff, loc) =>
+    case TypedAst.Exp.SelectChannel(rules, default, tpe, eff, loc) =>
       val rs = rules.map(visitSelectChannelRule)
       val d = default.map(visitExp)
       val t = visitType(tpe)
@@ -764,19 +764,19 @@ object Lowering {
       val selectExp = mkChannelSelect(admins, d, loc)
       val cases = mkChannelCases(rs, channels, eff, loc)
       val defaultCase = mkSelectDefaultCase(d, loc)
-      val matchExp = LoweredAst.Expr.Match(selectExp, cases ++ defaultCase, t, eff, loc)
+      val matchExp = LoweredAst.Exp.Match(selectExp, cases ++ defaultCase, t, eff, loc)
 
-      channels.foldRight[LoweredAst.Expr](matchExp) {
-        case ((sym, c), e) => LoweredAst.Expr.Let(sym, c, e, t, eff, loc)
+      channels.foldRight[LoweredAst.Exp](matchExp) {
+        case ((sym, c), e) => LoweredAst.Exp.Let(sym, c, e, t, eff, loc)
       }
 
-    case TypedAst.Expr.Spawn(exp1, exp2, tpe, eff, loc) =>
+    case TypedAst.Exp.Spawn(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(e1, e2), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.Spawn, List(e1, e2), t, eff, loc)
 
-    case TypedAst.Expr.ParYield(frags, exp, tpe, eff, loc) =>
+    case TypedAst.Exp.ParYield(frags, exp, tpe, eff, loc) =>
       val fs = frags.map {
         case TypedAst.ParYieldFragment(pat, fragExp, fragLoc) => LoweredAst.ParYieldFragment(visitPat(pat), visitExp(fragExp), fragLoc)
       }
@@ -784,33 +784,33 @@ object Lowering {
       val t = visitType(tpe)
       mkParYield(fs, e, t, eff, loc)
 
-    case TypedAst.Expr.Lazy(exp, tpe, loc) =>
+    case TypedAst.Exp.Lazy(exp, tpe, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Lazy, List(e), t, Type.Pure, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.Lazy, List(e), t, Type.Pure, loc)
 
-    case TypedAst.Expr.Force(exp, tpe, eff, loc) =>
+    case TypedAst.Exp.Force(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Force, List(e), t, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(AtomicOp.Force, List(e), t, eff, loc)
 
-    case TypedAst.Expr.FixpointConstraintSet(cs, _, loc) =>
+    case TypedAst.Exp.FixpointConstraintSet(cs, _, loc) =>
       mkDatalog(cs, loc)
 
-    case TypedAst.Expr.FixpointLambda(pparams, exp, _, eff, loc) =>
+    case TypedAst.Exp.FixpointLambda(pparams, exp, _, eff, loc) =>
       val defn = Defs.lookup(Defs.Rename)
       val predExps = mkList(pparams.map(pparam => mkPredSym(pparam.pred)), Types.PredSym, loc)
       val argExps = predExps :: visitExp(exp) :: Nil
       val resultType = Types.Datalog
-      LoweredAst.Expr.ApplyDef(defn.sym, argExps, List.empty, Types.RenameType, resultType, eff, loc)
+      LoweredAst.Exp.ApplyDef(defn.sym, argExps, List.empty, Types.RenameType, resultType, eff, loc)
 
-    case TypedAst.Expr.FixpointMerge(exp1, exp2, _, eff, loc) =>
+    case TypedAst.Exp.FixpointMerge(exp1, exp2, _, eff, loc) =>
       val defn = Defs.lookup(Defs.Merge)
       val argExps = visitExp(exp1) :: visitExp(exp2) :: Nil
       val resultType = Types.Datalog
-      LoweredAst.Expr.ApplyDef(defn.sym, argExps, List.empty, Types.MergeType, resultType, eff, loc)
+      LoweredAst.Exp.ApplyDef(defn.sym, argExps, List.empty, Types.MergeType, resultType, eff, loc)
 
-    case TypedAst.Expr.FixpointQueryWithProvenance(exps, select, withh, tpe, eff, loc) =>
+    case TypedAst.Exp.FixpointQueryWithProvenance(exps, select, withh, tpe, eff, loc) =>
       // Create appropriate call to Fixpoint.Solver.provenanceOf. This requires creating a mapping, mkExtVar, from
       // PredSym and terms to an extensible variant.
       val defn = Defs.lookup(Defs.ProvenanceOf)
@@ -826,9 +826,9 @@ object Lowering {
       val lambdaExp = mkExtVarLambda(preds, extVarType, loc)
       val argExps = goalPredSym :: goalTerms :: withPredSyms :: lambdaExp :: mergedExp :: Nil
       val itpe = Types.mkProvenanceOf(extVarType, loc)
-      LoweredAst.Expr.ApplyDef(defn.sym, argExps, List.empty, itpe, tpe, eff, loc)
+      LoweredAst.Exp.ApplyDef(defn.sym, argExps, List.empty, itpe, tpe, eff, loc)
 
-    case TypedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, _, pred, tpe, eff, loc) =>
+    case TypedAst.Exp.FixpointQueryWithSelect(exps, queryExp, selects, _, _, pred, tpe, eff, loc) =>
       val loweredExps = exps.map(visitExp)
       val loweredQueryExp = visitExp(queryExp)
 
@@ -851,13 +851,13 @@ object Lowering {
 
       // Merge and solve exps
       val mergedExp = mergeExps(loweredQueryExp :: loweredExps, loc)
-      val solvedExp = LoweredAst.Expr.ApplyDef(Defs.Solve, mergedExp :: Nil, List.empty, Types.SolveType, Types.Datalog, eff, loc)
+      val solvedExp = LoweredAst.Exp.ApplyDef(Defs.Solve, mergedExp :: Nil, List.empty, Types.SolveType, Types.Datalog, eff, loc)
 
       // Put everything together
       val argExps = mkPredSym(pred) :: solvedExp :: Nil
-      LoweredAst.Expr.ApplyDef(sym, argExps, targs, defTpe, tpe, eff, loc)
+      LoweredAst.Exp.ApplyDef(sym, argExps, targs, defTpe, tpe, eff, loc)
 
-    case TypedAst.Expr.FixpointSolveWithProject(exps0, optPreds, mode, _, eff, loc) =>
+    case TypedAst.Exp.FixpointSolveWithProject(exps0, optPreds, mode, _, eff, loc) =>
       // Rewrites
       //     solve e₁, e₂, e₃ project P₁, P₂, P₃
       // to
@@ -871,19 +871,19 @@ object Lowering {
       val exps = exps0.map(visitExp)
       val mergedExp = mergeExps(exps, loc)
       val argExps = mergedExp :: Nil
-      val solvedExp = LoweredAst.Expr.ApplyDef(defn.sym, argExps, List.empty, Types.SolveType, Types.Datalog, eff, loc)
+      val solvedExp = LoweredAst.Exp.ApplyDef(defn.sym, argExps, List.empty, Types.SolveType, Types.Datalog, eff, loc)
       val tmpVarSym = Symbol.freshVarSym("tmp%", BoundBy.Let, loc)
       val letBodyExp = optPreds match {
         case Some(preds) =>
           mergeExps(preds.map(pred => {
-            val varExp = LoweredAst.Expr.Var(tmpVarSym, Types.Datalog, loc)
+            val varExp = LoweredAst.Exp.Var(tmpVarSym, Types.Datalog, loc)
             projectSym(mkPredSym(pred), varExp, loc)
           }), loc)
-        case None => LoweredAst.Expr.Var(tmpVarSym, Types.Datalog, loc)
+        case None => LoweredAst.Exp.Var(tmpVarSym, Types.Datalog, loc)
       }
-      LoweredAst.Expr.Let(tmpVarSym, solvedExp, letBodyExp, Types.Datalog, eff, loc)
+      LoweredAst.Exp.Let(tmpVarSym, solvedExp, letBodyExp, Types.Datalog, eff, loc)
 
-    case TypedAst.Expr.FixpointInjectInto(exps, predsAndArities, _, _, loc) =>
+    case TypedAst.Exp.FixpointInjectInto(exps, predsAndArities, _, _, loc) =>
       val loweredExps = exps.zip(predsAndArities).map {
         case (exp, PredicateAndArity(pred, _)) =>
           // Compute the types arguments of the functor F[(a, b, c)] or F[a].
@@ -904,11 +904,11 @@ object Lowering {
 
           // Put everything together.
           val argExps = mkPredSym(pred) :: visitExp(exp) :: Nil
-          LoweredAst.Expr.ApplyDef(sym, argExps, targ :: targs, defTpe, Types.Datalog, exp.eff, loc)
+          LoweredAst.Exp.ApplyDef(sym, argExps, targ :: targs, defTpe, Types.Datalog, exp.eff, loc)
       }
       mergeExps(loweredExps, loc)
 
-    case TypedAst.Expr.Error(m, _, _) =>
+    case TypedAst.Exp.Error(m, _, _) =>
       throw InternalCompilerException(s"Unexpected error expression near", m.loc)
 
   }
@@ -1123,7 +1123,7 @@ object Lowering {
   /**
     * Constructs a `Fixpoint/Ast/Datalog.Datalog` value from the given list of Datalog constraints `cs`.
     */
-  private def mkDatalog(cs: List[TypedAst.Constraint], loc: SourceLocation)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Expr = {
+  private def mkDatalog(cs: List[TypedAst.Constraint], loc: SourceLocation)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Exp = {
     val factExps = cs.filter(c => c.body.isEmpty).map(visitConstraint)
     val ruleExps = cs.filter(c => c.body.nonEmpty).map(visitConstraint)
 
@@ -1137,7 +1137,7 @@ object Lowering {
   /**
     * Lowers the given constraint `c0`.
     */
-  private def visitConstraint(c0: TypedAst.Constraint)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Expr = c0 match {
+  private def visitConstraint(c0: TypedAst.Constraint)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Exp = c0 match {
     case TypedAst.Constraint(cparams, head, body, loc) =>
       val headExp = visitHeadPred(cparams, head)
       val bodyExp = mkVector(body.map(visitBodyPred(cparams, _)), Types.BodyPredicate, loc)
@@ -1148,7 +1148,7 @@ object Lowering {
   /**
     * Lowers the given head predicate `p0`.
     */
-  private def visitHeadPred(cparams0: List[TypedAst.ConstraintParam], p0: TypedAst.Predicate.Head)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Expr = p0 match {
+  private def visitHeadPred(cparams0: List[TypedAst.ConstraintParam], p0: TypedAst.Predicate.Head)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Exp = p0 match {
     case TypedAst.Predicate.Head.Atom(pred, den, terms, _, loc) =>
       val predSymExp = mkPredSym(pred)
       val denotationExp = mkDenotation(den, terms.lastOption.map(_.tpe), loc)
@@ -1160,7 +1160,7 @@ object Lowering {
   /**
     * Lowers the given body predicate `p0`.
     */
-  private def visitBodyPred(cparams0: List[TypedAst.ConstraintParam], p0: TypedAst.Predicate.Body)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Expr = p0 match {
+  private def visitBodyPred(cparams0: List[TypedAst.ConstraintParam], p0: TypedAst.Predicate.Body)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Exp = p0 match {
     case TypedAst.Predicate.Body.Atom(pred, den, polarity, fixity, terms, _, loc) =>
       val predSymExp = mkPredSym(pred)
       val denotationExp = mkDenotation(den, terms.lastOption.map(_.tpe), loc)
@@ -1188,7 +1188,7 @@ object Lowering {
   /**
     * Lowers the given head term `exp0`.
     */
-  private def visitHeadTerm(cparams0: List[TypedAst.ConstraintParam], exp0: TypedAst.Expr)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Expr = {
+  private def visitHeadTerm(cparams0: List[TypedAst.ConstraintParam], exp0: TypedAst.Exp)(implicit scope: Scope, root: TypedAst.Root, flix: Flix): LoweredAst.Exp = {
     //
     // We need to consider four cases:
     //
@@ -1198,7 +1198,7 @@ object Lowering {
     // Case 3: The expression contains quantified variables. We translate it to an application term.
     //
     exp0 match {
-      case TypedAst.Expr.Var(sym, _, _) =>
+      case TypedAst.Exp.Var(sym, _, _) =>
         // Case 1: Variable term.
         if (isQuantifiedVar(sym, cparams0)) {
           // Case 1.1: Quantified variable.
@@ -1225,7 +1225,7 @@ object Lowering {
   /**
     * Lowers the given body term `pat0`.
     */
-  private def visitBodyTerm(cparams0: List[TypedAst.ConstraintParam], pat0: TypedAst.Pattern): LoweredAst.Expr = pat0 match {
+  private def visitBodyTerm(cparams0: List[TypedAst.ConstraintParam], pat0: TypedAst.Pattern): LoweredAst.Exp = pat0 match {
     case TypedAst.Pattern.Wild(_, loc) =>
       mkBodyTermWild(loc)
 
@@ -1235,11 +1235,11 @@ object Lowering {
         mkBodyTermVar(sym)
       } else {
         // Case 2: Lexically bound variable *expression*.
-        mkBodyTermLit(box(LoweredAst.Expr.Var(sym, tpe, loc)))
+        mkBodyTermLit(box(LoweredAst.Exp.Var(sym, tpe, loc)))
       }
 
     case TypedAst.Pattern.Cst(cst, tpe, loc) =>
-      mkBodyTermLit(box(LoweredAst.Expr.Cst(cst, tpe, loc)))
+      mkBodyTermLit(box(LoweredAst.Exp.Cst(cst, tpe, loc)))
 
     case TypedAst.Pattern.Tag(_, _, _, loc) => throw InternalCompilerException(s"Unexpected pattern: '$pat0'.", loc)
 
@@ -1265,7 +1265,7 @@ object Lowering {
   /**
     * Constructs a `Fixpoint/Ast/Datalog.HeadTerm.Var` from the given variable symbol `sym`.
     */
-  private def mkHeadTermVar(sym: Symbol.VarSym): LoweredAst.Expr = {
+  private def mkHeadTermVar(sym: Symbol.VarSym): LoweredAst.Exp = {
     val innerExp = List(mkVarSym(sym))
     mkTag(Enums.HeadTerm, "Var", innerExp, Types.HeadTerm, sym.loc)
   }
@@ -1273,21 +1273,21 @@ object Lowering {
   /**
     * Constructs a `Fixpoint/Ast/Datalog.HeadTerm.Lit` value which wraps the given expression `exp`.
     */
-  private def mkHeadTermLit(exp: LoweredAst.Expr): LoweredAst.Expr = {
+  private def mkHeadTermLit(exp: LoweredAst.Exp): LoweredAst.Exp = {
     mkTag(Enums.HeadTerm, "Lit", List(exp), Types.HeadTerm, exp.loc)
   }
 
   /**
     * Constructs a `Fixpoint/Ast/Datalog.BodyTerm.Wild` from the given source location `loc`.
     */
-  private def mkBodyTermWild(loc: SourceLocation): LoweredAst.Expr = {
+  private def mkBodyTermWild(loc: SourceLocation): LoweredAst.Exp = {
     mkTag(Enums.BodyTerm, "Wild", Nil, Types.BodyTerm, loc)
   }
 
   /**
     * Constructs a `Fixpoint/Ast/Datalog.BodyTerm.Var` from the given variable symbol `sym`.
     */
-  private def mkBodyTermVar(sym: Symbol.VarSym): LoweredAst.Expr = {
+  private def mkBodyTermVar(sym: Symbol.VarSym): LoweredAst.Exp = {
     val innerExp = List(mkVarSym(sym))
     mkTag(Enums.BodyTerm, "Var", innerExp, Types.BodyTerm, sym.loc)
   }
@@ -1295,7 +1295,7 @@ object Lowering {
   /**
     * Constructs a `Fixpoint/Ast/Datalog.BodyTerm.Lit` from the given expression `exp0`.
     */
-  private def mkBodyTermLit(exp: LoweredAst.Expr): LoweredAst.Expr = {
+  private def mkBodyTermLit(exp: LoweredAst.Exp): LoweredAst.Exp = {
     mkTag(Enums.BodyTerm, "Lit", List(exp), Types.BodyTerm, exp.loc)
   }
 
@@ -1303,7 +1303,7 @@ object Lowering {
     * Constructs a `Fixpoint/Ast/Shared.Denotation` from the given denotation `d` and type `tpeOpt`
     * (which must be the optional type of the last term).
     */
-  private def mkDenotation(d: Denotation, tpeOpt: Option[Type], loc: SourceLocation)(implicit root: TypedAst.Root, flix: Flix): LoweredAst.Expr = d match {
+  private def mkDenotation(d: Denotation, tpeOpt: Option[Type], loc: SourceLocation)(implicit root: TypedAst.Root, flix: Flix): LoweredAst.Exp = d match {
     case Denotation.Relational =>
       mkTag(Enums.Denotation, "Relational", Nil, Types.Denotation, loc)
 
@@ -1324,15 +1324,15 @@ object Lowering {
           val boxSym: Symbol.DefnSym = Symbol.mkDefnSym(s"Fixpoint${Defs.version}.Ast.Shared.box")
           val boxType: Type = Type.mkPureArrow(unboxedDenotationType, boxedDenotationType, loc)
 
-          val innerApply = LoweredAst.Expr.ApplyDef(latticeSym, List(LoweredAst.Expr.Cst(Constant.Unit, Type.Unit, loc)), List(innerType), latticeType, unboxedDenotationType, Type.Pure, loc)
-          LoweredAst.Expr.ApplyDef(boxSym, List(innerApply), List(innerType), boxType, boxedDenotationType, Type.Pure, loc)
+          val innerApply = LoweredAst.Exp.ApplyDef(latticeSym, List(LoweredAst.Exp.Cst(Constant.Unit, Type.Unit, loc)), List(innerType), latticeType, unboxedDenotationType, Type.Pure, loc)
+          LoweredAst.Exp.ApplyDef(boxSym, List(innerApply), List(innerType), boxType, boxedDenotationType, Type.Pure, loc)
       }
   }
 
   /**
     * Constructs a `Fixpoint/Ast/Datalog.Polarity` from the given polarity `p`.
     */
-  private def mkPolarity(p: Polarity, loc: SourceLocation): LoweredAst.Expr = p match {
+  private def mkPolarity(p: Polarity, loc: SourceLocation): LoweredAst.Exp = p match {
     case Polarity.Positive =>
       mkTag(Enums.Polarity, "Positive", Nil, Types.Polarity, loc)
 
@@ -1343,7 +1343,7 @@ object Lowering {
   /**
     * Constructs a `Fixpoint/Ast/Datalog.Fixity` from the given fixity `f`.
     */
-  private def mkFixity(f: Fixity, loc: SourceLocation): LoweredAst.Expr = f match {
+  private def mkFixity(f: Fixity, loc: SourceLocation): LoweredAst.Exp = f match {
     case Fixity.Loose =>
       mkTag(Enums.Fixity, "Loose", Nil, Types.Fixity, loc)
 
@@ -1354,10 +1354,10 @@ object Lowering {
   /**
     * Constructs a `Fixpoint/Ast/Shared.PredSym` from the given predicate `pred`.
     */
-  private def mkPredSym(pred: Name.Pred): LoweredAst.Expr = pred match {
+  private def mkPredSym(pred: Name.Pred): LoweredAst.Exp = pred match {
     case Name.Pred(sym, loc) =>
-      val nameExp = LoweredAst.Expr.Cst(Constant.Str(sym), Type.Str, loc)
-      val idExp = LoweredAst.Expr.Cst(Constant.Int64(0), Type.Int64, loc)
+      val nameExp = LoweredAst.Exp.Cst(Constant.Str(sym), Type.Str, loc)
+      val idExp = LoweredAst.Exp.Cst(Constant.Int64(0), Type.Int64, loc)
       val inner = List(nameExp, idExp)
       mkTag(Enums.PredSym, "PredSym", inner, Types.PredSym, loc)
   }
@@ -1365,24 +1365,24 @@ object Lowering {
   /**
     * Constructs a `Fixpoint/Ast/Datalog.VarSym` from the given variable symbol `sym`.
     */
-  private def mkVarSym(sym: Symbol.VarSym): LoweredAst.Expr = {
-    val nameExp = LoweredAst.Expr.Cst(Constant.Str(sym.text), Type.Str, sym.loc)
+  private def mkVarSym(sym: Symbol.VarSym): LoweredAst.Exp = {
+    val nameExp = LoweredAst.Exp.Cst(Constant.Str(sym.text), Type.Str, sym.loc)
     mkTag(Enums.VarSym, "VarSym", List(nameExp), Types.VarSym, sym.loc)
   }
 
   /**
     * Returns the given expression `exp` in a box.
     */
-  private def box(exp: LoweredAst.Expr): LoweredAst.Expr = {
+  private def box(exp: LoweredAst.Exp): LoweredAst.Exp = {
     val loc = exp.loc
     val tpe = Type.mkPureArrow(exp.tpe, Types.Boxed, loc)
-    LoweredAst.Expr.ApplyDef(Defs.Box, List(exp), List(exp.tpe), tpe, Types.Boxed, Type.Pure, loc)
+    LoweredAst.Exp.ApplyDef(Defs.Box, List(exp), List(exp.tpe), tpe, Types.Boxed, Type.Pure, loc)
   }
 
   /**
     * Returns a `Fixpoint/Ast/Datalog.BodyPredicate.GuardX`.
     */
-  private def mkGuard(fvs: List[(Symbol.VarSym, Type)], exp: LoweredAst.Expr, loc: SourceLocation)(implicit scope: Scope, flix: Flix): LoweredAst.Expr = {
+  private def mkGuard(fvs: List[(Symbol.VarSym, Type)], exp: LoweredAst.Exp, loc: SourceLocation)(implicit scope: Scope, flix: Flix): LoweredAst.Exp = {
     // Compute the number of free variables.
     val arity = fvs.length
 
@@ -1397,7 +1397,7 @@ object Lowering {
       // Construct a lambda that takes the unit argument.
       val fparam = LoweredAst.FormalParam(sym, Type.Unit, loc)
       val tpe = Type.mkPureArrow(Type.Unit, exp.tpe, loc)
-      val lambdaExp = LoweredAst.Expr.Lambda(fparam, exp, tpe, loc)
+      val lambdaExp = LoweredAst.Exp.Lambda(fparam, exp, tpe, loc)
       return mkTag(Enums.BodyPredicate, s"Guard0", List(lambdaExp), Types.BodyPredicate, loc)
     }
 
@@ -1415,7 +1415,7 @@ object Lowering {
         val freshSym = freshVars(oldSym)
         val fparam = LoweredAst.FormalParam(freshSym, tpe, loc)
         val lambdaType = Type.mkPureArrow(tpe, acc.tpe, loc)
-        LoweredAst.Expr.Lambda(fparam, acc, lambdaType, loc)
+        LoweredAst.Exp.Lambda(fparam, acc, lambdaType, loc)
     }
 
     // Lift the lambda expression to operate on boxed values.
@@ -1430,7 +1430,7 @@ object Lowering {
   /**
     * Returns a `Fixpoint/Ast/Datalog.BodyPredicate.Functional`.
     */
-  private def mkFunctional(outVars: List[Symbol.VarSym], inVars: List[(Symbol.VarSym, Type)], exp: LoweredAst.Expr, loc: SourceLocation)(implicit flix: Flix): LoweredAst.Expr = {
+  private def mkFunctional(outVars: List[Symbol.VarSym], inVars: List[(Symbol.VarSym, Type)], exp: LoweredAst.Exp, loc: SourceLocation)(implicit flix: Flix): LoweredAst.Exp = {
     // Compute the number of in and out variables.
     val numberOfInVars = inVars.length
     val numberOfOutVars = outVars.length
@@ -1459,7 +1459,7 @@ object Lowering {
         val freshSym = freshVars(oldSym)
         val fparam = LoweredAst.FormalParam(freshSym, tpe, loc)
         val lambdaType = Type.mkPureArrow(tpe, acc.tpe, loc)
-        LoweredAst.Expr.Lambda(fparam, acc, lambdaType, loc)
+        LoweredAst.Exp.Lambda(fparam, acc, lambdaType, loc)
     }
 
     // Lift the lambda expression to operate on boxed values.
@@ -1475,7 +1475,7 @@ object Lowering {
   /**
     * Returns a `Fixpoint/Ast/Datalog.HeadTerm.AppX`.
     */
-  private def mkAppTerm(fvs: List[(Symbol.VarSym, Type)], exp: LoweredAst.Expr, loc: SourceLocation)(implicit flix: Flix): LoweredAst.Expr = {
+  private def mkAppTerm(fvs: List[(Symbol.VarSym, Type)], exp: LoweredAst.Exp, loc: SourceLocation)(implicit flix: Flix): LoweredAst.Exp = {
     // Compute the number of free variables.
     val arity = fvs.length
 
@@ -1498,7 +1498,7 @@ object Lowering {
         val freshSym = freshVars(oldSym)
         val fparam = LoweredAst.FormalParam(freshSym, tpe, loc)
         val lambdaType = Type.mkPureArrow(tpe, acc.tpe, loc)
-        LoweredAst.Expr.Lambda(fparam, acc, lambdaType, loc)
+        LoweredAst.Exp.Lambda(fparam, acc, lambdaType, loc)
     }
 
     // Lift the lambda expression to operate on boxed values.
@@ -1513,47 +1513,47 @@ object Lowering {
   /**
     * Make a new channel expression
     */
-  private def mkNewChannel(exp: LoweredAst.Expr, tpe: Type, eff: Type, loc: SourceLocation): LoweredAst.Expr = {
+  private def mkNewChannel(exp: LoweredAst.Exp, tpe: Type, eff: Type, loc: SourceLocation): LoweredAst.Exp = {
     val itpe = Type.mkIoArrow(exp.tpe, tpe, loc)
     val (targ, _) = extractChannelTpe(tpe)
-    LoweredAst.Expr.ApplyDef(Defs.ChannelNew, exp :: Nil, List(targ), itpe, tpe, eff, loc)
+    LoweredAst.Exp.ApplyDef(Defs.ChannelNew, exp :: Nil, List(targ), itpe, tpe, eff, loc)
   }
 
   /**
     * Make a new channel tuple (sender, receiver) expression
     */
-  private def mkNewChannelTuple(exp: LoweredAst.Expr, tpe: Type, eff: Type, loc: SourceLocation): LoweredAst.Expr = {
+  private def mkNewChannelTuple(exp: LoweredAst.Exp, tpe: Type, eff: Type, loc: SourceLocation): LoweredAst.Exp = {
     val itpe = Type.mkIoArrow(exp.tpe, tpe, loc)
     val (targ, _) = extractChannelTpe(tpe.typeArguments.head) // TODO make helper
-    LoweredAst.Expr.ApplyDef(Defs.ChannelNewTuple, exp :: Nil, List(targ), itpe, tpe, eff, loc)
+    LoweredAst.Exp.ApplyDef(Defs.ChannelNewTuple, exp :: Nil, List(targ), itpe, tpe, eff, loc)
   }
 
   /**
     * Make a channel get expression
     */
-  private def mkGetChannel(exp: LoweredAst.Expr, tpe: Type, eff: Type, loc: SourceLocation): LoweredAst.Expr = {
+  private def mkGetChannel(exp: LoweredAst.Exp, tpe: Type, eff: Type, loc: SourceLocation): LoweredAst.Exp = {
     val itpe = Type.mkIoArrow(exp.tpe, tpe, loc)
-    LoweredAst.Expr.ApplyDef(Defs.ChannelGet, exp :: Nil, List(tpe), itpe, tpe, eff, loc)
+    LoweredAst.Exp.ApplyDef(Defs.ChannelGet, exp :: Nil, List(tpe), itpe, tpe, eff, loc)
   }
 
   /**
     * Make a channel put expression
     */
-  private def mkPutChannel(exp1: LoweredAst.Expr, exp2: LoweredAst.Expr, eff: Type, loc: SourceLocation): LoweredAst.Expr = {
+  private def mkPutChannel(exp1: LoweredAst.Exp, exp2: LoweredAst.Exp, eff: Type, loc: SourceLocation): LoweredAst.Exp = {
     val itpe = Type.mkIoUncurriedArrow(List(exp2.tpe, exp1.tpe), Type.Unit, loc)
     val targ = exp2.tpe
-    LoweredAst.Expr.ApplyDef(Defs.ChannelPut, List(exp2, exp1), List(targ), itpe, Type.Unit, eff, loc)
+    LoweredAst.Exp.ApplyDef(Defs.ChannelPut, List(exp2, exp1), List(targ), itpe, Type.Unit, eff, loc)
   }
 
   /**
     * Make the list of MpmcAdmin objects which will be passed to `selectFrom`
     */
-  private def mkChannelAdminList(rs: List[LoweredAst.SelectChannelRule], channels: List[(Symbol.VarSym, LoweredAst.Expr)], loc: SourceLocation): LoweredAst.Expr = {
+  private def mkChannelAdminList(rs: List[LoweredAst.SelectChannelRule], channels: List[(Symbol.VarSym, LoweredAst.Exp)], loc: SourceLocation): LoweredAst.Exp = {
     val admins = ListOps.zip(rs, channels) map {
       case (LoweredAst.SelectChannelRule(_, c, _), (chanSym, _)) =>
         val (targ, _) = extractChannelTpe(c.tpe)
         val itpe = Type.mkPureArrow(c.tpe, Types.ChannelMpmcAdmin, loc)
-        LoweredAst.Expr.ApplyDef(Defs.ChannelMpmcAdmin, List(LoweredAst.Expr.Var(chanSym, c.tpe, loc)), List(targ), itpe, Types.ChannelMpmcAdmin, Type.Pure, loc)
+        LoweredAst.Exp.ApplyDef(Defs.ChannelMpmcAdmin, List(LoweredAst.Exp.Var(chanSym, c.tpe, loc)), List(targ), itpe, Types.ChannelMpmcAdmin, Type.Pure, loc)
     }
     mkList(admins, Types.ChannelMpmcAdmin, loc)
   }
@@ -1561,22 +1561,22 @@ object Lowering {
   /**
     * Construct a call to `selectFrom` given a list of MpmcAdmin objects and optional default
     */
-  private def mkChannelSelect(admins: LoweredAst.Expr, default: Option[LoweredAst.Expr], loc: SourceLocation): LoweredAst.Expr = {
+  private def mkChannelSelect(admins: LoweredAst.Exp, default: Option[LoweredAst.Exp], loc: SourceLocation): LoweredAst.Exp = {
     val locksType = Types.mkList(Types.ConcurrentReentrantLock, loc)
 
     val selectRetTpe = Type.mkTuple(List(Type.Int32, locksType), loc)
     val itpe = Type.mkIoUncurriedArrow(List(admins.tpe, Type.Bool), selectRetTpe, loc)
     val blocking = default match {
-      case Some(_) => LoweredAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc)
-      case None => LoweredAst.Expr.Cst(Constant.Bool(true), Type.Bool, loc)
+      case Some(_) => LoweredAst.Exp.Cst(Constant.Bool(false), Type.Bool, loc)
+      case None => LoweredAst.Exp.Cst(Constant.Bool(true), Type.Bool, loc)
     }
-    LoweredAst.Expr.ApplyDef(Defs.ChannelSelectFrom, List(admins, blocking), List.empty, itpe, selectRetTpe, Type.IO, loc)
+    LoweredAst.Exp.ApplyDef(Defs.ChannelSelectFrom, List(admins, blocking), List.empty, itpe, selectRetTpe, Type.IO, loc)
   }
 
   /**
     * Construct a sequence of MatchRules corresponding to the given SelectChannelRules
     */
-  private def mkChannelCases(rs: List[LoweredAst.SelectChannelRule], channels: List[(Symbol.VarSym, LoweredAst.Expr)], eff: Type, loc: SourceLocation)(implicit scope: Scope, flix: Flix): List[LoweredAst.MatchRule] = {
+  private def mkChannelCases(rs: List[LoweredAst.SelectChannelRule], channels: List[(Symbol.VarSym, LoweredAst.Exp)], eff: Type, loc: SourceLocation)(implicit scope: Scope, flix: Flix): List[LoweredAst.MatchRule] = {
     val locksType = Types.mkList(Types.ConcurrentReentrantLock, loc)
 
     ListOps.zip(rs, channels).zipWithIndex map {
@@ -1585,9 +1585,9 @@ object Lowering {
         val pat = mkTuplePattern(Nel(LoweredAst.Pattern.Cst(Constant.Int32(i), Type.Int32, loc), List(LoweredAst.Pattern.Var(locksSym, locksType, loc))), loc)
         val (getTpe, _) = extractChannelTpe(chan.tpe)
         val itpe = Type.mkIoUncurriedArrow(List(chan.tpe, locksType), getTpe, loc)
-        val args = List(LoweredAst.Expr.Var(chSym, chan.tpe, loc), LoweredAst.Expr.Var(locksSym, locksType, loc))
-        val getExp = LoweredAst.Expr.ApplyDef(Defs.ChannelUnsafeGetAndUnlock, args, List(getTpe), itpe, getTpe, eff, loc)
-        val e = LoweredAst.Expr.Let(sym, getExp, exp, exp.tpe, eff, loc)
+        val args = List(LoweredAst.Exp.Var(chSym, chan.tpe, loc), LoweredAst.Exp.Var(locksSym, locksType, loc))
+        val getExp = LoweredAst.Exp.ApplyDef(Defs.ChannelUnsafeGetAndUnlock, args, List(getTpe), itpe, getTpe, eff, loc)
+        val e = LoweredAst.Exp.Let(sym, getExp, exp, exp.tpe, eff, loc)
         LoweredAst.MatchRule(pat, None, e)
     }
   }
@@ -1596,7 +1596,7 @@ object Lowering {
     * Construct additional MatchRule to handle the (optional) default case
     * NB: Does not need to unlock because that is handled inside Concurrent/Channel.selectFrom.
     */
-  private def mkSelectDefaultCase(default: Option[LoweredAst.Expr], loc: SourceLocation): List[LoweredAst.MatchRule] = {
+  private def mkSelectDefaultCase(default: Option[LoweredAst.Exp], loc: SourceLocation): List[LoweredAst.MatchRule] = {
     default match {
       case Some(defaultExp) =>
         val locksType = Types.mkList(Types.ConcurrentReentrantLock, loc)
@@ -1613,7 +1613,7 @@ object Lowering {
     *
     * Note: liftX and liftXb are similar and should probably be maintained together.
     */
-  private def liftX(exp0: LoweredAst.Expr, argTypes: List[Type], resultType: Type): LoweredAst.Expr = {
+  private def liftX(exp0: LoweredAst.Exp, argTypes: List[Type], resultType: Type): LoweredAst.Exp = {
     // Compute the liftXb symbol.
     val sym = Symbol.mkDefnSym(s"Fixpoint${Defs.version}.Boxable.lift${argTypes.length}")
 
@@ -1633,13 +1633,13 @@ object Lowering {
     val liftType = Type.mkPureArrow(argType, returnType, exp0.loc)
 
     // Construct a call to the liftX function.
-    LoweredAst.Expr.ApplyDef(sym, List(exp0), argTypes :+ resultType, liftType, returnType, Type.Pure, exp0.loc)
+    LoweredAst.Exp.ApplyDef(sym, List(exp0), argTypes :+ resultType, liftType, returnType, Type.Pure, exp0.loc)
   }
 
   /**
     * Lifts the given Boolean-valued lambda expression `exp0` with the given argument types `argTypes`.
     */
-  private def liftXb(exp0: LoweredAst.Expr, argTypes: List[Type]): LoweredAst.Expr = {
+  private def liftXb(exp0: LoweredAst.Exp, argTypes: List[Type]): LoweredAst.Exp = {
     // Compute the liftXb symbol.
     val sym = Symbol.mkDefnSym(s"Fixpoint${Defs.version}.Boxable.lift${argTypes.length}b")
 
@@ -1659,14 +1659,14 @@ object Lowering {
     val liftType = Type.mkPureArrow(argType, returnType, exp0.loc)
 
     // Construct a call to the liftXb function.
-    LoweredAst.Expr.ApplyDef(sym, List(exp0), argTypes, liftType, returnType, Type.Pure, exp0.loc)
+    LoweredAst.Exp.ApplyDef(sym, List(exp0), argTypes, liftType, returnType, Type.Pure, exp0.loc)
   }
 
 
   /**
     * Lifts the given lambda expression `exp0` with the given argument types `argTypes` and `resultType`.
     */
-  private def liftXY(outVars: List[Symbol.VarSym], exp0: LoweredAst.Expr, argTypes: List[Type], resultType: Type, loc: SourceLocation): LoweredAst.Expr = {
+  private def liftXY(outVars: List[Symbol.VarSym], exp0: LoweredAst.Exp, argTypes: List[Type], resultType: Type, loc: SourceLocation): LoweredAst.Exp = {
     // Compute the number of bound ("output") and free ("input") variables.
     val numberOfInVars = argTypes.length
     val numberOfOutVars = outVars.length
@@ -1693,13 +1693,13 @@ object Lowering {
     val liftType = Type.mkPureArrow(argType, returnType, loc)
 
     // Construct a call to the liftXY function.
-    LoweredAst.Expr.ApplyDef(sym, List(exp0), targs, liftType, returnType, Type.Pure, loc)
+    LoweredAst.Exp.ApplyDef(sym, List(exp0), targs, liftType, returnType, Type.Pure, loc)
   }
 
   /**
     * Returns a list expression constructed from the given `exps` with type list of `elmType`.
     */
-  private def mkList(exps: List[LoweredAst.Expr], elmType: Type, loc: SourceLocation): LoweredAst.Expr = {
+  private def mkList(exps: List[LoweredAst.Exp], elmType: Type, loc: SourceLocation): LoweredAst.Exp = {
     val nil = mkNil(elmType, loc)
     exps.foldRight(nil) {
       case (e, acc) => mkCons(e, acc, loc)
@@ -1709,30 +1709,30 @@ object Lowering {
   /**
     * Returns a vector expression constructed from the given `exps` with type list of `elmType`.
     */
-  private def mkVector(exps: List[LoweredAst.Expr], elmType: Type, loc: SourceLocation): LoweredAst.Expr = {
-    LoweredAst.Expr.VectorLit(exps, Type.mkVector(elmType, loc), Type.Pure, loc)
+  private def mkVector(exps: List[LoweredAst.Exp], elmType: Type, loc: SourceLocation): LoweredAst.Exp = {
+    LoweredAst.Exp.VectorLit(exps, Type.mkVector(elmType, loc), Type.Pure, loc)
   }
 
   /**
     * Returns a `Nil` expression with type list of `elmType`.
     */
-  private def mkNil(elmType: Type, loc: SourceLocation): LoweredAst.Expr = {
+  private def mkNil(elmType: Type, loc: SourceLocation): LoweredAst.Exp = {
     mkTag(Enums.FList, "Nil", Nil, Types.mkList(elmType, loc), loc)
   }
 
   /**
     * returns a `Cons(hd, tail)` expression with type `tail.tpe`.
     */
-  private def mkCons(hd: LoweredAst.Expr, tail: LoweredAst.Expr, loc: SourceLocation): LoweredAst.Expr = {
+  private def mkCons(hd: LoweredAst.Exp, tail: LoweredAst.Exp, loc: SourceLocation): LoweredAst.Exp = {
     mkTag(Enums.FList, "Cons", List(hd, tail), tail.tpe, loc)
   }
 
   /**
     * Returns a pure tag expression for the given `sym` and given `tag` with the given inner expression `exp`.
     */
-  private def mkTag(sym: Symbol.EnumSym, tag: String, exps: List[LoweredAst.Expr], tpe: Type, loc: SourceLocation): LoweredAst.Expr = {
+  private def mkTag(sym: Symbol.EnumSym, tag: String, exps: List[LoweredAst.Exp], tpe: Type, loc: SourceLocation): LoweredAst.Exp = {
     val caseSym = new Symbol.CaseSym(sym, tag, loc.asSynthetic)
-    LoweredAst.Expr.ApplyAtomic(AtomicOp.Tag(caseSym), exps, tpe, Type.Pure, loc)
+    LoweredAst.Exp.ApplyAtomic(AtomicOp.Tag(caseSym), exps, tpe, Type.Pure, loc)
   }
 
   /**
@@ -1748,26 +1748,26 @@ object Lowering {
   /**
     * Returns an expression merging `exps` using `Defs.Merge`.
     */
-  private def mergeExps(exps: List[LoweredAst.Expr], loc: SourceLocation)(implicit root: TypedAst.Root): LoweredAst.Expr =
+  private def mergeExps(exps: List[LoweredAst.Exp], loc: SourceLocation)(implicit root: TypedAst.Root): LoweredAst.Exp =
     exps.reduceRight {
       (exp, acc) =>
         val defn = Defs.lookup(Defs.Merge)
         val argExps = exp :: acc :: Nil
         val resultType = Types.Datalog
         val itpe = Types.MergeType
-        LoweredAst.Expr.ApplyDef(defn.sym, argExps, List.empty, itpe, resultType, exp.eff, loc)
+        LoweredAst.Exp.ApplyDef(defn.sym, argExps, List.empty, itpe, resultType, exp.eff, loc)
     }
 
   /**
     * Returns a new `Datalog` from `datalogExp` containing only facts from the predicate given by the `PredSym` `predSymExp`
     * using `Defs.Filter`.
     */
-  private def projectSym(predSymExp: LoweredAst.Expr, datalogExp: LoweredAst.Expr, loc: SourceLocation)(implicit root: TypedAst.Root): LoweredAst.Expr = {
+  private def projectSym(predSymExp: LoweredAst.Exp, datalogExp: LoweredAst.Exp, loc: SourceLocation)(implicit root: TypedAst.Root): LoweredAst.Exp = {
     val defn = Defs.lookup(Defs.Filter)
     val argExps = predSymExp :: datalogExp :: Nil
     val resultType = Types.Datalog
     val itpe = Types.FilterType
-    LoweredAst.Expr.ApplyDef(defn.sym, argExps, List.empty, itpe, resultType, datalogExp.eff, loc)
+    LoweredAst.Exp.ApplyDef(defn.sym, argExps, List.empty, itpe, resultType, datalogExp.eff, loc)
   }
 
   /**
@@ -1831,7 +1831,7 @@ object Lowering {
     * }}}
     * where `P1, P2, ...` are in `preds` with their respective term types.
     */
-  private def mkExtVarLambda(preds: List[(Name.Pred, List[Type])], tpe: Type, loc: SourceLocation)(implicit scope: Scope, flix: Flix): LoweredAst.Expr = {
+  private def mkExtVarLambda(preds: List[(Name.Pred, List[Type])], tpe: Type, loc: SourceLocation)(implicit scope: Scope, flix: Flix): LoweredAst.Exp = {
     val predSymVar = Symbol.freshVarSym("predSym", BoundBy.FormalParam, loc)
     val termsVar = Symbol.freshVarSym("terms", BoundBy.FormalParam, loc)
     mkLambdaExp(predSymVar, Types.PredSym,
@@ -1850,8 +1850,8 @@ object Lowering {
     * }}}
     * where `"paramName" == param.text` and `exp` has type `expType` and effect `eff`.
     */
-  private def mkLambdaExp(param: Symbol.VarSym, paramTpe: Type, exp: LoweredAst.Expr, expTpe: Type, eff: Type, loc: SourceLocation): LoweredAst.Expr =
-    LoweredAst.Expr.Lambda(
+  private def mkLambdaExp(param: Symbol.VarSym, paramTpe: Type, exp: LoweredAst.Exp, expTpe: Type, eff: Type, loc: SourceLocation): LoweredAst.Exp =
+    LoweredAst.Exp.Lambda(
       LoweredAst.FormalParam(param, paramTpe, loc),
       exp,
       Type.mkArrowWithEffect(paramTpe, eff, expTpe, loc),
@@ -1872,10 +1872,10 @@ object Lowering {
     * where `P1, P2, ...` are in `preds` with their respective term types, `"predSym" == predSymVar.text`
     * and `"terms" == termsVar.text`.
     */
-  private def mkExtVarBody(preds: List[(Name.Pred, List[Type])], predSymVar: Symbol.VarSym, termsVar: Symbol.VarSym, tpe: Type, loc: SourceLocation)(implicit scope: Scope, flix: Flix): LoweredAst.Expr = {
+  private def mkExtVarBody(preds: List[(Name.Pred, List[Type])], predSymVar: Symbol.VarSym, termsVar: Symbol.VarSym, tpe: Type, loc: SourceLocation)(implicit scope: Scope, flix: Flix): LoweredAst.Exp = {
     val nameVar = Symbol.freshVarSym(Name.Ident("name", loc), BoundBy.Pattern)
-    LoweredAst.Expr.Match(
-      exp = LoweredAst.Expr.Var(predSymVar, Types.PredSym, loc),
+    LoweredAst.Exp.Match(
+      exp = LoweredAst.Exp.Var(predSymVar, Types.PredSym, loc),
       rules = List(
         LoweredAst.MatchRule(
           pat = LoweredAst.Pattern.Tag(
@@ -1887,8 +1887,8 @@ object Lowering {
             tpe = Types.PredSym, loc = loc
           ),
           guard = None,
-          exp = LoweredAst.Expr.Match(
-            exp = LoweredAst.Expr.Var(nameVar, Type.Str, loc),
+          exp = LoweredAst.Exp.Match(
+            exp = LoweredAst.Exp.Var(nameVar, Type.Str, loc),
             rules = preds.map {
               case (p, types) => mkProvenanceMatchRule(termsVar, tpe, p, types, loc)
             },
@@ -1914,7 +1914,7 @@ object Lowering {
     LoweredAst.MatchRule(
       pat = LoweredAst.Pattern.Cst(Constant.Str(p.name), Type.Str, loc),
       guard = None,
-      exp = LoweredAst.Expr.ApplyAtomic(
+      exp = LoweredAst.Exp.ApplyAtomic(
         op = AtomicOp.ExtTag(Name.Label(p.name, loc)),
         exps = termsExps,
         tpe = tpe, eff = Type.Pure, loc = loc
@@ -1929,15 +1929,15 @@ object Lowering {
     * }}}
     * where `"terms" == termsVar.text`.
     */
-  private def mkUnboxedTerm(termsVar: Symbol.VarSym, tpe: Type, i: Int, loc: SourceLocation): LoweredAst.Expr = {
-    LoweredAst.Expr.ApplyDef(
+  private def mkUnboxedTerm(termsVar: Symbol.VarSym, tpe: Type, i: Int, loc: SourceLocation): LoweredAst.Exp = {
+    LoweredAst.Exp.ApplyDef(
       sym = Defs.Unbox,
       exps = List(
-        LoweredAst.Expr.ApplyDef(
+        LoweredAst.Exp.ApplyDef(
           sym = Symbol.mkDefnSym(s"Vector.get"),
           exps = List(
-            LoweredAst.Expr.Cst(Constant.Int32(i), Type.Int32, loc),
-            LoweredAst.Expr.Var(termsVar, Types.VectorOfBoxed, loc)
+            LoweredAst.Exp.Cst(Constant.Int32(i), Type.Int32, loc),
+            LoweredAst.Exp.Var(termsVar, Types.VectorOfBoxed, loc)
           ),
           targs = List.empty,
           itpe = Type.mkPureUncurriedArrow(List(Type.Int32, Types.VectorOfBoxed), Types.Boxed, loc),
@@ -1990,31 +1990,31 @@ object Lowering {
   /**
     * An expression for a channel variable called `sym`
     */
-  private def mkChannelExp(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation): LoweredAst.Expr = {
-    LoweredAst.Expr.Var(sym, mkChannelTpe(tpe, loc), loc)
+  private def mkChannelExp(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation): LoweredAst.Exp = {
+    LoweredAst.Exp.Var(sym, mkChannelTpe(tpe, loc), loc)
   }
 
   /**
     * Returns a full `par yield` expression.
     */
-  private def mkParChannels(exp: LoweredAst.Expr, chanSymsWithExps: List[(Symbol.VarSym, LoweredAst.Expr)]): LoweredAst.Expr = {
+  private def mkParChannels(exp: LoweredAst.Exp, chanSymsWithExps: List[(Symbol.VarSym, LoweredAst.Exp)]): LoweredAst.Exp = {
     // Make spawn expressions `spawn ch <- exp`.
-    val spawns = chanSymsWithExps.foldRight(exp: LoweredAst.Expr) {
+    val spawns = chanSymsWithExps.foldRight(exp: LoweredAst.Exp) {
       case ((sym, e), acc) =>
         val loc = e.loc.asSynthetic
         val e1 = mkChannelExp(sym, e.tpe, loc) // The channel `ch`
         val e2 = mkPutChannel(e1, e, Type.IO, loc) // The put exp: `ch <- exp0`.
-        val e3 = LoweredAst.Expr.Cst(Constant.Static, Type.mkRegionToStar(Type.IO, loc), loc)
-        val e4 = LoweredAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(e2, e3), Type.Unit, Type.IO, loc) // Spawn the put expression from above i.e. `spawn ch <- exp0`.
-        LoweredAst.Expr.Stm(e4, acc, acc.tpe, Type.mkUnion(e4.eff, acc.eff, loc), loc) // Return a statement expression containing the other spawn expressions along with this one.
+        val e3 = LoweredAst.Exp.Cst(Constant.Static, Type.mkRegionToStar(Type.IO, loc), loc)
+        val e4 = LoweredAst.Exp.ApplyAtomic(AtomicOp.Spawn, List(e2, e3), Type.Unit, Type.IO, loc) // Spawn the put expression from above i.e. `spawn ch <- exp0`.
+        LoweredAst.Exp.Stm(e4, acc, acc.tpe, Type.mkUnion(e4.eff, acc.eff, loc), loc) // Return a statement expression containing the other spawn expressions along with this one.
     }
 
     // Make let bindings `let ch = chan 1;`.
-    chanSymsWithExps.foldRight(spawns: LoweredAst.Expr) {
+    chanSymsWithExps.foldRight(spawns: LoweredAst.Exp) {
       case ((sym, e), acc) =>
         val loc = e.loc.asSynthetic
-        val chan = mkNewChannel(LoweredAst.Expr.Cst(Constant.Int32(1), Type.Int32, loc), mkChannelTpe(e.tpe, loc), Type.IO, loc) // The channel exp `chan 1`
-        LoweredAst.Expr.Let(sym, chan, acc, acc.tpe, Type.mkUnion(e.eff, acc.eff, loc), loc) // The let-binding `let ch = chan 1`
+        val chan = mkNewChannel(LoweredAst.Exp.Cst(Constant.Int32(1), Type.Int32, loc), mkChannelTpe(e.tpe, loc), Type.IO, loc) // The channel exp `chan 1`
+        LoweredAst.Exp.Let(sym, chan, acc, acc.tpe, Type.mkUnion(e.eff, acc.eff, loc), loc) // The let-binding `let ch = chan 1`
     }
   }
 
@@ -2031,16 +2031,16 @@ object Lowering {
     *   }
     * }}}
     */
-  private def mkLetMatch(pat: LoweredAst.Pattern, exp: LoweredAst.Expr, body: LoweredAst.Expr): LoweredAst.Expr = {
+  private def mkLetMatch(pat: LoweredAst.Pattern, exp: LoweredAst.Exp, body: LoweredAst.Exp): LoweredAst.Exp = {
     val loc = exp.loc.asSynthetic
     val rule = List(LoweredAst.MatchRule(pat, None, body))
     val eff = Type.mkUnion(exp.eff, body.eff, loc)
-    LoweredAst.Expr.Match(exp, rule, body.tpe, eff, loc)
+    LoweredAst.Exp.Match(exp, rule, body.tpe, eff, loc)
   }
 
   /**
     * Returns an expression where the pattern variables used in `exp` are
-    * bound to [[TypedAst.Expr.GetChannel]] expressions,
+    * bound to [[TypedAst.Exp.GetChannel]] expressions,
     * i.e.
     * {{{
     *   let pat1 = <- ch1;
@@ -2051,7 +2051,7 @@ object Lowering {
     *   exp
     * }}}
     */
-  private def mkBoundParWaits(patSymExps: List[(LoweredAst.Pattern, Symbol.VarSym, LoweredAst.Expr)], exp: LoweredAst.Expr): LoweredAst.Expr =
+  private def mkBoundParWaits(patSymExps: List[(LoweredAst.Pattern, Symbol.VarSym, LoweredAst.Exp)], exp: LoweredAst.Exp): LoweredAst.Exp =
     patSymExps.map {
       case (p, sym, e) =>
         val loc = e.loc.asSynthetic
@@ -2062,9 +2062,9 @@ object Lowering {
     }
 
   /**
-    * Returns a desugared [[TypedAst.Expr.ParYield]] expression as a nested match-expression.
+    * Returns a desugared [[TypedAst.Exp.ParYield]] expression as a nested match-expression.
     */
-  private def mkParYield(frags: List[LoweredAst.ParYieldFragment], exp: LoweredAst.Expr, tpe: Type, eff: Type, loc: SourceLocation)(implicit scope: Scope, flix: Flix): LoweredAst.Expr = {
+  private def mkParYield(frags: List[LoweredAst.ParYieldFragment], exp: LoweredAst.Exp, tpe: Type, eff: Type, loc: SourceLocation)(implicit scope: Scope, flix: Flix): LoweredAst.Exp = {
     // Only generate channels for n-1 fragments. We use the current thread for the last fragment.
     val fs = frags.init
     val last = frags.last
@@ -2083,7 +2083,7 @@ object Lowering {
     val blockExp = mkParChannels(desugaredYieldExp, chanSymsWithExp)
 
     // Wrap everything in a purity cast,
-    LoweredAst.Expr.Cast(blockExp, None, Some(Type.Pure), tpe, eff, loc.asSynthetic)
+    LoweredAst.Exp.Cast(blockExp, None, Some(Type.Pure), tpe, eff, loc.asSynthetic)
   }
 
   /**
@@ -2099,7 +2099,7 @@ object Lowering {
     * A variable is quantified (i.e. *NOT* lexically bound) if it occurs in the expression `exp0`
     * but not in the constraint params `cparams0` of the constraint.
     */
-  private def quantifiedVars(cparams0: List[TypedAst.ConstraintParam], exp0: TypedAst.Expr): List[(Symbol.VarSym, Type)] = {
+  private def quantifiedVars(cparams0: List[TypedAst.ConstraintParam], exp0: TypedAst.Exp): List[(Symbol.VarSym, Type)] = {
     TypedAstOps.freeVars(exp0).toList.filter {
       case (sym, _) => isQuantifiedVar(sym, cparams0)
     }
@@ -2116,77 +2116,77 @@ object Lowering {
   /**
     * Applies the given substitution `subst` to the given expression `exp0`.
     */
-  private def substExp(exp0: LoweredAst.Expr, subst: Map[Symbol.VarSym, Symbol.VarSym]): LoweredAst.Expr = exp0 match {
-    case LoweredAst.Expr.Cst(_, _, _) => exp0
+  private def substExp(exp0: LoweredAst.Exp, subst: Map[Symbol.VarSym, Symbol.VarSym]): LoweredAst.Exp = exp0 match {
+    case LoweredAst.Exp.Cst(_, _, _) => exp0
 
-    case LoweredAst.Expr.Var(sym, tpe, loc) =>
+    case LoweredAst.Exp.Var(sym, tpe, loc) =>
       val s = subst.getOrElse(sym, sym)
-      LoweredAst.Expr.Var(s, tpe, loc)
+      LoweredAst.Exp.Var(s, tpe, loc)
 
-    case LoweredAst.Expr.Lambda(fparam, exp, tpe, loc) =>
+    case LoweredAst.Exp.Lambda(fparam, exp, tpe, loc) =>
       val p = substFormalParam(fparam, subst)
       val e = substExp(exp, subst)
-      LoweredAst.Expr.Lambda(p, e, tpe, loc)
+      LoweredAst.Exp.Lambda(p, e, tpe, loc)
 
-    case LoweredAst.Expr.ApplyClo(exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyClo(exp1, exp2, tpe, eff, loc) =>
       val e1 = substExp(exp1, subst)
       val e2 = substExp(exp2, subst)
-      LoweredAst.Expr.ApplyClo(e1, e2, tpe, eff, loc)
+      LoweredAst.Exp.ApplyClo(e1, e2, tpe, eff, loc)
 
-    case LoweredAst.Expr.ApplyDef(sym, exps, targs, itpe, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyDef(sym, exps, targs, itpe, tpe, eff, loc) =>
       val es = exps.map(substExp(_, subst))
-      LoweredAst.Expr.ApplyDef(sym, es, targs, itpe, tpe, eff, loc)
+      LoweredAst.Exp.ApplyDef(sym, es, targs, itpe, tpe, eff, loc)
 
-    case LoweredAst.Expr.ApplyLocalDef(sym, exps, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyLocalDef(sym, exps, tpe, eff, loc) =>
       val es = exps.map(substExp(_, subst))
-      LoweredAst.Expr.ApplyLocalDef(sym, es, tpe, eff, loc)
+      LoweredAst.Exp.ApplyLocalDef(sym, es, tpe, eff, loc)
 
-    case LoweredAst.Expr.ApplyOp(sym, exps, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyOp(sym, exps, tpe, eff, loc) =>
       val es = exps.map(substExp(_, subst))
-      LoweredAst.Expr.ApplyOp(sym, es, tpe, eff, loc)
+      LoweredAst.Exp.ApplyOp(sym, es, tpe, eff, loc)
 
-    case LoweredAst.Expr.ApplySig(sym, exps, targ, targs, itpe, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplySig(sym, exps, targ, targs, itpe, tpe, eff, loc) =>
       val es = exps.map(substExp(_, subst))
-      LoweredAst.Expr.ApplySig(sym, es, targ, targs, itpe, tpe, eff, loc)
+      LoweredAst.Exp.ApplySig(sym, es, targ, targs, itpe, tpe, eff, loc)
 
-    case LoweredAst.Expr.ApplyAtomic(op, exps, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyAtomic(op, exps, tpe, eff, loc) =>
       val es = exps.map(substExp(_, subst))
-      LoweredAst.Expr.ApplyAtomic(op, es, tpe, eff, loc)
+      LoweredAst.Exp.ApplyAtomic(op, es, tpe, eff, loc)
 
-    case LoweredAst.Expr.Let(sym, exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.Let(sym, exp1, exp2, tpe, eff, loc) =>
       val s = subst.getOrElse(sym, sym)
       val e1 = substExp(exp1, subst)
       val e2 = substExp(exp2, subst)
-      LoweredAst.Expr.Let(s, e1, e2, tpe, eff, loc)
+      LoweredAst.Exp.Let(s, e1, e2, tpe, eff, loc)
 
-    case LoweredAst.Expr.LocalDef(sym, fparams, exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.LocalDef(sym, fparams, exp1, exp2, tpe, eff, loc) =>
       val s = subst.getOrElse(sym, sym)
       val fps = fparams.map(substFormalParam(_, subst))
       val e1 = substExp(exp1, subst)
       val e2 = substExp(exp2, subst)
-      LoweredAst.Expr.LocalDef(s, fps, e1, e2, tpe, eff, loc)
+      LoweredAst.Exp.LocalDef(s, fps, e1, e2, tpe, eff, loc)
 
-    case LoweredAst.Expr.Region(sym, regionVar, exp, tpe, eff, loc) =>
+    case LoweredAst.Exp.Region(sym, regionVar, exp, tpe, eff, loc) =>
       val s = subst.getOrElse(sym, sym)
       val e = substExp(exp, subst)
-      LoweredAst.Expr.Region(s, regionVar, e, tpe, eff, loc)
+      LoweredAst.Exp.Region(s, regionVar, e, tpe, eff, loc)
 
-    case LoweredAst.Expr.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
+    case LoweredAst.Exp.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
       val e1 = substExp(exp1, subst)
       val e2 = substExp(exp2, subst)
       val e3 = substExp(exp3, subst)
-      LoweredAst.Expr.IfThenElse(e1, e2, e3, tpe, eff, loc)
+      LoweredAst.Exp.IfThenElse(e1, e2, e3, tpe, eff, loc)
 
-    case LoweredAst.Expr.Stm(exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.Stm(exp1, exp2, tpe, eff, loc) =>
       val e1 = substExp(exp1, subst)
       val e2 = substExp(exp2, subst)
-      LoweredAst.Expr.Stm(e1, e2, tpe, eff, loc)
+      LoweredAst.Exp.Stm(e1, e2, tpe, eff, loc)
 
-    case LoweredAst.Expr.Discard(exp, eff, loc) =>
+    case LoweredAst.Exp.Discard(exp, eff, loc) =>
       val e = substExp(exp, subst)
-      LoweredAst.Expr.Discard(e, eff, loc)
+      LoweredAst.Exp.Discard(e, eff, loc)
 
-    case LoweredAst.Expr.Match(exp, rules, tpe, eff, loc) =>
+    case LoweredAst.Exp.Match(exp, rules, tpe, eff, loc) =>
       val e = substExp(exp, subst)
       val rs = rules.map {
         case LoweredAst.MatchRule(pat, guard, exp1) =>
@@ -2195,9 +2195,9 @@ object Lowering {
           val e1 = substExp(exp1, subst)
           LoweredAst.MatchRule(p, g, e1)
       }
-      LoweredAst.Expr.Match(e, rs, tpe, eff, loc)
+      LoweredAst.Exp.Match(e, rs, tpe, eff, loc)
 
-    case LoweredAst.Expr.ExtMatch(exp, rules, tpe, eff, loc) =>
+    case LoweredAst.Exp.ExtMatch(exp, rules, tpe, eff, loc) =>
       val e = substExp(exp, subst)
       val rs = rules.map {
         case LoweredAst.ExtMatchRule(pat, exp1, loc1) =>
@@ -2205,9 +2205,9 @@ object Lowering {
           val e1 = substExp(exp1, subst)
           LoweredAst.ExtMatchRule(p, e1, loc1)
       }
-      LoweredAst.Expr.ExtMatch(e, rs, tpe, eff, loc)
+      LoweredAst.Exp.ExtMatch(e, rs, tpe, eff, loc)
 
-    case LoweredAst.Expr.TypeMatch(exp, rules, tpe, eff, loc) =>
+    case LoweredAst.Exp.TypeMatch(exp, rules, tpe, eff, loc) =>
       val e = substExp(exp, subst)
       val rs = rules.map {
         case LoweredAst.TypeMatchRule(sym, tpe1, exp1) =>
@@ -2215,30 +2215,30 @@ object Lowering {
           val e1 = substExp(exp1, subst)
           LoweredAst.TypeMatchRule(s, tpe1, e1)
       }
-      LoweredAst.Expr.TypeMatch(e, rs, tpe, eff, loc)
+      LoweredAst.Exp.TypeMatch(e, rs, tpe, eff, loc)
 
-    case LoweredAst.Expr.VectorLit(exps, tpe, eff, loc) =>
+    case LoweredAst.Exp.VectorLit(exps, tpe, eff, loc) =>
       val es = exps.map(substExp(_, subst))
-      LoweredAst.Expr.VectorLit(es, tpe, eff, loc)
+      LoweredAst.Exp.VectorLit(es, tpe, eff, loc)
 
-    case LoweredAst.Expr.VectorLoad(exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.VectorLoad(exp1, exp2, tpe, eff, loc) =>
       val e1 = substExp(exp1, subst)
       val e2 = substExp(exp2, subst)
-      LoweredAst.Expr.VectorLoad(e1, e2, tpe, eff, loc)
+      LoweredAst.Exp.VectorLoad(e1, e2, tpe, eff, loc)
 
-    case LoweredAst.Expr.VectorLength(exp, loc) =>
+    case LoweredAst.Exp.VectorLength(exp, loc) =>
       val e = substExp(exp, subst)
-      LoweredAst.Expr.VectorLength(e, loc)
+      LoweredAst.Exp.VectorLength(e, loc)
 
-    case LoweredAst.Expr.Ascribe(exp, tpe, eff, loc) =>
+    case LoweredAst.Exp.Ascribe(exp, tpe, eff, loc) =>
       val e = substExp(exp, subst)
-      LoweredAst.Expr.Ascribe(e, tpe, eff, loc)
+      LoweredAst.Exp.Ascribe(e, tpe, eff, loc)
 
-    case LoweredAst.Expr.Cast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+    case LoweredAst.Exp.Cast(exp, declaredType, declaredEff, tpe, eff, loc) =>
       val e = substExp(exp, subst)
-      LoweredAst.Expr.Cast(e, declaredType, declaredEff, tpe, eff, loc)
+      LoweredAst.Exp.Cast(e, declaredType, declaredEff, tpe, eff, loc)
 
-    case LoweredAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>
+    case LoweredAst.Exp.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = substExp(exp, subst)
       val rs = rules.map {
         case LoweredAst.CatchRule(sym, clazz, exp1) =>
@@ -2246,9 +2246,9 @@ object Lowering {
           val e1 = substExp(exp1, subst)
           LoweredAst.CatchRule(s, clazz, e1)
       }
-      LoweredAst.Expr.TryCatch(e, rs, tpe, eff, loc)
+      LoweredAst.Exp.TryCatch(e, rs, tpe, eff, loc)
 
-    case LoweredAst.Expr.RunWith(exp, effSymUse, rules, tpe, eff, loc) =>
+    case LoweredAst.Exp.RunWith(exp, effSymUse, rules, tpe, eff, loc) =>
       val e = substExp(exp, subst)
       val rs = rules.map {
         case LoweredAst.HandlerRule(opSymUse, fparams, hexp) =>
@@ -2256,9 +2256,9 @@ object Lowering {
           val he = substExp(hexp, subst)
           LoweredAst.HandlerRule(opSymUse, fps, he)
       }
-      LoweredAst.Expr.RunWith(e, effSymUse, rs, tpe, eff, loc)
+      LoweredAst.Exp.RunWith(e, effSymUse, rs, tpe, eff, loc)
 
-    case LoweredAst.Expr.NewObject(_, _, _, _, _, _) => exp0
+    case LoweredAst.Exp.NewObject(_, _, _, _, _, _) => exp0
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
@@ -447,70 +447,70 @@ object Monomorpher {
     *
     * Replaces every local variable symbol with a fresh local variable symbol.
     */
-  private def specializeExp(exp0: LoweredAst.Expr, env0: Map[Symbol.VarSym, Symbol.VarSym], subst: StrictSubstitution)(implicit ctx: Context, instances: Map[(Symbol.TraitSym, TypeConstructor), Instance], root: LoweredAst.Root, flix: Flix): MonoAst.Expr = exp0 match {
-    case LoweredAst.Expr.Var(sym, tpe, loc) =>
-      MonoAst.Expr.Var(env0(sym), subst(tpe), loc)
+  private def specializeExp(exp0: LoweredAst.Exp, env0: Map[Symbol.VarSym, Symbol.VarSym], subst: StrictSubstitution)(implicit ctx: Context, instances: Map[(Symbol.TraitSym, TypeConstructor), Instance], root: LoweredAst.Root, flix: Flix): MonoAst.Exp = exp0 match {
+    case LoweredAst.Exp.Var(sym, tpe, loc) =>
+      MonoAst.Exp.Var(env0(sym), subst(tpe), loc)
 
-    case LoweredAst.Expr.Cst(cst, tpe, loc) =>
-      MonoAst.Expr.Cst(cst, subst(tpe), loc)
+    case LoweredAst.Exp.Cst(cst, tpe, loc) =>
+      MonoAst.Exp.Cst(cst, subst(tpe), loc)
 
-    case LoweredAst.Expr.Lambda(fparam, exp, tpe, loc) =>
+    case LoweredAst.Exp.Lambda(fparam, exp, tpe, loc) =>
       val (p, env1) = specializeFormalParam(fparam, subst)
       val e = specializeExp(exp, env0 ++ env1, subst)
-      MonoAst.Expr.Lambda(p, e, subst(tpe), loc)
+      MonoAst.Exp.Lambda(p, e, subst(tpe), loc)
 
-    case LoweredAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(clazz), exps, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyAtomic(AtomicOp.InstanceOf(clazz), exps, tpe, eff, loc) =>
       // In bytecode, instanceof can only be called on reference types
       val es = exps.map(specializeExp(_, env0, subst))
       val List(e) = es
       if (isPrimType(e.tpe)) {
         // If it's a primitive type, evaluate the expression but return false
-        MonoAst.Expr.Stm(e, MonoAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc), Type.Bool, e.eff, loc)
+        MonoAst.Exp.Stm(e, MonoAst.Exp.Cst(Constant.Bool(false), Type.Bool, loc), Type.Bool, e.eff, loc)
       } else {
         // If it's a reference type, then do the instanceof check
-        MonoAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(clazz), es, subst(tpe), subst(eff), loc)
+        MonoAst.Exp.ApplyAtomic(AtomicOp.InstanceOf(clazz), es, subst(tpe), subst(eff), loc)
       }
 
-    case LoweredAst.Expr.ApplyAtomic(op, exps, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyAtomic(op, exps, tpe, eff, loc) =>
       val es = exps.map(specializeExp(_, env0, subst))
-      MonoAst.Expr.ApplyAtomic(op, es, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.ApplyAtomic(op, es, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.ApplyClo(exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyClo(exp1, exp2, tpe, eff, loc) =>
       val e1 = specializeExp(exp1, env0, subst)
       val e2 = specializeExp(exp2, env0, subst)
-      MonoAst.Expr.ApplyClo(e1, e2, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.ApplyClo(e1, e2, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.ApplyDef(sym, exps, _, itpe, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyDef(sym, exps, _, itpe, tpe, eff, loc) =>
       val it = subst(itpe)
       val newSym = specializeDefnSym(sym, it)
       val es = exps.map(specializeExp(_, env0, subst))
-      MonoAst.Expr.ApplyDef(newSym, es, it, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.ApplyDef(newSym, es, it, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.ApplyLocalDef(sym, exps, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyLocalDef(sym, exps, tpe, eff, loc) =>
       val newSym = env0(sym)
       val es = exps.map(specializeExp(_, env0, subst))
       val t = subst(tpe)
       val ef = subst(eff)
-      MonoAst.Expr.ApplyLocalDef(newSym, es, t, ef, loc)
+      MonoAst.Exp.ApplyLocalDef(newSym, es, t, ef, loc)
 
-    case LoweredAst.Expr.ApplyOp(sym, exps, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplyOp(sym, exps, tpe, eff, loc) =>
       val es = exps.map(specializeExp(_, env0, subst))
-      MonoAst.Expr.ApplyOp(sym, es, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.ApplyOp(sym, es, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.ApplySig(sym, exps, _, _, itpe, tpe, eff, loc) =>
+    case LoweredAst.Exp.ApplySig(sym, exps, _, _, itpe, tpe, eff, loc) =>
       val it = subst(itpe)
       val newSym = specializeSigSym(sym, it)
       val es = exps.map(specializeExp(_, env0, subst))
-      MonoAst.Expr.ApplyDef(newSym, es, it, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.ApplyDef(newSym, es, it, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.Let(sym, exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.Let(sym, exp1, exp2, tpe, eff, loc) =>
       val freshSym = Symbol.freshVarSym(sym)
       val env1 = env0 + (sym -> freshSym)
       val e1 = specializeExp(exp1, env0, subst)
       val e2 = specializeExp(exp2, env1, subst)
-      MonoAst.Expr.Let(freshSym, e1, e2, subst(tpe), subst(eff), Occur.Unknown, loc)
+      MonoAst.Exp.Let(freshSym, e1, e2, subst(tpe), subst(eff), Occur.Unknown, loc)
 
-    case LoweredAst.Expr.LocalDef(sym, fparams, exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.LocalDef(sym, fparams, exp1, exp2, tpe, eff, loc) =>
       val freshSym = Symbol.freshVarSym(sym)
       val env1 = env0 + (sym -> freshSym)
       val (fps, env2) = specializeFormalParams(fparams, subst)
@@ -518,29 +518,29 @@ object Monomorpher {
       val e2 = specializeExp(exp2, env1, subst)
       val t = subst(tpe)
       val ef = subst(eff)
-      MonoAst.Expr.LocalDef(freshSym, fps, e1, e2, t, ef, Occur.Unknown, loc)
+      MonoAst.Exp.LocalDef(freshSym, fps, e1, e2, t, ef, Occur.Unknown, loc)
 
-    case LoweredAst.Expr.Region(sym, regionVar, exp, tpe, eff, loc) =>
+    case LoweredAst.Exp.Region(sym, regionVar, exp, tpe, eff, loc) =>
       val freshSym = Symbol.freshVarSym(sym)
       val env1 = env0 + (sym -> freshSym)
-      MonoAst.Expr.Region(freshSym, regionVar, specializeExp(exp, env1, subst), subst(tpe), subst(eff), loc)
+      MonoAst.Exp.Region(freshSym, regionVar, specializeExp(exp, env1, subst), subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
+    case LoweredAst.Exp.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
       val e1 = specializeExp(exp1, env0, subst)
       val e2 = specializeExp(exp2, env0, subst)
       val e3 = specializeExp(exp3, env0, subst)
-      MonoAst.Expr.IfThenElse(e1, e2, e3, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.IfThenElse(e1, e2, e3, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.Stm(exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.Stm(exp1, exp2, tpe, eff, loc) =>
       val e1 = specializeExp(exp1, env0, subst)
       val e2 = specializeExp(exp2, env0, subst)
-      MonoAst.Expr.Stm(e1, e2, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.Stm(e1, e2, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.Discard(exp, eff, loc) =>
+    case LoweredAst.Exp.Discard(exp, eff, loc) =>
       val e = specializeExp(exp, env0, subst)
-      MonoAst.Expr.Discard(e, subst(eff), loc)
+      MonoAst.Exp.Discard(e, subst(eff), loc)
 
-    case LoweredAst.Expr.Match(exp, rules, tpe, eff, loc) =>
+    case LoweredAst.Exp.Match(exp, rules, tpe, eff, loc) =>
       val rs = rules map {
         case LoweredAst.MatchRule(pat, guard, body) =>
           val (p, env1) = specializePat(pat, subst)
@@ -549,9 +549,9 @@ object Monomorpher {
           val b = specializeExp(body, extendedEnv, subst)
           MonoAst.MatchRule(p, g, b)
       }
-      MonoAst.Expr.Match(specializeExp(exp, env0, subst), rs, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.Match(specializeExp(exp, env0, subst), rs, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.ExtMatch(exp, rules, tpe, eff, loc) =>
+    case LoweredAst.Exp.ExtMatch(exp, rules, tpe, eff, loc) =>
       val e = specializeExp(exp, env0, subst)
       val rs = rules.map {
         case LoweredAst.ExtMatchRule(pat, exp1, loc1) =>
@@ -560,9 +560,9 @@ object Monomorpher {
           val e1 = specializeExp(exp1, extendedEnv, subst)
           MonoAst.ExtMatchRule(p, e1, loc1)
       }
-      MonoAst.Expr.ExtMatch(e, rs, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.ExtMatch(e, rs, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.TypeMatch(exp, rules, tpe, _, loc) =>
+    case LoweredAst.Exp.TypeMatch(exp, rules, tpe, _, loc) =>
       // Use the non-strict substitution to allow free type variables to match with anything.
       val expTpe = subst.nonStrict(exp.tpe)
       // Make the tvars in `exp`'s type rigid so that `Nil: List[x%123]` can only match `List[_]`
@@ -585,32 +585,32 @@ object Monomorpher {
               // Visit the body under the extended environment.
               val body = specializeExp(body0, env1, subst1)
               val eff = Type.mkUnion(e.eff, body.eff, loc.asSynthetic)
-              Some(MonoAst.Expr.Let(freshSym, e, body, subst1(tpe), subst1(eff), Occur.Unknown, loc))
+              Some(MonoAst.Exp.Let(freshSym, e, body, subst1(tpe), subst1(eff), Occur.Unknown, loc))
           }
       }.get // This is safe since the last case can always match.
 
-    case LoweredAst.Expr.VectorLit(exps, tpe, eff, loc) =>
+    case LoweredAst.Exp.VectorLit(exps, tpe, eff, loc) =>
       val es = exps.map(specializeExp(_, env0, subst))
-      MonoAst.Expr.VectorLit(es, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.VectorLit(es, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.VectorLoad(exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Exp.VectorLoad(exp1, exp2, tpe, eff, loc) =>
       val e1 = specializeExp(exp1, env0, subst)
       val e2 = specializeExp(exp2, env0, subst)
-      MonoAst.Expr.VectorLoad(e1, e2, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.VectorLoad(e1, e2, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.VectorLength(exp, loc) =>
+    case LoweredAst.Exp.VectorLength(exp, loc) =>
       val e = specializeExp(exp, env0, subst)
-      MonoAst.Expr.VectorLength(e, loc)
+      MonoAst.Exp.VectorLength(e, loc)
 
-    case LoweredAst.Expr.Ascribe(exp, _, _, _) =>
+    case LoweredAst.Exp.Ascribe(exp, _, _, _) =>
       specializeExp(exp, env0, subst)
 
-    case LoweredAst.Expr.Cast(exp, _, _, tpe, eff, loc) =>
+    case LoweredAst.Exp.Cast(exp, _, _, tpe, eff, loc) =>
       // Drop the declaredType and declaredEff.
       val e = specializeExp(exp, env0, subst)
       mkCast(e, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>
+    case LoweredAst.Exp.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = specializeExp(exp, env0, subst)
       val rs = rules map {
         case LoweredAst.CatchRule(sym, clazz, body) =>
@@ -619,9 +619,9 @@ object Monomorpher {
           val b = specializeExp(body, env1, subst)
           MonoAst.CatchRule(freshSym, clazz, b)
       }
-      MonoAst.Expr.TryCatch(e, rs, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.TryCatch(e, rs, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.RunWith(exp, effSymUse, rules, tpe, eff, loc) =>
+    case LoweredAst.Exp.RunWith(exp, effSymUse, rules, tpe, eff, loc) =>
       val e = specializeExp(exp, env0, subst)
       val rs = rules map {
         case LoweredAst.HandlerRule(opSymUse, fparams0, body0) =>
@@ -630,11 +630,11 @@ object Monomorpher {
           val body = specializeExp(body0, env1, subst)
           MonoAst.HandlerRule(opSymUse, fparams, body)
       }
-      MonoAst.Expr.RunWith(e, effSymUse, rs, subst(tpe), subst(eff), loc)
+      MonoAst.Exp.RunWith(e, effSymUse, rs, subst(tpe), subst(eff), loc)
 
-    case LoweredAst.Expr.NewObject(name, clazz, tpe, eff, methods0, loc) =>
+    case LoweredAst.Exp.NewObject(name, clazz, tpe, eff, methods0, loc) =>
       val methods = methods0.map(specializeJvmMethod(_, env0, subst))
-      MonoAst.Expr.NewObject(name, clazz, subst(tpe), subst(eff), methods, loc)
+      MonoAst.Exp.NewObject(name, clazz, subst(tpe), subst(eff), methods, loc)
 
   }
 
@@ -644,22 +644,22 @@ object Monomorpher {
     * If `exp` and `tpe` is bytecode incompatible, a runtime crash is inserted to appease the
     * bytecode verifier.
     */
-  private def mkCast(exp: MonoAst.Expr, tpe: Type, eff: Type, loc: SourceLocation): MonoAst.Expr = {
+  private def mkCast(exp: MonoAst.Exp, tpe: Type, eff: Type, loc: SourceLocation): MonoAst.Exp = {
     (exp.tpe, tpe) match {
-      case (Type.Char, Type.Char) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (Type.Char, Type.Int16) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (Type.Int16, Type.Char) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (Type.Bool, Type.Bool) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (Type.Int8, Type.Int8) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (Type.Int16, Type.Int16) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (Type.Int32, Type.Int32) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (Type.Int64, Type.Int64) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (Type.Float32, Type.Float32) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (Type.Float64, Type.Float64) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (x, y) if !isPrimType(x) && !isPrimType(y) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
+      case (Type.Char, Type.Char) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (Type.Char, Type.Int16) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (Type.Int16, Type.Char) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (Type.Bool, Type.Bool) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (Type.Int8, Type.Int8) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (Type.Int16, Type.Int16) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (Type.Int32, Type.Int32) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (Type.Int64, Type.Int64) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (Type.Float32, Type.Float32) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (Type.Float64, Type.Float64) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
+      case (x, y) if !isPrimType(x) && !isPrimType(y) => MonoAst.Exp.Cast(exp, tpe, eff, loc)
       case (x, y) =>
-        val crash = MonoAst.Expr.ApplyAtomic(AtomicOp.CastError(erasedString(x), erasedString(y)), Nil, tpe, eff, loc)
-        MonoAst.Expr.Stm(exp, crash, tpe, eff, loc)
+        val crash = MonoAst.Exp.ApplyAtomic(AtomicOp.CastError(erasedString(x), erasedString(y)), Nil, tpe, eff, loc)
+        MonoAst.Exp.Stm(exp, crash, tpe, eff, loc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -601,83 +601,83 @@ object Namer {
   /**
     * Performs naming on the given expression `exp0`.
     */
-  private def visitExp(exp0: DesugaredAst.Expr)(implicit scope: Scope, sctx: SharedContext, flix: Flix): NamedAst.Expr = exp0 match {
-    case DesugaredAst.Expr.Ambiguous(name, loc) =>
-      NamedAst.Expr.Ambiguous(name, loc)
+  private def visitExp(exp0: DesugaredAst.Exp)(implicit scope: Scope, sctx: SharedContext, flix: Flix): NamedAst.Exp = exp0 match {
+    case DesugaredAst.Exp.Ambiguous(name, loc) =>
+      NamedAst.Exp.Ambiguous(name, loc)
 
-    case DesugaredAst.Expr.OpenAs(name, exp, loc) =>
+    case DesugaredAst.Exp.OpenAs(name, exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.OpenAs(name, e, loc)
+      NamedAst.Exp.OpenAs(name, e, loc)
 
-    case DesugaredAst.Expr.Open(name, loc) =>
-      NamedAst.Expr.Open(name, loc)
+    case DesugaredAst.Exp.Open(name, loc) =>
+      NamedAst.Exp.Open(name, loc)
 
-    case DesugaredAst.Expr.Hole(name, loc) =>
-      NamedAst.Expr.Hole(name, loc)
+    case DesugaredAst.Exp.Hole(name, loc) =>
+      NamedAst.Exp.Hole(name, loc)
 
-    case DesugaredAst.Expr.HoleWithExp(exp, loc) =>
+    case DesugaredAst.Exp.HoleWithExp(exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.HoleWithExp(e, loc)
+      NamedAst.Exp.HoleWithExp(e, loc)
 
-    case DesugaredAst.Expr.Use(uses0, exp, loc) =>
+    case DesugaredAst.Exp.Use(uses0, exp, loc) =>
       val uses = uses0.map(visitUseOrImport)
       val e = visitExp(exp)
       uses.foldRight(e) {
-        case (use, acc) => NamedAst.Expr.Use(use, acc, loc)
+        case (use, acc) => NamedAst.Exp.Use(use, acc, loc)
       }
 
-    case DesugaredAst.Expr.Cst(cst, loc) =>
-      NamedAst.Expr.Cst(cst, loc)
+    case DesugaredAst.Exp.Cst(cst, loc) =>
+      NamedAst.Exp.Cst(cst, loc)
 
-    case DesugaredAst.Expr.Apply(exp, exps, loc) =>
+    case DesugaredAst.Exp.Apply(exp, exps, loc) =>
       val e = visitExp(exp)
       val es = exps.map(visitExp(_))
-      NamedAst.Expr.Apply(e, es, loc)
+      NamedAst.Exp.Apply(e, es, loc)
 
-    case DesugaredAst.Expr.Lambda(fparam, exp, loc) =>
+    case DesugaredAst.Exp.Lambda(fparam, exp, loc) =>
       val fp = visitFormalParam(fparam)
       val e = visitExp(exp)
-      NamedAst.Expr.Lambda(fp, e, loc)
+      NamedAst.Exp.Lambda(fp, e, loc)
 
-    case DesugaredAst.Expr.Unary(sop, exp, loc) =>
+    case DesugaredAst.Exp.Unary(sop, exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.Unary(sop, e, loc)
+      NamedAst.Exp.Unary(sop, e, loc)
 
-    case DesugaredAst.Expr.Binary(sop, exp1, exp2, loc) =>
+    case DesugaredAst.Exp.Binary(sop, exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.Binary(sop, e1, e2, loc)
+      NamedAst.Exp.Binary(sop, e1, e2, loc)
 
-    case DesugaredAst.Expr.IfThenElse(exp1, exp2, exp3, loc) =>
+    case DesugaredAst.Exp.IfThenElse(exp1, exp2, exp3, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      NamedAst.Expr.IfThenElse(e1, e2, e3, loc)
+      NamedAst.Exp.IfThenElse(e1, e2, e3, loc)
 
-    case DesugaredAst.Expr.Stm(exp1, exp2, loc) =>
+    case DesugaredAst.Exp.Stm(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.Stm(e1, e2, loc)
+      NamedAst.Exp.Stm(e1, e2, loc)
 
-    case DesugaredAst.Expr.Discard(exp, loc) =>
+    case DesugaredAst.Exp.Discard(exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.Discard(e, loc)
+      NamedAst.Exp.Discard(e, loc)
 
-    case DesugaredAst.Expr.Let(ident, exp1, exp2, loc) =>
+    case DesugaredAst.Exp.Let(ident, exp1, exp2, loc) =>
       // make a fresh variable symbol for the local variable.
       val sym = Symbol.freshVarSym(ident, BoundBy.Let)
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.Let(sym, e1, e2, loc)
+      NamedAst.Exp.Let(sym, e1, e2, loc)
 
-    case DesugaredAst.Expr.LocalDef(ident, fparams, exp1, exp2, loc) =>
+    case DesugaredAst.Exp.LocalDef(ident, fparams, exp1, exp2, loc) =>
       val sym = Symbol.freshVarSym(ident, BoundBy.LocalDef)
       val fps = fparams.map(visitFormalParam(_))
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.LocalDef(sym, fps, e1, e2, loc)
+      NamedAst.Exp.LocalDef(sym, fps, e1, e2, loc)
 
-    case DesugaredAst.Expr.Region(ident, exp, loc) =>
+    case DesugaredAst.Exp.Region(ident, exp, loc) =>
       // Introduce a rigid region variable for the region.
       val regSym = Symbol.freshRegionSym(ident)
 
@@ -690,241 +690,241 @@ object Namer {
 
       // Visit the body in the inner scope
       val e = visitExp(exp)(newScope, sctx, flix)
-      NamedAst.Expr.Region(sym, regSym, e, loc)
+      NamedAst.Exp.Region(sym, regSym, e, loc)
 
-    case DesugaredAst.Expr.Match(exp, rules, loc) =>
+    case DesugaredAst.Exp.Match(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitMatchRule(_))
-      NamedAst.Expr.Match(e, rs, loc)
+      NamedAst.Exp.Match(e, rs, loc)
 
-    case DesugaredAst.Expr.TypeMatch(exp, rules, loc) =>
+    case DesugaredAst.Exp.TypeMatch(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitTypeMatchRule)
-      NamedAst.Expr.TypeMatch(e, rs, loc)
+      NamedAst.Exp.TypeMatch(e, rs, loc)
 
-    case DesugaredAst.Expr.RestrictableChoose(star, exp, rules, loc) =>
+    case DesugaredAst.Exp.RestrictableChoose(star, exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitRestrictableChooseRule)
-      NamedAst.Expr.RestrictableChoose(star, e, rs, loc)
+      NamedAst.Exp.RestrictableChoose(star, e, rs, loc)
 
-    case DesugaredAst.Expr.ExtMatch(exp, rules, loc) =>
+    case DesugaredAst.Exp.ExtMatch(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitExtMatchRule)
-      NamedAst.Expr.ExtMatch(e, rs, loc)
+      NamedAst.Exp.ExtMatch(e, rs, loc)
 
-    case DesugaredAst.Expr.ExtTag(label, exps, loc) =>
+    case DesugaredAst.Exp.ExtTag(label, exps, loc) =>
       val es = exps.map(visitExp(_))
-      NamedAst.Expr.ExtTag(label, es, loc)
+      NamedAst.Exp.ExtTag(label, es, loc)
 
-    case DesugaredAst.Expr.Tuple(exps, loc) =>
+    case DesugaredAst.Exp.Tuple(exps, loc) =>
       val es = exps.map(visitExp(_))
-      NamedAst.Expr.Tuple(es, loc)
+      NamedAst.Exp.Tuple(es, loc)
 
-    case DesugaredAst.Expr.RecordSelect(exp, label, loc) =>
+    case DesugaredAst.Exp.RecordSelect(exp, label, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.RecordSelect(e, label, loc)
+      NamedAst.Exp.RecordSelect(e, label, loc)
 
-    case DesugaredAst.Expr.RecordExtend(label, exp1, exp2, loc) =>
+    case DesugaredAst.Exp.RecordExtend(label, exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.RecordExtend(label, e1, e2, loc)
+      NamedAst.Exp.RecordExtend(label, e1, e2, loc)
 
-    case DesugaredAst.Expr.RecordRestrict(label, exp, loc) =>
+    case DesugaredAst.Exp.RecordRestrict(label, exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.RecordRestrict(label, e, loc)
+      NamedAst.Exp.RecordRestrict(label, e, loc)
 
-    case DesugaredAst.Expr.ArrayLit(exps, exp, loc) =>
+    case DesugaredAst.Exp.ArrayLit(exps, exp, loc) =>
       val es = exps.map(visitExp(_))
       val e = visitExp(exp)
-      NamedAst.Expr.ArrayLit(es, e, loc)
+      NamedAst.Exp.ArrayLit(es, e, loc)
 
-    case DesugaredAst.Expr.ArrayNew(exp1, exp2, exp3, loc) =>
+    case DesugaredAst.Exp.ArrayNew(exp1, exp2, exp3, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      NamedAst.Expr.ArrayNew(e1, e2, e3, loc)
+      NamedAst.Exp.ArrayNew(e1, e2, e3, loc)
 
-    case DesugaredAst.Expr.ArrayLoad(exp1, exp2, loc) =>
+    case DesugaredAst.Exp.ArrayLoad(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.ArrayLoad(e1, e2, loc)
+      NamedAst.Exp.ArrayLoad(e1, e2, loc)
 
-    case DesugaredAst.Expr.ArrayStore(exp1, exp2, exp3, loc) =>
+    case DesugaredAst.Exp.ArrayStore(exp1, exp2, exp3, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      NamedAst.Expr.ArrayStore(e1, e2, e3, loc)
+      NamedAst.Exp.ArrayStore(e1, e2, e3, loc)
 
-    case DesugaredAst.Expr.ArrayLength(exp, loc) =>
+    case DesugaredAst.Exp.ArrayLength(exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.ArrayLength(e, loc)
+      NamedAst.Exp.ArrayLength(e, loc)
 
-    case DesugaredAst.Expr.StructNew(qname, exps, exp, loc) =>
+    case DesugaredAst.Exp.StructNew(qname, exps, exp, loc) =>
       val e = visitExp(exp)
       val es = exps.map(visitStructField)
-      NamedAst.Expr.StructNew(qname, es, e, loc)
+      NamedAst.Exp.StructNew(qname, es, e, loc)
 
-    case DesugaredAst.Expr.StructGet(exp, name, loc) =>
+    case DesugaredAst.Exp.StructGet(exp, name, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.StructGet(e, name, loc)
+      NamedAst.Exp.StructGet(e, name, loc)
 
-    case DesugaredAst.Expr.StructPut(exp1, name, exp2, loc) =>
+    case DesugaredAst.Exp.StructPut(exp1, name, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.StructPut(e1, name, e2, loc)
+      NamedAst.Exp.StructPut(e1, name, e2, loc)
 
-    case DesugaredAst.Expr.VectorLit(exps, loc) =>
+    case DesugaredAst.Exp.VectorLit(exps, loc) =>
       val es = exps.map(visitExp(_))
-      NamedAst.Expr.VectorLit(es, loc)
+      NamedAst.Exp.VectorLit(es, loc)
 
-    case DesugaredAst.Expr.VectorLoad(exp1, exp2, loc) =>
+    case DesugaredAst.Exp.VectorLoad(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.VectorLoad(e1, e2, loc)
+      NamedAst.Exp.VectorLoad(e1, e2, loc)
 
-    case DesugaredAst.Expr.VectorLength(exp, loc) =>
+    case DesugaredAst.Exp.VectorLength(exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.VectorLength(e, loc)
+      NamedAst.Exp.VectorLength(e, loc)
 
-    case DesugaredAst.Expr.Ascribe(exp, tpe, eff, loc) =>
-      val e = visitExp(exp)
-      val t = tpe.map(visitType)
-      val ef = eff.map(visitType)
-      NamedAst.Expr.Ascribe(e, t, ef, loc)
-
-    case DesugaredAst.Expr.InstanceOf(exp, className, loc) =>
-      val e = visitExp(exp)
-      NamedAst.Expr.InstanceOf(e, className, loc)
-
-    case DesugaredAst.Expr.CheckedCast(c, exp, loc) =>
-      val e = visitExp(exp)
-      NamedAst.Expr.CheckedCast(c, e, loc)
-
-    case DesugaredAst.Expr.UncheckedCast(exp, tpe, eff, loc) =>
+    case DesugaredAst.Exp.Ascribe(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = tpe.map(visitType)
       val ef = eff.map(visitType)
-      NamedAst.Expr.UncheckedCast(e, t, ef, loc)
+      NamedAst.Exp.Ascribe(e, t, ef, loc)
 
-    case DesugaredAst.Expr.Unsafe(exp, eff0, loc) =>
+    case DesugaredAst.Exp.InstanceOf(exp, className, loc) =>
+      val e = visitExp(exp)
+      NamedAst.Exp.InstanceOf(e, className, loc)
+
+    case DesugaredAst.Exp.CheckedCast(c, exp, loc) =>
+      val e = visitExp(exp)
+      NamedAst.Exp.CheckedCast(c, e, loc)
+
+    case DesugaredAst.Exp.UncheckedCast(exp, tpe, eff, loc) =>
+      val e = visitExp(exp)
+      val t = tpe.map(visitType)
+      val ef = eff.map(visitType)
+      NamedAst.Exp.UncheckedCast(e, t, ef, loc)
+
+    case DesugaredAst.Exp.Unsafe(exp, eff0, loc) =>
       val e = visitExp(exp)
       val eff = visitType(eff0)
-      NamedAst.Expr.Unsafe(e, eff, loc)
+      NamedAst.Exp.Unsafe(e, eff, loc)
 
-    case DesugaredAst.Expr.Without(exp, qname, loc) =>
+    case DesugaredAst.Exp.Without(exp, qname, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.Without(e, qname, loc)
+      NamedAst.Exp.Without(e, qname, loc)
 
-    case DesugaredAst.Expr.TryCatch(exp, rules, loc) =>
+    case DesugaredAst.Exp.TryCatch(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitTryCatchRule)
-      NamedAst.Expr.TryCatch(e, rs, loc)
+      NamedAst.Exp.TryCatch(e, rs, loc)
 
-    case DesugaredAst.Expr.Throw(exp, loc) =>
+    case DesugaredAst.Exp.Throw(exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.Throw(e, loc)
+      NamedAst.Exp.Throw(e, loc)
 
-    case DesugaredAst.Expr.Handler(qname, rules, loc) =>
+    case DesugaredAst.Exp.Handler(qname, rules, loc) =>
       val rs = rules.map(visitRunWithRule)
-      NamedAst.Expr.Handler(qname, rs, loc)
+      NamedAst.Exp.Handler(qname, rs, loc)
 
-    case DesugaredAst.Expr.RunWith(exp1, exp2, loc) =>
+    case DesugaredAst.Exp.RunWith(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.RunWith(e1, e2, loc)
+      NamedAst.Exp.RunWith(e1, e2, loc)
 
-    case DesugaredAst.Expr.InvokeConstructor(className, exps, loc) =>
+    case DesugaredAst.Exp.InvokeConstructor(className, exps, loc) =>
       val es = exps.map(visitExp(_))
-      NamedAst.Expr.InvokeConstructor(className, es, loc)
+      NamedAst.Exp.InvokeConstructor(className, es, loc)
 
-    case DesugaredAst.Expr.InvokeMethod(exp, name, exps, loc) =>
+    case DesugaredAst.Exp.InvokeMethod(exp, name, exps, loc) =>
       val e = visitExp(exp)
       val es = exps.map(visitExp(_))
-      NamedAst.Expr.InvokeMethod(e, name, es, loc)
+      NamedAst.Exp.InvokeMethod(e, name, es, loc)
 
-    case DesugaredAst.Expr.GetField(exp, name, loc) =>
+    case DesugaredAst.Exp.GetField(exp, name, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.GetField(e, name, loc)
+      NamedAst.Exp.GetField(e, name, loc)
 
-    case DesugaredAst.Expr.NewObject(tpe, methods, loc) =>
+    case DesugaredAst.Exp.NewObject(tpe, methods, loc) =>
       val t = visitType(tpe)
       val ms = methods.map(visitJvmMethod)
       val name = s"Anon$$${flix.genSym.freshId()}"
-      NamedAst.Expr.NewObject(name, t, ms, loc)
+      NamedAst.Exp.NewObject(name, t, ms, loc)
 
-    case DesugaredAst.Expr.NewChannel(exp, loc) =>
+    case DesugaredAst.Exp.NewChannel(exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.NewChannel(e, loc)
+      NamedAst.Exp.NewChannel(e, loc)
 
-    case DesugaredAst.Expr.GetChannel(exp, loc) =>
+    case DesugaredAst.Exp.GetChannel(exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.GetChannel(e, loc)
+      NamedAst.Exp.GetChannel(e, loc)
 
-    case DesugaredAst.Expr.PutChannel(exp1, exp2, loc) =>
+    case DesugaredAst.Exp.PutChannel(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.PutChannel(e1, e2, loc)
+      NamedAst.Exp.PutChannel(e1, e2, loc)
 
-    case DesugaredAst.Expr.SelectChannel(rules, exp, loc) =>
+    case DesugaredAst.Exp.SelectChannel(rules, exp, loc) =>
       val rs = rules.map(visitSelectChannelRule)
       val e = exp.map(visitExp(_))
-      NamedAst.Expr.SelectChannel(rs, e, loc)
+      NamedAst.Exp.SelectChannel(rs, e, loc)
 
-    case DesugaredAst.Expr.Spawn(exp1, exp2, loc) =>
+    case DesugaredAst.Exp.Spawn(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.Spawn(e1, e2, loc)
+      NamedAst.Exp.Spawn(e1, e2, loc)
 
-    case DesugaredAst.Expr.ParYield(frags, exp, loc) =>
+    case DesugaredAst.Exp.ParYield(frags, exp, loc) =>
       val e = visitExp(exp)
       val fs = frags.map(visitParYieldFragment(_))
-      NamedAst.Expr.ParYield(fs, e, loc)
+      NamedAst.Exp.ParYield(fs, e, loc)
 
-    case DesugaredAst.Expr.Lazy(exp, loc) =>
+    case DesugaredAst.Exp.Lazy(exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.Lazy(e, loc)
+      NamedAst.Exp.Lazy(e, loc)
 
-    case DesugaredAst.Expr.Force(exp, loc) =>
+    case DesugaredAst.Exp.Force(exp, loc) =>
       val e = visitExp(exp)
-      NamedAst.Expr.Force(e, loc)
+      NamedAst.Exp.Force(e, loc)
 
-    case DesugaredAst.Expr.FixpointConstraintSet(cs0, loc) =>
+    case DesugaredAst.Exp.FixpointConstraintSet(cs0, loc) =>
       val cs = cs0.map(visitConstraint)
-      NamedAst.Expr.FixpointConstraintSet(cs, loc)
+      NamedAst.Exp.FixpointConstraintSet(cs, loc)
 
-    case DesugaredAst.Expr.FixpointLambda(pparams, exp, loc) =>
+    case DesugaredAst.Exp.FixpointLambda(pparams, exp, loc) =>
       val ps = pparams.map(visitPredicateParam)
       val e = visitExp(exp)
-      NamedAst.Expr.FixpointLambda(ps, e, loc)
+      NamedAst.Exp.FixpointLambda(ps, e, loc)
 
-    case DesugaredAst.Expr.FixpointMerge(exp1, exp2, loc) =>
+    case DesugaredAst.Exp.FixpointMerge(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      NamedAst.Expr.FixpointMerge(e1, e2, loc)
+      NamedAst.Exp.FixpointMerge(e1, e2, loc)
 
-    case DesugaredAst.Expr.FixpointQueryWithProvenance(exps, select, withh, loc) =>
+    case DesugaredAst.Exp.FixpointQueryWithProvenance(exps, select, withh, loc) =>
       val es = exps.map(visitExp)
       val s = visitHeadPredicate(select)
-      NamedAst.Expr.FixpointQueryWithProvenance(es, s, withh, loc)
+      NamedAst.Exp.FixpointQueryWithProvenance(es, s, withh, loc)
 
-    case DesugaredAst.Expr.FixpointSolveWithProject(exps, optPreds, mode, loc) =>
+    case DesugaredAst.Exp.FixpointSolveWithProject(exps, optPreds, mode, loc) =>
       val es = exps.map(visitExp)
-      NamedAst.Expr.FixpointSolveWithProject(es, optPreds, mode, loc)
+      NamedAst.Exp.FixpointSolveWithProject(es, optPreds, mode, loc)
 
-    case DesugaredAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
+    case DesugaredAst.Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
       val es = exps.map(visitExp)
       val qe = visitExp(queryExp)
       val ss = selects.map(visitExp)
       val f = from.map(visitBodyPredicate)
       val w = where.map(visitExp)
-      NamedAst.Expr.FixpointQueryWithSelect(es, qe, ss, f, w, pred, loc)
+      NamedAst.Exp.FixpointQueryWithSelect(es, qe, ss, f, w, pred, loc)
 
-    case DesugaredAst.Expr.FixpointInjectInto(exps, predsAndArities, loc) =>
+    case DesugaredAst.Exp.FixpointInjectInto(exps, predsAndArities, loc) =>
       val es = exps.map(visitExp)
-      NamedAst.Expr.FixpointInjectInto(es, predsAndArities, loc)
+      NamedAst.Exp.FixpointInjectInto(es, predsAndArities, loc)
 
-    case DesugaredAst.Expr.Error(m) =>
-      NamedAst.Expr.Error(m)
+    case DesugaredAst.Exp.Error(m) =>
+      NamedAst.Exp.Error(m)
 
   }
 
@@ -973,7 +973,7 @@ object Namer {
   /**
     * Performs naming on the given struct field expression `exp0`.
     */
-  private def visitStructField(field: (Name.Label, DesugaredAst.Expr))(implicit scope: Scope, sctx: SharedContext, flix: Flix): (Name.Label, NamedAst.Expr) = field match {
+  private def visitStructField(field: (Name.Label, DesugaredAst.Exp))(implicit scope: Scope, sctx: SharedContext, flix: Flix): (Name.Label, NamedAst.Exp) = field match {
     case (n, exp0) =>
       val e = visitExp(exp0)
       (n, e)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.*
-import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, ParYieldFragment, Pattern, Root}
+import ca.uwaterloo.flix.language.ast.TypedAst.{Exp, ParYieldFragment, Pattern, Root}
 import ca.uwaterloo.flix.language.ast.shared.Constant
 import ca.uwaterloo.flix.language.ast.shared.SymUse.CaseSymUse
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
@@ -118,62 +118,62 @@ object PatMatch {
     * @param tast The expression to check
     * @param root The AST root
     */
-  private def visitExp(tast: TypedAst.Expr)(implicit sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def visitExp(tast: TypedAst.Exp)(implicit sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     tast match {
-      case Expr.Var(_, _, _) => ()
+      case Exp.Var(_, _, _) => ()
 
-      case Expr.Hole(_, _, _, _, _) => ()
+      case Exp.Hole(_, _, _, _, _) => ()
 
-      case Expr.HoleWithExp(exp, _, _, _, _) => visitExp(exp)
+      case Exp.HoleWithExp(exp, _, _, _, _) => visitExp(exp)
 
-      case Expr.OpenAs(_, exp, _, _) => visitExp(exp)
+      case Exp.OpenAs(_, exp, _, _) => visitExp(exp)
 
-      case Expr.Use(_, _, exp, _) => visitExp(exp)
+      case Exp.Use(_, _, exp, _) => visitExp(exp)
 
-      case Expr.Cst(_, _, _) => ()
+      case Exp.Cst(_, _, _) => ()
 
-      case Expr.Lambda(_, body, _, _) => visitExp(body)
+      case Exp.Lambda(_, body, _, _) => visitExp(body)
 
-      case Expr.ApplyClo(exp1, exp2, _, _, _) =>
+      case Exp.ApplyClo(exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.ApplyDef(_, exps, _, _, _, _, _) => exps.foreach(visitExp)
+      case Exp.ApplyDef(_, exps, _, _, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.ApplyLocalDef(_, exps, _, _, _, _) => exps.foreach(visitExp)
+      case Exp.ApplyLocalDef(_, exps, _, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.ApplyOp(_, exps, _, _, _) => exps.foreach(visitExp)
+      case Exp.ApplyOp(_, exps, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.ApplySig(_, exps, _, _, _, _, _, _) => exps.foreach(visitExp)
+      case Exp.ApplySig(_, exps, _, _, _, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.Unary(_, exp, _, _, _) => visitExp(exp)
+      case Exp.Unary(_, exp, _, _, _) => visitExp(exp)
 
-      case Expr.Binary(_, exp1, exp2, _, _, _) =>
+      case Exp.Binary(_, exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.Let(_, exp1, exp2, _, _, _) =>
+      case Exp.Let(_, exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.LocalDef(_, _, exp1, exp2, _, _, _) =>
+      case Exp.LocalDef(_, _, exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.Region(_, _, exp, _, _, _) => visitExp(exp)
+      case Exp.Region(_, _, exp, _, _, _) => visitExp(exp)
 
-      case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
+      case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
         visitExp(exp3)
 
-      case Expr.Stm(exp1, exp2, _, _, _) =>
+      case Exp.Stm(exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.Discard(exp, _, _) => visitExp(exp)
+      case Exp.Discard(exp, _, _) => visitExp(exp)
 
-      case Expr.Match(exp, rules, _, _, _) =>
+      case Exp.Match(exp, rules, _, _, _) =>
         visitExp(exp)
         rules.foreach { r =>
           visitExp(r.exp)
@@ -181,170 +181,170 @@ object PatMatch {
         }
         checkRules(exp, rules, root)
 
-      case Expr.TypeMatch(exp, rules, _, _, _) =>
+      case Exp.TypeMatch(exp, rules, _, _, _) =>
         visitExp(exp)
         rules.foreach(r => visitExp(r.exp))
 
-      case Expr.RestrictableChoose(_, exp, rules, _, _, _) =>
+      case Exp.RestrictableChoose(_, exp, rules, _, _, _) =>
         visitExp(exp)
         rules.foreach(r => visitExp(r.exp))
 
-      case Expr.ExtMatch(exp, rules, _, _, _) =>
+      case Exp.ExtMatch(exp, rules, _, _, _) =>
         // Exhaustiveness does not make sense for extensible variants.
         visitExp(exp)
         rules.foreach(r => visitExp(r.exp))
 
-      case Expr.Tag(_, exps, _, _, _) => exps.foreach(visitExp)
+      case Exp.Tag(_, exps, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.RestrictableTag(_, exps, _, _, _) => exps.foreach(visitExp)
+      case Exp.RestrictableTag(_, exps, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.ExtTag(_, exps, _, _, _) => exps.foreach(visitExp)
+      case Exp.ExtTag(_, exps, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.Tuple(elms, _, _, _) => elms.foreach(visitExp)
+      case Exp.Tuple(elms, _, _, _) => elms.foreach(visitExp)
 
-      case Expr.RecordSelect(base, _, _, _, _) => visitExp(base)
+      case Exp.RecordSelect(base, _, _, _, _) => visitExp(base)
 
-      case Expr.RecordExtend(_, value, rest, _, _, _) =>
+      case Exp.RecordExtend(_, value, rest, _, _, _) =>
         visitExp(value)
         visitExp(rest)
 
-      case Expr.RecordRestrict(_, rest, _, _, _) => visitExp(rest)
+      case Exp.RecordRestrict(_, rest, _, _, _) => visitExp(rest)
 
-      case Expr.ArrayLit(exps, exp, _, _, _) =>
+      case Exp.ArrayLit(exps, exp, _, _, _) =>
         visitExp(exp)
         exps.foreach(visitExp)
 
-      case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) =>
+      case Exp.ArrayNew(exp1, exp2, exp3, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
         visitExp(exp3)
 
-      case Expr.ArrayLoad(base, index, _, _, _) =>
+      case Exp.ArrayLoad(base, index, _, _, _) =>
         visitExp(base)
         visitExp(index)
 
-      case Expr.ArrayStore(base, index, elm, _, _) =>
+      case Exp.ArrayStore(base, index, elm, _, _) =>
         visitExp(base)
         visitExp(index)
         visitExp(elm)
 
-      case Expr.ArrayLength(base, _, _) => visitExp(base)
+      case Exp.ArrayLength(base, _, _) => visitExp(base)
 
-      case Expr.StructNew(_, fields, region, _, _, _) =>
+      case Exp.StructNew(_, fields, region, _, _, _) =>
         visitExp(region)
         fields.foreach { case (_, v) => visitExp(v) }
 
-      case Expr.StructGet(exp, _, _, _, _) => visitExp(exp)
+      case Exp.StructGet(exp, _, _, _, _) => visitExp(exp)
 
-      case Expr.StructPut(exp1, _, exp2, _, _, _) =>
+      case Exp.StructPut(exp1, _, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.VectorLit(exps, _, _, _) => exps.foreach(visitExp)
+      case Exp.VectorLit(exps, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.VectorLoad(exp1, exp2, _, _, _) =>
+      case Exp.VectorLoad(exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.VectorLength(exp, _) => visitExp(exp)
+      case Exp.VectorLength(exp, _) => visitExp(exp)
 
-      case Expr.Ascribe(exp, _, _, _, _, _) => visitExp(exp)
+      case Exp.Ascribe(exp, _, _, _, _, _) => visitExp(exp)
 
-      case Expr.InstanceOf(exp, _, _) => visitExp(exp)
+      case Exp.InstanceOf(exp, _, _) => visitExp(exp)
 
-      case Expr.CheckedCast(_, exp, _, _, _) => visitExp(exp)
+      case Exp.CheckedCast(_, exp, _, _, _) => visitExp(exp)
 
-      case Expr.UncheckedCast(exp, _, _, _, _, _) => visitExp(exp)
+      case Exp.UncheckedCast(exp, _, _, _, _, _) => visitExp(exp)
 
-      case Expr.Unsafe(exp, _, _, _, _) => visitExp(exp)
+      case Exp.Unsafe(exp, _, _, _, _) => visitExp(exp)
 
-      case Expr.Without(exp, _, _, _, _) => visitExp(exp)
+      case Exp.Without(exp, _, _, _, _) => visitExp(exp)
 
-      case Expr.TryCatch(exp, rules, _, _, _) =>
+      case Exp.TryCatch(exp, rules, _, _, _) =>
         visitExp(exp)
         rules.foreach(r => visitExp(r.exp))
 
-      case TypedAst.Expr.Throw(exp, _, _, _) => visitExp(exp)
+      case TypedAst.Exp.Throw(exp, _, _, _) => visitExp(exp)
 
-      case Expr.Handler(_, rules, _, _, _, _, _) =>
+      case Exp.Handler(_, rules, _, _, _, _, _) =>
         rules.foreach(r => visitExp(r.exp))
 
-      case Expr.RunWith(exp1, exp2, _, _, _) =>
+      case Exp.RunWith(exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.InvokeConstructor(_, args, _, _, _) => args.foreach(visitExp)
+      case Exp.InvokeConstructor(_, args, _, _, _) => args.foreach(visitExp)
 
-      case Expr.InvokeMethod(_, exp, args, _, _, _) =>
+      case Exp.InvokeMethod(_, exp, args, _, _, _) =>
         visitExp(exp)
         args.foreach(visitExp)
 
-      case Expr.InvokeStaticMethod(_, args, _, _, _) => args.foreach(visitExp)
+      case Exp.InvokeStaticMethod(_, args, _, _, _) => args.foreach(visitExp)
 
-      case Expr.GetField(_, exp, _, _, _) => visitExp(exp)
+      case Exp.GetField(_, exp, _, _, _) => visitExp(exp)
 
-      case Expr.PutField(_, exp1, exp2, _, _, _) =>
+      case Exp.PutField(_, exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.GetStaticField(_, _, _, _) => ()
+      case Exp.GetStaticField(_, _, _, _) => ()
 
-      case Expr.PutStaticField(_, exp, _, _, _) => visitExp(exp)
+      case Exp.PutStaticField(_, exp, _, _, _) => visitExp(exp)
 
-      case Expr.NewObject(_, _, _, _, methods, _) => methods.foreach(m => visitExp(m.exp))
+      case Exp.NewObject(_, _, _, _, methods, _) => methods.foreach(m => visitExp(m.exp))
 
-      case Expr.NewChannel(exp, _, _, _) => visitExp(exp)
+      case Exp.NewChannel(exp, _, _, _) => visitExp(exp)
 
-      case Expr.GetChannel(exp, _, _, _) => visitExp(exp)
+      case Exp.GetChannel(exp, _, _, _) => visitExp(exp)
 
-      case Expr.PutChannel(exp1, exp2, _, _, _) =>
+      case Exp.PutChannel(exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.SelectChannel(rules, default, _, _, _) =>
+      case Exp.SelectChannel(rules, default, _, _, _) =>
         rules.foreach { r =>
           visitExp(r.exp)
           visitExp(r.chan)
         }
         default.foreach(visitExp)
 
-      case Expr.Spawn(exp1, exp2, _, _, _) =>
+      case Exp.Spawn(exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.ParYield(frags, exp, _, _, loc) =>
+      case Exp.ParYield(frags, exp, _, _, loc) =>
         visitExp(exp)
         frags.foreach(f => visitExp(f.exp))
         checkFrags(frags, root, loc)
 
-      case Expr.Lazy(exp, _, _) => visitExp(exp)
+      case Exp.Lazy(exp, _, _) => visitExp(exp)
 
-      case Expr.Force(exp, _, _, _) => visitExp(exp)
+      case Exp.Force(exp, _, _, _) => visitExp(exp)
 
-      case Expr.FixpointConstraintSet(cs, _, _) => cs.foreach(visitConstraint)
+      case Exp.FixpointConstraintSet(cs, _, _) => cs.foreach(visitConstraint)
 
-      case Expr.FixpointLambda(_, exp, _, _, _) => visitExp(exp)
+      case Exp.FixpointLambda(_, exp, _, _, _) => visitExp(exp)
 
-      case Expr.FixpointMerge(exp1, exp2, _, _, _) =>
+      case Exp.FixpointMerge(exp1, exp2, _, _, _) =>
         visitExp(exp1)
         visitExp(exp2)
 
-      case Expr.FixpointQueryWithProvenance(exps, select, _, _, _, _) =>
+      case Exp.FixpointQueryWithProvenance(exps, select, _, _, _, _) =>
         exps.foreach(visitExp)
         visitHeadPred(select)
 
-      case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) => exps.foreach(visitExp)
+      case Exp.FixpointSolveWithProject(exps, _, _, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
+      case Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
         exps.foreach(visitExp)
         visitExp(queryExp)
         selects.foreach(visitExp)
         from.foreach(visitBodyPred)
         where.foreach(visitExp)
 
-      case Expr.FixpointInjectInto(exps, _, _, _, _) => exps.foreach(visitExp)
+      case Exp.FixpointInjectInto(exps, _, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.Error(_, _, _) => ()
+      case Exp.Error(_, _, _) => ()
     }
   }
 
@@ -391,7 +391,7 @@ object PatMatch {
     * @param rules The rules to check
     * @return
     */
-  private def checkRules(exp: TypedAst.Expr, rules: List[TypedAst.MatchRule], root: TypedAst.Root)(implicit sctx: SharedContext): Unit = {
+  private def checkRules(exp: TypedAst.Exp, rules: List[TypedAst.MatchRule], root: TypedAst.Root)(implicit sctx: SharedContext): Unit = {
     // Filter down to the unguarded rules.
     // Guarded rules cannot contribute to exhaustiveness (the guard could be e.g. `false`)
     val unguardedRules = rules.filter(r => r.guard.isEmpty)

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -90,221 +90,221 @@ object PredDeps {
   /**
     * Returns the labelled graph of the given expression `exp0`.
     */
-  private def visitExp(exp0: Expr)(implicit sctx: SharedContext): Unit = exp0 match {
-    case Expr.Cst(_, _, _) => ()
+  private def visitExp(exp0: Exp)(implicit sctx: SharedContext): Unit = exp0 match {
+    case Exp.Cst(_, _, _) => ()
 
-    case Expr.Var(_, _, _) => ()
+    case Exp.Var(_, _, _) => ()
 
-    case Expr.Hole(_, _, _, _, _) => ()
+    case Exp.Hole(_, _, _, _, _) => ()
 
-    case Expr.HoleWithExp(exp, _, _, _, _) =>
+    case Exp.HoleWithExp(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.OpenAs(_, exp, _, _) =>
+    case Exp.OpenAs(_, exp, _, _) =>
       visitExp(exp)
 
-    case Expr.Use(_, _, exp, _) =>
+    case Exp.Use(_, _, exp, _) =>
       visitExp(exp)
 
-    case Expr.Lambda(_, exp, _, _) =>
+    case Exp.Lambda(_, exp, _, _) =>
       visitExp(exp)
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
+    case Exp.ApplyClo(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.ApplyDef(_, exps, _, _, _, _, _) =>
+    case Exp.ApplyDef(_, exps, _, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.ApplyLocalDef(_, exps, _, _, _, _) =>
+    case Exp.ApplyLocalDef(_, exps, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.ApplyOp(_, exps, _, _, _) =>
+    case Exp.ApplyOp(_, exps, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.ApplySig(_, exps, _, _, _, _, _, _) =>
+    case Exp.ApplySig(_, exps, _, _, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.Unary(_, exp, _, _, _) =>
+    case Exp.Unary(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Binary(_, exp1, exp2, _, _, _) =>
+    case Exp.Binary(_, exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.Let(_, exp1, exp2, _, _, _) =>
+    case Exp.Let(_, exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.LocalDef(_, _, exp1, exp2, _, _, _) =>
+    case Exp.LocalDef(_, _, exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.Region(_, _, exp, _, _, _) =>
+    case Exp.Region(_, _, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
 
-    case Expr.Stm(exp1, exp2, _, _, _) =>
+    case Exp.Stm(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.Discard(exp, _, _) =>
+    case Exp.Discard(exp, _, _) =>
       visitExp(exp)
 
-    case Expr.Match(exp, rules, _, _, _) =>
+    case Exp.Match(exp, rules, _, _, _) =>
       visitExp(exp)
       rules.foreach { case MatchRule(_, g, b, _) =>
         g.foreach(visitExp)
         visitExp(b)
       }
 
-    case Expr.TypeMatch(exp, rules, _, _, _) =>
+    case Exp.TypeMatch(exp, rules, _, _, _) =>
       visitExp(exp)
       rules.foreach { case TypeMatchRule(_, _, b, _) => visitExp(b) }
 
-    case Expr.RestrictableChoose(_, exp, rules, _, _, _) =>
+    case Exp.RestrictableChoose(_, exp, rules, _, _, _) =>
       visitExp(exp)
       rules.foreach { case RestrictableChooseRule(_, body) => visitExp(body) }
 
-    case Expr.ExtMatch(exp, rules, _, _, _) =>
+    case Exp.ExtMatch(exp, rules, _, _, _) =>
       visitExp(exp)
       rules.foreach(r => visitExp(r.exp))
 
-    case Expr.Tag(_, exps, _, _, _) =>
+    case Exp.Tag(_, exps, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.RestrictableTag(_, exps, _, _, _) =>
+    case Exp.RestrictableTag(_, exps, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.ExtTag(_, exps, _, _, _) =>
+    case Exp.ExtTag(_, exps, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.Tuple(elms, _, _, _) =>
+    case Exp.Tuple(elms, _, _, _) =>
       elms.foreach(visitExp)
 
-    case Expr.RecordSelect(base, _, _, _, _) =>
+    case Exp.RecordSelect(base, _, _, _, _) =>
       visitExp(base)
 
-    case Expr.RecordExtend(_, value, rest, _, _, _) =>
+    case Exp.RecordExtend(_, value, rest, _, _, _) =>
       visitExp(value)
       visitExp(rest)
 
-    case Expr.RecordRestrict(_, rest, _, _, _) =>
+    case Exp.RecordRestrict(_, rest, _, _, _) =>
       visitExp(rest)
 
-    case Expr.ArrayLit(elms, exp, _, _, _) =>
+    case Exp.ArrayLit(elms, exp, _, _, _) =>
       elms.foreach(visitExp)
       visitExp(exp)
 
-    case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) =>
+    case Exp.ArrayNew(exp1, exp2, exp3, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
 
-    case Expr.ArrayLoad(base, index, _, _, _) =>
+    case Exp.ArrayLoad(base, index, _, _, _) =>
       visitExp(base)
       visitExp(index)
 
-    case Expr.ArrayLength(base, _, _) =>
+    case Exp.ArrayLength(base, _, _) =>
       visitExp(base)
 
-    case Expr.ArrayStore(base, index, elm, _, _) =>
+    case Exp.ArrayStore(base, index, elm, _, _) =>
       visitExp(base)
       visitExp(index)
       visitExp(elm)
 
-    case Expr.StructNew(_, fields, region, _, _, _) =>
+    case Exp.StructNew(_, fields, region, _, _, _) =>
       visitExp(region)
       fields.foreach { case (_, e) => visitExp(e) }
 
-    case Expr.StructGet(e, _, _, _, _) =>
+    case Exp.StructGet(e, _, _, _, _) =>
       visitExp(e)
 
-    case Expr.StructPut(exp1, _, exp2, _, _, _) =>
+    case Exp.StructPut(exp1, _, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.VectorLit(exps, _, _, _) =>
+    case Exp.VectorLit(exps, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.VectorLoad(exp1, exp2, _, _, _) =>
+    case Exp.VectorLoad(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.VectorLength(exp, _) =>
+    case Exp.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, _, _, _, _, _) =>
+    case Exp.Ascribe(exp, _, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.InstanceOf(exp, _, _) =>
+    case Exp.InstanceOf(exp, _, _) =>
       visitExp(exp)
 
-    case Expr.CheckedCast(_, exp, _, _, _) =>
+    case Exp.CheckedCast(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.UncheckedCast(exp, _, _, _, _, _) =>
+    case Exp.UncheckedCast(exp, _, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Unsafe(exp, _, _, _, _) =>
+    case Exp.Unsafe(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Without(exp, _, _, _, _) =>
+    case Exp.Without(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.TryCatch(exp, rules, _, _, _) =>
+    case Exp.TryCatch(exp, rules, _, _, _) =>
       visitExp(exp)
       rules.foreach { case CatchRule(_, _, e, _) => visitExp(e) }
 
-    case Expr.Throw(exp, _, _, _) =>
+    case Exp.Throw(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Handler(_, rules, _, _, _, _, _) =>
+    case Exp.Handler(_, rules, _, _, _, _, _) =>
       rules.foreach { case HandlerRule(_, _, e, _) => visitExp(e) }
 
-    case Expr.RunWith(exp1, exp2, _, _, _) =>
+    case Exp.RunWith(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.InvokeConstructor(_, args, _, _, _) =>
+    case Exp.InvokeConstructor(_, args, _, _, _) =>
       args.foreach(visitExp)
 
-    case Expr.InvokeMethod(_, exp, args, _, _, _) =>
+    case Exp.InvokeMethod(_, exp, args, _, _, _) =>
       visitExp(exp)
       args.foreach(visitExp)
 
-    case Expr.InvokeStaticMethod(_, args, _, _, _) =>
+    case Exp.InvokeStaticMethod(_, args, _, _, _) =>
       args.foreach(visitExp)
 
-    case Expr.GetField(_, exp, _, _, _) =>
+    case Exp.GetField(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.PutField(_, exp1, exp2, _, _, _) =>
+    case Exp.PutField(_, exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.GetStaticField(_, _, _, _) => ()
+    case Exp.GetStaticField(_, _, _, _) => ()
 
-    case Expr.PutStaticField(_, exp, _, _, _) =>
+    case Exp.PutStaticField(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.NewObject(_, _, _, _, _, _) => ()
+    case Exp.NewObject(_, _, _, _, _, _) => ()
 
-    case Expr.NewChannel(exp, _, _, _) =>
+    case Exp.NewChannel(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.GetChannel(exp, _, _, _) =>
+    case Exp.GetChannel(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.PutChannel(exp1, exp2, _, _, _) =>
+    case Exp.PutChannel(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.SelectChannel(rules, default, _, _, _) =>
+    case Exp.SelectChannel(rules, default, _, _, _) =>
       default.foreach(visitExp)
       rules.foreach {
         case SelectChannelRule(_, exp1, exp2, _) =>
@@ -312,49 +312,49 @@ object PredDeps {
           visitExp(exp2)
       }
 
-    case Expr.Spawn(exp1, exp2, _, _, _) =>
+    case Exp.Spawn(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.ParYield(frags, exp, _, _, _) =>
+    case Exp.ParYield(frags, exp, _, _, _) =>
       visitExp(exp)
       frags.foreach {
         case ParYieldFragment(_, e, _) => visitExp(e)
       }
 
-    case Expr.Lazy(exp, _, _) =>
+    case Exp.Lazy(exp, _, _) =>
       visitExp(exp)
 
-    case Expr.Force(exp, _, _, _) =>
+    case Exp.Force(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.FixpointConstraintSet(cs, _, _) =>
+    case Exp.FixpointConstraintSet(cs, _, _) =>
       cs.foreach(visitConstraint)
 
-    case Expr.FixpointLambda(_, exp, _, _, _) =>
+    case Exp.FixpointLambda(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.FixpointMerge(exp1, exp2, _, _, _) =>
+    case Exp.FixpointMerge(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.FixpointQueryWithProvenance(exps, Head.Atom(_, _, terms, _, _), _, _, _, _) =>
+    case Exp.FixpointQueryWithProvenance(exps, Head.Atom(_, _, terms, _, _), _, _, _, _) =>
       exps.foreach(visitExp)
       terms.foreach(visitExp)
 
-    case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
+    case Exp.FixpointSolveWithProject(exps, _, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) =>
+    case Exp.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) =>
       exps.foreach(visitExp)
       visitExp(queryExp)
       selects.foreach(visitExp)
       where.foreach(visitExp)
 
-    case Expr.FixpointInjectInto(exps, _, _, _, _) =>
+    case Exp.FixpointInjectInto(exps, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.Error(_, _, _) => ()
+    case Exp.Error(_, _, _) => ()
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -59,90 +59,90 @@ object Safety {
   /**
     * Checks the safety and well-formedness of `exp0`.
     *
-    *   - [[Expr.TypeMatch]] must end with a default case.
-    *   - [[Expr.Handler]] are not defined for primitive effects.
+    *   - [[Exp.TypeMatch]] must end with a default case.
+    *   - [[Exp.Handler]] are not defined for primitive effects.
     *   - JVM operations and casts are allowed by the relevant [[SecurityContext]].
-    *   - [[Expr.UncheckedCast]] are not impossible.
-    *   - [[Expr.Throw]] only throws exceptions.
-    *   - [[Expr.NewObject]] are valid (see [[checkObjectImplementation]]).
-    *   - [[Expr.FixpointConstraintSet]] are valid (see [[checkConstraint]]).
+    *   - [[Exp.UncheckedCast]] are not impossible.
+    *   - [[Exp.Throw]] only throws exceptions.
+    *   - [[Exp.NewObject]] are valid (see [[checkObjectImplementation]]).
+    *   - [[Exp.FixpointConstraintSet]] are valid (see [[checkConstraint]]).
     */
-  private def visitExp(exp0: Expr)(implicit renv: RigidityEnv, sctx: SharedContext, flix: Flix): Unit = exp0 match {
-    case Expr.Cst(_, _, _) =>
+  private def visitExp(exp0: Exp)(implicit renv: RigidityEnv, sctx: SharedContext, flix: Flix): Unit = exp0 match {
+    case Exp.Cst(_, _, _) =>
       ()
 
-    case Expr.Var(_, _, _) =>
+    case Exp.Var(_, _, _) =>
       ()
 
-    case Expr.Hole(_, _, _, _, _) =>
+    case Exp.Hole(_, _, _, _, _) =>
       ()
 
-    case Expr.HoleWithExp(exp, _, _, _, _) =>
+    case Exp.HoleWithExp(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.OpenAs(_, exp, _, _) =>
+    case Exp.OpenAs(_, exp, _, _) =>
       visitExp(exp)
 
-    case Expr.Use(_, _, exp, _) =>
+    case Exp.Use(_, _, exp, _) =>
       visitExp(exp)
 
-    case Expr.Lambda(_, exp, _, _) =>
+    case Exp.Lambda(_, exp, _, _) =>
       visitExp(exp)
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
+    case Exp.ApplyClo(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.ApplyDef(_, exps, _, _, _, _, _) =>
+    case Exp.ApplyDef(_, exps, _, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.ApplyLocalDef(_, exps, _, _, _, _) =>
+    case Exp.ApplyLocalDef(_, exps, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.ApplyOp(_, exps, _, _, _) =>
+    case Exp.ApplyOp(_, exps, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.ApplySig(_, exps, _, _, _, _, _, _) =>
+    case Exp.ApplySig(_, exps, _, _, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.Unary(_, exp, _, _, _) =>
+    case Exp.Unary(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Binary(_, exp1, exp2, _, _, _) =>
+    case Exp.Binary(_, exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.Let(_, exp1, exp2, _, _, _) =>
+    case Exp.Let(_, exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.LocalDef(_, _, exp1, exp2, _, _, _) =>
+    case Exp.LocalDef(_, _, exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.Region(_, _, exp, _, _, _) =>
+    case Exp.Region(_, _, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
 
-    case Expr.Stm(exp1, exp2, _, _, _) =>
+    case Exp.Stm(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.Discard(exp, _, _) =>
+    case Exp.Discard(exp, _, _) =>
       visitExp(exp)
 
-    case Expr.Match(exp, rules, _, _, _) =>
+    case Exp.Match(exp, rules, _, _, _) =>
       visitExp(exp)
       rules.foreach { rule =>
         rule.guard.foreach(visitExp)
         visitExp(rule.exp)
       }
 
-    case Expr.TypeMatch(exp, rules, _, _, _) =>
+    case Exp.TypeMatch(exp, rules, _, _, _) =>
       // Check whether the last case in the type match looks like `..: _`.
       rules.lastOption match {
         // Use top scope since the rigidity check only cares if it's a syntactically known variable.
@@ -154,108 +154,108 @@ object Safety {
       visitExp(exp)
       rules.foreach(rule => visitExp(rule.exp))
 
-    case Expr.RestrictableChoose(_, exp, rules, _, _, _) =>
+    case Exp.RestrictableChoose(_, exp, rules, _, _, _) =>
       visitExp(exp)
       rules.foreach(rule => visitExp(rule.exp))
 
-    case Expr.ExtMatch(exp, rules, _, _, _) =>
+    case Exp.ExtMatch(exp, rules, _, _, _) =>
       visitExp(exp)
       rules.foreach(r => visitExp(r.exp))
 
-    case Expr.Tag(_, exps, _, _, _) =>
+    case Exp.Tag(_, exps, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.RestrictableTag(_, exps, _, _, _) =>
+    case Exp.RestrictableTag(_, exps, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.ExtTag(_, exps, _, _, _) =>
+    case Exp.ExtTag(_, exps, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.Tuple(elms, _, _, _) =>
+    case Exp.Tuple(elms, _, _, _) =>
       elms.foreach(visitExp)
 
-    case Expr.RecordSelect(exp, _, _, _, _) =>
+    case Exp.RecordSelect(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.RecordExtend(_, value, rest, _, _, _) =>
+    case Exp.RecordExtend(_, value, rest, _, _, _) =>
       visitExp(value)
       visitExp(rest)
 
-    case Expr.RecordRestrict(_, rest, _, _, _) =>
+    case Exp.RecordRestrict(_, rest, _, _, _) =>
       visitExp(rest)
 
-    case Expr.ArrayLit(elms, exp, _, _, _) =>
+    case Exp.ArrayLit(elms, exp, _, _, _) =>
       elms.foreach(visitExp)
       visitExp(exp)
 
-    case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) =>
+    case Exp.ArrayNew(exp1, exp2, exp3, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
 
-    case Expr.ArrayLoad(exp1, exp2, _, _, _) =>
+    case Exp.ArrayLoad(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.ArrayLength(base, _, _) =>
+    case Exp.ArrayLength(base, _, _) =>
       visitExp(base)
 
-    case Expr.ArrayStore(exp1, exp2, exp3, _, _) =>
+    case Exp.ArrayStore(exp1, exp2, exp3, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
 
-    case Expr.StructNew(_, fields, region, _, _, _) =>
+    case Exp.StructNew(_, fields, region, _, _, _) =>
       fields.foreach { case (_, exp) => visitExp(exp) }
       visitExp(region)
 
-    case Expr.StructGet(e, _, _, _, _) =>
+    case Exp.StructGet(e, _, _, _, _) =>
       visitExp(e)
 
-    case Expr.StructPut(exp1, _, exp2, _, _, _) =>
+    case Exp.StructPut(exp1, _, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.VectorLit(elms, _, _, _) =>
+    case Exp.VectorLit(elms, _, _, _) =>
       elms.foreach(visitExp)
 
-    case Expr.VectorLoad(exp1, exp2, _, _, _) =>
+    case Exp.VectorLoad(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.VectorLength(exp, _) =>
+    case Exp.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, _, _, _, _, _) =>
+    case Exp.Ascribe(exp, _, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.InstanceOf(exp, _, _) =>
+    case Exp.InstanceOf(exp, _, _) =>
       visitExp(exp)
 
-    case cast@Expr.CheckedCast(castType, exp, _, _, _) =>
+    case cast@Exp.CheckedCast(castType, exp, _, _, _) =>
       castType match {
         case CheckedCastType.TypeCast => checkCheckedTypeCast(cast)
         case CheckedCastType.EffectCast => ()
       }
       visitExp(exp)
 
-    case cast@Expr.UncheckedCast(exp, _, _, _, _, loc) =>
+    case cast@Exp.UncheckedCast(exp, _, _, _, _, loc) =>
       verifyUncheckedCast(cast)
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       visitExp(exp)
 
-    case Expr.Unsafe(exp, _, _, _, loc) =>
+    case Exp.Unsafe(exp, _, _, _, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       visitExp(exp)
 
-    case Expr.Without(exp, _, _, _, _) =>
+    case Exp.Without(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.TryCatch(exp, rules, _, _, _) =>
+    case Exp.TryCatch(exp, rules, _, _, _) =>
       visitExp(exp)
       rules.foreach { case CatchRule(bnd, clazz, e, loc) =>
         if (flix.options.checkTrust) {
@@ -265,85 +265,85 @@ object Safety {
         visitExp(e)
       }
 
-    case Expr.Throw(exp, _, _, loc) =>
+    case Exp.Throw(exp, _, _, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       visitExp(exp)
       checkThrow(exp)
 
-    case Expr.Handler(symUse, rules, _, _, _, _, _) =>
+    case Exp.Handler(symUse, rules, _, _, _, _, _) =>
       // Check for [[PrimitiveEffectInRunWith]]
       if (Symbol.isPrimitiveEff(symUse.sym)) {
         sctx.errors.add(PrimitiveEffectInRunWith(symUse.sym, symUse.qname.loc))
       }
       rules.foreach(rule => visitExp(rule.exp))
 
-    case Expr.RunWith(exp1, exp2, _, _, _) =>
+    case Exp.RunWith(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.InvokeConstructor(_, args, _, _, loc) =>
+    case Exp.InvokeConstructor(_, args, _, _, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       args.foreach(visitExp)
 
-    case Expr.InvokeMethod(_, exp, args, _, _, loc) =>
+    case Exp.InvokeMethod(_, exp, args, _, _, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       visitExp(exp)
       args.foreach(visitExp)
 
-    case Expr.InvokeStaticMethod(_, args, _, _, loc) =>
+    case Exp.InvokeStaticMethod(_, args, _, _, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       args.foreach(visitExp)
 
-    case Expr.GetField(_, exp, _, _, loc) =>
+    case Exp.GetField(_, exp, _, _, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       visitExp(exp)
 
-    case Expr.PutField(_, exp1, exp2, _, _, loc) =>
+    case Exp.PutField(_, exp1, exp2, _, _, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.GetStaticField(_, _, _, loc) =>
+    case Exp.GetStaticField(_, _, _, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
 
-    case Expr.PutStaticField(_, exp, _, _, loc) =>
+    case Exp.PutStaticField(_, exp, _, _, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       visitExp(exp)
 
-    case newObject@Expr.NewObject(_, _, _, _, methods, loc) =>
+    case newObject@Exp.NewObject(_, _, _, _, methods, loc) =>
       if (flix.options.checkTrust) {
         checkPermissions(loc.security, loc)
       }
       checkObjectImplementation(newObject)
       methods.foreach(method => visitExp(method.exp))
 
-    case Expr.NewChannel(exp, _, _, _) =>
+    case Exp.NewChannel(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.GetChannel(exp, _, _, _) =>
+    case Exp.GetChannel(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.PutChannel(exp1, exp2, _, _, _) =>
+    case Exp.PutChannel(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.SelectChannel(rules, default, _, _, _) =>
+    case Exp.SelectChannel(rules, default, _, _, _) =>
       rules.foreach {
         case SelectChannelRule(_, chan, body, _) =>
           visitExp(chan)
@@ -351,47 +351,47 @@ object Safety {
       }
       default.map(visitExp).getOrElse(Nil)
 
-    case Expr.Spawn(exp1, exp2, _, _, _) =>
+    case Exp.Spawn(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.ParYield(frags, exp, _, _, _) =>
+    case Exp.ParYield(frags, exp, _, _, _) =>
       frags.foreach(fragment => visitExp(fragment.exp))
       visitExp(exp)
 
-    case Expr.Lazy(exp, _, _) =>
+    case Exp.Lazy(exp, _, _) =>
       visitExp(exp)
 
-    case Expr.Force(exp, _, _, _) =>
+    case Exp.Force(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.FixpointConstraintSet(cs, _, _) =>
+    case Exp.FixpointConstraintSet(cs, _, _) =>
       cs.foreach(checkConstraint)
 
-    case Expr.FixpointLambda(_, exp, _, _, _) =>
+    case Exp.FixpointLambda(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.FixpointMerge(exp1, exp2, _, _, _) =>
+    case Exp.FixpointMerge(exp1, exp2, _, _, _) =>
       visitExp(exp1)
       visitExp(exp2)
 
-    case Expr.FixpointQueryWithProvenance(exps, Predicate.Head.Atom(_, _, terms, _, _), _, _, _, _) =>
+    case Exp.FixpointQueryWithProvenance(exps, Predicate.Head.Atom(_, _, terms, _, _), _, _, _, _) =>
       exps.foreach(visitExp)
       terms.foreach(visitExp)
 
-    case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
+    case Exp.FixpointSolveWithProject(exps, _, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) =>
+    case Exp.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) =>
       exps.foreach(visitExp)
       visitExp(queryExp)
       selects.foreach(visitExp)
       where.foreach(visitExp)
 
-    case Expr.FixpointInjectInto(exps, _, _, _, _) =>
+    case Exp.FixpointInjectInto(exps, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.Error(_, _, _) =>
+    case Exp.Error(_, _, _) =>
       ()
 
   }
@@ -405,8 +405,8 @@ object Safety {
   }
 
   /** Checks if `cast` is legal. */
-  private def checkCheckedTypeCast(cast: Expr.CheckedCast)(implicit sctx: SharedContext, flix: Flix): Unit = cast match {
-    case Expr.CheckedCast(_, exp, tpe, _, loc) =>
+  private def checkCheckedTypeCast(cast: Exp.CheckedCast)(implicit sctx: SharedContext, flix: Flix): Unit = cast match {
+    case Exp.CheckedCast(_, exp, tpe, _, loc) =>
       val from = exp.tpe
       val to = tpe
       (Type.eraseAliases(from).baseType, Type.eraseAliases(to).baseType) match {
@@ -470,8 +470,8 @@ object Safety {
     *   - No primitive type can be cast to a reference type and vice-versa.
     *   - No Bool type can be cast to a non-Bool type and vice-versa.
     */
-  private def verifyUncheckedCast(cast: Expr.UncheckedCast)(implicit sctx: SharedContext, flix: Flix): Unit = cast match {
-    case Expr.UncheckedCast(exp, declaredType, _, _, _, loc) =>
+  private def verifyUncheckedCast(cast: Exp.UncheckedCast)(implicit sctx: SharedContext, flix: Flix): Unit = cast match {
+    case Exp.UncheckedCast(exp, declaredType, _, _, _, loc) =>
       val from = exp.tpe
       val to = declaredType
       val primitives = List(
@@ -657,7 +657,7 @@ object Safety {
   }
 
   /** Checks that the free variables in `exps` does not include `latVars`. */
-  private def checkTerms(exps: List[Expr], latVars: Set[Symbol.VarSym], loc: SourceLocation)(implicit sctx: SharedContext): Unit = {
+  private def checkTerms(exps: List[Exp], latVars: Set[Symbol.VarSym], loc: SourceLocation)(implicit sctx: SharedContext): Unit = {
     val allFreeVars = exps.flatMap(t => freeVars(t).keys).toSet
 
     // Compute the lattice variables that are illegally used in the exps.
@@ -693,7 +693,7 @@ object Safety {
     classOf[Throwable].isAssignableFrom(clazz)
 
   /** Checks that the type of the argument to `throw` is [[java.lang.Throwable]] or a subclass. */
-  private def checkThrow(exp: Expr)(implicit sctx: SharedContext): Unit =
+  private def checkThrow(exp: Exp)(implicit sctx: SharedContext): Unit =
     if (!isThrowableType(exp.tpe)) sctx.errors.add(IllegalThrowType(exp.loc))
 
   /** Returns `true` if `tpe` is [[java.lang.Throwable]] or a subclass of it. */
@@ -716,8 +716,8 @@ object Safety {
     *   - `methods` must not include non-existing methods.
     *   - `methods` must not let control effects escape.
     */
-  private def checkObjectImplementation(newObject: Expr.NewObject)(implicit flix: Flix, sctx: SharedContext): Unit = newObject match {
-    case Expr.NewObject(_, clazz, tpe0, _, methods, loc) =>
+  private def checkObjectImplementation(newObject: Exp.NewObject)(implicit flix: Flix, sctx: SharedContext): Unit = newObject match {
+    case Exp.NewObject(_, clazz, tpe0, _, methods, loc) =>
       val tpe = Type.eraseAliases(tpe0)
       // `clazz` must be an interface or have a non-private constructor without arguments.
       if (!clazz.isInterface && !hasNonPrivateZeroArgConstructor(clazz)) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -99,345 +99,345 @@ object Stratifier {
   /**
     * Performs stratification of the given expression `exp0`.
     */
-  private def visitExp(exp0: Expr)(implicit g: LabelledPrecedenceGraph, sctx: SharedContext, root: Root, flix: Flix): Expr = exp0 match {
-    case Expr.Cst(_, _, _) => exp0
+  private def visitExp(exp0: Exp)(implicit g: LabelledPrecedenceGraph, sctx: SharedContext, root: Root, flix: Flix): Exp = exp0 match {
+    case Exp.Cst(_, _, _) => exp0
 
-    case Expr.Var(_, _, _) => exp0
+    case Exp.Var(_, _, _) => exp0
 
-    case Expr.Hole(_, _, _, _, _) => exp0
+    case Exp.Hole(_, _, _, _, _) => exp0
 
-    case Expr.HoleWithExp(exp, env, tpe, eff, loc) =>
+    case Exp.HoleWithExp(exp, env, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.HoleWithExp(e, env, tpe, eff, loc)
+      Exp.HoleWithExp(e, env, tpe, eff, loc)
 
-    case Expr.OpenAs(sym, exp, tpe, loc) =>
+    case Exp.OpenAs(sym, exp, tpe, loc) =>
       val e = visitExp(exp)
-      Expr.OpenAs(sym, e, tpe, loc)
+      Exp.OpenAs(sym, e, tpe, loc)
 
-    case Expr.Use(sym, alias, exp, loc) =>
+    case Exp.Use(sym, alias, exp, loc) =>
       val e = visitExp(exp)
-      Expr.Use(sym, alias, e, loc)
+      Exp.Use(sym, alias, e, loc)
 
-    case Expr.Lambda(fparam, exp, tpe, loc) =>
+    case Exp.Lambda(fparam, exp, tpe, loc) =>
       val e = visitExp(exp)
-      Expr.Lambda(fparam, e, tpe, loc)
+      Exp.Lambda(fparam, e, tpe, loc)
 
-    case Expr.ApplyClo(exp1, exp2, tpe, eff, loc) =>
+    case Exp.ApplyClo(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.ApplyClo(e1, e2, tpe, eff, loc)
+      Exp.ApplyClo(e1, e2, tpe, eff, loc)
 
-    case Expr.ApplyDef(symUse, exps, targs, itpe, tpe, eff, loc) =>
+    case Exp.ApplyDef(symUse, exps, targs, itpe, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.ApplyDef(symUse, es, targs, itpe, tpe, eff, loc)
+      Exp.ApplyDef(symUse, es, targs, itpe, tpe, eff, loc)
 
-    case Expr.ApplyLocalDef(symUse, exps, arrowTpe, tpe, eff, loc) =>
+    case Exp.ApplyLocalDef(symUse, exps, arrowTpe, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.ApplyLocalDef(symUse, es, arrowTpe, tpe, eff, loc)
+      Exp.ApplyLocalDef(symUse, es, arrowTpe, tpe, eff, loc)
 
-    case Expr.ApplyOp(sym, exps, tpe, eff, loc) =>
+    case Exp.ApplyOp(sym, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.ApplyOp(sym, es, tpe, eff, loc)
+      Exp.ApplyOp(sym, es, tpe, eff, loc)
 
-    case Expr.ApplySig(symUse, exps, targ, targs, itpe, tpe, eff, loc) =>
+    case Exp.ApplySig(symUse, exps, targ, targs, itpe, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.ApplySig(symUse, es, targ, targs, itpe, tpe, eff, loc)
+      Exp.ApplySig(symUse, es, targ, targs, itpe, tpe, eff, loc)
 
-    case Expr.Unary(sop, exp, tpe, eff, loc) =>
+    case Exp.Unary(sop, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Unary(sop, e, tpe, eff, loc)
+      Exp.Unary(sop, e, tpe, eff, loc)
 
-    case Expr.Binary(sop, exp1, exp2, tpe, eff, loc) =>
+    case Exp.Binary(sop, exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.Binary(sop, e1, e2, tpe, eff, loc)
+      Exp.Binary(sop, e1, e2, tpe, eff, loc)
 
-    case Expr.Let(sym, exp1, exp2, tpe, eff, loc) =>
+    case Exp.Let(sym, exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.Let(sym, e1, e2, tpe, eff, loc)
+      Exp.Let(sym, e1, e2, tpe, eff, loc)
 
-    case Expr.LocalDef(sym, fparams, exp1, exp2, tpe, eff, loc) =>
+    case Exp.LocalDef(sym, fparams, exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.LocalDef(sym, fparams, e1, e2, tpe, eff, loc)
+      Exp.LocalDef(sym, fparams, e1, e2, tpe, eff, loc)
 
-    case Expr.Region(sym, regionVar, exp, tpe, eff, loc) =>
+    case Exp.Region(sym, regionVar, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Region(sym, regionVar, e, tpe, eff, loc)
+      Exp.Region(sym, regionVar, e, tpe, eff, loc)
 
-    case Expr.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
+    case Exp.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      Expr.IfThenElse(e1, e2, e3, tpe, eff, loc)
+      Exp.IfThenElse(e1, e2, e3, tpe, eff, loc)
 
-    case Expr.Stm(exp1, exp2, tpe, eff, loc) =>
+    case Exp.Stm(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.Stm(e1, e2, tpe, eff, loc)
+      Exp.Stm(e1, e2, tpe, eff, loc)
 
-    case Expr.Discard(exp, eff, loc) =>
+    case Exp.Discard(exp, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Discard(e, eff, loc)
+      Exp.Discard(e, eff, loc)
 
-    case Expr.Match(exp, rules, tpe, eff, loc) =>
+    case Exp.Match(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitMatchRule)
-      Expr.Match(e, rs, tpe, eff, loc)
+      Exp.Match(e, rs, tpe, eff, loc)
 
-    case Expr.TypeMatch(exp, rules, tpe, eff, loc) =>
+    case Exp.TypeMatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitTypeMatchRule)
-      Expr.TypeMatch(e, rs, tpe, eff, loc)
+      Exp.TypeMatch(e, rs, tpe, eff, loc)
 
-    case Expr.RestrictableChoose(star, exp, rules, tpe, eff, loc) =>
+    case Exp.RestrictableChoose(star, exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitRestrictableChooseRule)
-      Expr.RestrictableChoose(star, e, rs, tpe, eff, loc)
+      Exp.RestrictableChoose(star, e, rs, tpe, eff, loc)
 
-    case Expr.ExtMatch(exp, rules, tpe, eff, loc) =>
+    case Exp.ExtMatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitExtMatchRule)
-      Expr.ExtMatch(e, rs, tpe, eff, loc)
+      Exp.ExtMatch(e, rs, tpe, eff, loc)
 
-    case Expr.Tag(symUse, exps, tpe, eff, loc) =>
+    case Exp.Tag(symUse, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.Tag(symUse, es, tpe, eff, loc)
+      Exp.Tag(symUse, es, tpe, eff, loc)
 
-    case Expr.RestrictableTag(symUse, exps, tpe, eff, loc) =>
+    case Exp.RestrictableTag(symUse, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.RestrictableTag(symUse, es, tpe, eff, loc)
+      Exp.RestrictableTag(symUse, es, tpe, eff, loc)
 
-    case Expr.ExtTag(label, exps, tpe, eff, loc) =>
+    case Exp.ExtTag(label, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.ExtTag(label, es, tpe, eff, loc)
+      Exp.ExtTag(label, es, tpe, eff, loc)
 
-    case Expr.Tuple(exps, tpe, eff, loc) =>
+    case Exp.Tuple(exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.Tuple(es, tpe, eff, loc)
+      Exp.Tuple(es, tpe, eff, loc)
 
-    case Expr.RecordSelect(exp, label, tpe, eff, loc) =>
+    case Exp.RecordSelect(exp, label, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.RecordSelect(e, label, tpe, eff, loc)
+      Exp.RecordSelect(e, label, tpe, eff, loc)
 
-    case Expr.RecordExtend(label, exp1, exp2, tpe, eff, loc) =>
+    case Exp.RecordExtend(label, exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.RecordExtend(label, e1, e2, tpe, eff, loc)
+      Exp.RecordExtend(label, e1, e2, tpe, eff, loc)
 
-    case Expr.RecordRestrict(label, exp, tpe, eff, loc) =>
+    case Exp.RecordRestrict(label, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.RecordRestrict(label, e, tpe, eff, loc)
+      Exp.RecordRestrict(label, e, tpe, eff, loc)
 
-    case Expr.ArrayLit(exps, exp, tpe, eff, loc) =>
+    case Exp.ArrayLit(exps, exp, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val e = visitExp(exp)
-      Expr.ArrayLit(es, e, tpe, eff, loc)
+      Exp.ArrayLit(es, e, tpe, eff, loc)
 
-    case Expr.ArrayNew(exp1, exp2, exp3, tpe, eff, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      val e3 = visitExp(exp3)
-      Expr.ArrayNew(e1, e2, e3, tpe, eff, loc)
-
-    case Expr.ArrayLoad(exp1, exp2, tpe, eff, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      Expr.ArrayLoad(e1, e2, tpe, eff, loc)
-
-    case Expr.ArrayLength(exp, eff, loc) =>
-      val e = visitExp(exp)
-      Expr.ArrayLength(e, eff, loc)
-
-    case Expr.ArrayStore(exp1, exp2, exp3, eff, loc) =>
+    case Exp.ArrayNew(exp1, exp2, exp3, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      Expr.ArrayStore(e1, e2, e3, eff, loc)
+      Exp.ArrayNew(e1, e2, e3, tpe, eff, loc)
 
-    case Expr.StructNew(sym, fields0, region0, tpe, eff, loc) =>
+    case Exp.ArrayLoad(exp1, exp2, tpe, eff, loc) =>
+      val e1 = visitExp(exp1)
+      val e2 = visitExp(exp2)
+      Exp.ArrayLoad(e1, e2, tpe, eff, loc)
+
+    case Exp.ArrayLength(exp, eff, loc) =>
+      val e = visitExp(exp)
+      Exp.ArrayLength(e, eff, loc)
+
+    case Exp.ArrayStore(exp1, exp2, exp3, eff, loc) =>
+      val e1 = visitExp(exp1)
+      val e2 = visitExp(exp2)
+      val e3 = visitExp(exp3)
+      Exp.ArrayStore(e1, e2, e3, eff, loc)
+
+    case Exp.StructNew(sym, fields0, region0, tpe, eff, loc) =>
       val fields = fields0.map {
         case (name, e0) => name -> visitExp(e0)
       }
       val region = visitExp(region0)
-      Expr.StructNew(sym, fields, region, tpe, eff, loc)
+      Exp.StructNew(sym, fields, region, tpe, eff, loc)
 
-    case Expr.StructGet(e0, field, tpe, eff, loc) =>
+    case Exp.StructGet(e0, field, tpe, eff, loc) =>
       val e = visitExp(e0)
-      Expr.StructGet(e, field, tpe, eff, loc)
+      Exp.StructGet(e, field, tpe, eff, loc)
 
-    case Expr.StructPut(exp1, field, exp2, tpe, eff, loc) =>
+    case Exp.StructPut(exp1, field, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.StructPut(e1, field, e2, tpe, eff, loc)
+      Exp.StructPut(e1, field, e2, tpe, eff, loc)
 
-    case Expr.VectorLit(exps, tpe, eff, loc) =>
+    case Exp.VectorLit(exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.VectorLit(es, tpe, eff, loc)
+      Exp.VectorLit(es, tpe, eff, loc)
 
-    case Expr.VectorLoad(exp1, exp2, tpe, eff, loc) =>
+    case Exp.VectorLoad(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.VectorLoad(e1, e2, tpe, eff, loc)
+      Exp.VectorLoad(e1, e2, tpe, eff, loc)
 
-    case Expr.VectorLength(exp, loc) =>
+    case Exp.VectorLength(exp, loc) =>
       val e = visitExp(exp)
-      Expr.VectorLength(e, loc)
+      Exp.VectorLength(e, loc)
 
-    case Expr.Ascribe(exp, expectedType, expectedEff, tpe, eff, loc) =>
+    case Exp.Ascribe(exp, expectedType, expectedEff, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Ascribe(e, expectedType, expectedEff, tpe, eff, loc)
+      Exp.Ascribe(e, expectedType, expectedEff, tpe, eff, loc)
 
-    case Expr.InstanceOf(exp, clazz, loc) =>
+    case Exp.InstanceOf(exp, clazz, loc) =>
       val e = visitExp(exp)
-      Expr.InstanceOf(e, clazz, loc)
+      Exp.InstanceOf(e, clazz, loc)
 
-    case Expr.CheckedCast(cast, exp, tpe, eff, loc) =>
+    case Exp.CheckedCast(cast, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.CheckedCast(cast, e, tpe, eff, loc)
+      Exp.CheckedCast(cast, e, tpe, eff, loc)
 
-    case Expr.UncheckedCast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+    case Exp.UncheckedCast(exp, declaredType, declaredEff, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.UncheckedCast(e, declaredType, declaredEff, tpe, eff, loc)
+      Exp.UncheckedCast(e, declaredType, declaredEff, tpe, eff, loc)
 
-    case Expr.Unsafe(exp, runEff, tpe, eff, loc) =>
+    case Exp.Unsafe(exp, runEff, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Unsafe(e, runEff, tpe, eff, loc)
+      Exp.Unsafe(e, runEff, tpe, eff, loc)
 
-    case Expr.Without(exp, symUse, tpe, eff, loc) =>
+    case Exp.Without(exp, symUse, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Without(e, symUse, tpe, eff, loc)
+      Exp.Without(e, symUse, tpe, eff, loc)
 
-    case Expr.TryCatch(exp, rules, tpe, eff, loc) =>
+    case Exp.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitTryCatchRule)
-      Expr.TryCatch(e, rs, tpe, eff, loc)
+      Exp.TryCatch(e, rs, tpe, eff, loc)
 
-    case Expr.Throw(exp, tpe, eff, loc) =>
+    case Exp.Throw(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Throw(e, tpe, eff, loc)
+      Exp.Throw(e, tpe, eff, loc)
 
-    case Expr.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
+    case Exp.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
       val rs = rules.map(visitRunWithRule)
-      Expr.Handler(symUse, rs, bodyTpe, bodyEff, handledEff, tpe, loc)
+      Exp.Handler(symUse, rs, bodyTpe, bodyEff, handledEff, tpe, loc)
 
-    case Expr.RunWith(exp1, exp2, tpe, eff, loc) =>
+    case Exp.RunWith(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.RunWith(e1, e2, tpe, eff, loc)
+      Exp.RunWith(e1, e2, tpe, eff, loc)
 
-    case Expr.InvokeConstructor(constructor, exps, tpe, eff, loc) =>
+    case Exp.InvokeConstructor(constructor, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.InvokeConstructor(constructor, es, tpe, eff, loc)
+      Exp.InvokeConstructor(constructor, es, tpe, eff, loc)
 
-    case Expr.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
+    case Exp.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
       val e = visitExp(exp)
       val es = exps.map(visitExp)
-      Expr.InvokeMethod(method, e, es, tpe, eff, loc)
+      Exp.InvokeMethod(method, e, es, tpe, eff, loc)
 
-    case Expr.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
+    case Exp.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.InvokeStaticMethod(method, es, tpe, eff, loc)
+      Exp.InvokeStaticMethod(method, es, tpe, eff, loc)
 
-    case Expr.GetField(field, exp, tpe, eff, loc) =>
+    case Exp.GetField(field, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.GetField(field, e, tpe, eff, loc)
+      Exp.GetField(field, e, tpe, eff, loc)
 
-    case Expr.PutField(field, exp1, exp2, tpe, eff, loc) =>
+    case Exp.PutField(field, exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.PutField(field, e1, e2, tpe, eff, loc)
+      Exp.PutField(field, e1, e2, tpe, eff, loc)
 
-    case Expr.GetStaticField(field, tpe, eff, loc) =>
-      Expr.GetStaticField(field, tpe, eff, loc)
+    case Exp.GetStaticField(field, tpe, eff, loc) =>
+      Exp.GetStaticField(field, tpe, eff, loc)
 
-    case Expr.PutStaticField(field, exp, tpe, eff, loc) =>
+    case Exp.PutStaticField(field, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.PutStaticField(field, e, tpe, eff, loc)
+      Exp.PutStaticField(field, e, tpe, eff, loc)
 
-    case Expr.NewObject(name, clazz, tpe, eff, methods, loc) =>
+    case Exp.NewObject(name, clazz, tpe, eff, methods, loc) =>
       val ms = methods.map(visitJvmMethod)
-      Expr.NewObject(name, clazz, tpe, eff, ms, loc)
+      Exp.NewObject(name, clazz, tpe, eff, ms, loc)
 
-    case Expr.NewChannel(exp, tpe, eff, loc) =>
+    case Exp.NewChannel(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.NewChannel(e, tpe, eff, loc)
+      Exp.NewChannel(e, tpe, eff, loc)
 
-    case Expr.GetChannel(exp, tpe, eff, loc) =>
+    case Exp.GetChannel(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.GetChannel(e, tpe, eff, loc)
+      Exp.GetChannel(e, tpe, eff, loc)
 
-    case Expr.PutChannel(exp1, exp2, tpe, eff, loc) =>
+    case Exp.PutChannel(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.PutChannel(e1, e2, tpe, eff, loc)
+      Exp.PutChannel(e1, e2, tpe, eff, loc)
 
-    case Expr.SelectChannel(rules, exp, tpe, eff, loc) =>
+    case Exp.SelectChannel(rules, exp, tpe, eff, loc) =>
       val e = exp.map(visitExp)
       val rs = rules.map(visitSelectChannelRule)
-      Expr.SelectChannel(rs, e, tpe, eff, loc)
+      Exp.SelectChannel(rs, e, tpe, eff, loc)
 
-    case Expr.Spawn(exp1, exp2, tpe, eff, loc) =>
+    case Exp.Spawn(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.Spawn(e1, e2, tpe, eff, loc)
+      Exp.Spawn(e1, e2, tpe, eff, loc)
 
-    case Expr.ParYield(frags, exp, tpe, eff, loc) =>
+    case Exp.ParYield(frags, exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val fs = frags.map(visitParYieldFragment)
-      Expr.ParYield(fs, e, tpe, eff, loc)
+      Exp.ParYield(fs, e, tpe, eff, loc)
 
-    case Expr.Lazy(exp, tpe, loc) =>
+    case Exp.Lazy(exp, tpe, loc) =>
       val e = visitExp(exp)
-      Expr.Lazy(e, tpe, loc)
+      Exp.Lazy(e, tpe, loc)
 
-    case Expr.Force(exp, tpe, eff, loc) =>
+    case Exp.Force(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Force(e, tpe, eff, loc)
+      Exp.Force(e, tpe, eff, loc)
 
-    case Expr.FixpointConstraintSet(cs0, tpe, loc) =>
+    case Exp.FixpointConstraintSet(cs0, tpe, loc) =>
       // Compute the stratification.
       stratify(g, tpe, loc)
       val cs = cs0.map(reorder)
-      Expr.FixpointConstraintSet(cs, tpe, loc)
+      Exp.FixpointConstraintSet(cs, tpe, loc)
 
-    case Expr.FixpointLambda(pparams, exp, tpe, eff, loc) =>
+    case Exp.FixpointLambda(pparams, exp, tpe, eff, loc) =>
       // Compute the stratification.
       stratify(g, tpe, loc)
-      Expr.FixpointLambda(pparams, exp, tpe, eff, loc)
+      Exp.FixpointLambda(pparams, exp, tpe, eff, loc)
 
-    case Expr.FixpointMerge(exp1, exp2, tpe, eff, loc) =>
+    case Exp.FixpointMerge(exp1, exp2, tpe, eff, loc) =>
       // Compute the stratification.
       stratify(g, tpe, loc)
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      Expr.FixpointMerge(e1, e2, tpe, eff, loc)
+      Exp.FixpointMerge(e1, e2, tpe, eff, loc)
 
-    case Expr.FixpointQueryWithProvenance(exps, Head.Atom(pred, den, terms, tpe2, loc2), withh, tpe1, eff1, loc1) =>
+    case Exp.FixpointQueryWithProvenance(exps, Head.Atom(pred, den, terms, tpe2, loc2), withh, tpe1, eff1, loc1) =>
       val es = exps.map(visitExp)
       val ts = terms.map(visitExp)
-      Expr.FixpointQueryWithProvenance(es, Head.Atom(pred, den, ts, tpe2, loc2), withh, tpe1, eff1, loc1)
+      Exp.FixpointQueryWithProvenance(es, Head.Atom(pred, den, ts, tpe2, loc2), withh, tpe1, eff1, loc1)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, tpe, eff, loc) =>
+    case Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val qe = visitExp(queryExp)
       val ss = selects.map(visitExp)
       val w = where.map(visitExp)
-      Expr.FixpointQueryWithSelect(es, qe, ss, from, w, pred, tpe, eff, loc)
+      Exp.FixpointQueryWithSelect(es, qe, ss, from, w, pred, tpe, eff, loc)
 
-    case Expr.FixpointSolveWithProject(exps, optPreds, mode, tpe, eff, loc) =>
+    case Exp.FixpointSolveWithProject(exps, optPreds, mode, tpe, eff, loc) =>
       // Compute the stratification.
       stratify(g, tpe, loc)
       val es = exps.map(visitExp)
-      Expr.FixpointSolveWithProject(es, optPreds, mode, tpe, eff, loc)
+      Exp.FixpointSolveWithProject(es, optPreds, mode, tpe, eff, loc)
 
-    case Expr.FixpointInjectInto(exps, predsAndArities, tpe, eff, loc) =>
+    case Exp.FixpointInjectInto(exps, predsAndArities, tpe, eff, loc) =>
       val es = exps.map(visitExp)
-      Expr.FixpointInjectInto(es, predsAndArities, tpe, eff, loc)
+      Exp.FixpointInjectInto(es, predsAndArities, tpe, eff, loc)
 
-    case Expr.Error(m, tpe, eff) =>
-      Expr.Error(m, tpe, eff)
+    case Exp.Error(m, tpe, eff) =>
+      Exp.Error(m, tpe, eff)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
@@ -65,88 +65,88 @@ object TreeShaker1 {
   }
 
   /** Returns the symbols reachable from `e0`. */
-  private def visitExp(e0: Expr): Set[ReachableSym] = e0 match {
-    case Expr.Cst(_, _, _) =>
+  private def visitExp(e0: Exp): Set[ReachableSym] = e0 match {
+    case Exp.Cst(_, _, _) =>
       Set.empty
 
-    case Expr.Var(_, _, _) =>
+    case Exp.Var(_, _, _) =>
       Set.empty
 
-    case Expr.Lambda(_, exp, _, _) =>
+    case Exp.Lambda(_, exp, _, _) =>
       visitExp(exp)
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
+    case Exp.ApplyClo(exp1, exp2, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2)
 
-    case Expr.ApplyDef(sym, exps, _, _, _, _, _) =>
+    case Exp.ApplyDef(sym, exps, _, _, _, _, _) =>
       Set(ReachableSym.DefnSym(sym)) ++ visitExps(exps)
 
-    case Expr.ApplyLocalDef(_, exps, _, _, _) =>
+    case Exp.ApplyLocalDef(_, exps, _, _, _) =>
       visitExps(exps)
 
-    case Expr.ApplyOp(_, exps, _, _, _) =>
+    case Exp.ApplyOp(_, exps, _, _, _) =>
       visitExps(exps)
 
-    case Expr.ApplySig(sym, exps, _, _, _, _, _, _) =>
+    case Exp.ApplySig(sym, exps, _, _, _, _, _, _) =>
       Set(ReachableSym.SigSym(sym)) ++ visitExps(exps)
 
-    case Expr.ApplyAtomic(_, exps, _, _, _) =>
+    case Exp.ApplyAtomic(_, exps, _, _, _) =>
       visitExps(exps)
 
-    case Expr.Let(_, exp1, exp2, _, _, _) =>
+    case Exp.Let(_, exp1, exp2, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2)
 
-    case Expr.LocalDef(_, _, exp1, exp2, _, _, _) =>
+    case Exp.LocalDef(_, _, exp1, exp2, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2)
 
-    case Expr.Region(_, _, exp, _, _, _) =>
+    case Exp.Region(_, _, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
 
-    case Expr.Stm(exp1, exp2, _, _, _) =>
+    case Exp.Stm(exp1, exp2, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2)
 
-    case Expr.Discard(exp, _, _) =>
+    case Exp.Discard(exp, _, _) =>
       visitExp(exp)
 
-    case Expr.Match(exp, rules, _, _, _) =>
+    case Exp.Match(exp, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp)) ++ visitExps(rules.flatMap(_.guard))
 
-    case Expr.ExtMatch(exp, rules, _, _, _) =>
+    case Exp.ExtMatch(exp, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp))
 
-    case Expr.TypeMatch(exp, rules, _, _, _) =>
+    case Exp.TypeMatch(exp, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp))
 
-    case Expr.VectorLit(exps, _, _, _) =>
+    case Exp.VectorLit(exps, _, _, _) =>
       visitExps(exps)
 
-    case Expr.VectorLoad(exp1, exp2, _, _, _) =>
+    case Exp.VectorLoad(exp1, exp2, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2)
 
-    case Expr.VectorLength(exp, _) =>
+    case Exp.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, _, _, _) =>
+    case Exp.Ascribe(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Cast(exp, _, _, _, _, _) =>
+    case Exp.Cast(exp, _, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.TryCatch(exp, rules, _, _, _) =>
+    case Exp.TryCatch(exp, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp))
 
-    case Expr.NewObject(_, _, _, _, methods, _) =>
+    case Exp.NewObject(_, _, _, _, methods, _) =>
       visitExps(methods.map(_.exp))
 
-    case Expr.RunWith(exp, _, rules, _, _, _) =>
+    case Exp.RunWith(exp, _, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp))
   }
 
   /** Returns the symbols reachable from `exps`. */
-  private def visitExps(exps: List[Expr]): Set[ReachableSym] =
+  private def visitExps(exps: List[Exp]): Set[ReachableSym] =
     exps.map(visitExp).fold(Set())(_ ++ _)
 
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker2.scala
@@ -54,50 +54,50 @@ object TreeShaker2 {
   }
 
   /** Returns the function symbols reachable from `e0`. */
-  private def visitExp(e0: Expr): Set[Symbol.DefnSym] = e0 match {
-    case Expr.Cst(_, _, _) =>
+  private def visitExp(e0: Exp): Set[Symbol.DefnSym] = e0 match {
+    case Exp.Cst(_, _, _) =>
       Set.empty
 
-    case Expr.Var(_, _, _) =>
+    case Exp.Var(_, _, _) =>
       Set.empty
 
-    case Expr.ApplyAtomic(op, exps, _, _, _) =>
+    case Exp.ApplyAtomic(op, exps, _, _, _) =>
       visitAtomicOp(op) ++ visitExps(exps)
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
+    case Exp.ApplyClo(exp1, exp2, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2)
 
-    case Expr.ApplyDef(sym, exps, _, _, _) =>
+    case Exp.ApplyDef(sym, exps, _, _, _) =>
       Set(sym) ++ visitExps(exps)
 
-    case Expr.ApplyOp(_, exps, _, _, _) =>
+    case Exp.ApplyOp(_, exps, _, _, _) =>
       visitExps(exps)
 
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
 
-    case Expr.Branch(exp, branches, _, _, _) =>
+    case Exp.Branch(exp, branches, _, _, _) =>
       visitExp(exp) ++ visitExps(branches.values.toList)
 
-    case Expr.JumpTo(_, _, _, _) =>
+    case Exp.JumpTo(_, _, _, _) =>
       Set.empty
 
-    case Expr.Let(_, exp1, exp2, _, _, _) =>
+    case Exp.Let(_, exp1, exp2, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2)
 
-    case Expr.Stm(exp1, exp2, _, _, _) =>
+    case Exp.Stm(exp1, exp2, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2)
 
-    case Expr.Region(_, exp, _, _, _) =>
+    case Exp.Region(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.TryCatch(exp, rules, _, _, _) =>
+    case Exp.TryCatch(exp, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp))
 
-    case Expr.RunWith(exp, _, rules, _, _, _) =>
+    case Exp.RunWith(exp, _, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp))
 
-    case Expr.NewObject(_, _, _, _, methods, _) =>
+    case Exp.NewObject(_, _, _, _, methods, _) =>
       visitExps(methods.map(_.clo))
 
   }
@@ -109,7 +109,7 @@ object TreeShaker2 {
   }
 
   /** Returns the function symbols reachable from `es`. */
-  private def visitExps(es: List[Expr]): Set[Symbol.DefnSym] =
+  private def visitExps(es: List[Exp]): Set[Symbol.DefnSym] =
     es.map(visitExp).fold(Set())(_ ++ _)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -86,104 +86,104 @@ object TypeReconstruction {
   /**
     * Reconstructs types in the given expression.
     */
-  private def visitExp(exp0: KindedAst.Expr)(implicit subst: SubstitutionTree): TypedAst.Expr = exp0 match {
-    case KindedAst.Expr.Var(sym, loc) =>
-      TypedAst.Expr.Var(sym, subst(sym.tvar), loc)
+  private def visitExp(exp0: KindedAst.Exp)(implicit subst: SubstitutionTree): TypedAst.Exp = exp0 match {
+    case KindedAst.Exp.Var(sym, loc) =>
+      TypedAst.Exp.Var(sym, subst(sym.tvar), loc)
 
-    case KindedAst.Expr.Hole(sym, env, tpe, evar, loc) =>
-      TypedAst.Expr.Hole(sym, env, subst(tpe), subst(evar), loc)
+    case KindedAst.Exp.Hole(sym, env, tpe, evar, loc) =>
+      TypedAst.Exp.Hole(sym, env, subst(tpe), subst(evar), loc)
 
-    case KindedAst.Expr.HoleWithExp(exp, env, tvar, evar, loc) =>
+    case KindedAst.Exp.HoleWithExp(exp, env, tvar, evar, loc) =>
       val e = visitExp(exp)
-      TypedAst.Expr.HoleWithExp(e, env, subst(tvar), subst(evar), loc)
+      TypedAst.Exp.HoleWithExp(e, env, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.OpenAs(symUse, exp, tvar, loc) =>
+    case KindedAst.Exp.OpenAs(symUse, exp, tvar, loc) =>
       val e = visitExp(exp)
-      TypedAst.Expr.OpenAs(symUse, e, subst(tvar), loc)
+      TypedAst.Exp.OpenAs(symUse, e, subst(tvar), loc)
 
-    case KindedAst.Expr.Use(sym, alias, exp, loc) =>
+    case KindedAst.Exp.Use(sym, alias, exp, loc) =>
       val e = visitExp(exp)
-      TypedAst.Expr.Use(sym, alias, e, loc)
+      TypedAst.Exp.Use(sym, alias, e, loc)
 
-    case KindedAst.Expr.Cst(Constant.Null, loc) =>
-      TypedAst.Expr.Cst(Constant.Null, Type.Null, loc)
+    case KindedAst.Exp.Cst(Constant.Null, loc) =>
+      TypedAst.Exp.Cst(Constant.Null, Type.Null, loc)
 
-    case KindedAst.Expr.Cst(cst, loc) => TypedAst.Expr.Cst(cst, Type.constantType(cst), loc)
+    case KindedAst.Exp.Cst(cst, loc) => TypedAst.Exp.Cst(cst, Type.constantType(cst), loc)
 
-    case KindedAst.Expr.ApplyClo(exp1, exp2, tvar, evar, loc) =>
+    case KindedAst.Exp.ApplyClo(exp1, exp2, tvar, evar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      TypedAst.Expr.ApplyClo(e1, e2, subst(tvar), subst(evar), loc)
+      TypedAst.Exp.ApplyClo(e1, e2, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.ApplyDef(symUse, exps, targs, itvar, tvar, evar, loc) =>
+    case KindedAst.Exp.ApplyDef(symUse, exps, targs, itvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)
       val tas = targs.map(subst.apply)
-      TypedAst.Expr.ApplyDef(symUse, es, tas, subst(itvar), subst(tvar), subst(evar), loc)
+      TypedAst.Exp.ApplyDef(symUse, es, tas, subst(itvar), subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, evar, loc) =>
+    case KindedAst.Exp.ApplyLocalDef(symUse, exps, arrowTvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)
       val at = subst(arrowTvar)
       val t = subst(tvar)
       val ef = subst(evar)
-      TypedAst.Expr.ApplyLocalDef(symUse, es, at, t, ef, loc)
+      TypedAst.Exp.ApplyLocalDef(symUse, es, at, t, ef, loc)
 
-    case KindedAst.Expr.ApplyOp(symUse, exps, tvar, evar, loc) =>
+    case KindedAst.Exp.ApplyOp(symUse, exps, tvar, evar, loc) =>
       val es = exps.map(visitExp(_))
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.ApplyOp(symUse, es, tpe, eff, loc)
+      TypedAst.Exp.ApplyOp(symUse, es, tpe, eff, loc)
 
-    case KindedAst.Expr.ApplySig(symUse, exps, targ, targs, itvar, tvar, evar, loc) =>
+    case KindedAst.Exp.ApplySig(symUse, exps, targ, targs, itvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)
       val ta = subst(targ)
       val tas = targs.map(subst.apply)
-      TypedAst.Expr.ApplySig(symUse, es, ta, tas, subst(itvar), subst(tvar), subst(evar), loc)
+      TypedAst.Exp.ApplySig(symUse, es, ta, tas, subst(itvar), subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.Lambda(fparam, exp, _, loc) =>
+    case KindedAst.Exp.Lambda(fparam, exp, _, loc) =>
       val p = visitFormalParam(fparam, subst)
       val e = visitExp(exp)
       val t = Type.mkArrowWithEffect(p.tpe, e.eff, e.tpe, loc)
-      TypedAst.Expr.Lambda(p, e, t, loc)
+      TypedAst.Exp.Lambda(p, e, t, loc)
 
-    case KindedAst.Expr.Unary(sop, exp, tvar, loc) =>
+    case KindedAst.Exp.Unary(sop, exp, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      TypedAst.Expr.Unary(sop, e, subst(tvar), eff, loc)
+      TypedAst.Exp.Unary(sop, e, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.Binary(sop, exp1, exp2, tvar, loc) =>
+    case KindedAst.Exp.Binary(sop, exp1, exp2, tvar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val eff = Type.mkUnion(e1.eff, e2.eff, loc)
-      TypedAst.Expr.Binary(sop, e1, e2, subst(tvar), eff, loc)
+      TypedAst.Exp.Binary(sop, e1, e2, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.IfThenElse(exp1, exp2, exp3, loc) =>
+    case KindedAst.Exp.IfThenElse(exp1, exp2, exp3, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
       val tpe = e2.tpe
       val eff = Type.mkUnion(e1.eff, e2.eff, e3.eff, loc)
-      TypedAst.Expr.IfThenElse(e1, e2, e3, tpe, eff, loc)
+      TypedAst.Exp.IfThenElse(e1, e2, e3, tpe, eff, loc)
 
-    case KindedAst.Expr.Stm(exp1, exp2, loc) =>
+    case KindedAst.Exp.Stm(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val tpe = e2.tpe
       val eff = Type.mkUnion(e1.eff, e2.eff, loc)
-      TypedAst.Expr.Stm(e1, e2, tpe, eff, loc)
+      TypedAst.Exp.Stm(e1, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.Discard(exp, loc) =>
+    case KindedAst.Exp.Discard(exp, loc) =>
       val e = visitExp(exp)
-      TypedAst.Expr.Discard(e, e.eff, loc)
+      TypedAst.Exp.Discard(e, e.eff, loc)
 
-    case KindedAst.Expr.Let(sym, exp1, exp2, loc) =>
+    case KindedAst.Exp.Let(sym, exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val bnd = TypedAst.Binder(sym, e1.tpe)
       val tpe = e2.tpe
       val eff = Type.mkUnion(e1.eff, e2.eff, loc)
-      TypedAst.Expr.Let(bnd, e1, e2, tpe, eff, loc)
+      TypedAst.Exp.Let(bnd, e1, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.LocalDef(sym, fparams, exp1, exp2, loc) =>
+    case KindedAst.Exp.LocalDef(sym, fparams, exp1, exp2, loc) =>
       val fps = fparams.map(visitFormalParam(_, subst))
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
@@ -191,17 +191,17 @@ object TypeReconstruction {
       val eff = e2.eff
       val boundType = Type.mkUncurriedArrowWithEffect(fps.map(_.tpe), e1.tpe, e1.eff, SourceLocation.Unknown)
       val bnd = TypedAst.Binder(sym, boundType)
-      TypedAst.Expr.LocalDef(bnd, fps, e1, e2, tpe, eff, loc)
+      TypedAst.Exp.LocalDef(bnd, fps, e1, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.Region(sym, regSym, exp, tvar, evar, loc) =>
+    case KindedAst.Exp.Region(sym, regSym, exp, tvar, evar, loc) =>
       // Use the appropriate branch for the scope.
       val e = visitExp(exp)(subst.branches.getOrElse(regSym, SubstitutionTree.empty))
       val tpe = subst(tvar)
       val eff = subst(evar)
       val bnd = TypedAst.Binder(sym, eff)
-      TypedAst.Expr.Region(bnd, regSym, e, tpe, eff, loc)
+      TypedAst.Exp.Region(bnd, regSym, e, tpe, eff, loc)
 
-    case KindedAst.Expr.Match(matchExp, rules, loc) =>
+    case KindedAst.Exp.Match(matchExp, rules, loc) =>
       val e1 = visitExp(matchExp)
       val rs = rules map {
         case KindedAst.MatchRule(pat, guard, exp, ruleLoc) =>
@@ -214,9 +214,9 @@ object TypeReconstruction {
       val eff = rs.foldLeft(e1.eff) {
         case (acc, TypedAst.MatchRule(_, g, b, _)) => Type.mkUnion(g.map(_.eff).toList ::: List(b.eff, acc), loc)
       }
-      TypedAst.Expr.Match(e1, rs, tpe, eff, loc)
+      TypedAst.Exp.Match(e1, rs, tpe, eff, loc)
 
-    case KindedAst.Expr.TypeMatch(matchExp, rules, loc) =>
+    case KindedAst.Exp.TypeMatch(matchExp, rules, loc) =>
       val e1 = visitExp(matchExp)
       val rs = rules map {
         case KindedAst.TypeMatchRule(sym, tpe0, exp, ruleLoc) =>
@@ -229,9 +229,9 @@ object TypeReconstruction {
       val eff = rs.foldLeft(e1.eff) {
         case (acc, TypedAst.TypeMatchRule(_, _, b, _)) => Type.mkUnion(b.eff, acc, loc)
       }
-      TypedAst.Expr.TypeMatch(e1, rs, tpe, eff, loc)
+      TypedAst.Exp.TypeMatch(e1, rs, tpe, eff, loc)
 
-    case KindedAst.Expr.RestrictableChoose(star, exp, rules, tvar, loc) =>
+    case KindedAst.Exp.RestrictableChoose(star, exp, rules, tvar, loc) =>
       val e = visitExp(exp)
       val rs = rules.map {
         case KindedAst.RestrictableChooseRule(pat0, body0) =>
@@ -249,164 +249,164 @@ object TypeReconstruction {
           TypedAst.RestrictableChooseRule(pat, body)
       }
       val eff = Type.mkUnion(rs.map(_.exp.eff), loc)
-      TypedAst.Expr.RestrictableChoose(star, e, rs, subst(tvar), eff, loc)
+      TypedAst.Exp.RestrictableChoose(star, e, rs, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.ExtMatch(exp, rules, loc) =>
+    case KindedAst.Exp.ExtMatch(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules.map(visitExtMatchRule)
       val tpe = rs.head.exp.tpe // Note: We are guaranteed to have at least one rule.
       val eff = Type.mkUnion(e.eff :: rs.map(_.exp.eff), loc)
-      TypedAst.Expr.ExtMatch(e, rs, tpe, eff, loc)
+      TypedAst.Exp.ExtMatch(e, rs, tpe, eff, loc)
 
-    case KindedAst.Expr.Tag(symUse, exps, tvar, loc) =>
+    case KindedAst.Exp.Tag(symUse, exps, tvar, loc) =>
       val es = exps.map(visitExp)
       val eff = Type.mkUnion(es.map(_.eff), loc)
-      TypedAst.Expr.Tag(symUse, es, subst(tvar), eff, loc)
+      TypedAst.Exp.Tag(symUse, es, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.RestrictableTag(symUse, exps, _, tvar, evar, loc) =>
+    case KindedAst.Exp.RestrictableTag(symUse, exps, _, tvar, evar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.RestrictableTag(symUse, es, subst(tvar), subst(evar), loc)
+      TypedAst.Exp.RestrictableTag(symUse, es, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.ExtTag(label, exps, tvar, loc) =>
+    case KindedAst.Exp.ExtTag(label, exps, tvar, loc) =>
       val es = exps.map(visitExp)
       val tpe = subst(tvar)
       val eff = Type.mkUnion(es.map(_.eff), loc)
-      TypedAst.Expr.ExtTag(label, es, tpe, eff, loc)
+      TypedAst.Exp.ExtTag(label, es, tpe, eff, loc)
 
-    case KindedAst.Expr.Tuple(elms, loc) =>
+    case KindedAst.Exp.Tuple(elms, loc) =>
       val es = elms.map(visitExp(_))
       val tpe = Type.mkTuple(es.map(_.tpe), loc)
       val eff = Type.mkUnion(es.map(_.eff), loc)
-      TypedAst.Expr.Tuple(es, tpe, eff, loc)
+      TypedAst.Exp.Tuple(es, tpe, eff, loc)
 
-    case KindedAst.Expr.RecordSelect(exp, field, tvar, loc) =>
+    case KindedAst.Exp.RecordSelect(exp, field, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      TypedAst.Expr.RecordSelect(e, field, subst(tvar), eff, loc)
+      TypedAst.Exp.RecordSelect(e, field, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.RecordExtend(field, value, rest, tvar, loc) =>
+    case KindedAst.Exp.RecordExtend(field, value, rest, tvar, loc) =>
       val v = visitExp(value)
       val r = visitExp(rest)
       val eff = Type.mkUnion(v.eff, r.eff, loc)
-      TypedAst.Expr.RecordExtend(field, v, r, subst(tvar), eff, loc)
+      TypedAst.Exp.RecordExtend(field, v, r, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.RecordRestrict(field, rest, tvar, loc) =>
+    case KindedAst.Exp.RecordRestrict(field, rest, tvar, loc) =>
       val r = visitExp(rest)
       val eff = r.eff
-      TypedAst.Expr.RecordRestrict(field, r, subst(tvar), eff, loc)
+      TypedAst.Exp.RecordRestrict(field, r, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.ArrayLit(exps, exp, tvar, evar, loc) =>
+    case KindedAst.Exp.ArrayLit(exps, exp, tvar, evar, loc) =>
       val es = exps.map(visitExp(_))
       val e = visitExp(exp)
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.ArrayLit(es, e, tpe, eff, loc)
+      TypedAst.Exp.ArrayLit(es, e, tpe, eff, loc)
 
-    case KindedAst.Expr.ArrayNew(exp1, exp2, exp3, tvar, evar, loc) =>
+    case KindedAst.Exp.ArrayNew(exp1, exp2, exp3, tvar, evar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.ArrayNew(e1, e2, e3, tpe, eff, loc)
+      TypedAst.Exp.ArrayNew(e1, e2, e3, tpe, eff, loc)
 
-    case KindedAst.Expr.ArrayLoad(exp1, exp2, tvar, evar, loc) =>
+    case KindedAst.Exp.ArrayLoad(exp1, exp2, tvar, evar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.ArrayLoad(e1, e2, tpe, eff, loc)
+      TypedAst.Exp.ArrayLoad(e1, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.ArrayStore(exp1, exp2, exp3, evar, loc) =>
+    case KindedAst.Exp.ArrayStore(exp1, exp2, exp3, evar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
       val eff = subst(evar)
-      TypedAst.Expr.ArrayStore(e1, e2, e3, eff, loc)
+      TypedAst.Exp.ArrayStore(e1, e2, e3, eff, loc)
 
-    case KindedAst.Expr.ArrayLength(exp, evar, loc) =>
+    case KindedAst.Exp.ArrayLength(exp, evar, loc) =>
       val e = visitExp(exp)
       val eff = subst(evar)
-      TypedAst.Expr.ArrayLength(e, eff, loc)
+      TypedAst.Exp.ArrayLength(e, eff, loc)
 
-    case KindedAst.Expr.StructNew(sym, fields0, region0, tvar, evar, loc) =>
+    case KindedAst.Exp.StructNew(sym, fields0, region0, tvar, evar, loc) =>
       val region = visitExp(region0)
       val fields = fields0.map { case (k, v) => (k, visitExp(v)) }
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.StructNew(sym, fields, region, tpe, eff, loc)
+      TypedAst.Exp.StructNew(sym, fields, region, tpe, eff, loc)
 
-    case KindedAst.Expr.StructGet(e0, symUse, tvar, evar, loc) =>
+    case KindedAst.Exp.StructGet(e0, symUse, tvar, evar, loc) =>
       val e = visitExp(e0)
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.StructGet(e, symUse, tpe, eff, loc)
+      TypedAst.Exp.StructGet(e, symUse, tpe, eff, loc)
 
-    case KindedAst.Expr.StructPut(exp1, symUse, exp2, tvar, evar, loc) =>
+    case KindedAst.Exp.StructPut(exp1, symUse, exp2, tvar, evar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.StructPut(e1, symUse, e2, tpe, eff, loc)
+      TypedAst.Exp.StructPut(e1, symUse, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.VectorLit(exps, tvar, evar, loc) =>
+    case KindedAst.Exp.VectorLit(exps, tvar, evar, loc) =>
       val es = exps.map(visitExp(_))
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.VectorLit(es, tpe, eff, loc)
+      TypedAst.Exp.VectorLit(es, tpe, eff, loc)
 
-    case KindedAst.Expr.VectorLoad(exp1, exp2, tvar, evar, loc) =>
+    case KindedAst.Exp.VectorLoad(exp1, exp2, tvar, evar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.VectorLoad(e1, e2, tpe, eff, loc)
+      TypedAst.Exp.VectorLoad(e1, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.VectorLength(exp, loc) =>
+    case KindedAst.Exp.VectorLength(exp, loc) =>
       val e = visitExp(exp)
-      TypedAst.Expr.VectorLength(e, loc)
+      TypedAst.Exp.VectorLength(e, loc)
 
-    case KindedAst.Expr.Ascribe(exp, expectedType, expectedEff, tvar, loc) =>
+    case KindedAst.Exp.Ascribe(exp, expectedType, expectedEff, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      TypedAst.Expr.Ascribe(e, expectedType, expectedEff, subst(tvar), eff, loc)
+      TypedAst.Exp.Ascribe(e, expectedType, expectedEff, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.InstanceOf(exp, clazz, loc) =>
+    case KindedAst.Exp.InstanceOf(exp, clazz, loc) =>
       val e1 = visitExp(exp)
-      TypedAst.Expr.InstanceOf(e1, clazz, loc)
+      TypedAst.Exp.InstanceOf(e1, clazz, loc)
 
-    case KindedAst.Expr.CheckedCast(cast, exp, tvar, evar, loc) =>
+    case KindedAst.Exp.CheckedCast(cast, exp, tvar, evar, loc) =>
       cast match {
         case CheckedCastType.TypeCast =>
           val e = visitExp(exp)
           val tpe = subst(tvar)
-          TypedAst.Expr.CheckedCast(cast, e, tpe, e.eff, loc)
+          TypedAst.Exp.CheckedCast(cast, e, tpe, e.eff, loc)
         case CheckedCastType.EffectCast =>
           val e = visitExp(exp)
           val eff = Type.mkUnion(e.eff, subst(evar), loc)
-          TypedAst.Expr.CheckedCast(cast, e, e.tpe, eff, loc)
+          TypedAst.Exp.CheckedCast(cast, e, e.tpe, eff, loc)
       }
 
-    case KindedAst.Expr.UncheckedCast(exp, declaredType0, declaredEff0, tvar, loc) =>
+    case KindedAst.Exp.UncheckedCast(exp, declaredType0, declaredEff0, tvar, loc) =>
       val e = visitExp(exp)
       val declaredType = declaredType0.map(tpe => subst(tpe))
       val declaredEff = declaredEff0.map(eff => subst(eff))
       val tpe = subst(tvar)
       val eff = declaredEff0.getOrElse(e.eff)
-      TypedAst.Expr.UncheckedCast(e, declaredType, declaredEff, tpe, eff, loc)
+      TypedAst.Exp.UncheckedCast(e, declaredType, declaredEff, tpe, eff, loc)
 
-    case KindedAst.Expr.Unsafe(exp, eff0, loc) =>
+    case KindedAst.Exp.Unsafe(exp, eff0, loc) =>
       val e = visitExp(exp)
       val eff = Type.mkDifference(e.eff, eff0, loc)
-      TypedAst.Expr.Unsafe(e, eff0, e.tpe, eff, loc)
+      TypedAst.Exp.Unsafe(e, eff0, e.tpe, eff, loc)
 
-    case KindedAst.Expr.Without(exp, symUse, loc) =>
+    case KindedAst.Exp.Without(exp, symUse, loc) =>
       val e = visitExp(exp)
       val tpe = e.tpe
       val eff = e.eff
-      TypedAst.Expr.Without(e, symUse, tpe, eff, loc)
+      TypedAst.Exp.Without(e, symUse, tpe, eff, loc)
 
-    case KindedAst.Expr.TryCatch(exp, rules, loc) =>
+    case KindedAst.Exp.TryCatch(exp, rules, loc) =>
       val e = visitExp(exp)
       val rs = rules map {
         case KindedAst.CatchRule(sym, clazz, body, ruleLoc) =>
@@ -416,15 +416,15 @@ object TypeReconstruction {
       }
       val tpe = rs.head.exp.tpe
       val eff = Type.mkUnion(e.eff :: rs.map(_.exp.eff), loc)
-      TypedAst.Expr.TryCatch(e, rs, tpe, eff, loc)
+      TypedAst.Exp.TryCatch(e, rs, tpe, eff, loc)
 
-    case KindedAst.Expr.Throw(exp, tvar, evar, loc) =>
+    case KindedAst.Exp.Throw(exp, tvar, evar, loc) =>
       val e = visitExp(exp)
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.Throw(e, tpe, eff, loc)
+      TypedAst.Exp.Throw(e, tpe, eff, loc)
 
-    case KindedAst.Expr.Handler(effectSymUse, rules, tvar, evar1, evar2, loc) =>
+    case KindedAst.Exp.Handler(effectSymUse, rules, tvar, evar1, evar2, loc) =>
       val rs = rules map {
         case KindedAst.HandlerRule(opSymUse, fparams, hexp, _, ruleLoc) =>
           val fps = fparams.map(visitFormalParam(_, subst))
@@ -435,14 +435,14 @@ object TypeReconstruction {
       val bodyEff = subst(evar1)
       val handledEff = subst(evar2)
       val tpe = Type.mkArrowWithEffect(Type.mkArrowWithEffect(Type.Unit, bodyEff, bodyTpe, loc.asSynthetic), handledEff, bodyTpe, loc.asSynthetic)
-      TypedAst.Expr.Handler(effectSymUse, rs, bodyTpe, bodyEff, handledEff, tpe, loc)
+      TypedAst.Exp.Handler(effectSymUse, rs, bodyTpe, bodyEff, handledEff, tpe, loc)
 
-    case KindedAst.Expr.RunWith(exp1, exp2, tvar, evar, loc) =>
+    case KindedAst.Exp.RunWith(exp1, exp2, tvar, evar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      TypedAst.Expr.RunWith(e1, e2, subst(tvar), Type.mkUnion(subst(evar), e2.eff, loc.asSynthetic), loc)
+      TypedAst.Exp.RunWith(e1, e2, subst(tvar), Type.mkUnion(subst(evar), e2.eff, loc.asSynthetic), loc)
 
-    case KindedAst.Expr.InvokeConstructor(clazz, exps, jvar, evar, loc) =>
+    case KindedAst.Exp.InvokeConstructor(clazz, exps, jvar, evar, loc) =>
       val es0 = exps.map(visitExp)
       val constructorTpe = subst(jvar)
       val tpe = Type.getFlixType(clazz)
@@ -450,12 +450,12 @@ object TypeReconstruction {
       constructorTpe match {
         case Type.Cst(TypeConstructor.JvmConstructor(constructor), _) =>
           val es = getArgumentsWithVarArgs(constructor, es0, loc)
-          TypedAst.Expr.InvokeConstructor(constructor, es, tpe, eff, loc)
+          TypedAst.Exp.InvokeConstructor(constructor, es, tpe, eff, loc)
         case _ =>
-          TypedAst.Expr.Error(TypeError.UnresolvedConstructor(loc), tpe, eff)
+          TypedAst.Exp.Error(TypeError.UnresolvedConstructor(loc), tpe, eff)
       }
 
-    case KindedAst.Expr.InvokeMethod(exp, _, exps, jvar, tvar, evar, loc) =>
+    case KindedAst.Exp.InvokeMethod(exp, _, exps, jvar, tvar, evar, loc) =>
       val e = visitExp(exp)
       val es0 = exps.map(visitExp)
       val returnTpe = subst(tvar)
@@ -464,12 +464,12 @@ object TypeReconstruction {
       methodTpe match {
         case Type.Cst(TypeConstructor.JvmMethod(method), methLoc) =>
           val es = getArgumentsWithVarArgs(method, es0, methLoc)
-          TypedAst.Expr.InvokeMethod(method, e, es, returnTpe, eff, methLoc)
+          TypedAst.Exp.InvokeMethod(method, e, es, returnTpe, eff, methLoc)
         case _ =>
-          TypedAst.Expr.Error(TypeError.UnresolvedMethod(loc), methodTpe, eff)
+          TypedAst.Exp.Error(TypeError.UnresolvedMethod(loc), methodTpe, eff)
       }
 
-    case KindedAst.Expr.InvokeStaticMethod(_, _, exps, jvar, tvar, evar, loc) =>
+    case KindedAst.Exp.InvokeStaticMethod(_, _, exps, jvar, tvar, evar, loc) =>
       val es0 = exps.map(visitExp)
       val methodTpe = subst(jvar)
       val returnTpe = subst(tvar)
@@ -477,63 +477,63 @@ object TypeReconstruction {
       methodTpe match {
         case Type.Cst(TypeConstructor.JvmMethod(method), methLoc) =>
           val es = getArgumentsWithVarArgs(method, es0, methLoc)
-          TypedAst.Expr.InvokeStaticMethod(method, es, returnTpe, eff, methLoc)
+          TypedAst.Exp.InvokeStaticMethod(method, es, returnTpe, eff, methLoc)
         case _ =>
-          TypedAst.Expr.Error(TypeError.UnresolvedStaticMethod(loc), methodTpe, eff)
+          TypedAst.Exp.Error(TypeError.UnresolvedStaticMethod(loc), methodTpe, eff)
       }
 
-    case KindedAst.Expr.GetField(exp, _, jvar, tvar, evar, loc) =>
+    case KindedAst.Exp.GetField(exp, _, jvar, tvar, evar, loc) =>
       val e = visitExp(exp)
       val fieldType = subst(tvar)
       val jvarType = subst(jvar)
       val eff = subst(evar)
       jvarType match {
         case Type.Cst(TypeConstructor.JvmField(field), fieldLoc) =>
-          TypedAst.Expr.GetField(field, e, fieldType, eff, fieldLoc)
+          TypedAst.Exp.GetField(field, e, fieldType, eff, fieldLoc)
         case _ =>
-          TypedAst.Expr.Error(TypeError.UnresolvedField(loc), jvarType, eff)
+          TypedAst.Exp.Error(TypeError.UnresolvedField(loc), jvarType, eff)
       }
 
-    case KindedAst.Expr.PutField(field, _, exp1, exp2, loc) =>
+    case KindedAst.Exp.PutField(field, _, exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val tpe = Type.Unit
       val eff = Type.mkUnion(e1.eff, e2.eff, Type.IO, loc)
-      TypedAst.Expr.PutField(field, e1, e2, tpe, eff, loc)
+      TypedAst.Exp.PutField(field, e1, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.GetStaticField(field, loc) =>
+    case KindedAst.Exp.GetStaticField(field, loc) =>
       val tpe = getFlixType(field.getType)
       val eff = Type.IO
-      TypedAst.Expr.GetStaticField(field, tpe, eff, loc)
+      TypedAst.Exp.GetStaticField(field, tpe, eff, loc)
 
-    case KindedAst.Expr.PutStaticField(field, exp, loc) =>
+    case KindedAst.Exp.PutStaticField(field, exp, loc) =>
       val e = visitExp(exp)
       val tpe = Type.Unit
       val eff = Type.mkUnion(e.eff, Type.IO, loc)
-      TypedAst.Expr.PutStaticField(field, e, tpe, eff, loc)
+      TypedAst.Exp.PutStaticField(field, e, tpe, eff, loc)
 
-    case KindedAst.Expr.NewObject(name, clazz, methods, loc) =>
+    case KindedAst.Exp.NewObject(name, clazz, methods, loc) =>
       val tpe = getFlixType(clazz)
       val eff = Type.IO
       val ms = methods map visitJvmMethod
-      TypedAst.Expr.NewObject(name, clazz, tpe, eff, ms, loc)
+      TypedAst.Exp.NewObject(name, clazz, tpe, eff, ms, loc)
 
-    case KindedAst.Expr.NewChannel(exp, tvar, loc) =>
+    case KindedAst.Exp.NewChannel(exp, tvar, loc) =>
       val e = visitExp(exp)
       val eff = Type.mkUnion(e.eff, Type.Chan, loc)
-      TypedAst.Expr.NewChannel(e, subst(tvar), eff, loc)
+      TypedAst.Exp.NewChannel(e, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.GetChannel(exp, tvar, evar, loc) =>
+    case KindedAst.Exp.GetChannel(exp, tvar, evar, loc) =>
       val e = visitExp(exp)
-      TypedAst.Expr.GetChannel(e, subst(tvar), subst(evar), loc)
+      TypedAst.Exp.GetChannel(e, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.PutChannel(exp1, exp2, evar, loc) =>
+    case KindedAst.Exp.PutChannel(exp1, exp2, evar, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val tpe = Type.mkUnit(loc)
-      TypedAst.Expr.PutChannel(e1, e2, tpe, subst(evar), loc)
+      TypedAst.Exp.PutChannel(e1, e2, tpe, subst(evar), loc)
 
-    case KindedAst.Expr.SelectChannel(rules, default, tvar, evar, loc) =>
+    case KindedAst.Exp.SelectChannel(rules, default, tvar, evar, loc) =>
       val rs = rules map {
         case KindedAst.SelectChannelRule(sym, chan, exp, ruleLoc) =>
           val c = visitExp(chan)
@@ -542,16 +542,16 @@ object TypeReconstruction {
           TypedAst.SelectChannelRule(bnd, c, b, ruleLoc)
       }
       val d = default.map(visitExp(_))
-      TypedAst.Expr.SelectChannel(rs, d, subst(tvar), subst(evar), loc)
+      TypedAst.Exp.SelectChannel(rs, d, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.Spawn(exp1, exp2, loc) =>
+    case KindedAst.Exp.Spawn(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val tpe = Type.Unit
       val eff = Type.mkUnion(e1.eff, e2.eff, loc)
-      TypedAst.Expr.Spawn(e1, e2, tpe, eff, loc)
+      TypedAst.Exp.Spawn(e1, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.ParYield(frags, exp, loc) =>
+    case KindedAst.Exp.ParYield(frags, exp, loc) =>
       val e = visitExp(exp)
       val fs = frags map {
         case KindedAst.ParYieldFragment(pat, e0, l0) =>
@@ -563,44 +563,44 @@ object TypeReconstruction {
       val eff = fs.foldLeft(e.eff) {
         case (acc, TypedAst.ParYieldFragment(_, e1, _)) => Type.mkUnion(acc, e1.eff, loc)
       }
-      TypedAst.Expr.ParYield(fs, e, tpe, eff, loc)
+      TypedAst.Exp.ParYield(fs, e, tpe, eff, loc)
 
-    case KindedAst.Expr.Lazy(exp, loc) =>
+    case KindedAst.Exp.Lazy(exp, loc) =>
       val e = visitExp(exp)
       val tpe = Type.mkLazy(e.tpe, loc)
-      TypedAst.Expr.Lazy(e, tpe, loc)
+      TypedAst.Exp.Lazy(e, tpe, loc)
 
-    case KindedAst.Expr.Force(exp, tvar, loc) =>
+    case KindedAst.Exp.Force(exp, tvar, loc) =>
       val e = visitExp(exp)
       val tpe = subst(tvar)
       val eff = e.eff
-      TypedAst.Expr.Force(e, tpe, eff, loc)
+      TypedAst.Exp.Force(e, tpe, eff, loc)
 
-    case KindedAst.Expr.FixpointConstraintSet(cs0, tvar, loc) =>
+    case KindedAst.Exp.FixpointConstraintSet(cs0, tvar, loc) =>
       val cs = cs0.map(visitConstraint)
-      TypedAst.Expr.FixpointConstraintSet(cs, subst(tvar), loc)
+      TypedAst.Exp.FixpointConstraintSet(cs, subst(tvar), loc)
 
-    case KindedAst.Expr.FixpointLambda(pparams, exp, tvar, loc) =>
+    case KindedAst.Exp.FixpointLambda(pparams, exp, tvar, loc) =>
       val ps = pparams.map(visitPredicateParam)
       val e = visitExp(exp)
       val tpe = subst(tvar)
       val eff = e.eff
-      TypedAst.Expr.FixpointLambda(ps, e, tpe, eff, loc)
+      TypedAst.Exp.FixpointLambda(ps, e, tpe, eff, loc)
 
-    case KindedAst.Expr.FixpointMerge(exp1, exp2, loc) =>
+    case KindedAst.Exp.FixpointMerge(exp1, exp2, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val tpe = e1.tpe
       val eff = Type.mkUnion(e1.eff, e2.eff, loc)
-      TypedAst.Expr.FixpointMerge(e1, e2, tpe, eff, loc)
+      TypedAst.Exp.FixpointMerge(e1, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.FixpointQueryWithProvenance(exps, select, withh, tvar, loc) =>
+    case KindedAst.Exp.FixpointQueryWithProvenance(exps, select, withh, tvar, loc) =>
       val es = exps.map(visitExp)
       val s = visitHeadPredicate(select)
       val eff = Type.mkUnion(es.map(_.eff), loc)
-      TypedAst.Expr.FixpointQueryWithProvenance(es, s, withh, subst(tvar), eff, loc)
+      TypedAst.Exp.FixpointQueryWithProvenance(es, s, withh, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, tvar, loc) =>
+    case KindedAst.Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, tvar, loc) =>
       val es = exps.map(visitExp)
       val qe = visitExp(queryExp)
       val ss = selects.map(visitExp)
@@ -608,35 +608,35 @@ object TypeReconstruction {
       val w = where.map(visitExp)
       val effs = es.map(_.eff) ::: ss.map(_.eff) ::: w.map(_.eff)
       val eff = Type.mkUnion(effs, loc)
-      TypedAst.Expr.FixpointQueryWithSelect(es, qe, ss, f, w, pred, subst(tvar), eff, loc)
+      TypedAst.Exp.FixpointQueryWithSelect(es, qe, ss, f, w, pred, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.FixpointSolveWithProject(exps, optPreds, mode, tvar, loc) =>
+    case KindedAst.Exp.FixpointSolveWithProject(exps, optPreds, mode, tvar, loc) =>
       val es = exps.map(visitExp)
       val tpe = subst(tvar)
       val eff = Type.mkUnion(es.map(_.eff), loc)
-      TypedAst.Expr.FixpointSolveWithProject(es, optPreds, mode, tpe, eff, loc)
+      TypedAst.Exp.FixpointSolveWithProject(es, optPreds, mode, tpe, eff, loc)
 
-    case KindedAst.Expr.FixpointInjectInto(exps, predsAndArities, tvar, evar, loc) =>
+    case KindedAst.Exp.FixpointInjectInto(exps, predsAndArities, tvar, evar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.FixpointInjectInto(es, predsAndArities, subst(tvar), subst(evar), loc)
+      TypedAst.Exp.FixpointInjectInto(es, predsAndArities, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.Error(m, tvar, evar) =>
+    case KindedAst.Exp.Error(m, tvar, evar) =>
       val tpe = subst(tvar)
       val eff = subst(evar)
-      TypedAst.Expr.Error(m, tpe, eff)
+      TypedAst.Exp.Error(m, tpe, eff)
   }
 
   /**
     * Returns the given arguments `es` possibly with an empty VarArgs array added as the last argument.
     */
-  private def getArgumentsWithVarArgs(exc: Executable, es: List[TypedAst.Expr], loc: SourceLocation): List[TypedAst.Expr] = {
+  private def getArgumentsWithVarArgs(exc: Executable, es: List[TypedAst.Exp], loc: SourceLocation): List[TypedAst.Exp] = {
     val declaredArity = exc.getParameterCount
     val actualArity = es.length
     // Check if (a) an argument is missing and (b) the constructor/method is VarArgs.
     if (actualArity == declaredArity - 1 && exc.isVarArgs) {
       // Case 1: Argument missing. Introduce a new empty vector argument.
       val varArgsType = Type.mkNative(exc.getParameterTypes.last.getComponentType, loc)
-      val varArgs = TypedAst.Expr.VectorLit(Nil, Type.mkVector(varArgsType, loc), Type.Pure, loc)
+      val varArgs = TypedAst.Exp.VectorLit(Nil, Type.mkVector(varArgsType, loc), Type.Pure, loc)
       es ::: varArgs :: Nil
     } else {
       // Case 2: No argument missing. Return the arguments as-is.

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -50,7 +50,7 @@ object CodeHinter {
     * @param root The root AST node of the Flix project
     * @return A collection of code quality hints.
     */
-  private def visitApplyDef(sym: Symbol.DefnSym, exps: List[Expr])(implicit root: Root): List[CodeHint] = {
+  private def visitApplyDef(sym: Symbol.DefnSym, exps: List[Exp])(implicit root: Root): List[CodeHint] = {
     exps.flatMap(e => checkEffect(sym, e.tpe, e.loc))
   }
 
@@ -107,7 +107,7 @@ object CodeHinter {
     * @param enumOccurs     All occurrences of enums.
     * @param traitOccurs    All occurrences of traits.
     */
-  private case class Occurrences(applyDefOccurs: List[(Symbol.DefnSym, List[Expr])], defOccurs: List[DefSymUse], enumOccurs: List[(Symbol.EnumSym, SourceLocation)], traitOccurs: List[TraitSymUse])
+  private case class Occurrences(applyDefOccurs: List[(Symbol.DefnSym, List[Exp])], defOccurs: List[DefSymUse], enumOccurs: List[(Symbol.EnumSym, SourceLocation)], traitOccurs: List[TraitSymUse])
 
   /**
     * Returns a [[Occurrences]] for the Flix project.
@@ -116,7 +116,7 @@ object CodeHinter {
     * @return A [[Occurrences]] for the Flix project.
     */
   private def getOccurrences(implicit root: Root): Occurrences = {
-    var applyDefOccurs: List[(Symbol.DefnSym, List[Expr])] = Nil
+    var applyDefOccurs: List[(Symbol.DefnSym, List[Exp])] = Nil
     var defOccurs: List[DefSymUse] = Nil
     var enumOccurs: List[(Symbol.EnumSym, SourceLocation)] = Nil
     var traitOccurs: List[TraitSymUse] = Nil
@@ -126,8 +126,8 @@ object CodeHinter {
 
       override def consumeDefSymUse(symUse: DefSymUse): Unit = defOccurs = symUse :: defOccurs
 
-      override def consumeExpr(exp: Expr): Unit = exp match {
-        case TypedAst.Expr.ApplyDef(symUse, exps, _, _, _, _, _) => applyDefOccurs = (symUse.sym, exps) :: applyDefOccurs
+      override def consumeExpr(exp: Exp): Unit = exp match {
+        case TypedAst.Exp.ApplyDef(symUse, exps, _, _, _, _, _) => applyDefOccurs = (symUse.sym, exps) :: applyDefOccurs
         case _ => ()
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -60,7 +60,7 @@ object GenFunAndClosureClasses {
 
   private def isFunction(defn: Def): Boolean = defn.cparams.isEmpty
 
-  private def isControlPure(defn: Def): Boolean = Purity.isControlPure(defn.expr.purity)
+  private def isControlPure(defn: Def): Boolean = Purity.isControlPure(defn.exp.purity)
 
   /**
     * Generates the following code for control-pure functions.
@@ -283,7 +283,7 @@ object GenFunAndClosureClasses {
     val localOffset = 0
     val labelEnv = Map.empty[Symbol.LabelSym, Label]
     val ctx = GenExpression.DirectStaticContext(enterLabel, labelEnv, localOffset)
-    GenExpression.compileExpr(defn.expr)(m, ctx, root, flix)
+    GenExpression.compileExpr(defn.exp)(m, ctx, root, flix)
 
     BytecodeInstructions.xReturn(BackendObjType.Result.toTpe)
 
@@ -361,9 +361,9 @@ object GenFunAndClosureClasses {
     loadParamsOf(cparams)
     loadParamsOf(fparams)
 
-    if (Purity.isControlPure(defn.expr.purity)) {
+    if (Purity.isControlPure(defn.exp.purity)) {
       val ctx = GenExpression.DirectInstanceContext(enterLabel, Map.empty, localOffset)
-      GenExpression.compileExpr(defn.expr)(m, ctx, root, flix)
+      GenExpression.compileExpr(defn.exp)(m, ctx, root, flix)
     } else {
       val pcLabels: Vector[Label] = Vector.range(0, defn.pcPoints).map(_ => new Label())
       if (defn.pcPoints > 0) {
@@ -400,7 +400,7 @@ object GenFunAndClosureClasses {
       }
 
       val ctx = GenExpression.EffectContext(enterLabel, Map.empty, newFrame, setPc, localOffset, pcLabels.prepended(null), Array(0))
-      GenExpression.compileExpr(defn.expr)(m, ctx, root, flix)
+      GenExpression.compileExpr(defn.exp)(m, ctx, root, flix)
       assert(ctx.pcCounter(0) == pcLabels.size, s"${(className, ctx.pcCounter(0), pcLabels.size)}")
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/RestrictableChooseConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/RestrictableChooseConstraintGen.scala
@@ -36,14 +36,14 @@ object RestrictableChooseConstraintGen {
     *
     * {{{
     *     match x {
-    *         case Expr.Var(y) => Expr.Cst(22)
-    *         case Expr.Xor(y, z) => Expr.Xor(y, z)
-    *         case Expr.Cst(y)    => Expr.Cst(y)
-    *         case Expr.And(y, z) => Expr.Or(x, y)
+    *         case Exp.Var(y) => Exp.Cst(22)
+    *         case Exp.Xor(y, z) => Exp.Xor(y, z)
+    *         case Exp.Cst(y)    => Exp.Cst(y)
+    *         case Exp.And(y, z) => Exp.Or(x, y)
     *     }
     * }}}
     *
-    * then it returns { Expr.Var, Expr.Xor, Expr.Cst, Expr.And }.
+    * then it returns { Exp.Var, Exp.Xor, Exp.Cst, Exp.And }.
     */
   private def dom(rules: List[KindedAst.RestrictableChooseRule]): Set[Symbol.RestrictableCaseSym] = {
     rules.flatMap {
@@ -71,11 +71,11 @@ object RestrictableChooseConstraintGen {
   /**
     * Performs type inference on the given restrictable choose expression.
     */
-  def visitRestrictableChoose(exp: KindedAst.Expr.RestrictableChoose)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitRestrictableChoose(exp: KindedAst.Exp.RestrictableChoose)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
 
     exp match {
-      case KindedAst.Expr.RestrictableChoose(false, exp0, rules0, tpe0, loc) =>
+      case KindedAst.Exp.RestrictableChoose(false, exp0, rules0, tpe0, loc) =>
 
         // Get the enum symbols for the matched type
         rules0.headOption match {
@@ -117,7 +117,7 @@ object RestrictableChooseConstraintGen {
           }
         }
 
-      case KindedAst.Expr.RestrictableChoose(true, exp0, rules0, tpe0, loc) =>
+      case KindedAst.Exp.RestrictableChoose(true, exp0, rules0, tpe0, loc) =>
 
         // Get the enum symbols for the matched type
         rules0.headOption match {
@@ -191,9 +191,9 @@ object RestrictableChooseConstraintGen {
   /**
     * Performs type inference on the given restrictable tag expression.
     */
-  def visitApplyRestrictableTag(exp: KindedAst.Expr.RestrictableTag)(implicit scope: Scope, c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitApplyRestrictableTag(exp: KindedAst.Exp.RestrictableTag)(implicit scope: Scope, c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     exp match {
-      case KindedAst.Expr.RestrictableTag(symUse, exps, isOpen, tvar, evar, loc) =>
+      case KindedAst.Exp.RestrictableTag(symUse, exps, isOpen, tvar, evar, loc) =>
 
         // Lookup the enum declaration.
         val enumSym = symUse.sym.enumSym
@@ -268,10 +268,10 @@ object RestrictableChooseConstraintGen {
     * -------------------------------------
     * Γ ⊢ open_as X e : X[s + φ][α1 ... αn]
     */
-  def visitOpenAs(exp0: KindedAst.Expr.OpenAs)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitOpenAs(exp0: KindedAst.Exp.OpenAs)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
     exp0 match {
-      case KindedAst.Expr.OpenAs(RestrictableEnumSymUse(sym, _), exp, tvar, loc) =>
+      case KindedAst.Exp.OpenAs(RestrictableEnumSymUse(sym, _), exp, tvar, loc) =>
         val `enum` = root.restrictableEnums(sym)
 
         val (enumType, indexVar, targs) = instantiatedEnumType(`enum`, loc.asSynthetic)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
@@ -26,10 +26,10 @@ import ca.uwaterloo.flix.util.InternalCompilerException
 
 object SchemaConstraintGen {
 
-  def visitFixpointConstraintSet(e: KindedAst.Expr.FixpointConstraintSet)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitFixpointConstraintSet(e: KindedAst.Exp.FixpointConstraintSet)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
     e match {
-      case KindedAst.Expr.FixpointConstraintSet(cs, tvar, loc) =>
+      case KindedAst.Exp.FixpointConstraintSet(cs, tvar, loc) =>
         val constraintTypes = cs.map(visitConstraint)
         c.unifyAllTypes(constraintTypes, loc)
         val schemaRow = constraintTypes.headOption.getOrElse(Type.freshVar(Kind.SchemaRow, loc))
@@ -40,10 +40,10 @@ object SchemaConstraintGen {
     }
   }
 
-  def visitFixpointLambda(e: KindedAst.Expr.FixpointLambda)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitFixpointLambda(e: KindedAst.Exp.FixpointLambda)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
     e match {
-      case KindedAst.Expr.FixpointLambda(pparams, exp, tvar, loc) =>
+      case KindedAst.Exp.FixpointLambda(pparams, exp, tvar, loc) =>
 
         def mkRowExtend(pparam: KindedAst.PredicateParam, restRow: Type): Type = pparam match {
           case KindedAst.PredicateParam(pred, paramTpe, _) => Type.mkSchemaRowExtend(pred, paramTpe, restRow, paramTpe.loc)
@@ -63,10 +63,10 @@ object SchemaConstraintGen {
     }
   }
 
-  def visitFixpointMerge(e: KindedAst.Expr.FixpointMerge)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitFixpointMerge(e: KindedAst.Exp.FixpointMerge)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
     e match {
-      case KindedAst.Expr.FixpointMerge(exp1, exp2, loc) =>
+      case KindedAst.Exp.FixpointMerge(exp1, exp2, loc) =>
         //
         //  exp1 : #{...}    exp2 : #{...}
         //  ------------------------------
@@ -81,10 +81,10 @@ object SchemaConstraintGen {
     }
   }
 
-  def visitFixpointQueryWithProvenance(e: KindedAst.Expr.FixpointQueryWithProvenance)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitFixpointQueryWithProvenance(e: KindedAst.Exp.FixpointQueryWithProvenance)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
     e match {
-      case KindedAst.Expr.FixpointQueryWithProvenance(exps, select, withh, tvar, loc1) =>
+      case KindedAst.Exp.FixpointQueryWithProvenance(exps, select, withh, tvar, loc1) =>
         val (tpes, effs) = exps.map(visitExp).unzip
         val selectRow = visitHeadPredicate(select)
         val (withRow, resultRow) = mkSchemaRowPair(withh, loc1)
@@ -96,10 +96,10 @@ object SchemaConstraintGen {
     }
   }
 
-  def visitFixpointQueryWithSelect(e: KindedAst.Expr.FixpointQueryWithSelect)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitFixpointQueryWithSelect(e: KindedAst.Exp.FixpointQueryWithSelect)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
     e match {
-      case KindedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, _, pred, tvar, loc) =>
+      case KindedAst.Exp.FixpointQueryWithSelect(exps, queryExp, selects, _, _, pred, tvar, loc) =>
         //
         //  exp = exps[0] <+> exps[1] <+> ... (exp is conceptual; it does not actually exist)
         //
@@ -125,10 +125,10 @@ object SchemaConstraintGen {
     }
   }
 
-  def visitFixpointSolveWithProject(e: KindedAst.Expr.FixpointSolveWithProject)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitFixpointSolveWithProject(e: KindedAst.Exp.FixpointSolveWithProject)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
     e match {
-      case KindedAst.Expr.FixpointSolveWithProject(exps, optPreds, _, tvar, loc) =>
+      case KindedAst.Exp.FixpointSolveWithProject(exps, optPreds, _, tvar, loc) =>
         //
         //  exp = exps₁ <+> exps₂ <+> ... <+> expsₘ
         //
@@ -154,10 +154,10 @@ object SchemaConstraintGen {
     }
   }
 
-  def visitFixpointInjectInto(e: KindedAst.Expr.FixpointInjectInto)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  def visitFixpointInjectInto(e: KindedAst.Exp.FixpointInjectInto)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
     e match {
-      case KindedAst.Expr.FixpointInjectInto(exps, predsAndArities, tvar, evar, loc) =>
+      case KindedAst.Exp.FixpointInjectInto(exps, predsAndArities, tvar, evar, loc) =>
         predsAndArities.zip(exps).foreach {
           case (PredicateAndArity(pred, arity), exp) =>
             //

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/SetFormula.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/SetFormula.scala
@@ -326,11 +326,11 @@ object SetFormula {
     * The case set bounds include what cases the set will always have and
     * cases the set can maximally have.
     * {{{
-    * formatLowerAndUpperBounds(Expr[s ++ <Expr.Cst>][Int32]) =
+    * formatLowerAndUpperBounds(Exp[s ++ <Exp.Cst>][Int32]) =
     *     Lowerbound: {Cst}
     *     Upperbound: {Cst, Var, Not, And, Or, Xor}
     *
-    * formatLowerAndUpperBounds(Expr[s1 -- s2 -- <Expr.Xor, Expr.And> ++ <Expr.Cst, Expr.Not>]) =
+    * formatLowerAndUpperBounds(Exp[s1 -- s2 -- <Exp.Xor, Exp.And> ++ <Exp.Cst, Exp.Not>]) =
     *     Lowerbound: {Cst, Not}
     *     Upperbound: {Cst, Var, Not, Or}
     * }}}
@@ -345,11 +345,11 @@ object SetFormula {
     * include what cases the set will always have and what cases the set can
     * maximally have.
     * {{{
-    * restrictableEnumBounds(Expr[s ++ <Expr.Cst>][Int32]) =
+    * restrictableEnumBounds(Exp[s ++ <Exp.Cst>][Int32]) =
     *     Lowerbound: {Cst}
     *     Upperbound: {Cst, Var, Not, And, Or, Xor}
     *
-    * restrictableEnumBounds(Expr[s1 -- s2 -- <Expr.Xor, Expr.And> ++ <Expr.Cst, Expr.Not>]) =
+    * restrictableEnumBounds(Exp[s1 -- s2 -- <Exp.Xor, Exp.And> ++ <Exp.Cst, Exp.Not>]) =
     *     Lowerbound: {Cst, Not}
     *     Upperbound: {Cst, Var, Not, Or}
     * }}}
@@ -388,10 +388,10 @@ object SetFormula {
     * always be present (lowerBound) and which cases that can maximally be
     * present (upperBound).
     * {{{
-    * boundsAnalysisType(s ++ <Expr.Cst>) =
+    * boundsAnalysisType(s ++ <Exp.Cst>) =
     *     Some(({Cst}, {Cst, Var, Not, And, Or, Xor}))
     *
-    * boundsAnalysisType(s1 -- s2 -- <Expr.Xor, Expr.And> ++ <Expr.Cst, Expr.Not>) =
+    * boundsAnalysisType(s1 -- s2 -- <Exp.Xor, Exp.And> ++ <Exp.Cst, Exp.Not>) =
     *     Some(({Cst, Not}, {Cst, Var, Not, Or}))
     *
     * boundsAnalysisType(Int32) = None

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/zhegalkin/ZhegalkinExpr.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/zhegalkin/ZhegalkinExpr.scala
@@ -311,7 +311,7 @@ object ZhegalkinExpr {
 
 }
 
-/** Represents a Zhegalkin expr: c ⊕ t1 ⊕ t2 ⊕ ... ⊕ tn */
+/** Represents a Zhegalkin exp: c ⊕ t1 ⊕ t2 ⊕ ... ⊕ tn */
 case class ZhegalkinExpr[T](cst: T, terms: List[ZhegalkinTerm[T]]) {
 
   // Representation Invariants:

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Category.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Category.scala
@@ -32,7 +32,7 @@ object Category {
   /**
     * Represents source code that is an expression.
     */
-  case object Expr extends Category
+  case object Exp extends Category
 
   /**
     * Represents source code whose category cannot be determined.
@@ -52,7 +52,7 @@ object Category {
       val start = tokens(0).kind
       (start.isFirstInDecl, start.isFirstInExp) match {
         case (true, _) => Category.Decl
-        case (_, true) => Category.Expr
+        case (_, true) => Category.Exp
         case _ => Category.Unknown
       }
     } else {

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -302,7 +302,7 @@ class Shell(bootstrap: Bootstrap, options: Options) {
             w.println("Error: Declaration ignored due to previous error(s).")
         }
 
-      case Category.Expr =>
+      case Category.Exp =>
         // The input is an expression. Wrap it in main and run it.
 
         // The name of the generated main function.

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.tools
 
-import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, ExtMatchRule, Root}
+import ca.uwaterloo.flix.language.ast.TypedAst.{Exp, ExtMatchRule, Root}
 import ca.uwaterloo.flix.language.ast.shared.{CheckedCastType, Input, SecurityContext, Source}
 import ca.uwaterloo.flix.language.ast.{SourceLocation, SourcePosition, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.util.InternalCompilerException
@@ -185,95 +185,95 @@ object Summary {
     FileData.naiveSum(l.map(_.data))
   }
 
-  private def countCheckedEcasts(expr: TypedAst.Expr): Int = expr match {
-    case Expr.Cst(_, _, _) => 0
-    case Expr.Var(_, _, _) => 0
-    case Expr.Hole(_, _, _, _, _) => 0
-    case Expr.HoleWithExp(exp, _, _, _, _) => countCheckedEcasts(exp)
-    case Expr.OpenAs(_, exp, _, _) => countCheckedEcasts(exp)
-    case Expr.Use(_, _, exp, _) => countCheckedEcasts(exp)
-    case Expr.Lambda(_, exp, _, _) => countCheckedEcasts(exp)
-    case Expr.ApplyClo(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.ApplyDef(_, exps, _, _, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.ApplyLocalDef(_, exps, _, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.ApplyOp(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.ApplySig(_, exps, _, _, _, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.Unary(_, exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.Binary(_, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.Let(_, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.LocalDef(_, _, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.Region(_, _, exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) => List(exp1, exp2, exp3).map(countCheckedEcasts).sum
-    case Expr.Stm(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.Discard(exp, _, _) => countCheckedEcasts(exp)
-    case Expr.Match(exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map {
+  private def countCheckedEcasts(exp: TypedAst.Exp): Int = exp match {
+    case Exp.Cst(_, _, _) => 0
+    case Exp.Var(_, _, _) => 0
+    case Exp.Hole(_, _, _, _, _) => 0
+    case Exp.HoleWithExp(exp, _, _, _, _) => countCheckedEcasts(exp)
+    case Exp.OpenAs(_, exp, _, _) => countCheckedEcasts(exp)
+    case Exp.Use(_, _, exp, _) => countCheckedEcasts(exp)
+    case Exp.Lambda(_, exp, _, _) => countCheckedEcasts(exp)
+    case Exp.ApplyClo(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.ApplyDef(_, exps, _, _, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.ApplyLocalDef(_, exps, _, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.ApplyOp(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.ApplySig(_, exps, _, _, _, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.Unary(_, exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.Binary(_, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.Let(_, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.LocalDef(_, _, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.Region(_, _, exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.IfThenElse(exp1, exp2, exp3, _, _, _) => List(exp1, exp2, exp3).map(countCheckedEcasts).sum
+    case Exp.Stm(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.Discard(exp, _, _) => countCheckedEcasts(exp)
+    case Exp.Match(exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map {
       case TypedAst.MatchRule(_, guard, exp, loc) => guard.map(countCheckedEcasts).sum + countCheckedEcasts(exp)
     }.sum
-    case Expr.TypeMatch(exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map {
+    case Exp.TypeMatch(exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map {
       case TypedAst.TypeMatchRule(_, _, exp, _) => countCheckedEcasts(exp)
     }.sum
-    case Expr.RestrictableChoose(_, exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map {
+    case Exp.RestrictableChoose(_, exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map {
       case TypedAst.RestrictableChooseRule(_, exp) => countCheckedEcasts(exp)
     }.sum
-    case Expr.ExtMatch(exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map(r => countCheckedEcasts(r.exp)).sum
-    case Expr.Tag(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.RestrictableTag(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.ExtTag(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.Tuple(exps, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.RecordSelect(exp, _, _, _, _) => countCheckedEcasts(exp)
-    case Expr.RecordExtend(_, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.RecordRestrict(_, exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.ArrayLit(exps, exp, _, _, _) => (exp :: exps).map(countCheckedEcasts).sum
-    case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) => List(exp1, exp2, exp3).map(countCheckedEcasts).sum
-    case Expr.ArrayLoad(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.ArrayLength(exp, _, _) => countCheckedEcasts(exp)
-    case Expr.ArrayStore(exp1, exp2, exp3, _, _) => List(exp1, exp2, exp3).map(countCheckedEcasts).sum
-    case Expr.StructNew(_, fields, region, _, _, _) => countCheckedEcasts(region) + fields.map {
+    case Exp.ExtMatch(exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map(r => countCheckedEcasts(r.exp)).sum
+    case Exp.Tag(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.RestrictableTag(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.ExtTag(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.Tuple(exps, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.RecordSelect(exp, _, _, _, _) => countCheckedEcasts(exp)
+    case Exp.RecordExtend(_, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.RecordRestrict(_, exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.ArrayLit(exps, exp, _, _, _) => (exp :: exps).map(countCheckedEcasts).sum
+    case Exp.ArrayNew(exp1, exp2, exp3, _, _, _) => List(exp1, exp2, exp3).map(countCheckedEcasts).sum
+    case Exp.ArrayLoad(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.ArrayLength(exp, _, _) => countCheckedEcasts(exp)
+    case Exp.ArrayStore(exp1, exp2, exp3, _, _) => List(exp1, exp2, exp3).map(countCheckedEcasts).sum
+    case Exp.StructNew(_, fields, region, _, _, _) => countCheckedEcasts(region) + fields.map {
       case (_, exp) => countCheckedEcasts(exp)
     }.sum
-    case Expr.StructGet(exp, _, _, _, _) => countCheckedEcasts(exp)
-    case Expr.StructPut(exp1, _, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.VectorLit(exps, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.VectorLoad(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.VectorLength(exp, _) => countCheckedEcasts(exp)
-    case Expr.Ascribe(exp, _, _, _, _, _) => countCheckedEcasts(exp)
-    case Expr.InstanceOf(exp, _, _) => countCheckedEcasts(exp)
-    case Expr.CheckedCast(CheckedCastType.EffectCast, exp, _, _, _) => 1 + countCheckedEcasts(exp)
-    case Expr.CheckedCast(CheckedCastType.TypeCast, exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.UncheckedCast(exp, _, _, _, _, _) => countCheckedEcasts(exp)
-    case Expr.Unsafe(exp, _, _, _, _) => countCheckedEcasts(exp)
-    case Expr.Without(exp, _, _, _, _) => countCheckedEcasts(exp)
-    case Expr.TryCatch(exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map {
+    case Exp.StructGet(exp, _, _, _, _) => countCheckedEcasts(exp)
+    case Exp.StructPut(exp1, _, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.VectorLit(exps, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.VectorLoad(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.VectorLength(exp, _) => countCheckedEcasts(exp)
+    case Exp.Ascribe(exp, _, _, _, _, _) => countCheckedEcasts(exp)
+    case Exp.InstanceOf(exp, _, _) => countCheckedEcasts(exp)
+    case Exp.CheckedCast(CheckedCastType.EffectCast, exp, _, _, _) => 1 + countCheckedEcasts(exp)
+    case Exp.CheckedCast(CheckedCastType.TypeCast, exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.UncheckedCast(exp, _, _, _, _, _) => countCheckedEcasts(exp)
+    case Exp.Unsafe(exp, _, _, _, _) => countCheckedEcasts(exp)
+    case Exp.Without(exp, _, _, _, _) => countCheckedEcasts(exp)
+    case Exp.TryCatch(exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map {
       case TypedAst.CatchRule(_, _, exp, _) => countCheckedEcasts(exp)
     }.sum
-    case Expr.Throw(exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.Handler(_, rules, _, _, _, _, _) => rules.map {
+    case Exp.Throw(exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.Handler(_, rules, _, _, _, _, _) => rules.map {
       case TypedAst.HandlerRule(_, _, exp, _) => countCheckedEcasts(exp)
     }.sum
-    case Expr.RunWith(exp1, exp2, _, _, _) => countCheckedEcasts(exp1) + countCheckedEcasts(exp2)
-    case Expr.InvokeConstructor(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.InvokeMethod(_, exp, exps, _, _, _) => (exp :: exps).map(countCheckedEcasts).sum
-    case Expr.InvokeStaticMethod(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.GetField(_, exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.PutField(_, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.GetStaticField(_, _, _, _) => 0
-    case Expr.PutStaticField(_, exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.NewObject(_, _, _, _, methods, _) => methods.map {
+    case Exp.RunWith(exp1, exp2, _, _, _) => countCheckedEcasts(exp1) + countCheckedEcasts(exp2)
+    case Exp.InvokeConstructor(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.InvokeMethod(_, exp, exps, _, _, _) => (exp :: exps).map(countCheckedEcasts).sum
+    case Exp.InvokeStaticMethod(_, exps, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.GetField(_, exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.PutField(_, exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.GetStaticField(_, _, _, _) => 0
+    case Exp.PutStaticField(_, exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.NewObject(_, _, _, _, methods, _) => methods.map {
       case TypedAst.JvmMethod(_, _, exp, _, _, _) => countCheckedEcasts(exp)
     }.sum
-    case Expr.NewChannel(exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.GetChannel(exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.PutChannel(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.SelectChannel(rules, default, _, _, _) => default.map(countCheckedEcasts).sum + rules.map {
+    case Exp.NewChannel(exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.GetChannel(exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.PutChannel(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.SelectChannel(rules, default, _, _, _) => default.map(countCheckedEcasts).sum + rules.map {
       case TypedAst.SelectChannelRule(_, chan, exp, _) => countCheckedEcasts(chan) + countCheckedEcasts(exp)
     }.sum
-    case Expr.Spawn(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.ParYield(frags, exp, _, _, _) => countCheckedEcasts(exp) + frags.map {
+    case Exp.Spawn(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.ParYield(frags, exp, _, _, _) => countCheckedEcasts(exp) + frags.map {
       case TypedAst.ParYieldFragment(_, exp, _) => countCheckedEcasts(exp)
     }.sum
-    case Expr.Lazy(exp, _, _) => countCheckedEcasts(exp)
-    case Expr.Force(exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.FixpointConstraintSet(cs, _, _) => cs.map {
+    case Exp.Lazy(exp, _, _) => countCheckedEcasts(exp)
+    case Exp.Force(exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.FixpointConstraintSet(cs, _, _) => cs.map {
       case TypedAst.Constraint(_, head, body, _) =>
         (head match {
           case TypedAst.Predicate.Head.Atom(_, _, terms, _, _) => terms.map(countCheckedEcasts).sum
@@ -283,15 +283,15 @@ object Summary {
           case TypedAst.Predicate.Body.Guard(exp, _) => countCheckedEcasts(exp)
         }.sum
     }.sum
-    case Expr.FixpointLambda(_, exp, _, _, _) => countCheckedEcasts(exp)
-    case Expr.FixpointMerge(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
-    case Expr.FixpointQueryWithProvenance(exps, TypedAst.Predicate.Head.Atom(_, _, terms, _, _), _, _, _, _) =>
+    case Exp.FixpointLambda(_, exp, _, _, _) => countCheckedEcasts(exp)
+    case Exp.FixpointMerge(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Exp.FixpointQueryWithProvenance(exps, TypedAst.Predicate.Head.Atom(_, _, terms, _, _), _, _, _, _) =>
       exps.map(countCheckedEcasts).sum + terms.map(countCheckedEcasts).sum
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) =>
+    case Exp.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) =>
       exps.map(countCheckedEcasts).sum + countCheckedEcasts(queryExp) + selects.map(countCheckedEcasts).sum + where.map(countCheckedEcasts).sum
-    case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.FixpointInjectInto(exps, _, _, _, _) => exps.map(countCheckedEcasts).sum
-    case Expr.Error(_, _, _) => 0
+    case Exp.FixpointSolveWithProject(exps, _, _, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.FixpointInjectInto(exps, _, _, _, _) => exps.map(countCheckedEcasts).sum
+    case Exp.Error(_, _, _) => 0
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -628,8 +628,8 @@ class TestCompletionProvider extends AnyFunSuite {
     var occurs: Set[SymUse.DefSymUse] = Set.empty
 
     object DefSymUseConsumer extends Consumer {
-      override def consumeExpr(exp: TypedAst.Expr): Unit = exp match {
-        case TypedAst.Expr.ApplyDef(symUse, _, _, _, _, _, _) if symUse.loc.isReal =>
+      override def consumeExpr(exp: TypedAst.Exp): Unit = exp match {
+        case TypedAst.Exp.ApplyDef(symUse, _, _, _, _, _, _) if symUse.loc.isReal =>
           occurs += symUse
         case _ =>
       }
@@ -647,8 +647,8 @@ class TestCompletionProvider extends AnyFunSuite {
     var occurs: Set[(Symbol.VarSym, SourceLocation)] = Set.empty
 
     object VarConsumer extends Consumer {
-      override def consumeExpr(exp: TypedAst.Expr): Unit = exp match {
-        case TypedAst.Expr.Var(sym, _, loc) if sym.loc.isReal => occurs += ((sym, loc))
+      override def consumeExpr(exp: TypedAst.Exp): Unit = exp match {
+        case TypedAst.Exp.Var(sym, _, loc) if sym.loc.isReal => occurs += ((sym, loc))
         case _ =>
       }
     }

--- a/main/test/ca/uwaterloo/flix/language/TestTypeSimplifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestTypeSimplifier.scala
@@ -57,7 +57,7 @@ class TestTypeSimplifier extends AnyFunSuite with TestUtils {
     Visitor.visitRoot(
       root,
       new Consumer {
-        override def consumeExpr(exp: TypedAst.Expr): Unit = types.append(exp.tpe)
+        override def consumeExpr(exp: TypedAst.Exp): Unit = types.append(exp.tpe)
       },
       (_: SourceLocation) => true
     )

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -909,12 +909,12 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestChoose.01") {
     val input =
       """
-        |restrictable enum Expr[s] {
+        |restrictable enum Exp[s] {
         |    case Cst, Var, Not, And, Or, Xor
         |}
         |
-        |pub def foo(): Bool = choose Expr.Cst {
-        |    case Expr.Var(_) => true
+        |pub def foo(): Bool = choose Exp.Cst {
+        |    case Exp.Var(_) => true
         |}
         |""".stripMargin
     expectError[TypeError](compile(input, Options.TestWithLibNix))
@@ -923,21 +923,21 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestChoose.02") {
     val input =
       """
-        |restrictable enum Expr[s] {
+        |restrictable enum Exp[s] {
         |    case Cst, Var, Not, And, Or, Xor
         |}
         |
         | pub def testChoose06(): Bool = {
         |     let f = x -> choose x {
-        |         case Expr.Cst(_) => false
-        |         case Expr.Var(_) => true
+        |         case Exp.Cst(_) => false
+        |         case Exp.Var(_) => true
         |     };
         |     let g = x -> choose x {
-        |         case Expr.Cst(_) => false
-        |         case Expr.Xor(_) => true
+        |         case Exp.Cst(_) => false
+        |         case Exp.Xor(_) => true
         |     };
         |     let h = if (true) f else g;
-        |     h(Expr.Var)
+        |     h(Exp.Var)
         | }
         |""".stripMargin
     expectError[TypeError](compile(input, Options.TestWithLibNix))
@@ -946,24 +946,24 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestChoose.03") {
     val input =
       """
-        |restrictable enum Expr[s] {
+        |restrictable enum Exp[s] {
         |    case Cst, Var, Not, And, Or, Xor
         |}
         |
         | pub def testChoose06(): Bool = {
         |     let f = x -> choose x {
-        |         case Expr.Cst(_) => false
-        |         case Expr.Var(_) => true
-        |         case Expr.Not(_) => false
+        |         case Exp.Cst(_) => false
+        |         case Exp.Var(_) => true
+        |         case Exp.Not(_) => false
         |     };
         |     let g = x -> choose x {
-        |         case Expr.Cst(_) => false
-        |         case Expr.Xor(_) => true
-        |         case Expr.Not(_) => false
+        |         case Exp.Cst(_) => false
+        |         case Exp.Xor(_) => true
+        |         case Exp.Not(_) => false
         |     };
         |     let h = if (true) f else g;
         |
-        |     let cstOrNotOrVar = if (true) open_variant Expr.Cst else if (true) open_variant Expr.Not else open_variant Expr.Var;
+        |     let cstOrNotOrVar = if (true) open_variant Exp.Cst else if (true) open_variant Exp.Not else open_variant Exp.Var;
         |
         |     h(cstOrNotOrVar)
         | }
@@ -974,17 +974,17 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestChooseStar.01") {
     val input =
       """
-        |restrictable enum Expr[s] {
+        |restrictable enum Exp[s] {
         |    case Cst, Var, Not, And, Or, Xor
         |}
         |
         |pub def foo(): Bool = {
         |    // P2: check the lower bound by using result in a choose
-        |    let star = choose* Expr.Cst {
-        |        case Expr.Cst(_) => Expr.Var()
+        |    let star = choose* Exp.Cst {
+        |        case Exp.Cst(_) => Exp.Var()
         |    };
         |    choose star {
-        |        case Expr.Cst(_) => false
+        |        case Exp.Cst(_) => false
         |    }
         |}
         |""".stripMargin
@@ -994,19 +994,19 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestChooseStar.02") {
     val input =
       """
-        |restrictable enum Expr[s] {
+        |restrictable enum Exp[s] {
         |    case Cst, Var, Not, And, Or, Xor
         |}
         |
         |pub def quack(): Bool = {
         |    // P2: check the lower bound by using result in a choose
-        |    let star = choose* Expr.Cst {
-        |        case Expr.Cst(_) => Expr.Var()
-        |        case Expr.Not(_) => Expr.Var()
-        |        case Expr.Xor(_) => Expr.Var()
+        |    let star = choose* Exp.Cst {
+        |        case Exp.Cst(_) => Exp.Var()
+        |        case Exp.Not(_) => Exp.Var()
+        |        case Exp.Xor(_) => Exp.Var()
         |    };
         |    choose star {
-        |        case Expr.Xor(_) => false
+        |        case Exp.Xor(_) => false
         |    }
         |}
         |""".stripMargin
@@ -1016,19 +1016,19 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestChooseStar.03") {
     val input =
       """
-        |restrictable enum Expr[s] {
+        |restrictable enum Exp[s] {
         |    case Cst, Var, Not, And, Or, Xor
         |}
         |
         |pub def liquorice(): Bool = {
         |    // P2: check the lower bound by using result in a choose
-        |    let star = choose* Expr.Cst {
-        |        case Expr.Cst(_) => Expr.Var()
-        |        case Expr.Not(_) => Expr.Var()
-        |        case Expr.Xor(_) => Expr.Not()
+        |    let star = choose* Exp.Cst {
+        |        case Exp.Cst(_) => Exp.Var()
+        |        case Exp.Not(_) => Exp.Var()
+        |        case Exp.Xor(_) => Exp.Not()
         |    };
         |    choose star {
-        |        case Expr.Not(_) => false
+        |        case Exp.Not(_) => false
         |    }
         |}
         |""".stripMargin
@@ -1038,20 +1038,20 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestChooseStar.04") {
     val input =
       """
-        |restrictable enum Expr[s] {
+        |restrictable enum Exp[s] {
         |    case Cst, Var, Not, And, Or, Xor
         |}
         |
         |pub def testChooseStar4(): Bool = {
         |    // P2: check the lower bound by using result in a choose
-        |    let star = choose* Expr.Cst {
-        |        case Expr.Cst(_) => Expr.Var()
-        |        case Expr.Not(_) => Expr.Var()
-        |        case Expr.Xor(_) => Expr.Not()
+        |    let star = choose* Exp.Cst {
+        |        case Exp.Cst(_) => Exp.Var()
+        |        case Exp.Not(_) => Exp.Var()
+        |        case Exp.Xor(_) => Exp.Not()
         |    };
         |    choose star {
-        |        case Expr.Var(_) => true
-        |        case Expr.Xor(_) => false
+        |        case Exp.Var(_) => true
+        |        case Exp.Xor(_) => false
         |    }
         |}
         |""".stripMargin
@@ -1061,18 +1061,18 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestChooseStar.05") {
     val input =
       """
-        |restrictable enum Expr[s] {
+        |restrictable enum Exp[s] {
         |    case Cst, Var, Not, And, Or, Xor
         |}
         |
         |pub def foo(): Bool = {
         |    // P2: check the lower bound by using result in a choose
-        |    let star = choose* Expr.Cst {
-        |        case Expr.Not(_) => Expr.Not()
-        |        case Expr.Cst(_) => Expr.Var()
+        |    let star = choose* Exp.Cst {
+        |        case Exp.Not(_) => Exp.Not()
+        |        case Exp.Cst(_) => Exp.Var()
         |    };
         |    choose star {
-        |        case Expr.Cst(_) => false
+        |        case Exp.Cst(_) => false
         |    }
         |}
         |""".stripMargin

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestCaseSetUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestCaseSetUnification.scala
@@ -42,17 +42,17 @@ class TestCaseSetUnification extends AnyFunSuite with TestUtils {
   private val C2 = Symbol.mkRestrictableCaseSym(E, mkIdent("C2"))
   private val C3 = Symbol.mkRestrictableCaseSym(E, mkIdent("C3"))
 
-  private val Expr = Symbol.mkRestrictableEnumSym(
+  private val Exp = Symbol.mkRestrictableEnumSym(
     Name.RootNS,
-    mkIdent("Expr"),
+    mkIdent("Exp"),
     List("And", "Xor", "Or", "Var", "Not", "Cst").map(mkIdent)
   )
-  private val And = Symbol.mkRestrictableCaseSym(Expr, mkIdent("And"))
-  private val Xor = Symbol.mkRestrictableCaseSym(Expr, mkIdent("Xor"))
-  private val Or = Symbol.mkRestrictableCaseSym(Expr, mkIdent("Or"))
-  private val Var = Symbol.mkRestrictableCaseSym(Expr, mkIdent("Var"))
-  private val Not = Symbol.mkRestrictableCaseSym(Expr, mkIdent("Not"))
-  private val Cst = Symbol.mkRestrictableCaseSym(Expr, mkIdent("Cst"))
+  private val And = Symbol.mkRestrictableCaseSym(Exp, mkIdent("And"))
+  private val Xor = Symbol.mkRestrictableCaseSym(Exp, mkIdent("Xor"))
+  private val Or = Symbol.mkRestrictableCaseSym(Exp, mkIdent("Or"))
+  private val Var = Symbol.mkRestrictableCaseSym(Exp, mkIdent("Var"))
+  private val Not = Symbol.mkRestrictableCaseSym(Exp, mkIdent("Not"))
+  private val Cst = Symbol.mkRestrictableCaseSym(Exp, mkIdent("Cst"))
 
   test("Test.CaseSetUnification.01") {
     // ∅ ≐ ∅
@@ -321,22 +321,22 @@ class TestCaseSetUnification extends AnyFunSuite with TestUtils {
   }
 
   test("Test.CaseSetUnification.17") {
-    val varS1 = mkTypeVarSym("s1", Expr)
-    val varS2 = mkTypeVarSym("s2", Expr)
+    val varS1 = mkTypeVarSym("s1", Exp)
+    val varS2 = mkTypeVarSym("s2", Exp)
 
-    val caseAnd = Type.Cst(TypeConstructor.CaseSet(SortedSet(And), Expr), loc)
-    val caseXor = Type.Cst(TypeConstructor.CaseSet(SortedSet(Xor), Expr), loc)
-    val caseOr = Type.Cst(TypeConstructor.CaseSet(SortedSet(Or), Expr), loc)
+    val caseAnd = Type.Cst(TypeConstructor.CaseSet(SortedSet(And), Exp), loc)
+    val caseXor = Type.Cst(TypeConstructor.CaseSet(SortedSet(Xor), Exp), loc)
+    val caseOr = Type.Cst(TypeConstructor.CaseSet(SortedSet(Or), Exp), loc)
 
     val tpe1 = Type.mkCaseIntersection(
       Type.Var(varS1, loc),
       Type.mkCaseUnion(
         caseAnd,
         caseXor,
-        Expr,
+        Exp,
         loc
       ),
-      Expr,
+      Exp,
       loc
     )
 
@@ -345,28 +345,28 @@ class TestCaseSetUnification extends AnyFunSuite with TestUtils {
       Type.mkCaseUnion(
         caseOr,
         caseXor,
-        Expr,
+        Exp,
         loc
       ),
-      Expr,
+      Exp,
       loc
     )
 
     val renv = RigidityEnv.empty
-    assertUnifies(tpe1, tpe2, renv, Expr)
+    assertUnifies(tpe1, tpe2, renv, Exp)
   }
 
   test("Test.CaseSetUnification.18") {
-    val varS1 = mkTypeVarSym("s1", Expr)
-    val varS2 = mkTypeVarSym("s2", Expr)
+    val varS1 = mkTypeVarSym("s1", Exp)
+    val varS2 = mkTypeVarSym("s2", Exp)
 
-    val caseAnd = Type.Cst(TypeConstructor.CaseSet(SortedSet(And), Expr), loc)
-    val caseXor = Type.Cst(TypeConstructor.CaseSet(SortedSet(Xor), Expr), loc)
+    val caseAnd = Type.Cst(TypeConstructor.CaseSet(SortedSet(And), Exp), loc)
+    val caseXor = Type.Cst(TypeConstructor.CaseSet(SortedSet(Xor), Exp), loc)
 
     val tpe1 = Type.mkCaseUnion(
       Type.Var(varS1, loc),
       caseXor,
-      Expr,
+      Exp,
       loc
     )
 
@@ -375,15 +375,15 @@ class TestCaseSetUnification extends AnyFunSuite with TestUtils {
       Type.mkCaseUnion(
         caseXor,
         caseAnd,
-        Expr,
+        Exp,
         loc
       ),
-      Expr,
+      Exp,
       loc
     )
 
     val renv = RigidityEnv.empty
-    assertUnifies(tpe1, tpe2, renv, Expr)
+    assertUnifies(tpe1, tpe2, renv, Exp)
   }
 
   test("Test.CaseSetUnification.Fail.01") {

--- a/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
@@ -72,316 +72,316 @@ object EffectVerifier {
   /**
     * Verifies the effects in the given expression
     */
-  def visitExp(e: Expr)(implicit eqEnv: EqualityEnv, flix: Flix): Unit = e match {
-    case Expr.Cst(cst, tpe, loc) => ()
-    case Expr.Var(sym, tpe, loc) => ()
-    case Expr.Hole(sym, env, tpe, eff, loc) => ()
-    case Expr.HoleWithExp(exp, env, tpe, eff, loc) =>
+  def visitExp(e: Exp)(implicit eqEnv: EqualityEnv, flix: Flix): Unit = e match {
+    case Exp.Cst(cst, tpe, loc) => ()
+    case Exp.Var(sym, tpe, loc) => ()
+    case Exp.Hole(sym, env, tpe, eff, loc) => ()
+    case Exp.HoleWithExp(exp, env, tpe, eff, loc) =>
       visitExp(exp)
     // TODO ?
-    case Expr.OpenAs(symUse, exp, tpe, loc) =>
+    case Exp.OpenAs(symUse, exp, tpe, loc) =>
       visitExp(exp)
-    case Expr.Use(sym, alias, exp, loc) =>
+    case Exp.Use(sym, alias, exp, loc) =>
       visitExp(exp)
-    case Expr.Lambda(fparam, exp, tpe, loc) =>
+    case Exp.Lambda(fparam, exp, tpe, loc) =>
       visitExp(exp)
-    case Expr.ApplyClo(exp1, exp2, tpe, eff, loc) =>
+    case Exp.ApplyClo(exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       val expected = Type.mkUnion(Type.eraseTopAliases(exp1.tpe).arrowEffectType :: exp1.eff :: exp2.eff :: Nil, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.ApplyDef(_, exps, _, itpe, _, eff, loc) =>
+    case Exp.ApplyDef(_, exps, _, itpe, _, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(Type.eraseTopAliases(itpe).arrowEffectType :: exps.map(_.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.ApplyLocalDef(_, exps, arrowTpe, _, eff, loc) =>
+    case Exp.ApplyLocalDef(_, exps, arrowTpe, _, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(Type.eraseTopAliases(arrowTpe).arrowEffectType :: exps.map(_.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.ApplyOp(op, exps, tpe, eff, loc) =>
+    case Exp.ApplyOp(op, exps, tpe, eff, loc) =>
       exps.foreach(visitExp)
       // TODO effect stuff
       ()
-    case Expr.ApplySig(_, exps, _, _, itpe, _, eff, loc) =>
+    case Exp.ApplySig(_, exps, _, _, itpe, _, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(Type.eraseTopAliases(itpe).arrowEffectType :: exps.map(_.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Unary(sop, exp, tpe, eff, loc) =>
+    case Exp.Unary(sop, exp, tpe, eff, loc) =>
       visitExp(exp)
       val expected = exp.eff
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Binary(sop, exp1, exp2, tpe, eff, loc) =>
+    case Exp.Binary(sop, exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       val expected = Type.mkUnion(exp1.eff, exp2.eff, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Let(sym, exp1, exp2, tpe, eff, loc) =>
+    case Exp.Let(sym, exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       val expected = Type.mkUnion(exp1.eff, exp2.eff, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.LocalDef(_, _, exp1, exp2, _, eff, loc) =>
+    case Exp.LocalDef(_, _, exp1, exp2, _, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       val expected = exp2.eff
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Region(sym, regSym, exp, tpe, eff, loc) =>
+    case Exp.Region(sym, regSym, exp, tpe, eff, loc) =>
       visitExp(exp)
       val expected = Type.purifyRegion(exp.eff, regSym)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
+    case Exp.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
       val expected = Type.mkUnion(exp1.eff, exp2.eff, exp3.eff, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Stm(exp1, exp2, tpe, eff, loc) =>
+    case Exp.Stm(exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       val expected = Type.mkUnion(exp1.eff, exp2.eff, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Discard(exp, eff, loc) =>
+    case Exp.Discard(exp, eff, loc) =>
       visitExp(exp)
       val expected = exp.eff
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Match(exp, rules, tpe, eff, loc) =>
+    case Exp.Match(exp, rules, tpe, eff, loc) =>
       visitExp(exp)
       rules.foreach { r => r.guard.foreach(visitExp); visitExp(r.exp) }
       val expected = Type.mkUnion(exp.eff :: rules.map(_.exp.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.TypeMatch(exp, rules, tpe, eff, loc) =>
+    case Exp.TypeMatch(exp, rules, tpe, eff, loc) =>
       visitExp(exp)
       rules.foreach { r => visitExp(r.exp) }
       val expected = Type.mkUnion(exp.eff :: rules.map(_.exp.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.RestrictableChoose(star, exp, rules, tpe, eff, loc) =>
+    case Exp.RestrictableChoose(star, exp, rules, tpe, eff, loc) =>
       visitExp(exp)
       rules.foreach { r => visitExp(r.exp) }
       val expected = Type.mkUnion(exp.eff :: rules.map(_.exp.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.ExtMatch(exp, rules, _, eff, loc) =>
+    case Exp.ExtMatch(exp, rules, _, eff, loc) =>
       visitExp(exp)
       rules.foreach(r => visitExp(r.exp))
       val expected = Type.mkUnion(exp.eff :: rules.map(r => r.exp.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Tag(symUse, exps, tpe, eff, loc) =>
+    case Exp.Tag(symUse, exps, tpe, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(exps.map(_.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.RestrictableTag(symUse, exps, tpe, eff, loc) =>
+    case Exp.RestrictableTag(symUse, exps, tpe, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(exps.map(_.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.ExtTag(_, exps, _, eff, loc) =>
+    case Exp.ExtTag(_, exps, _, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(exps.map(_.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Tuple(elms, tpe, eff, loc) =>
+    case Exp.Tuple(elms, tpe, eff, loc) =>
       elms.foreach(visitExp)
       val expected = Type.mkUnion(elms.map(_.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.RecordSelect(exp, label, tpe, eff, loc) =>
+    case Exp.RecordSelect(exp, label, tpe, eff, loc) =>
       visitExp(exp)
       val expected = exp.eff
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.RecordExtend(label, exp1, exp2, tpe, eff, loc) =>
+    case Exp.RecordExtend(label, exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       val expected = Type.mkUnion(exp1.eff, exp2.eff, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.RecordRestrict(label, exp, tpe, eff, loc) =>
+    case Exp.RecordRestrict(label, exp, tpe, eff, loc) =>
       visitExp(exp)
       val expected = exp.eff
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.ArrayLit(exps, exp, tpe, eff, loc) =>
+    case Exp.ArrayLit(exps, exp, tpe, eff, loc) =>
       exps.foreach(visitExp)
       visitExp(exp)
       // TODO region stuff
       ()
-    case Expr.ArrayNew(exp1, exp2, exp3, tpe, eff, loc) =>
+    case Exp.ArrayNew(exp1, exp2, exp3, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
       // TODO region stuff
       ()
-    case Expr.ArrayLoad(exp1, exp2, tpe, eff, loc) =>
+    case Exp.ArrayLoad(exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       // TODO region stuff
       ()
-    case Expr.ArrayLength(exp, eff, loc) =>
+    case Exp.ArrayLength(exp, eff, loc) =>
       visitExp(exp)
       val expected = exp.eff
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.ArrayStore(exp1, exp2, exp3, eff, loc) =>
+    case Exp.ArrayStore(exp1, exp2, exp3, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       visitExp(exp3)
       // TODO region stuff
       ()
-    case Expr.StructNew(sym, fields, region, tpe, eff, loc) =>
+    case Exp.StructNew(sym, fields, region, tpe, eff, loc) =>
       fields.map { case (k, v) => v }.foreach(visitExp)
       visitExp(region)
       // TODO region stuff
       ()
-    case Expr.StructGet(e, _, t, _, _) =>
+    case Exp.StructGet(e, _, t, _, _) =>
       // JOE TODO region stuff
       visitExp(e)
-    case Expr.StructPut(e1, _, e2, t, _, _) =>
+    case Exp.StructPut(e1, _, e2, t, _, _) =>
       // JOE TODO region stuff
       visitExp(e1)
       visitExp(e2)
-    case Expr.VectorLit(exps, tpe, eff, loc) =>
+    case Exp.VectorLit(exps, tpe, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(exps.map(_.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.VectorLoad(exp1, exp2, tpe, eff, loc) =>
+    case Exp.VectorLoad(exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       val expected = Type.mkUnion(exp1.eff, exp2.eff, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.VectorLength(exp, loc) =>
+    case Exp.VectorLength(exp, loc) =>
       visitExp(exp)
-    case Expr.Ascribe(exp, expectedType, expectedEff, tpe, eff, loc) =>
+    case Exp.Ascribe(exp, expectedType, expectedEff, tpe, eff, loc) =>
       visitExp(exp)
-    case Expr.InstanceOf(exp, clazz, loc) =>
+    case Exp.InstanceOf(exp, clazz, loc) =>
       visitExp(exp)
-    case Expr.CheckedCast(cast, exp, tpe, eff, loc) =>
+    case Exp.CheckedCast(cast, exp, tpe, eff, loc) =>
       visitExp(exp)
-    case Expr.UncheckedCast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+    case Exp.UncheckedCast(exp, declaredType, declaredEff, tpe, eff, loc) =>
       visitExp(exp)
-    case Expr.Unsafe(exp, runEff, tpe, eff, loc) =>
+    case Exp.Unsafe(exp, runEff, tpe, eff, loc) =>
       visitExp(exp)
       val expected = Type.mkDifference(exp.eff, runEff, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Without(exp, symUse, tpe, eff, loc) =>
+    case Exp.Without(exp, symUse, tpe, eff, loc) =>
       visitExp(exp)
       val expected = exp.eff
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.TryCatch(exp, rules, tpe, eff, loc) =>
+    case Exp.TryCatch(exp, rules, tpe, eff, loc) =>
       visitExp(exp)
       rules.foreach { r => visitExp(r.exp) }
       val expected = Type.mkUnion(exp.eff :: rules.map(_.exp.eff), loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Throw(exp, _, eff, loc) =>
+    case Exp.Throw(exp, _, eff, loc) =>
       visitExp(exp)
       expectType(eff, Type.mkUnion(exp.eff, Type.IO, loc), loc)
-    case Expr.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
+    case Exp.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
       rules.foreach { r => visitExp(r.exp) }
       // TODO effect stuff
       ()
-    case Expr.RunWith(exp1, exp2, tpe, eff, loc) =>
+    case Exp.RunWith(exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       // TODO effect stuff
       ()
-    case Expr.InvokeConstructor(constructor, exps, tpe, eff, loc) =>
+    case Exp.InvokeConstructor(constructor, exps, tpe, eff, loc) =>
       exps.foreach(visitExp)
       // TODO Java stuff
       ()
-    case Expr.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
+    case Exp.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
       visitExp(exp)
       exps.foreach(visitExp)
       // TODO Java stuff
       ()
-    case Expr.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
+    case Exp.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
       exps.foreach(visitExp)
       // TODO Java stuff
       ()
-    case Expr.GetField(field, exp, tpe, eff, loc) =>
+    case Exp.GetField(field, exp, tpe, eff, loc) =>
       visitExp(exp)
       // TODO Java stuff
       ()
-    case Expr.PutField(field, exp1, exp2, tpe, eff, loc) =>
+    case Exp.PutField(field, exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       // TODO Java stuff
       ()
-    case Expr.GetStaticField(field, tpe, eff, loc) =>
+    case Exp.GetStaticField(field, tpe, eff, loc) =>
       // TODO Java stuff
       ()
-    case Expr.PutStaticField(field, exp, tpe, eff, loc) =>
+    case Exp.PutStaticField(field, exp, tpe, eff, loc) =>
       visitExp(exp)
       // TODO Java stuff
       ()
-    case Expr.NewObject(name, clazz, tpe, eff, methods, loc) =>
+    case Exp.NewObject(name, clazz, tpe, eff, methods, loc) =>
       methods.foreach { m => visitExp(m.exp) }
       // TODO Java stuff
       ()
-    case Expr.NewChannel(exp, tpe, eff, loc) =>
+    case Exp.NewChannel(exp, tpe, eff, loc) =>
       visitExp(exp)
       // TODO region stuff
       ()
-    case Expr.GetChannel(exp, tpe, eff, loc) =>
+    case Exp.GetChannel(exp, tpe, eff, loc) =>
       visitExp(exp)
       // TODO region stuff
       ()
-    case Expr.PutChannel(exp1, exp2, tpe, eff, loc) =>
+    case Exp.PutChannel(exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       // TODO region stuff
       ()
-    case Expr.SelectChannel(rules, default, tpe, eff, loc) =>
+    case Exp.SelectChannel(rules, default, tpe, eff, loc) =>
       rules.foreach { r => visitExp(r.exp) }
       default.foreach { d => visitExp(d) }
       // TODO region stuff
       ()
-    case Expr.Spawn(exp1, exp2, tpe, eff, loc) =>
+    case Exp.Spawn(exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       // TODO ?
       ()
-    case Expr.ParYield(frags, exp, tpe, eff, loc) =>
+    case Exp.ParYield(frags, exp, tpe, eff, loc) =>
       frags.foreach { f => visitExp(f.exp) }
       visitExp(exp)
       // TODO ?
       ()
-    case Expr.Lazy(exp, tpe, loc) =>
+    case Exp.Lazy(exp, tpe, loc) =>
       visitExp(exp)
-    case Expr.Force(exp, tpe, eff, loc) =>
+    case Exp.Force(exp, tpe, eff, loc) =>
       visitExp(exp)
     // TODO ?
-    case Expr.FixpointConstraintSet(cs, tpe, loc) =>
+    case Exp.FixpointConstraintSet(cs, tpe, loc) =>
     // TODO inner exps
-    case Expr.FixpointLambda(pparams, exp, tpe, eff, loc) =>
+    case Exp.FixpointLambda(pparams, exp, tpe, eff, loc) =>
       visitExp(exp)
       // TODO ?
       ()
-    case Expr.FixpointMerge(exp1, exp2, tpe, eff, loc) =>
+    case Exp.FixpointMerge(exp1, exp2, tpe, eff, loc) =>
       visitExp(exp1)
       visitExp(exp2)
       // TODO ?
       ()
-    case Expr.FixpointQueryWithProvenance(exps, select, withh, tpe1, eff1, loc1) =>
+    case Exp.FixpointQueryWithProvenance(exps, select, withh, tpe1, eff1, loc1) =>
       exps.foreach(visitExp)
       select match {
         case TypedAst.Predicate.Head.Atom(pred, den, terms, tpe2, loc2) =>
@@ -389,20 +389,20 @@ object EffectVerifier {
       }
       // TODO ?
       ()
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, tpe, eff, loc) =>
+    case Exp.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, tpe, eff, loc) =>
       exps.foreach(visitExp)
       where.foreach(visitExp)
       // TODO ?
       ()
-    case Expr.FixpointSolveWithProject(exps, optPreds, mode, tpe, eff, loc) =>
+    case Exp.FixpointSolveWithProject(exps, optPreds, mode, tpe, eff, loc) =>
       exps.foreach(visitExp)
       // TODO ?
       ()
-    case Expr.FixpointInjectInto(exps, predsAndArities, tpe, eff, loc) =>
+    case Exp.FixpointInjectInto(exps, predsAndArities, tpe, eff, loc) =>
       exps.foreach(visitExp)
       // TODO ?
       ()
-    case Expr.Error(m, tpe, eff) => ()
+    case Exp.Error(m, tpe, eff) => ()
   }
 
   /**


### PR DESCRIPTION
Avoid this double naming of both expr and exp