### PR TITLE
refactor: `BPlusTree` should not use `typematch`

### DIFF
--- a/main/src/library/BPlusTree.flix
+++ b/main/src/library/BPlusTree.flix
@@ -46,8 +46,9 @@
 /// `rc` is the region for the tree.
 ///
 /// `search` is only used internally within the Fixpoint module where keys are of type
-/// `Vector[Int64]`. A `Search` describes the order in which elements should be
-/// compared. E.g. [0, 1, 2, ..., n] is the natural order.
+/// `Vector[Int64]`. A `search` describes the order in which elements should be
+/// compared. E.g. [0, 1, 2, ..., n] is the natural order. A `search` may only be used
+/// when using `Vector[Int64]` as keys.
 ///
 /// `counter` is used for keeping track of the number of inserted elements.
 ///
@@ -258,7 +259,7 @@ mod BPlusTree {
     ///
     /// Thread-safe.
     ///
-    pub def adjust(f: v -> v \ ef, k: k, t: BPlusTree[k, v, r]): Unit \ ef + r with Order[k] = 
+    pub def adjust(f: v -> v \ ef, k: k, t: BPlusTree[k, v, r]): Unit \ ef + r with Order[k] =
         adjustWithKey(_ -> v -> f(v), k, t)
 
     ///
@@ -268,7 +269,7 @@ mod BPlusTree {
     ///
     /// Thread-safe.
     ///
-    pub def adjustWithKey(f: k -> v -> v \ ef, k: k, t: BPlusTree[k, v, r]): Unit \ ef + r with Order[k] = 
+    pub def adjustWithKey(f: k -> v -> v \ ef, k: k, t: BPlusTree[k, v, r]): Unit \ ef + r with Order[k] =
         let (node, stamp) = findLeaf(k, t);
         Node.adjustWithKey(f, k, stamp, t, node)
 
@@ -316,15 +317,15 @@ mod BPlusTree {
     ///
     /// Not thread-safe.
     ///
-    pub def forAll(f: k -> v -> Bool \ ef, t: BPlusTree[k, v, r]): Bool \ ef + r = 
+    pub def forAll(f: k -> v -> Bool \ ef, t: BPlusTree[k, v, r]): Bool \ ef + r =
         not exists(k -> v -> not f(k, v), t)
-    
+
     ///
     /// Returns `true` if and only if there exists `k => v` in `t` such that `f(k, v) == true`.
     ///
     /// Not thread-safe.
     ///
-    pub def exists(f: k -> v -> Bool \ ef, t: BPlusTree[k, v, r]): Bool \ ef + r = 
+    pub def exists(f: k -> v -> Bool \ ef, t: BPlusTree[k, v, r]): Bool \ ef + r =
         Node.exists(f, 0, Node.leftMostChild(t->root))
 
     ///
@@ -332,7 +333,7 @@ mod BPlusTree {
     ///
     /// Not thread-safe.
     ///
-    pub def find(f: k -> v -> Bool \ ef, t: BPlusTree[k, v, r]): Option[(k, v)] \ ef + r = 
+    pub def find(f: k -> v -> Bool \ ef, t: BPlusTree[k, v, r]): Option[(k, v)] \ ef + r =
         findLeft(f, t)
 
     ///
@@ -340,8 +341,8 @@ mod BPlusTree {
     ///
     /// Not thread-safe.
     ///
-    pub def findLeft(f: k -> v -> Bool \ ef, t: BPlusTree[k, v, r]): Option[(k, v)] \ ef + r = 
-        Node.findLeft(f, 0, Node.leftMostChild(t->root)) 
+    pub def findLeft(f: k -> v -> Bool \ ef, t: BPlusTree[k, v, r]): Option[(k, v)] \ ef + r =
+        Node.findLeft(f, 0, Node.leftMostChild(t->root))
 
     ///
     /// Increments the stored size of `t`.
@@ -427,7 +428,7 @@ mod BPlusTree {
     ///
     /// Applies `f` to a start value `i` and all values in `t` going from left to right.
     ///
-    pub def foldLeft(f: b -> v -> b \ ef, i: b, t: BPlusTree[k, v, r]): b \ ef + r with Order[k] = 
+    pub def foldLeft(f: b -> v -> b \ ef, i: b, t: BPlusTree[k, v, r]): b \ ef + r with Order[k] =
         List.foldLeft(f, i, valuesOf(t))
 
     ///
@@ -618,7 +619,7 @@ mod BPlusTree {
     ///
     /// Thread-safe.
     ///
-    pub def nonEmpty(t: BPlusTree[k, v, r]): Bool \ r = 
+    pub def nonEmpty(t: BPlusTree[k, v, r]): Bool \ r =
         not BPlusTree.isEmpty(t)
 
     ///
@@ -987,31 +988,22 @@ mod BPlusTree {
             f(0, length - 1)
 
         ///
-        /// Compare `val1` to `val2`. If `search` has non-zero length and `val1` and `val2` are of type `Vector[Int64]`
-        /// compare the lements in the order defined by `search`.
+        /// Compare `val1` to `val2`. If `search` has length zero then the order on `k` is used for the comparison.
+        ///
+        /// If `search` has non-zero length `val1` and `val2` is assumed to be of type `Vector[Int64]`.
+        /// The elements will be compared in the order given by `search`.
         ///
         def comparison(val1: k, val2: k, search: Search): Int32 with Order[k] = {
             let len = Vector.length(search);
             // If the values are of type Vector[Int64] check whether a specific search is given.
             // If so use the custom compare function for that search.
-            typematch val1 {
-                case val_1: Vector[Int64] =>
-                    if (len == 0) {
-                        let comp = val1 <=> val2;
-                        if (comp == Comparison.GreaterThan) 1
-                        else if (comp == Comparison.LessThan) -1
-                        else 0
-                    } else {
-                        typematch val2 {
-                            case val_2: Vector[Int64] => vectorComp(val_1, val_2, len, 0, search)
-                            case _: _ => unreachable!()
-                        }
-                    }
-                case _: _ =>
-                    let comp = val1 <=> val2;
-                    if (comp == Comparison.GreaterThan) 1
-                    else if (comp == Comparison.LessThan) -1
-                    else 0
+            if (len == 0) {
+                let comp = val1 <=> val2;
+                if (comp == Comparison.GreaterThan) 1
+                else if (comp == Comparison.LessThan) -1
+                else 0
+            } else {
+                vectorComp(unchecked_cast(val1 as Vector[Int64]), unchecked_cast(val2 as Vector[Int64]), len, 0, search)
             }
         }
 
@@ -1068,7 +1060,7 @@ mod BPlusTree {
             unchecked_cast((JObjects.equals(obj1, obj2): _ \ IO) as _ \ {})
 
         ///
-        /// Optionally returns the first mapping satisfying the function `f` in `node` and 
+        /// Optionally returns the first mapping satisfying the function `f` in `node` and
         /// to the right of `node`.
         ///
         /// Not thread-safe.
@@ -1082,9 +1074,9 @@ mod BPlusTree {
             if (index < node->size) {
                 let k = Array.get(index, node->keys);
                 let v = Array.get(index, node->values);
-                if (f(k, v)) 
+                if (f(k, v))
                     Some((k, v))
-                else 
+                else
                     findLeft(f, index + 1, node)
             } else match node->next {
                 case None => None
@@ -1106,9 +1098,9 @@ mod BPlusTree {
             if (index < node->size) {
                 let k = Array.get(index, node->keys);
                 let v = Array.get(index, node->values);
-                if (f(k, v)) 
+                if (f(k, v))
                     true
-                else 
+                else
                     exists(f, index + 1, node)
             } else match node->next {
                 case None => false

--- a/main/src/library/Fixpoint3/ProvenanceReconstruct.flix
+++ b/main/src/library/Fixpoint3/ProvenanceReconstruct.flix
@@ -81,15 +81,18 @@ mod Fixpoint3.ProvenanceReconstruct {
         match Map.get(makeFakeRelSym(pred), idb) {
             case None           => unreachable!() // No facts for `pred`.
             case Some(fullTree) =>
+                // We are dealing with `Vector[Boxed]` so we cannot use build ordering of `BPlusTree.emptyWithSearch`.
+                // Instead we must manually reorder them to match the `search`.
                 let (search, vals) = Vector.unzip(searchAndVals);
+                let reorderedVals = Vector.init(i -> Vector.get(i, vals), Vector.length(search));
                 let innerMap = BPlusTree.computeIfAbsent(() -> BPlusTree.empty(rc), pred, lookupStruct);
                 match BPlusTree.get(search, innerMap) {
-                    case Some(tree) => BPlusTree.get(vals, tree)
+                    case Some(tree) => BPlusTree.get(reorderedVals, tree)
                     case None =>
                         // We have never encountered this search before. Initialize the `BPlusTree` for it.
                         // Initializing happens by mapping every fact to the search-part and non-search part
                         // and inserting them as key-value pairs in a `BPLookup`.
-                        let tree = BPlusTree.emptyWithSearch(rc, search);
+                        let tree = BPlusTree.empty(rc);
                         let extractSearchPart = k -> Vector.init(i -> Vector.get(Vector.get(i, search), k), Vector.length(search));
                         let nonSearch = Vector.range(0, arity) |> Vector.filter(v -> not Vector.memberOf(v, search));
                         let extractNonSearchPart = k -> Vector.init(i -> Vector.get(Vector.get(i, nonSearch), k), Vector.length(nonSearch));
@@ -100,7 +103,7 @@ mod Fixpoint3.ProvenanceReconstruct {
                             BPlusTree.putWith(_ -> old -> newVal :: old, searchPart, newVal :: Nil, tree)
                         };
                         BPlusTree.put(search, tree, innerMap);
-                        BPlusTree.get(vals, tree)
+                        BPlusTree.get(reorderedVals, tree)
                 }
         }
 


### PR DESCRIPTION
Sorry for all the spacing edits in `BPlusTree.flix`. Intellij auto-formatted the file.

The only changes of substance is the documentation for `BPlusTree` and the changes around line 1000 of `comparison`.

Furthermore I discovered that we had used it in `ProvenanceReconstruct`, but on `Vector[Boxed]`. Seeing as the method (and module in general) was not written with high performance in mind I changed it to simply reorder the keys that are stored.

Fixes #11932