### PR TITLE
feat: basic test reflection (related to #11970)

### DIFF
--- a/main/src/library/Assert.flix
+++ b/main/src/library/Assert.flix
@@ -31,6 +31,30 @@ mod Assert {
 
     use RichString.{blue, red, text, yellow};
     import java.lang.AssertionError;
+    use Assert.FnInfo.FnInfo
+    use Assert.SourceLocation.SourceLocation
+    use Assert.SourcePosition.SourcePosition
+    pub enum SourcePosition({lineOneIndexed = Int32, colOneIndexed = Int32})
+    pub enum SourceLocation({source = String, sp1 = SourcePosition, sp2= SourcePosition})
+    pub enum FnInfo[ef: Eff]({name = String, sourceLocation = SourceLocation, fn = Unit -> Unit \ Assert + ef})
+    pub def getTests() : Vector[FnInfo[IO]] =
+        Vector#{mkFnInfo("ExampleTest", "ExampleFile", 0, 0, 0, 0, _ -> checked_ecast(Assert.assertTrue(true)))}
+
+    def mkSourceLocation(source: String, line1: Int32, col1: Int32, line2: Int32, col2: Int32) : SourceLocation =
+        SourceLocation(
+            {
+                source=source,
+                sp1 = SourcePosition({lineOneIndexed=line1, colOneIndexed=col1}),
+                sp2 = SourcePosition({lineOneIndexed=line2, colOneIndexed=col2})
+            }
+                )
+
+    def mkFnInfo(name: String, source: String, line1: Int32, col1: Int32, line2: Int32, col2: Int32, fn: Unit -> Unit \ Assert + ef) : FnInfo[ef] =
+        FnInfo({name=name, sourceLocation=mkSourceLocation(source, line1, col1, line2, col2), fn = fn})
+
+    pub def getTestsIO() : Vector[FnInfo[IO]] = Vector#{}
+    pub def getTestsPure() : Vector[FnInfo[{}]] = Vector#{}
+
 
     ///
     /// Asserts that the given condition `cond` is `true`.


### PR DESCRIPTION
Draft PR for test reflection.

Right now the reflection functions and their datatypes are located in Assert. However, I think that they should be either moved to their own module if we keep a single global getTests() (which does not seem like a bad idea) or removed if we follow the approach of generating a getTests for each module (which in my opinion is much trickier).

Right now the difference between Pure and Impure functions is not implemented, this is because there is a decision to be made in regards to whether we perform some unification with just Assert or we just do it in some other manner. 

Right now also, in the Scala code I use an example Test function as a blueprint to remove some boilerplate, but this can be removed easily just by writing manually the type of the function with 7 args. 

Aside from that, the current code works with getTests(), calling getTests() will return the tests defined in the program with their information. 

Here is an example:

```
@Test
def myTest1(): Unit \ Assert = Assert.assertTrue(true)

@Test
def myTest2(): Unit \ Assert = Assert.assertFalse(false)

def main(): Unit \ IO =
    use Assert.FnInfo.FnInfo;
    use Assert.SourceLocation.SourceLocation;
    use Assert.SourcePosition.SourcePosition;
    Assert.runWithIO(_ ->
        Vector.forEach( match FnInfo({
                                        name = n,
                                        sourceLocation = SourceLocation({source=src,
                                                                         sp1 = SourcePosition({lineOneIndexed=l1, colOneIndexed=col1}),
                                                                         sp2 = SourcePosition({lineOneIndexed=l2, colOneIndexed=col2})}),
                                        fn = f
                                     }) -> println("TestFunction name: ${n}, source location: ${src} ${l1}:${col1}-${l2}:${col2}, res : ${f()}")
                        ,Assert.getTests()
                    )
    )
```