### PR TITLE
chore: apply `visitType` to all types in `Specialization`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -1,0 +1,17 @@
+package ca.uwaterloo.flix.language.phase.monomorph
+
+import ca.uwaterloo.flix.language.ast.Type
+
+object Lowering {
+
+  /**
+    * Lowers the type `t`. Currently implemented as a no-op.
+    *
+    * When implemented:
+    * Replaces schema types with the Datalog enum type and channel-related types with the channel enum type.
+    *
+    * @param t the type to be lowered.
+    * @return
+    */
+   def lowerType(t: Type): Type = t
+}


### PR DESCRIPTION
Added the `visitType` calls from #11855

Note that the plan involves removing all the calls later.

Last part before functionality can be moved.