### PR TITLE
refactor: move lowering of `NewChannel` to monomorph phase

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/shared/Annotations.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/Annotations.scala
@@ -84,7 +84,7 @@ case class Annotations(annotations: List[Annotation]) {
   /**
     * Returns `true` if `this` sequence contains the `@LoweringTarget` annotation.
     */
-  def isLoweringTarget: Boolean = annotations contains Annotation.LoweringTarget
+  def isLoweringTarget: Boolean = annotations exists (_.isInstanceOf[Annotation.LoweringTarget])
 
   /**
     * Returns `true` if `this` sequence contains the `@MustUse` annotation.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -712,7 +712,7 @@ object Lowering {
     case TypedAst.Expr.NewChannel(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
-      mkNewChannelTuple(e, t, eff, loc)
+      LoweredAst.Expr.NewChannel(e, t, eff, loc)
 
     // Channel get expressions are rewritten as follows:
     //     <- c
@@ -1518,15 +1518,6 @@ object Lowering {
     val itpe = Type.mkIoArrow(exp.tpe, tpe, loc)
     val (targ, _) = extractChannelTpe(tpe)
     LoweredAst.Expr.ApplyDef(Defs.ChannelNew, exp :: Nil, List(targ), itpe, tpe, eff, loc)
-  }
-
-  /**
-    * Make a new channel tuple (sender, receiver) expression
-    */
-  private def mkNewChannelTuple(exp: LoweredAst.Expr, tpe: Type, eff: Type, loc: SourceLocation): LoweredAst.Expr = {
-    val itpe = Type.mkIoArrow(exp.tpe, tpe, loc)
-    val (targ, _) = extractChannelTpe(tpe.typeArguments.head) // TODO make helper
-    LoweredAst.Expr.ApplyDef(Defs.ChannelNewTuple, exp :: Nil, List(targ), itpe, tpe, eff, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -18,9 +18,10 @@
 package ca.uwaterloo.flix.language.phase.monomorph
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.{LoweredAst, MonoAst, SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{LoweredAst, MonoAst, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization.Context
-import ca.uwaterloo.flix.language.phase.monomorph.Symbols.Defs
+import ca.uwaterloo.flix.language.phase.monomorph.Symbols.{Defs, Types}
+import ca.uwaterloo.flix.util.InternalCompilerException
 
 /**
   * This phase translates AST expressions related to the Datalog subset of the
@@ -42,10 +43,48 @@ object Lowering {
     * When implemented:
     * Replaces schema types with the Datalog enum type and channel-related types with the channel enum type.
     *
-    * @param t the type to be lowered.
+    * @param tpe0 the type to be lowered.
     * @return
     */
-   def lowerType(t: Type): Type = t
+   def lowerType(tpe0: Type): Type = tpe0 match {
+     case Type.Cst(_, _) => tpe0 // Performance: Reuse tpe0.
+
+     case Type.Var(_, _) => tpe0
+
+     // Rewrite Sender[t] to Concurrent.Channel.Mpmc[t, IO]
+     case Type.Apply(Type.Cst(TypeConstructor.Sender, loc), tpe, _) =>
+       val t = lowerType(tpe)
+       mkChannelTpe(t, loc)
+
+     // Rewrite Receiver[t] to Concurrent.Channel.Mpmc[t, IO]
+     case Type.Apply(Type.Cst(TypeConstructor.Receiver, loc), tpe, _) =>
+       val t = lowerType(tpe)
+       mkChannelTpe(t, loc)
+
+     case Type.Apply(tpe1, tpe2, loc) =>
+       val t1 = lowerType(tpe1)
+       val t2 = lowerType(tpe2)
+       // Performance: Reuse tpe0, if possible.
+       if ((t1 eq tpe1) && (t2 eq tpe2)) {
+         tpe0
+       } else {
+         Type.Apply(t1, t2, loc)
+       }
+
+     case Type.Alias(sym, args, t, loc) =>
+       Type.Alias(sym, args.map(lowerType), lowerType(t), loc)
+
+     case Type.AssocType(cst, args, kind, loc) =>
+       // TODO: It appears that substitution (`reduceAssocType`) removes `AssocTypes`, so this should be an `InternalCompilerError`, right?
+       Type.AssocType(cst, args.map(lowerType), kind, loc)
+
+     case Type.JvmToType(_, loc) => throw InternalCompilerException("unexpected JVM type", loc)
+
+     case Type.JvmToEff(_, loc) => throw InternalCompilerException("unexpected JVM eff", loc)
+
+     case Type.UnresolvedJvmType(_, loc) => throw InternalCompilerException("unexpected JVM type", loc)
+
+   }
 
   /**
     * Returns the definition associated with the given symbol `sym`.
@@ -64,6 +103,20 @@ object Lowering {
     val itpe = Type.mkIoArrow(exp.tpe, tpe, loc)
     val defnSym = lookup(Defs.ChannelNewTuple, itpe)
     MonoAst.Expr.ApplyDef(defnSym, exp :: Nil, lowerType(itpe), lowerType(tpe), eff, loc)
+  }
+
+  /**
+    * The type of a channel which can transmit variables of type `tpe`.
+    */
+  private def mkChannelTpe(tpe: Type, loc: SourceLocation): Type = {
+    mkChannelTpe(tpe, Type.IO, loc)
+  }
+
+  /**
+    * The type of a channel which can transmit variables of type `tpe1` in region `tpe2`.
+    */
+  private def mkChannelTpe(tpe1: Type, tpe2: Type, loc: SourceLocation): Type = {
+    Type.Apply(Type.Apply(Types.ChannelMpmc, tpe1, loc), tpe2, loc)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -122,7 +122,7 @@ object Specialization {
     *   - No type aliases
     *   - Equivalent types are uniquely represented (e.g. fields in records types are alphabetized)
     */
-  private case class StrictSubstitution(s: Substitution) {
+  protected[monomorph] case class StrictSubstitution(s: Substitution) {
 
     /**
       * Applies `this` substitution to the given type `tpe`, returning a normalized type.
@@ -636,6 +636,11 @@ object Specialization {
       val methods = methods0.map(specializeJvmMethod(_, env0, subst))
       MonoAst.Expr.NewObject(name, clazz, Lowering.lowerType(subst(tpe)), subst(eff), methods, loc)
 
+    // New channel expressions are rewritten as follows:
+    //     %%CHANNEL_NEW%%(m)
+    // becomes a call to the standard library function:
+    //     Concurrent/Channel.newChannel(10)
+    //
     case LoweredAst.Expr.NewChannel(innerExp, tpe, eff, loc) =>
       val exp = specializeExp(innerExp, env0, subst)
       Lowering.visitNewChannel(exp, subst(tpe), eff, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Symbols.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Symbols.scala
@@ -17,12 +17,22 @@
 
 package ca.uwaterloo.flix.language.phase.monomorph
 
-import ca.uwaterloo.flix.language.ast.Symbol
+import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.phase.Lowering.Enums
 
 object Symbols {
   protected[monomorph] object Defs {
 
     lazy val ChannelNewTuple: Symbol.DefnSym = Symbol.mkDefnSym("Concurrent.Channel.newChannelTuple")
+
+  }
+
+  protected[monomorph] object Enums {
+    lazy val ChannelMpmc: Symbol.EnumSym = Symbol.mkEnumSym("Concurrent.Channel.Mpmc")
+  }
+
+  protected[monomorph] object Types {
+    lazy val ChannelMpmc: Type = Type.Cst(TypeConstructor.Enum(Enums.ChannelMpmc, Kind.Star ->: Kind.Eff ->: Kind.Star), SourceLocation.Unknown)
 
   }
 


### PR DESCRIPTION
I've moved `NewChannel` from `Lowering` to `monomorph/Lowering`. This was used as a case for getting the structure in place. I've also implemented the `lowerTypes` (copied the definition from `Lowering`, without Datalog lowering).

I'm unsure why `Annotations` need to be the way it is now. `TreeShaker1` would probably have worked as was, but we need the transitive dependencies at some point so it would just have happened later otherwise.

We still need the call to `visitType` in `Lowering`, unless we also `Datalog` in `lowerType`.