### PR TITLE
ci: rename package manager job

### DIFF
--- a/.github/workflows/package-manager.yaml
+++ b/.github/workflows/package-manager.yaml
@@ -11,7 +11,7 @@ concurrency:
   group: test-flix-package-manager-${{ github.ref }}
 
 jobs:
-  build-and-test:
+  build-and-test-pkg-man:
     runs-on: ubuntu-latest
     env:
       GRADLE_OPTS: "-Xms128m -Xmx4g"


### PR DESCRIPTION
Makes the package manager workflow optional.

Closes https://github.com/flix/flix/issues/11995