### PR TITLE
chore: update `List.toMapWith` signature

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1167,17 +1167,15 @@ mod List {
     ///
     /// Returns the association list `l` as a map.
     ///
-    /// If `l` contains multiple mappings with the same key, `toMap` does not
-    /// make any guarantees about which mapping will be in the resulting map.
+    /// If `l` contains multiple mappings with the same key the last occurrence is kept.
     ///
     pub def toMap(l: List[(a, b)]): Map[a, b] with Order[a] =
         foldLeft((acc, x) -> Map.insert(fst(x), snd(x), acc), Map.empty(), l)
 
     ///
-    /// Returns a map with elements of `s` as keys and `f` applied as values.
+    /// Returns a map with mappings `k => v` where `(k, v) = f(x)` for some `x` in `l`.
     ///
-    /// If `s` contains multiple mappings with the same key, `toMapWith` does not
-    /// make any guarantees about which mapping will be in the resulting map.
+    /// If multiple mappings with the same key are produced only the last occurrence is kept.
     ///
     pub def toMapWith(f: a -> (k, v), l: List[a]): Map[k, v] with Order[k] =
         foldLeft((acc, x) -> {

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -2039,6 +2039,9 @@ mod TestList {
     @Test
     def toMap03(): Unit \ Assert = assertEq(expected = Map#{1 => true, 2 => false}, List.toMap((1, true) :: (2, false) :: Nil))
 
+    @Test
+    def toMap04(): Unit \ Assert = assertEq(expected = Map#{1 => false}, List.toMap((1, true) :: (1, false) :: Nil))
+
     /////////////////////////////////////////////////////////////////////////////
     // toMapWith                                                               //
     /////////////////////////////////////////////////////////////////////////////
@@ -2062,6 +2065,10 @@ mod TestList {
     @Test
     def toMapWith05(): Unit \ Assert =
         assertEq(expected = Map#{2 => 11, 4 => 13, 7 => 16}, List.toMapWith(x -> (x + 1, x + 10), 3 :: 6 :: 1 :: Nil))
+
+    @Test
+    def toMapWith06(): Unit \ Assert =
+        assertEq(expected = Map#{3 => 5}, List.toMapWith(match (_, x) -> (3, x), (3, 4) :: (4, 5) :: Nil))
 
     /////////////////////////////////////////////////////////////////////////////
     // forEach                                                                 //


### PR DESCRIPTION
Implements #10388

Also changed two unrelated `foldRight` to `foldLeft` to avoid the `reverse`.