### PR TITLE
chore: update `List.groupBy` and add `List.groupWith`

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -957,15 +957,14 @@ mod List {
         }) |> List.map(Nel.reverse)
 
     ///
-    /// Partitions `l` into sublists such that for any two elements `x` and `y` in a sublist, if they are equal according to `Eq` on `a`.
+    /// Partitions `l` into sublists such that for any two elements `x` and `y` in a sublist,
+    /// if `f(x)` and `f(y)` are equal according to `Eq` on `b`.
     ///
     /// A sublist is created by iterating through the remaining elements of `l` from left to right and adding an
     /// element to the sublist if and only if doing so creates no conflicts with the elements already in the sublist.
     ///
-    /// `Eq` must define an equivalence relation.
-    ///
-    pub def groupBy(l: List[a]): List[Nel[a]] with Eq[a] =
-        groupWith(Eq.eq, l)
+    pub def groupBy(f: a -> b, l: List[a]): List[Nel[a]] with Eq[b] =
+        groupWith(Eq.eq `on` f, l)
 
     ///
     /// Helper function for `groupWith`.

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1636,13 +1636,13 @@ mod TestList {
     }
 
     @Test
-    def groupBy01(): Unit \ Assert = assertEq(expected = Nil, List.groupBy((Nil: List[A])))
+    def groupBy01(): Unit \ Assert = assertEq(expected = Nil, List.groupBy(identity, (Nil: List[A])))
 
     @Test
-    def groupBy02(): Unit \ Assert = assertEq(expected = (Nel.singleton(A.A(1, 1))) :: Nil, List.groupBy((A.A(1, 1) :: Nil)))
+    def groupBy02(): Unit \ Assert = assertEq(expected = (Nel.singleton(A.A(1, 1))) :: Nil, List.groupBy(identity, (A.A(1, 1) :: Nil)))
 
     @Test
-    def groupBy03(): Unit \ Assert = assertEq(expected = listToNel(A.A(1, 1), A.A(1, 2) :: A.A(1, 1) :: Nil) :: (listToNel(A.A(2, 1), A.A(2, 4) :: Nil)) :: Nil, List.groupBy((A.A(1, 1) :: A.A(2, 1) :: A.A(1, 2) :: A.A(1, 1) :: A.A(2, 4) :: Nil)))
+    def groupBy03(): Unit \ Assert = assertEq(expected = listToNel(A.A(1, 1), A.A(1, 2) :: A.A(1, 1) :: Nil) :: (listToNel(A.A(2, 1), A.A(2, 4) :: Nil)) :: Nil, List.groupBy(identity, (A.A(1, 1) :: A.A(2, 1) :: A.A(1, 2) :: A.A(1, 1) :: A.A(2, 4) :: Nil)))
 
     /////////////////////////////////////////////////////////////////////////////
     // groupWith                                                               //


### PR DESCRIPTION
Implements/fixes #11118

As summary `f` in `groupWith` (previously `groupBy`) should define an equivalence relation at best saving an `n` factor.

Also add `groupBy` which is simply `groupWith` using the `Eq.eq` for the type.