### PR TITLE
feat: add `if` expression without else

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -111,7 +111,7 @@ object WeededAst {
 
     case class Binary(sop: SemanticOp.BinaryOp, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
-    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Option[Expr], loc: SourceLocation) extends Expr
 
     case class Stm(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -536,7 +536,7 @@ object Desugar {
     case WeededAst.Expr.IfThenElse(exp1, exp2, exp3, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      val e3 = visitExp(exp3)
+      val e3 = exp3.map(visitExp).getOrElse(Expr.Cst(Constant.Unit, loc.asSynthetic))
       Expr.IfThenElse(e1, e2, e3, loc)
 
     case WeededAst.Expr.Stm(exp1, exp2, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1317,12 +1317,14 @@ object Weeder2 {
       pickAll(TreeKind.Expr.Expr, tree) match {
         case exprCondition :: exprThen :: exprElse :: Nil =>
           mapN(visitExpr(exprCondition), visitExpr(exprThen), visitExpr(exprElse)) {
-            (condition, tthen, eelse) => Expr.IfThenElse(condition, tthen, eelse, tree.loc)
+            (condition, tthen, eelse) => Expr.IfThenElse(condition, tthen, Some(eelse), tree.loc)
           }
-        case _ =>
-          val error = UnexpectedToken(NamedTokenSet.FromKinds(Set(TokenKind.KeywordElse)), actual = None, SyntacticContext.Expr.OtherExpr, hint = Some("the else-branch is required in Flix."), tree.loc)
-          sctx.errors.add(error)
-          Validation.Success(Expr.Error(error))
+        case exprCondition :: exprThen :: Nil =>
+          mapN(visitExpr(exprCondition), visitExpr(exprThen)) {
+            (condition, tthen) => Expr.IfThenElse(condition, tthen, None, tree.loc)
+          }
+        case exprs =>
+          throw InternalCompilerException(s"Parser error. Expected 2 expressions in statement but found '${exprs.length}'.", tree.loc)
       }
     }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -741,6 +741,17 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("BadIfThenElse.04") {
+    val input =
+      """
+        |def foo(): Unit \ IO = if (false) if (true) println(1) else println(1)
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("BadLetMatch.01") {
     val input =
       """

--- a/main/test/flix/Test.Exp.IfThen.flix
+++ b/main/test/flix/Test.Exp.IfThen.flix
@@ -1,0 +1,58 @@
+mod Test.Exp.IfThen {
+
+    @test
+    def testIfThen01(): Bool = region rc {
+        let ref = Ref.fresh(rc, false);
+        if (true) {
+            Ref.put(true, ref)
+        };
+        Ref.get(ref)
+    }
+
+    @test
+    def testIfThen02(): Bool = region rc {
+        let ref = Ref.fresh(rc, true);
+        if (false) {
+            Ref.put(false, ref)
+        };
+        Ref.get(ref)
+    }
+
+    @test
+    def testIfThen03(): Bool = region rc {
+        let ref = Ref.fresh(rc, true);
+        if (true) {
+            if (false) {
+                Ref.put(false, ref)
+            }
+        };
+        Ref.get(ref)
+    }
+
+    @test
+    def testIfThen04(): Bool = region rc {
+        let ref = Ref.fresh(rc, true);
+        if (true) {
+            if (false) {
+                Ref.put(false, ref)
+            } else {
+                Ref.put(true, ref)
+            }
+        };
+        Ref.get(ref)
+    }
+
+    @test
+    def testIfThen05(): Bool = region rc {
+        let ref = Ref.fresh(rc, true);
+        if (true) {
+            if (true) {
+                Ref.put(true, ref)
+            } else {
+                Ref.put(false, ref)
+            }
+        };
+        Ref.get(ref)
+    }
+
+}


### PR DESCRIPTION
Minimal implementation of #12021

The fact that `if (a) if (b) e else e` is illegal is an accident, but a happy one. The error is quite bad though and `if (a) if (b) e else e else e` is legal...