### PR TITLE
chore: report better error for signatures

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
@@ -500,6 +500,34 @@ object RedundancyError {
   }
 
   /**
+    * An error raised to indicate that the given type parameter `ident` is not used in the signature.
+    *
+    * @param ident the unused type variable.
+    */
+  case class UnusedTypeParamSignature(ident: Name.Ident, loc: SourceLocation) extends RedundancyError {
+    def summary: String = "Type parameter unused in function signature."
+
+    def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Unused type parameter '${red(ident.name)}'. The parameter is not referenced in the signature.
+         |
+         |${code(ident.loc, "type parameter unused in function signature.")}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = Some({
+      s"""
+         |Possible fixes:
+         |
+         |  (1)  Use the type parameter in the signature.
+         |  (2)  Remove type parameter.
+         |  (3)  Prefix the type parameter name with an underscore.
+         |
+         |""".stripMargin
+    })
+  }
+
+  /**
     * An error raised to indicate that the given variable symbol `sym` is not used.
     *
     * @param sym the unused variable symbol.

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -303,12 +303,12 @@ object Redundancy {
   /**
     * Finds unused type parameters.
     */
-  private def findUnusedTypeParameters(spec: Spec): List[UnusedTypeParam] = spec match {
+  private def findUnusedTypeParameters(spec: Spec): List[UnusedTypeParamSignature] = spec match {
     case Spec(_, _, _, tparams, fparams, _, tpe, eff, tconstrs, econstrs) =>
       val tpes = fparams.map(_.tpe) ::: tpe :: eff :: tconstrs.map(_.arg) ::: econstrs.map(_.tpe1) ::: econstrs.map(_.tpe2)
       val used = tpes.flatMap { t => t.typeVars.map(_.sym) }.toSet
       tparams.collect {
-        case tparam if deadTypeVar(tparam.sym, used) => UnusedTypeParam(tparam.name, tparam.loc)
+        case tparam if deadTypeVar(tparam.sym, used) => UnusedTypeParamSignature(tparam.name, tparam.loc)
       }
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -945,44 +945,57 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.UnusedFormalParam](result)
   }
 
-  test("UnusedTypeParam.Def.01") {
+  test("UnusedTypeParamSignature.Def.01") {
     val input =
       s"""
          |pub def f[a: Type](): Int32 = 123
          |
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[RedundancyError.UnusedTypeParam](result)
+    expectError[RedundancyError.UnusedTypeParamSignature](result)
   }
 
-  test("UnusedTypeParam.Def.02") {
+  test("UnusedTypeParamSignature.Def.02") {
     val input =
       s"""
          |pub def f[a: Type, b: Type](x: a): a = x
          |
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[RedundancyError.UnusedTypeParam](result)
+    expectError[RedundancyError.UnusedTypeParamSignature](result)
   }
 
-  test("UnusedTypeParam.Def.03") {
+  test("UnusedTypeParamSignature.Def.03") {
     val input =
       s"""
          |pub def f[a: Type, b: Type](x: b): b = x
          |
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[RedundancyError.UnusedTypeParam](result)
+    expectError[RedundancyError.UnusedTypeParamSignature](result)
   }
 
-  test("UnusedTypeParam.Def.04") {
+  test("UnusedTypeParamSignature.Def.04") {
     val input =
       s"""
          |pub def f[a: Type, b: Type, c: Type](x: a, y: c): (a, c) = (x, y)
          |
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[RedundancyError.UnusedTypeParam](result)
+    expectError[RedundancyError.UnusedTypeParamSignature](result)
+  }
+
+  test("UnusedTypeParamSignature.Def.05") {
+    val input =
+      s"""
+         |pub def f[a: Type](x: Int32): Int32 = {
+         | let x: a = ???;
+         | 1
+         |}
+         |
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[RedundancyError.UnusedTypeParamSignature](result)
   }
 
   test("UnusedTypeParam.Struct.01") {


### PR DESCRIPTION
Fixes #11960

I've simply specified the error message to mention that the type parameter must be used in the signature.