### PR TITLE
feat: use `HttpClient` in `GitHub` API wrapper

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -334,6 +334,8 @@ object GitHub {
       * Sends the HTTP request, `request`, and returns the response.
       *
       * Is blocking and thread-safe.
+      *
+      * May throw [[IOException]].
       */
     def sendRequest(request: HttpRequest): HttpResponse[String] = this.synchronized {
       HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString())


### PR DESCRIPTION
This is newer, i.e., Java 11+ and has better reliability than the lower level connection api. This also supports `PATCH` as a HTTP method which the old one didn't.