### PR TITLE
fix: don't remove negative `NotMemberOf`

### DIFF
--- a/main/src/library/Fixpoint3/Ast/Datalog.flix
+++ b/main/src/library/Fixpoint3/Ast/Datalog.flix
@@ -132,9 +132,9 @@ mod Fixpoint3.Ast.Datalog {
                     Map.joinWith(predSym -> facts -> {
                         let builder = StringBuilder.empty(rc);
                         foreach ((fact, annotation) <- facts) {
-                            StringBuilder.append("${indent}${fact} @ ${annotation},{String.lineSeparator()}${indent}", builder)
+                            StringBuilder.append("${indent}${fact} @ ${annotation},${String.lineSeparator()}${indent}", builder)
                         };
-                        let textOverflow = String.length("$,{String.lineSeparator()}${indent}");
+                        let textOverflow = String.length("$,${String.lineSeparator()}${indent}");
                         let rawFactString = StringBuilder.toString(builder);
                         let factsString = String.sliceLeft(end = String.length(rawFactString)- textOverflow, rawFactString);
                         "${predSym}:${String.lineSeparator()}${factsString}"

--- a/main/src/library/Fixpoint3/Ast/Ram.flix
+++ b/main/src/library/Fixpoint3/Ast/Ram.flix
@@ -207,8 +207,8 @@ mod Fixpoint3.Ast.Ram {
     ///
     /// `IsEmpty(relSym)`: True if there are no facts in relation `relSym`.
     ///
-    /// `NotMemberOf(terms, relSym)`: True if the tuple constructed from `terms` is not
-    /// in relation `relSym`.
+    /// `NotMemberOf(terms, relSym, repNegative)`: True if the tuple constructed from `terms` is not
+    /// in relation `relSym`. `repNegative` is true if `NotMemberOf` is introduced by a `not A(...)`.
     ///
     /// `NotBot(term, leq, bot)`: True if `term` is not a `bot`.
     /// `term` must be a Meet or RowLoad of a lattice var.
@@ -227,7 +227,7 @@ mod Fixpoint3.Ast.Ram {
     pub enum BoolExp {
         case Not(BoolExp)
         case IsEmpty(RelSym)
-        case NotMemberOf(Vector[RamTerm], RelSym)
+        case NotMemberOf(Vector[RamTerm], RelSym, Bool)
         case NotBot(RamTerm, Boxed -> Boxed -> Bool, Boxed)
         case Leq(Boxed, RowVar, RelSym)
         case Eq(RamTerm, RamTerm)
@@ -243,7 +243,7 @@ mod Fixpoint3.Ast.Ram {
             match exp {
                 case BoolExp.Not(boolExp)                  => "not (${boolExp})"
                 case BoolExp.IsEmpty(relSym)               => "${relSym} = ∅"
-                case BoolExp.NotMemberOf(terms, relSym)    => "(${terms |> Vector.join(", ")}) ∉ ${relSym}"
+                case BoolExp.NotMemberOf(terms, relSym, _) => "(${terms |> Vector.join(", ")}) ∉ ${relSym}"
                 case BoolExp.NotBot(term, _, _)            => "(${term}) ≠ ⊥"
                 case BoolExp.Leq(elem, _, term)            => "${elem} ≤ (${term})"
                 case BoolExp.Eq(lhs, rhs)                  => "${lhs} = ${rhs}"

--- a/main/src/library/Fixpoint3/Phase/Compiler.flix
+++ b/main/src/library/Fixpoint3/Phase/Compiler.flix
@@ -345,7 +345,7 @@ mod Fixpoint3.Phase.Compiler {
                     case Some(join) =>
                         let relSym = Predicate.headAtomToRelSym(headAtom, Full, predicates);
                         let loopBody = RelOp.If(
-                            Vector#{BoolExp.NotMemberOf(ramTerms, relSym)} ++ join,
+                            Vector#{BoolExp.NotMemberOf(ramTerms, relSym, false)} ++ join,
                             projection
                         );
                         let insert = (loopBody, augBody)
@@ -558,7 +558,7 @@ mod Fixpoint3.Phase.Compiler {
                             })
                     case BodyAtom(PredSym(_, id), _, Polarity.Negative, _, terms) =>
                         let ramTerms = Vector.mapWithIndex(compileBodyTerm(id), terms);
-                        Vector#{BoolExp.NotMemberOf(ramTerms, Predicate.bodyAtomToRelSym(atom, Full, predicates))}
+                        Vector#{BoolExp.NotMemberOf(ramTerms, Predicate.bodyAtomToRelSym(atom, Full, predicates), true)}
                     case Functional(_, _, _) => Vector.empty()
                     case Guard0(_) =>
                         Vector#{}

--- a/main/src/library/Fixpoint3/Phase/Hoisting.flix
+++ b/main/src/library/Fixpoint3/Phase/Hoisting.flix
@@ -441,7 +441,7 @@ mod Fixpoint3.Phase.Hoisting {
         match bexp {
             case BoolExp.Not(boolExp) => boolVariablesOf(termMap, equalitySets, boolExp)
             case BoolExp.IsEmpty(_) => Set#{}
-            case BoolExp.NotMemberOf(terms, _) => Vector.foldMap(termVarsOf, terms)
+            case BoolExp.NotMemberOf(terms, _, _) => Vector.foldMap(termVarsOf, terms)
             case BoolExp.NotBot(t1, _, _) => termVarsOf(t1)
             case BoolExp.Leq(_, rv, relSym) => getRepRowVar(termMap, equalitySets, rv, arityOfNonLat(relSym))
             case BoolExp.Eq(_, _) => Set#{}
@@ -528,7 +528,7 @@ mod Fixpoint3.Phase.Hoisting {
         match bexp {
             case BoolExp.Not(boolExp) => BoolExp.Not(replaceRec(boolExp))
             case BoolExp.IsEmpty(_) => bexp
-            case BoolExp.NotMemberOf(terms, rel) => BoolExp.NotMemberOf(Vector.map(replaceTerm, terms), rel)
+            case BoolExp.NotMemberOf(terms, rel, repNegative) => BoolExp.NotMemberOf(Vector.map(replaceTerm, terms), rel, repNegative)
             case BoolExp.NotBot(t1, f, bot) => BoolExp.NotBot(replaceTerm(t1), f, bot)
             case BoolExp.Leq(_, _, _) => bexp
             case BoolExp.Eq(t1, t2) => BoolExp.Eq(replaceTerm(t1), replaceTerm(t2))
@@ -584,7 +584,7 @@ mod Fixpoint3.Phase.Hoisting {
         match bexp {
             case BoolExp.Not(boolExp) => isBoolGround(termMap, equalitySets, boolExp)
             case BoolExp.IsEmpty(_) => unreachable!()
-            case BoolExp.NotMemberOf(terms, _) => Vector.forAll(termGround, terms)
+            case BoolExp.NotMemberOf(terms, _, _) => Vector.forAll(termGround, terms)
             case BoolExp.NotBot(t1, _, _) => termGround(t1)
             case BoolExp.Leq(_, rv, relSym) =>
                 Map.memberOf(getOrCrash(MutDisjointSets.find((rv, arityOfNonLat(relSym)), equalitySets)), termMap)

--- a/main/src/library/Fixpoint3/Phase/Lowering.flix
+++ b/main/src/library/Fixpoint3/Phase/Lowering.flix
@@ -463,7 +463,7 @@ mod Fixpoint3.Phase.Lowering {
                 let (_, placements) = indexInfo;
                 let sPos = getOrCrash(Map.get((s, 0), placements));
                 Some(ExecutableRam.BoolExp.IsEmpty(sPos))
-            case Ram.BoolExp.NotMemberOf(terms, s) =>
+            case Ram.BoolExp.NotMemberOf(terms, s, _) =>
                 let (_, placements) = indexInfo;
                 let den = toDenotation(s);
                 let sPos = getOrCrash(Map.get((s, 0), placements));

--- a/main/src/library/Fixpoint3/Phase/ProvenanceAugment.flix
+++ b/main/src/library/Fixpoint3/Phase/ProvenanceAugment.flix
@@ -27,7 +27,8 @@
 /// which has time/depth `k` then this facts has at most time/depth `k + 1`.
 ///
 /// This module removes `BoolExp.NotMemberOf` as the `ProvProject` introduced by `Lowering`
-/// must ensure this property.
+/// must ensure this property. Note that only this does not refers to the `NotMemberOf` relating
+/// to negative dependencies/the `not A(...)` constructs.
 ///
  mod Fixpoint3.Phase.ProvenanceAugment {
     use Fixpoint3.Ast.Ram
@@ -123,15 +124,19 @@
 
 
     ///
-    /// Returns the `BoolExp`'s in `boolExps` without `NotMemberOf`.
+    /// Returns the `BoolExp`'s in `boolExps` without `NotMemberOf`. The `NotMemberOf` introduced by
+    /// negative dependencies are kept (`not A(...)`).
     ///
     def removeNotMemberOf(boolExps: Vector[BoolExp]): Vector[BoolExp] = Vector.filterMap(notNotMemberOf, boolExps)
 
     ///
-    /// Returns `Some(boolExp)` if `boolExp` is not `NotMemberOf`. Otherwise returns `None`.
+    /// Returns `Some(boolExp)` if `boolExp` is not `NotMemberOf`.
+    ///
+    /// Otherwise if `boolExp` is `NotMemberOf` it returns `Some(boolExp)` if the expression was
+    /// introduced by a negative dependency (`not A(...)`).
     ///
     def notNotMemberOf(boolExp: BoolExp): Option[BoolExp] = match boolExp {
-        case BoolExp.NotMemberOf(_, _) => None
+        case BoolExp.NotMemberOf(_, _, false) => None
         case _ => Some(boolExp)
     }
 

--- a/main/src/library/Fixpoint3/Phase/Simplifier.flix
+++ b/main/src/library/Fixpoint3/Phase/Simplifier.flix
@@ -167,8 +167,8 @@ mod Fixpoint3.Phase.Simplifier {
                     })
                     // Partition into membership tests and rest.
                     |> Vector.partition(e -> match e {
-                        case BoolExp.NotMemberOf(_, _) => true
-                        case _                         => false
+                        case BoolExp.NotMemberOf(_, _, _) => true
+                        case _                            => false
                     });
                 let newTest = rest ++ memberOf;
                 // Simplify `if () then body` to `body`.

--- a/main/test/flix/Test.Exp.Fixpoint.PQuery.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.PQuery.flix
@@ -1172,4 +1172,38 @@ mod Test.Exp.Fixpoint.PQuery {
         assertEq(expected = expected, actual)
     }
 
+    /////////////////////////////////////////////////////////////////////////////
+    /// `pquery` should work with negative dependencies.
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def testPQueryNegative01(): Unit \ Assert =
+        let pr = #{
+            B(1) :- not A(1).
+        };
+
+        let pp = pquery pr select B(1) with {B};
+        let expected = Vector#{0};
+        let actual = Vector.map(v -> ematch v {
+            case B(_) => 0
+        }, pp);
+        assertEq(expected = expected, actual)
+
+    @Test
+    def testPQueryNegative02(): Unit \ Assert =
+        let pr = #{
+            A(1).
+            B(1) :- not A(1).
+            C(1) :- not B(1).
+        };
+
+        let pp = pquery pr select C(1) with {A, B, C};
+        let expected = Vector#{1};
+        let actual = Vector.map(v -> ematch v {
+            case A(_) => -1
+            case B(_) => 0
+            case C(_) => 1
+        }, pp);
+        assertEq(expected = expected, actual)
+
 }


### PR DESCRIPTION
First part of #12117

As part #11362 we removed the `NotMemberOf` expressions when doing provenance computations.

The purpose was to get rid of the check that a fact had already been computed. Unfortunately this also removed negative dependencies altogether, so the following program
```
A(x) :- B(x), not C(x).
```
Would become
```
A(x) :- B(x).
```
when run by the interpreter. `ProvenanceReconstruct` uses its own mini-datalog engine and cannot reconstruct `A(x)` if it was not supposed to be true leading to the weird crash in #12101. Note that we need one more fix before I consider #12101 to be complete fixed, though this will allow the example program to run.

(I've also fixed some slight formatting issues in our debugging/`ToString` of `Datalog`)