### PR TITLE
fix: `BPlusTree` should handle a `search` of length 0 correctly

### DIFF
--- a/main/src/library/BPlusTree.flix
+++ b/main/src/library/BPlusTree.flix
@@ -356,7 +356,7 @@ mod BPlusTree {
     ///
     /// Not thread-safe.
     ///
-    pub def map(rc1: Region[r1], f: v1 -> v2 \ ef, t: BPlusTree[k, v1, r]): BPlusTree[k, v2, r1] \ ef + r + r1 with Order[k] = 
+    pub def map(rc1: Region[r1], f: v1 -> v2 \ ef, t: BPlusTree[k, v1, r]): BPlusTree[k, v2, r1] \ ef + r + r1 with Order[k] =
         mapWithKey(rc1, _ -> v -> f(v), t)
 
     ///
@@ -403,17 +403,17 @@ mod BPlusTree {
     ///
     /// Not thread-safe.
     ///
-    pub def toMap(t: BPlusTree[k, v, r]): Map[k, v] \ r with Order[k] = 
+    pub def toMap(t: BPlusTree[k, v, r]): Map[k, v] \ r with Order[k] =
         (Map.empty(), t) ||> foldLeftWithKey(acc -> k -> v -> Map.insert(k, v, acc))
-    
+
     ///
     /// Returns `t` as a set of key-value pairs.
     ///
     /// Not thread-safe.
     ///
-    pub def toSet(t: BPlusTree[k, v, r]): Set[(k, v)] \ r with Order[k], Order[v] = 
+    pub def toSet(t: BPlusTree[k, v, r]): Set[(k, v)] \ r with Order[k], Order[v] =
         (Set.empty(), t) ||> foldLeftWithKey(acc -> k -> v -> Set.insert((k, v), acc))
-    
+
     ///
     /// Returns `t` as a vector of key-value pairs.
     ///
@@ -431,14 +431,14 @@ mod BPlusTree {
     /// Returns a fresh empty BPlusTree tree of standard arity.
     ///
     pub def empty(rc: Region[r]): BPlusTree[k, v, r] \ r =
-        emptyWithSearch(rc, Vector#{})
+        emptyWithSearch(rc, unchecked_cast(null as Vector[Int32]))
 
     ///
     /// Returns a fresh empty BPlusTree tree with arity `m` (the maximum keys/values per node).
     /// The arity must be at least 3.
     ///
     pub def emptyWithArity(rc: Region[r], m: Int32): BPlusTree[k, v, r] \ r =
-        emptyWithArityAndSearch(rc, m `Int32.max` 3, Vector#{})
+        emptyWithArityAndSearch(rc, m `Int32.max` 3, unchecked_cast(null as Vector[Int32]))
 
     ///
     /// Returns a fresh empty BPlusTree tree of arity `m` (the maximum keys/values per node).
@@ -545,7 +545,7 @@ mod BPlusTree {
     ///
     /// Returns `v` if `k => v` is in `t`. Otherwise, returns `d`.
     ///
-    /// Thread-safe. 
+    /// Thread-safe.
     ///
     pub def getWithDefault(k: k, d: v, t: BPlusTree[k, v, r]): v \ r with Order[k] =
         let (leaf, stamp) = BPlusTree.findLeaf(k, t);
@@ -1093,15 +1093,15 @@ mod BPlusTree {
         /// The elements will be compared in the order given by `search`.
         ///
         def comparison(val1: k, val2: k, search: Search): Int32 with Order[k] = {
-            let len = Vector.length(search);
-            // If the values are of type Vector[Int64] check whether a specific search is given.
-            // If so use the custom compare function for that search.
-            if (len == 0) {
+            // For the Datalog engine we support a custom order, but only for `Vector[Int64]`.
+            // This is checked by testing whether `search` is `null`.
+            if (Object.isNull(search)) {
                 let comp = val1 <=> val2;
                 if (comp == Comparison.GreaterThan) 1
                 else if (comp == Comparison.LessThan) -1
                 else 0
             } else {
+                let len = Vector.length(search);
                 vectorComp(unchecked_cast(val1 as Vector[Int64]), unchecked_cast(val2 as Vector[Int64]), len, 0, search)
             }
         }
@@ -1147,7 +1147,7 @@ mod BPlusTree {
             loop(1, node)
 
         ///
-        /// Return the mapping `k => v` at position `index` in `node`. Crashes if 
+        /// Return the mapping `k => v` at position `index` in `node`. Crashes if
         /// `index >= node->size`.
         ///
         pub def getKeyAndValueAt(index: Int32, node: Node[k, v, r]): (k, v) \ r = {

--- a/main/src/library/Fixpoint3/Boxing.flix
+++ b/main/src/library/Fixpoint3/Boxing.flix
@@ -89,7 +89,9 @@ mod Fixpoint3.Boxing {
         };
         foreach ((relSym, relFacts) <- f2) {
             let RelSym.Symbol(PredSym.PredSym(_, id), _, _) = relSym;
-            let newTree = MutMap.getOrElsePut(relSym, BPlusTree.empty(rc1), newFacts);
+            // Get some search. This means that we have to create one less index in the interpreter.
+            let search = getOrCrash(Map.get(relSym, indexes)) |> Vector.get(0);
+            let newTree = MutMap.getOrElsePut(relSym, BPlusTree.emptyWithArityAndSearch(rc1, usedArity(), search), newFacts);
             // `id` will always be a full `id`.
             mapAllFacts(relFacts, boxingInfo, TypeInfo.getTypeOf(id, typeInfo), newTree)
         };

--- a/main/src/library/Fixpoint3/Interpreter.flix
+++ b/main/src/library/Fixpoint3/Interpreter.flix
@@ -150,7 +150,12 @@ mod Fixpoint3.Interpreter {
         };
         let indexes = Array.empty(rc, indexNum);
         foreach ((relSym, searches) <- indexMap) {
-            let tuples = Map.getWithDefault(relSym, BPlusTree.empty(rc), facts);
+            // We need to ensure that we do not pass a tree with `null` as search.
+            let default = match Vector.head(searches) {
+                case None => BPlusTree.empty(rc) // The foreach will be empty.
+                case Some(search0) => BPlusTree.emptyWithArityAndSearch(rc, usedArity(), search0)
+            };
+            let tuples = Map.getWithDefault(relSym, default, facts);
             foreach ((num, search) <- ForEach.withIndex(searches)) {
                 let pos = match Map.get((relSym, num), posMap) {
                     case Some(v) => v

--- a/main/src/library/Fixpoint3/Phase/Compiler.flix
+++ b/main/src/library/Fixpoint3/Phase/Compiler.flix
@@ -30,10 +30,11 @@ mod Fixpoint3.Phase.Compiler {
     use Fixpoint3.Ast.Shared.PredSym.PredSym
     use Fixpoint3.Boxed
     use Fixpoint3.Counter
-    use Fixpoint3.Util.getOrCrash
+    use Fixpoint3.Options.usedArity
     use Fixpoint3.Predicate
     use Fixpoint3.Predicate.PredType.{Full, Delta, New}
     use Fixpoint3.TypeInfo.{getType, getTypeOf, Type, typeDatalog, TypeInformation}
+    use Fixpoint3.Util.getOrCrash
 
     ///
     /// Compile the given Datalog program `d` to RAM.
@@ -110,7 +111,7 @@ mod Fixpoint3.Phase.Compiler {
             match den {
                 case Relational =>
                     let sym = Predicate.headAtomToRelSym(headAtom, Full, predicates);
-                    let newFactsTree = MutMap.getOrElsePut(sym, BPlusTree.empty(Static), newFacts);
+                    let newFactsTree = MutMap.getOrElsePut(sym, BPlusTree.emptyWithArity(Static, usedArity()), newFacts);
                     BPlusTree.put(x, Boxed.NoValue, newFactsTree)
                 case Latticenal(bot, leq, lub, _) =>
                     // Remove p(;bot) from the facts
@@ -119,7 +120,7 @@ mod Fixpoint3.Phase.Compiler {
                         ()
                     } else {
                         let sym = Predicate.headAtomToRelSym(headAtom, Full, predicates);
-                        let newFactsTree = MutMap.getOrElsePut(sym, BPlusTree.empty(Static), newFacts);
+                        let newFactsTree = MutMap.getOrElsePut(sym, BPlusTree.emptyWithArity(Static, usedArity()), newFacts);
                         BPlusTree.putWith(lub, Vector.dropRight(1, x), latVal, newFactsTree)
                     }
             }

--- a/main/src/library/Fixpoint3/Phase/ProvenanceAugment.flix
+++ b/main/src/library/Fixpoint3/Phase/ProvenanceAugment.flix
@@ -36,6 +36,7 @@
     use Fixpoint3.Boxed
     use Fixpoint3.Boxed.BoxedInt64
     use Fixpoint3.Counter
+    use Fixpoint3.Options.usedArity
     use Fixpoint3.TypeInfo.{expandTypeToProv, expandTypeInfoToProv, provType}
 
     ///
@@ -75,7 +76,7 @@
     /// `[42i64, "someString", Nil, 0, -1]`.
     ///
     def augmentFacts(oldTree: BPlusTree[Vector[Boxed], Boxed, Static]): BPlusTree[Vector[Boxed], Boxed, Static] \ IO = {
-        let newTree = BPlusTree.empty(Static);
+        let newTree = BPlusTree.emptyWithArity(Static, usedArity());
         BPlusTree.forEach(tuple -> v ->
             let annotatedVector = tuple ++ Vector#{BoxedInt64(0i64), BoxedInt64(-1i64)};
             BPlusTree.put(annotatedVector, v, newTree)

--- a/main/test/flix/Test.Exp.Fixpoint.PQuery.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.PQuery.flix
@@ -241,7 +241,7 @@ mod Test.Exp.Fixpoint.PQuery {
         assertEq(expected = expected, actual)
 
     @Test
-    def testPQueryDepth2Nullary(): Unit \ Assert =
+    def testPQueryDepth2Nullary01(): Unit \ Assert =
         let pr = #{
             A.
             B :- A.
@@ -250,6 +250,25 @@ mod Test.Exp.Fixpoint.PQuery {
         let pp = pquery pr select R with {A};
         let expected = Vector#{42, 42};
         let actual = Vector.map(v -> ematch v { case A => 42 }, pp);
+        assertEq(expected = expected, actual)
+
+    @Test
+    def testPQueryDepth2Nullary02(): Unit \ Assert =
+        // We use negative dependencies because it forces the use of `memberOf`.
+        // Positive dependencies would simply translate to foreach loop.
+        let pr = #{
+            A.
+            B :- not A.
+            C :- not B.
+        };
+
+        let pp = pquery pr select C with {A, B, C};
+        let expected = Vector#{'C'};
+        let actual = Vector.map(v -> ematch v {
+            case A => 'A'
+            case B => 'B'
+            case C => 'C'
+        }, pp);
         assertEq(expected = expected, actual)
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #12101 (technically that was already fixed, but this issue is somewhat related)

This is a small fix for nullary atoms. It would only show up for negative dependencies (`not A`).

The problem is: For `pquery` with `A` (nullary) we represent this by `Vector#{depth, rule}` use the search `Vector#{}`. This gets interpreted as 'use the standard order' meaning we test whether `A` is true by checking whether it has been computed with some arbitrary annotation. This is not the wanted behavior.

I here use `null` to indicate that we should use the default order. We never want to use the default order in the interpreter and we would now crash instead of computing something incoherent (well it would probably crash during reconstruction anyway). We could in principle introduce a boolean in the `BPlusTree` struct, but I find that even less clean.

This is also the second part of #12117, which can be closed afterwards.