### PR TITLE
refactor: move last channel part to monomorpher

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -147,6 +147,8 @@ object LoweredAst {
 
     case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
+    case class ParYield(frags: List[ParYieldFragment], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
   }
 
   sealed trait Pattern {

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -123,6 +123,8 @@ object LoweredAstPrinter {
 
     case LoweredAst.Expr.SelectChannel(_, _, _, _, _) => DocAst.Expr.Unknown
 
+    case LoweredAst.Expr.ParYield(_, _, _, _, _) => DocAst.Expr.Unknown
+
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
@@ -162,6 +162,9 @@ object TreeShaker1 {
     case Expr.SelectChannel(selects, optExp, _, _, _) =>
       visitExps(selects.map(_.exp)) ++ visitExps(selects.map(_.chan)) ++ optExp.map(visitExp).getOrElse(Set())
 
+    case Expr.ParYield(frags, exp, _, _, _) =>
+      visitExps(frags.map(_.exp)) ++ visitExp(exp)
+
   }
 
   /** Returns the symbols reachable from `exps`. */

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -659,6 +659,17 @@ object Specialization {
       val default = default0.map { d => specializeExp(d, env0, subst) }
       Lowering.mkSelectChannel(rules, default, subst(tpe), subst(eff), loc)
 
+    case LoweredAst.Expr.ParYield(frags, exp, tpe, eff, loc) =>
+      var curEnv = env0
+      val fs = frags.map {
+        case LoweredAst.ParYieldFragment(pat, fragExp, fragLoc) =>
+          val (p, env1) = specializePat(pat, subst)
+          curEnv ++= env1
+          (p, specializeExp(fragExp, curEnv, subst), fragLoc)
+      }
+      val e = specializeExp(exp, curEnv, subst)
+      Lowering.mkParYield(fs, e, subst(tpe), subst(eff), loc)
+
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Symbols.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Symbols.scala
@@ -24,6 +24,7 @@ object Symbols {
   protected[monomorph] object Defs {
 
     lazy val ChannelGet: Symbol.DefnSym = Symbol.mkDefnSym("Concurrent.Channel.get")
+    lazy val ChannelNew: Symbol.DefnSym = Symbol.mkDefnSym("Concurrent.Channel.newChannel")
     lazy val ChannelPut: Symbol.DefnSym = Symbol.mkDefnSym("Concurrent.Channel.put")
     lazy val ChannelMpmcAdmin: Symbol.DefnSym = Symbol.mkDefnSym("Concurrent.Channel.mpmcAdmin")
     lazy val ChannelNewTuple: Symbol.DefnSym = Symbol.mkDefnSym("Concurrent.Channel.newChannelTuple")


### PR DESCRIPTION
This should be the final move before the refactor. With the closing of #12053 we can move forward with Lowering/monomorphing.

1. I've moved lowering of `ParYield` and removed the now unused code from `Lowering`.
2. I've disabled lowering of `Sender` and `Receiver` in `Lowering` since all code relating to it has been moved.
