### PR TITLE
ci: fix GitHub token secret in community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -36,8 +36,6 @@ jobs:
     strategy:
       # collect all the failures
       fail-fast: false
-      # run them one at a time
-      max-parallel: 1
       matrix:
         repo:
           - "flix/datalog2"


### PR DESCRIPTION
The github token was misconfigured. This seems to allow us to run the community build in parallel.