### PR TITLE
refactor: `Token.sp1` -> `Token.start` and `Token.start` to `Token.startIndex`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Formatter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Formatter.scala
@@ -123,8 +123,8 @@ object Formatter {
   private def createSeparatorTextEdit(prevLast: Token, nextFirst: Token, seperator: String) = {
     TextEdit(
       Range(
-        Position.from(prevLast.sp2),
-        Position.from(nextFirst.sp1)
+        Position.from(prevLast.end),
+        Position.from(nextFirst.start)
       ),
       seperator
     )

--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -18,39 +18,39 @@ package ca.uwaterloo.flix.language.ast
 import ca.uwaterloo.flix.language.ast.shared.Source
 
 /**
-  * A Token holding a kind, line and column.
+  * A Token holding a kind, a source, and a location.
   *
   * Token does not hold its lexeme directly to avoid duplication of common keywords like "def".
-  * Instead it holds a pointer to its source along with start and end offsets.
+  * Instead it holds a pointer to its source along with start and end indices.
   *
   * We take extra efforts to ensure that tokens are compact, i.e. have small memory footprint.
   *
   * We do so because [[Token]]s are very common objects.
   *
-  * @param kind  The kind of token this instance represents.
-  * @param src   A pointer to the source that this lexeme stems from.
-  * @param start The absolute character offset into `src` of the beginning of the lexeme. Must be zero-indexed.
-  * @param end   The absolute character offset into `src` of the end (exclusive) of the lexeme. Must be zero-indexed.
-  * @param sp1   The source position that the lexeme __starts__ on.
-  * @param sp2   The source position that the lexeme __ends__ on (exclusive).
+  * @param kind       The kind of token this instance represents.
+  * @param src        A pointer to the source that this lexeme stems from.
+  * @param startIndex The absolute character index into `src` of the beginning of the lexeme. Must be zero-indexed.
+  * @param endIndex   The absolute character index into `src` of the end (exclusive) of the lexeme. Must be zero-indexed.
+  * @param start      The source position that the lexeme __starts__ on.
+  * @param end        The source position that the lexeme __ends__ on (exclusive).
   */
-case class Token(kind: TokenKind, src: Source, start: Int, end: Int, sp1: SourcePosition, sp2: SourcePosition) extends SyntaxTree.Child {
+case class Token(kind: TokenKind, src: Source, startIndex: Int, endIndex: Int, start: SourcePosition, end: SourcePosition) extends SyntaxTree.Child {
   /**
     * Computes the lexeme that the token refers to by slicing it from `src`.
     *
     * Note: We do *not* cache the text because it takes up significant memory.
     */
-  def text: String = src.data.slice(start, end).mkString("")
+  def text: String = src.data.slice(startIndex, endIndex).mkString("")
 
   /**
     * Makes a [[SourceLocation]] spanning this token.
     *
     * NB: Tokens are zero-indexed
     */
-  def mkSourceLocation(isReal: Boolean = true): SourceLocation = SourceLocation(isReal, src, sp1, sp2)
+  def mkSourceLocation(isReal: Boolean = true): SourceLocation = SourceLocation(isReal, src, start, end)
 
   /**
     * Returns a one-indexed string representation of this token. Must only be used for debugging.
     */
-  override def toString: String = s"Token($kind, $text, ${sp1.lineOneIndexed}, ${sp1.colOneIndexed}, ${sp2.lineOneIndexed}, ${sp2.colOneIndexed})"
+  override def toString: String = s"Token($kind, $text, ${start.lineOneIndexed}, ${start.colOneIndexed}, ${end.lineOneIndexed}, ${end.colOneIndexed})"
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TokenPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TokenPrinter.scala
@@ -39,7 +39,7 @@ object TokenPrinter {
   }
 
   private def printContent(token: Token): String = {
-    if (token.start >= 0 && token.end <= token.src.data.length && token.start <= token.end) {
+    if (token.startIndex >= 0 && token.endIndex <= token.src.data.length && token.startIndex <= token.endIndex) {
       token.text.replace("\r\n", "\\n").replace("\n", "\\n")
     } else "!bad offset!"
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -186,11 +186,11 @@ object Parser2 {
           stack.head.loc = if (stack.head.children.length == 0)
             // If the subtree has no children, give it a zero length position just after the last
             // token.
-            mkSourceLocation(lastAdvance.sp2, lastAdvance.sp2)
+            mkSourceLocation(lastAdvance.end, lastAdvance.end)
           else
             // Otherwise the source location can span from the first to the last token in the
             // subtree.
-            mkSourceLocation(openToken.sp1, lastAdvance.sp2)
+            mkSourceLocation(openToken.start, lastAdvance.end)
           locationStack = locationStack.tail
           stack = stack.tail
           stack.head.children = stack.head.children :+ child
@@ -207,7 +207,7 @@ object Parser2 {
       isReal = true,
       s.src,
       SourcePosition.FirstPosition,
-      tokens.head.sp2
+      tokens.head.end
     )
 
     // The stack should now contain a single Source tree, and there should only be an <eof> token

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1234,7 +1234,7 @@ object Weeder2 {
                 // fold unary minus into a constant
                 case Some(lit) if opToken.text == "-" =>
                   // Construct a synthetic literal tree with the unary minus and visit that like any other literal expression
-                  val syntheticToken = Token(lit.kind, lit.src, opToken.start, lit.end, lit.sp1, lit.sp2)
+                  val syntheticToken = Token(lit.kind, lit.src, opToken.startIndex, lit.endIndex, lit.start, lit.end)
                   val syntheticLiteral = Tree(TreeKind.Expr.Literal, Array(syntheticToken), exprTree.loc.asSynthetic)
                   visitLiteralExpr(syntheticLiteral)
                 case _ => mapN(visitExpr(exprTree))(expr => {
@@ -2640,7 +2640,7 @@ object Weeder2 {
             // fold unary minus into a constant, and visit it like any other constant
             case Some(lit) if opToken.text == "-" =>
               // Construct a synthetic literal tree with the unary minus and visit that like any other literal expression
-              val syntheticToken = Token(lit.kind, lit.src, opToken.start, lit.end, lit.sp1, lit.sp2)
+              val syntheticToken = Token(lit.kind, lit.src, opToken.startIndex, lit.endIndex, lit.start, lit.end)
               val syntheticLiteral = Tree(TreeKind.Pattern.Literal, Array(syntheticToken), tree.loc.asSynthetic)
               visitLiteralPat(syntheticLiteral)
             case _ =>

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -718,8 +718,8 @@ class TestCompletionProvider extends AnyFunSuite {
     * If the token spans multiple lines, we will return all the positions on all the lines.
     */
   private def rangeOfInclusive(tok: Token): List[Position] = {
-    val initLine = tok.sp1.lineOneIndexed
-    val initCol = tok.sp1.colOneIndexed.toInt
+    val initLine = tok.start.lineOneIndexed
+    val initCol = tok.start.colOneIndexed.toInt
 
     tok.text
       .scanLeft((initLine, initCol)) {

--- a/main/test/ca/uwaterloo/flix/verifier/TokenVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/TokenVerifier.scala
@@ -88,8 +88,8 @@ object TokenVerifier {
   /** Checks I-Ranges. */
   private def checkRange(token: Token): Unit = {
     if (token.kind != TokenKind.Eof) {
-      if (token.start >= token.end) wrongOffsetRange(token)
-      if (!isStrictlyBefore(token.sp1, token.sp2)) wrongPositionRange(token)
+      if (token.startIndex >= token.endIndex) wrongOffsetRange(token)
+      if (!isStrictlyBefore(token.start, token.end)) wrongPositionRange(token)
     }
   }
 
@@ -104,25 +104,25 @@ object TokenVerifier {
   private def checkBounds(src: Source, token: Token): Unit = {
     // Tokens end offsets are exclusive and offsets are zero-indexed.
     def outOfBounds(i: Int): Boolean = i < 0 || src.data.length < i
-    if (outOfBounds(token.start) || outOfBounds(token.end)) outOfBoundOffset(token)
+    if (outOfBounds(token.startIndex) || outOfBounds(token.endIndex)) outOfBoundOffset(token)
   }
 
   /** Checks I-Offset. */
   private def checkOffsetOrder(left: Token, right: Token): Unit = {
     // Tokens end offsets are exclusive.
-    if (left.end > right.start) outOfOrderOffsets(left, right)
+    if (left.endIndex > right.startIndex) outOfOrderOffsets(left, right)
   }
 
   /** Checks I-Pos. */
   private def checkPositionOrder(left: Token, right: Token): Unit = {
     // Token end positions are exclusive.
-    if (!isBefore(left.sp2, right.sp1)) outOfOrderPositions(left, right)
+    if (!isBefore(left.end, right.start)) outOfOrderPositions(left, right)
   }
 
   /** Checks I-Col-End. */
   private def checkColEnd(token: Token): Unit = {
     if (token.kind != TokenKind.Eof) {
-      if (token.sp2.colOneIndexed == 1) unneccesaryEndCol(token)
+      if (token.end.colOneIndexed == 1) unneccesaryEndCol(token)
     }
   }
 
@@ -169,7 +169,7 @@ object TokenVerifier {
   private def wrongOffsetRange(found: Token): Nothing = {
     val loc = found.mkSourceLocation()
     val msg =
-      s""">> Invalid offset range: ${found.start} - ${found.end}.
+      s""">> Invalid offset range: ${found.startIndex} - ${found.endIndex}.
          |
          |${Formatter.NoFormatter.code(loc, s"here (${found.kind})")}
          |
@@ -179,7 +179,7 @@ object TokenVerifier {
 
   private def wrongPositionRange(found: Token): Nothing = {
     val loc = found.mkSourceLocation()
-    val positionRangeString = s"${found.sp1.lineOneIndexed}:${found.sp1.colOneIndexed} - ${found.sp2.lineOneIndexed}:${found.sp2.colOneIndexed}"
+    val positionRangeString = s"${found.start.lineOneIndexed}:${found.start.colOneIndexed} - ${found.end.lineOneIndexed}:${found.end.colOneIndexed}"
     val msg =
       s""">> Invalid position range: $positionRangeString.
          |
@@ -192,7 +192,7 @@ object TokenVerifier {
   private def outOfBoundOffset(found: Token): Nothing = {
     val loc = found.mkSourceLocation()
     val msg =
-      s""">> Token with out-of-bound offsets: ${found.start} - ${found.end}.
+      s""">> Token with out-of-bound offsets: ${found.startIndex} - ${found.endIndex}.
          |
          |${Formatter.NoFormatter.code(loc, s"here (${found.kind})")}
          |
@@ -202,8 +202,8 @@ object TokenVerifier {
 
   private def outOfOrderPositions(left: Token, right: Token): Nothing = {
     val loc = left.mkSourceLocation()
-    val leftPos = s"${left.sp1.lineOneIndexed}:${left.sp1.colOneIndexed} - ${left.sp2.lineOneIndexed}:${left.sp2.colOneIndexed}"
-    val rightPos = s"${right.sp1.lineOneIndexed}:${right.sp1.colOneIndexed} - ${right.sp2.lineOneIndexed}:${right.sp2.colOneIndexed}"
+    val leftPos = s"${left.start.lineOneIndexed}:${left.start.colOneIndexed} - ${left.end.lineOneIndexed}:${left.end.colOneIndexed}"
+    val rightPos = s"${right.start.lineOneIndexed}:${right.start.colOneIndexed} - ${right.end.lineOneIndexed}:${right.end.colOneIndexed}"
     val msg =
       s""">> Overlapping tokens (position): $leftPos and $rightPos.
          |
@@ -218,7 +218,7 @@ object TokenVerifier {
   private def outOfOrderOffsets(left: Token, right: Token): Nothing = {
     val loc = left.mkSourceLocation()
     val msg =
-      s""">> Overlapping tokens: ${left.start} - ${right.end} and ${right.start} - ${right.end}.
+      s""">> Overlapping tokens: ${left.startIndex} - ${right.endIndex} and ${right.startIndex} - ${right.endIndex}.
          |
          |${Formatter.NoFormatter.code(left.mkSourceLocation(), s"left token here (${left.kind})")}
          |


### PR DESCRIPTION
This way `SoureLocation` and `Token` and share naming scheme, tying the loose end of #12181