### PR TITLE
fix: check jar is zip archive

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -193,7 +193,7 @@ class Flix {
     if (!Files.isReadable(pNorm)) {
       return Result.Err(new IllegalArgumentException(s"'$pNorm' must be a readable file."))
     }
-    if (FileOps.checkExt(pNorm, "flix")) {
+    if (!FileOps.checkExt(pNorm, "flix")) {
       return Result.Err(new IllegalArgumentException(s"'$pNorm' must be a .flix file."))
     }
     Result.Ok(())


### PR DESCRIPTION
This PR adds a missing check that any jar file added to compilation is also a valid zip archive. Style-wise this PR also refactors the validation logic into its own function. Maybe these functions should be moved to `FileOps`?