### PR TITLE
fix: normalize paths for equality check

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -470,7 +470,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     }
 
     // Ensure all files in `buildDir` are valid class files.
-    val files = FileOps.getFilesIn(buildDir, Int.MaxValue)
+    val files = FileOps.getFilesIn(buildDir, Int.MaxValue).map(_.normalize())
     for (file <- files) {
       if (file.startsWith(classDir)) {
         if (!FileOps.checkExt(file, "class")) {
@@ -505,7 +505,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
 
     // Delete empty directories
     // Visit in reverse order to delete the innermost directories first
-    val directories = FileOps.getDirectoriesIn(buildDir, Int.MaxValue)
+    val directories = FileOps.getDirectoriesIn(buildDir, Int.MaxValue).map(_.normalize())
     for (dir <- directories.reverse) {
       checkForDangerousPath(dir) match {
         case Err(e) => return Err(e)


### PR DESCRIPTION
Normalizing paths ensures that paths can be compared since the `Path` type does not resolve the paths on the system (so it's likely a special string comparison). It is not clear that it normalizes paths internally before checking equality.

Otherwise, we want to use `isSameFile` which resolves the name to the resource in the file system (but that seems a bit slow) https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/nio/file/Files.html#isSameFile(java.nio.file.Path,java.nio.file.Path) 