### PR TITLE
refactor: return `Result` in `FileOps.writeString`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
@@ -136,19 +136,19 @@ object AstPrinter {
     */
   private def writeToDisk(phaseName: String, content: String)(implicit flix: Flix): Unit = {
     val filePath = phaseOutputPath(phaseName)
-    FileOps.writeString(filePath, content)
+    FileOps.writeString(filePath, content).unsafeGet
   }
 
   /** Makes sure that the phases file exists and is empty. */
   def resetPhaseFile()(implicit flix: Flix): Unit = {
     val filePath = astFolderPath.resolve("0phases.txt")
-    FileOps.writeString(filePath, "")
+    FileOps.writeString(filePath, "").unsafeGet
   }
 
   def appendPhaseToDisk(phaseName: String, hasAst: Boolean)(implicit flix: Flix): Unit = {
     val filePath = astFolderPath.resolve("0phases.txt")
     val line = s"$phaseName${if (hasAst) "" else " (no output)"}${System.lineSeparator()}"
-    FileOps.writeString(filePath, line, append = true)
+    FileOps.writeString(filePath, line, append = true).unsafeGet
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/zhegalkin/ZhegalkinPerf.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/zhegalkin/ZhegalkinPerf.scala
@@ -149,8 +149,8 @@ object ZhegalkinPerf {
     }
 
     val data = "Constraints,FlexVars,RigidVars,Effects" + "\n" + table.map(t => s"${t._1},${t._2},${t._3},${t._4}").mkString("\n")
-    FileOps.writeString(Paths.get("./data.txt"), data)
-    FileOps.writeString(Paths.get("./plots.py"), py1)
+    FileOps.writeString(Paths.get("./data.txt"), data).unsafeGet
+    FileOps.writeString(Paths.get("./plots.py"), py1).unsafeGet
 
 
     println("-" * 80)

--- a/main/src/ca/uwaterloo/flix/tools/CompilerPerf.scala
+++ b/main/src/ca/uwaterloo/flix/tools/CompilerPerf.scala
@@ -375,7 +375,7 @@ object CompilerPerf {
     //
     // Python Plot
     //
-    FileOps.writeString(o.outputPath.resolve("perf/").resolve("plots.py"), Python)
+    FileOps.writeString(o.outputPath.resolve("perf/").resolve("plots.py"), Python).unsafeGet
 
     println("~~~~ Flix Compiler Performance ~~~~")
     println()

--- a/main/test/ca/uwaterloo/flix/tools/pkg/TestBootstrap.scala
+++ b/main/test/ca/uwaterloo/flix/tools/pkg/TestBootstrap.scala
@@ -190,7 +190,7 @@ class TestBootstrap extends AnyFunSuite {
     val b = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
     b.build(PkgTestUtils.mkFlix)
     val buildDir = p.resolve("./build/").normalize()
-    FileOps.writeString(buildDir.resolve("./other.txt").normalize(), "hello")
+    FileOps.writeString(buildDir.resolve("./other.txt").normalize(), "hello").unsafeGet
     b.clean() match {
       case Result.Ok(_) => fail("expected clean to abort")
       case Result.Err(_) => succeed
@@ -216,7 +216,7 @@ class TestBootstrap extends AnyFunSuite {
     FileOps.writeString(p.resolve("./Main.flix").normalize(),
       """
         |def main(): Unit = ()
-        |""".stripMargin)
+        |""".stripMargin).unsafeGet
     val b = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
     val buildDir = p.resolve("./build/").normalize()
     if (Files.exists(buildDir)) {
@@ -239,7 +239,7 @@ class TestBootstrap extends AnyFunSuite {
         |"github:flix/test-pkg-trust-java" = { version = "0.1.0", security = "unrestricted" }
         |""".stripMargin
     )
-    FileOps.writeString(p.resolve("flix.toml").normalize(), toml)
+    FileOps.writeString(p.resolve("flix.toml").normalize(), toml).unsafeGet
 
     // Override main file
     val main =
@@ -247,7 +247,7 @@ class TestBootstrap extends AnyFunSuite {
         |pub def main(): Unit \ IO =
         |    TestPkgTrustTransitive.entry()
         |""".stripMargin
-    FileOps.writeString(p.resolve("src/Main.flix").normalize(), main)
+    FileOps.writeString(p.resolve("src/Main.flix").normalize(), main).unsafeGet
 
     // Assert effects.lock does not exist
     val effectLockFile = p.resolve("effects.lock").normalize()


### PR DESCRIPTION
Wraps all Java file calls in a `try-catch` and returns a `Result[Unit, Exception]` instead. All use sites except one (that is used safely in a `for-yield`) are updated to unsafely unwrap the result, thus keeping the current behavior of crashing in case of error.