### PR TITLE
style: add argument formatting to style

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,11 @@
 <component name="ProjectCodeStyleConfiguration">
     <code_scheme name="Project" version="173">
         <ScalaCodeStyleSettings>
-            <option name="USE_SCALADOC2_FORMATTING" value="true"/>
-            <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true"/>
+            <option name="USE_SCALADOC2_FORMATTING" value="true" />
+            <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
         </ScalaCodeStyleSettings>
+        <codeStyleSettings language="Scala">
+            <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+        </codeStyleSettings>
     </code_scheme>
 </component>


### PR DESCRIPTION
This styles arguments to case classes as

```scala
case class Foo(
  x: Asdf,
  y: Biuh,
)
```

instead of

```scala
case class Foo(
               x: Asdf,
               y: Biuh,
)
```