### PR TITLE
refactor: simplify `FixpointQueryWithSelect`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/effectlock/UseGraph.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/UseGraph.scala
@@ -268,12 +268,9 @@ object UseGraph {
     case Expr.FixpointQueryWithProvenance(exps, select, _, _, _, _) =>
       visitExps(exps) ++ visitPredicateHead(select)
 
-    case Expr.FixpointQueryWithSelect(exps1, exp, exps2, from, exps3, _, _, _, _) =>
+    case Expr.FixpointQueryWithSelect(exps1, exp, predArity, _, _, _, _) =>
       visitExps(exps1) ++
-        visitExp(exp) ++
-        visitExps(exps2) ++
-        from.map(visitPredicateBody).foldLeft(ListMap.empty[UsedSym, UsedSym])(_ ++ _) ++
-        visitExps(exps3)
+        visitExp(exp)
 
     case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
       visitExps(exps)

--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -587,12 +587,9 @@ object Visitor {
         exps.foreach(visitExpr)
         visitPredicate(select)
 
-      case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
+      case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, _, _) =>
         exps.foreach(visitExpr)
         visitExpr(queryExp)
-        selects.foreach(visitExpr)
-        from.foreach(visitPredicate)
-        where.foreach(visitExpr)
 
       case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
         exps.foreach(visitExpr)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -685,8 +685,8 @@ object SemanticTokensProvider {
     case Expr.FixpointQueryWithProvenance(exps, select, _, _, _, _) =>
       visitExps(exps) ++ visitHeadPredicate(select)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
-      visitExps(exps) ++ visitExp(queryExp) ++ visitExps(selects) ++ from.iterator.flatMap(visitBodyPredicate) ++ visitExps(where)
+    case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, _, _) =>
+      visitExps(exps) ++ visitExp(queryExp)
 
     case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
       visitExps(exps)

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -204,7 +204,7 @@ object DesugaredAst {
 
     case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Expr
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, predArity: Int, pred: Name.Pred, loc: SourceLocation) extends Expr
 
     case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -217,7 +217,7 @@ object KindedAst {
 
     case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], tvar: Type, loc: SourceLocation) extends Expr
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, tvar: Type, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, predArity: Int, pred: Name.Pred, tvar: Type, loc: SourceLocation) extends Expr
 
     case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, tvar: Type.Var, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -218,7 +218,7 @@ object NamedAst {
 
     case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Expr
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, predArity: Int, pred: Name.Pred, loc: SourceLocation) extends Expr
 
     case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -233,7 +233,7 @@ object ResolvedAst {
 
     case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], loc: SourceLocation) extends Expr
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, predArity: Int, pred: Name.Pred, loc: SourceLocation) extends Expr
 
     case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -270,7 +270,7 @@ object TypedAst {
 
     case class FixpointQueryWithProvenance(exps: List[Expr], select: Predicate.Head, withh: List[Name.Pred], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, selects: List[Expr], from: List[Predicate.Body], where: List[Expr], pred: Name.Pred, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class FixpointQueryWithSelect(exps: List[Expr], queryExp: Expr, predArity: Int, pred: Name.Pred, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -110,7 +110,7 @@ object TypedAstOps {
     case Expr.FixpointLambda(_, exp, _, _, _) => sigSymsOf(exp)
     case Expr.FixpointMerge(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
     case Expr.FixpointQueryWithProvenance(exps, Head.Atom(_, _, terms, _, _), _, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ terms.flatMap(sigSymsOf).toSet
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ sigSymsOf(queryExp) ++ selects.flatMap(sigSymsOf).toSet ++ where.flatMap(sigSymsOf).toSet
+    case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ sigSymsOf(queryExp)
     case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
     case Expr.FixpointInjectInto(exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
     case Expr.Error(_, _, _) => Set.empty
@@ -393,10 +393,8 @@ object TypedAstOps {
     case Expr.FixpointQueryWithProvenance(exps, select, _, _, _, _) =>
       freeVars(exps) ++ freeVars(select)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
-      freeVars(exps) ++ freeVars(queryExp) ++ freeVars(selects) ++ from.foldLeft(Map.empty[Symbol.VarSym, Type]) {
-        (acc, b) => acc ++ freeVars(b)
-      } ++ freeVars(where)
+    case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, _, _) =>
+      freeVars(exps) ++ freeVars(queryExp)
 
     case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
       exps.foldLeft(Map.empty[Symbol.VarSym, Type]) {

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -126,7 +126,7 @@ object ResolvedAstPrinter {
     case Expr.FixpointLambda(_, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointMerge(_, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointQueryWithProvenance(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointQueryWithSelect(_, _, _, _, _, _, _) => DocAst.Expr.Unknown
+    case Expr.FixpointQueryWithSelect(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointSolveWithProject(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointInjectInto(_, _, _) => DocAst.Expr.Unknown
     case Expr.Error(_) => DocAst.Expr.Error

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -99,7 +99,7 @@ object TypedAstPrinter {
     case Expr.FixpointLambda(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointMerge(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointQueryWithProvenance(_, _, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.FixpointQueryWithSelect(_, _, _, _, _, _, _, _, _) => DocAst.Expr.Unknown
+    case Expr.FixpointQueryWithSelect(_, _, _, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointSolveWithProject(_, _, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.FixpointInjectInto(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.Error(_, _, _) => DocAst.Expr.Error

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -506,12 +506,9 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, tpe, eff, _) =>
+    case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, tpe, eff, _) =>
       exps.foreach(visitExp)
       visitExp(queryExp)
-      selects.foreach(visitExp)
-      from.foreach(visitConstraintBody)
-      where.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -1373,7 +1373,7 @@ object Desugar {
     // Construct a constraint set that contains the single pseudo constraint.
     val queryExp = DesugaredAst.Expr.FixpointConstraintSet(List(pseudoConstraint), loc0)
 
-    DesugaredAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc0)
+    DesugaredAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects.length, pred, loc0)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -819,13 +819,10 @@ object Kinder {
         val s = visitHeadPredicate(select, kenv0, root)
         KindedAst.Expr.FixpointQueryWithProvenance(es, s, withh, Type.freshVar(Kind.Star, loc), loc)
 
-      case ResolvedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
+      case ResolvedAst.Expr.FixpointQueryWithSelect(exps, queryExp, predArity, pred, loc) =>
         val es = exps.map(visitExp(_, kenv0, root))
         val qe = visitExp(queryExp, kenv0, root)
-        val ss = selects.map(visitExp(_, kenv0, root))
-        val f = from.map(visitBodyPredicate(_, kenv0, root))
-        val w = where.map(visitExp(_, kenv0, root))
-        KindedAst.Expr.FixpointQueryWithSelect(es, qe, ss, f, w, pred, Type.freshVar(Kind.Star, loc), loc)
+        KindedAst.Expr.FixpointQueryWithSelect(es, qe, predArity, pred, Type.freshVar(Kind.Star, loc), loc)
 
       case ResolvedAst.Expr.FixpointSolveWithProject(exps, optPreds, mode, loc) =>
         val es = exps.map(visitExp(_, kenv0, root))

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -771,7 +771,7 @@ object Lowering {
       val itpe = Types.mkProvenanceOf(extVarType, loc)
       LoweredAst.Expr.ApplyDef(defn.sym, argExps, List.empty, itpe, tpe, eff, loc)
 
-    case TypedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, _, pred, tpe, eff, loc) =>
+    case TypedAst.Expr.FixpointQueryWithSelect(exps, queryExp, predArity, pred, tpe, eff, loc) =>
       val loweredExps = exps.map(visitExp)
       val loweredQueryExp = visitExp(queryExp)
 
@@ -785,8 +785,6 @@ object Lowering {
         }
         case t => throw InternalCompilerException(s"Unexpected non-foldable type: '${t}'.", loc)
       }
-
-      val predArity = selects.length
 
       // Define the name and type of the appropriate factsX function in Solver.flix
       val sym = Defs.Facts(predArity)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1020,13 +1020,10 @@ object Namer {
       val es = exps.map(visitExp)
       NamedAst.Expr.FixpointSolveWithProject(es, optPreds, mode, loc)
 
-    case DesugaredAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
+    case DesugaredAst.Expr.FixpointQueryWithSelect(exps, queryExp, predArity, pred, loc) =>
       val es = exps.map(visitExp)
       val qe = visitExp(queryExp)
-      val ss = selects.map(visitExp)
-      val f = from.map(visitBodyPredicate)
-      val w = where.map(visitExp)
-      NamedAst.Expr.FixpointQueryWithSelect(es, qe, ss, f, w, pred, loc)
+      NamedAst.Expr.FixpointQueryWithSelect(es, qe, predArity, pred, loc)
 
     case DesugaredAst.Expr.FixpointInjectInto(exps, predsAndArities, loc) =>
       val es = exps.map(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -335,12 +335,9 @@ object PatMatch {
 
       case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) => exps.foreach(visitExp)
 
-      case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
+      case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, _, _) =>
         exps.foreach(visitExp)
         visitExp(queryExp)
-        selects.foreach(visitExp)
-        from.foreach(visitBodyPred)
-        where.foreach(visitExp)
 
       case Expr.FixpointInjectInto(exps, _, _, _, _) => exps.foreach(visitExp)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -345,11 +345,9 @@ object PredDeps {
     case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) =>
+    case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, _, _) =>
       exps.foreach(visitExp)
       visitExp(queryExp)
-      selects.foreach(visitExp)
-      where.foreach(visitExp)
 
     case Expr.FixpointInjectInto(exps, _, _, _, _) =>
       exps.foreach(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -910,15 +910,10 @@ object Redundancy {
     case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
       visitExps(exps, env0, rc)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, _, _, _, _) =>
+    case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, _, _) =>
       val us1 = visitExps(exps, env0, rc)
       val us2 = visitExp(queryExp, env0, rc)
-      val us3 = visitExps(selects, env0, rc)
-      val us4 = from.foldLeft(Used.empty) {
-        case (acc, b) => acc ++ visitBodyPred(b, env0, rc)
-      }
-      val us5 = visitExps(where, env0, rc)
-      us1 ++ us2 ++ us3 ++ us4 ++ us5
+      us1 ++ us2
 
     case Expr.FixpointInjectInto(exps, _, _, _, _) =>
       visitExps(exps, env0, rc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1487,33 +1487,13 @@ object Resolver {
           ResolvedAst.Expr.FixpointQueryWithProvenance(es, s, withh, loc)
       }
 
-    case NamedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
+    case NamedAst.Expr.FixpointQueryWithSelect(exps, queryExp, predArity, pred, loc) =>
       val esVal = traverse(exps)(resolveExp(_, scp0))
       val qeVal = resolveExp(queryExp, scp0)
-      // We cannot call resolvePredicateBody as it does not allow new variables to be introduced
-      val fVal = traverse(from) {
-        case NamedAst.Predicate.Body.Atom(pred0, den, polarity, fixity, terms, loc1) =>
-          val ts = terms.map(resolvePattern(_, scp0, ns0, root))
-          Validation.Success(ResolvedAst.Predicate.Body.Atom(pred0, den, polarity, fixity, ts, loc1))
-        case _ => throw InternalCompilerException("Unexpected predicate body when expecting body atom", loc)
-      }
       // We have to bind variables appearing in the atoms before resolving the select and where exps
-      flatMapN(esVal, qeVal, fVal) {
-        case (es, qe, f) =>
-          // Collect all variables appearing in atoms and bind them
-          val ts = f.flatMap(_.terms)
-          val scp1 = ts.foldLeft(scp0)(
-            (acc, t) => t match {
-              case ResolvedAst.Pattern.Var(sym, _) => acc ++ mkVarScp(sym)
-              case _ => acc
-            })
-          // Resolve select and where exps
-          val sVal = traverse(selects)(resolveExp(_, scp1))
-          val wVal = traverse(where)(resolveExp(_, scp1))
-          mapN(sVal, wVal) {
-            case (s, w) =>
-              ResolvedAst.Expr.FixpointQueryWithSelect(es, qe, s, f, w, pred, loc)
-          }
+      mapN(esVal, qeVal) {
+        case (es, qe) =>
+              ResolvedAst.Expr.FixpointQueryWithSelect(es, qe, predArity, pred, loc)
       }
 
     case NamedAst.Expr.FixpointSolveWithProject(exps, optPreds, mode, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -367,11 +367,9 @@ object Safety {
     case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) =>
       exps.foreach(visitExp)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) =>
+    case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, _, _) =>
       exps.foreach(visitExp)
       visitExp(queryExp)
-      selects.foreach(visitExp)
-      where.foreach(visitExp)
 
     case Expr.FixpointInjectInto(exps, _, _, _, _) =>
       exps.foreach(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -419,12 +419,10 @@ object Stratifier {
       val ts = terms.map(visitExp)
       Expr.FixpointQueryWithProvenance(es, Head.Atom(pred, den, ts, tpe2, loc2), withh, tpe1, eff1, loc1)
 
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, tpe, eff, loc) =>
+    case Expr.FixpointQueryWithSelect(exps, queryExp, predArity, pred, tpe, eff, loc) =>
       val es = exps.map(visitExp)
       val qe = visitExp(queryExp)
-      val ss = selects.map(visitExp)
-      val w = where.map(visitExp)
-      Expr.FixpointQueryWithSelect(es, qe, ss, from, w, pred, tpe, eff, loc)
+      Expr.FixpointQueryWithSelect(es, qe, predArity, pred, tpe, eff, loc)
 
     case Expr.FixpointSolveWithProject(exps, optPreds, mode, tpe, eff, loc) =>
       // Compute the stratification.

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -600,15 +600,12 @@ object TypeReconstruction {
       val eff = Type.mkUnion(es.map(_.eff), loc)
       TypedAst.Expr.FixpointQueryWithProvenance(es, s, withh, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, tvar, loc) =>
+    case KindedAst.Expr.FixpointQueryWithSelect(exps, queryExp, predArity, pred, tvar, loc) =>
       val es = exps.map(visitExp)
       val qe = visitExp(queryExp)
-      val ss = selects.map(visitExp)
-      val f = from.map(visitBodyPredicate)
-      val w = where.map(visitExp)
-      val effs = es.map(_.eff) ::: ss.map(_.eff) ::: w.map(_.eff)
+      val effs = es.map(_.eff)
       val eff = Type.mkUnion(effs, loc)
-      TypedAst.Expr.FixpointQueryWithSelect(es, qe, ss, f, w, pred, subst(tvar), eff, loc)
+      TypedAst.Expr.FixpointQueryWithSelect(es, qe, predArity, pred, subst(tvar), eff, loc)
 
     case KindedAst.Expr.FixpointSolveWithProject(exps, optPreds, mode, tvar, loc) =>
       val es = exps.map(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
@@ -99,7 +99,7 @@ object SchemaConstraintGen {
   def visitFixpointQueryWithSelect(e: KindedAst.Expr.FixpointQueryWithSelect)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     implicit val scope: Scope = c.getScope
     e match {
-      case KindedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, _, pred, tvar, loc) =>
+      case KindedAst.Expr.FixpointQueryWithSelect(exps, queryExp, predArity, pred, tvar, loc) =>
         //
         //  exp = exps[0] <+> exps[1] <+> ... (exp is conceptual; it does not actually exist)
         //
@@ -108,7 +108,6 @@ object SchemaConstraintGen {
         //  --------------------------------------------------------------------
         //  FixpointQueryWithSelect(exps, queryExp, ...) : Vector[(α₁, α₂, ...)]
         //
-        val predArity = selects.length
         val freshRelOrLat = Type.freshVar(Kind.mkArrowTo(predArity, Kind.Predicate), loc)
         val freshTermVars = List.range(0, predArity).map(_ => Type.freshVar(Kind.Star, loc))
         val tuple = Type.mkTuplish(freshTermVars, loc)

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -289,8 +289,8 @@ object Summary {
     case Expr.FixpointMerge(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
     case Expr.FixpointQueryWithProvenance(exps, TypedAst.Predicate.Head.Atom(_, _, terms, _, _), _, _, _, _) =>
       exps.map(countCheckedEcasts).sum + terms.map(countCheckedEcasts).sum
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, _, where, _, _, _, _) =>
-      exps.map(countCheckedEcasts).sum + countCheckedEcasts(queryExp) + selects.map(countCheckedEcasts).sum + where.map(countCheckedEcasts).sum
+    case Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, _, _) =>
+      exps.map(countCheckedEcasts).sum + countCheckedEcasts(queryExp)
     case Expr.FixpointSolveWithProject(exps, _, _, _, _, _) => exps.map(countCheckedEcasts).sum
     case Expr.FixpointInjectInto(exps, _, _, _, _) => exps.map(countCheckedEcasts).sum
     case Expr.Error(_, _, _) => 0

--- a/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
@@ -389,9 +389,8 @@ object EffectVerifier {
       }
       // TODO ?
       ()
-    case Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, tpe, eff, loc) =>
+    case Expr.FixpointQueryWithSelect(exps, queryExp, _, pred, tpe, eff, loc) =>
       exps.foreach(visitExp)
-      where.foreach(visitExp)
       // TODO ?
       ()
     case Expr.FixpointSolveWithProject(exps, optPreds, mode, tpe, eff, loc) =>


### PR DESCRIPTION
The 3 arguments removed from the ast are not used in any shape.

I'm out of the loop here for why they are in the ast. Were these added as part of the general move away from desugaring? As in do we want to do the reverse and instead handle it in Lowering. If so just reject the PR. I just found them somewhat useless during the local move of Fixpoint/Datalog.