### PR TITLE
refactor: remove `--explain`

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -64,7 +64,6 @@ object Main {
       lib = cmdOpts.xlib,
       build = Build.Development,
       entryPoint = entryPoint,
-      explain = cmdOpts.explain,
       githubToken = githubToken,
       incremental = Options.Default.incremental,
       json = cmdOpts.json,
@@ -437,7 +436,6 @@ object Main {
   case class CmdOpts(command: Command = Command.None,
                      args: List[String] = Nil,
                      entryPoint: Option[String] = None,
-                     explain: Boolean = false,
                      installDeps: Boolean = true,
                      githubToken: Option[String] = None,
                      json: Boolean = false,
@@ -610,9 +608,6 @@ object Main {
 
       opt[String]("entrypoint").action((s, c) => c.copy(entryPoint = Some(s))).
         text("specifies the main entry point.")
-
-      opt[Unit]("explain").action((_, c) => c.copy(explain = true)).
-        text("provides suggestions on how to solve a problem.")
 
       opt[String]("github-token").action((s, c) => c.copy(githubToken = Some(s))).
         text("API key to use for GitHub dependency resolution.")

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -429,13 +429,9 @@ class Flix {
 
   /**
     * Converts a list of compiler error messages to a list of printable messages.
-    * Decides whether or not to append the explanation.
     */
   def mkMessages(errors: List[CompilationMessage]): List[String] = {
-    if (options.explain)
-      errors.sortBy(_.loc).map(cm => cm.messageWithLoc(formatter) + cm.explain(formatter).getOrElse(""))
-    else
-      errors.sortBy(_.loc).map(cm => cm.messageWithLoc(formatter))
+    errors.sortBy(_.loc).map(cm => cm.messageWithLoc(formatter))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
@@ -29,20 +29,12 @@ import scala.jdk.CollectionConverters.*
   * Companion object for [[Diagnostic]].
   */
 object Diagnostic {
-  def from(m: CompilationMessage, explain: Boolean, formatter: Formatter): Diagnostic = {
+  def from(m: CompilationMessage, formatter: Formatter): Diagnostic = {
     val range = Range.from(m.loc)
     val severity = Some(DiagnosticSeverity.Error)
     val code = m.kind.toString
     val summary = m.summary
-    val explanationHeading =
-      s"""
-         |${formatter.underline("Explanation:")}
-         |""".stripMargin
-    val explanation = m.explain(formatter) match {
-      case Some(expl) if explain => explanationHeading + expl
-      case _ => ""
-    }
-    val fullMessage = m.messageWithLoc(formatter) + explanation
+    val fullMessage = m.messageWithLoc(formatter)
     val relatedInformation = m.locs.map(l => DiagnosticRelatedInformation(Location.from(l), m.summary))
     Diagnostic(range, severity, Some(code), None, summary, fullMessage, Nil, relatedInformation)
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -238,13 +238,13 @@ object LspServer {
             this.currentErrors = errors
             // We provide diagnostics for errors and code hints.
             val codeHints = CodeHinter.run(sources.keysIterator.map(_.toString).toSet)(root1)
-            PublishDiagnosticsParams.fromMessages(currentErrors, flix.options.explain) ::: PublishDiagnosticsParams.fromCodeHints(codeHints)
+            PublishDiagnosticsParams.fromMessages(currentErrors) ::: PublishDiagnosticsParams.fromCodeHints(codeHints)
 
           // Case 2: Compilation failed so that we have only errors.
           case (None, errors) =>
             this.currentErrors = errors
             // We provide diagnostics only for errors.
-            PublishDiagnosticsParams.fromMessages(currentErrors, flix.options.explain)
+            PublishDiagnosticsParams.fromMessages(currentErrors)
         }
         publishDiagnostics(diagnostics)
       } catch {

--- a/main/src/ca/uwaterloo/flix/api/lsp/PublishDiagnosticsParams.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/PublishDiagnosticsParams.scala
@@ -28,7 +28,7 @@ import scala.jdk.CollectionConverters.*
   * Companion object of [[PublishDiagnosticsParams]].
   */
 object PublishDiagnosticsParams {
-  def fromMessages(errors: Iterable[CompilationMessage], explain: Boolean): List[PublishDiagnosticsParams] = {
+  def fromMessages(errors: Iterable[CompilationMessage]): List[PublishDiagnosticsParams] = {
     val formatter: Formatter = Formatter.NoFormatter
 
     // Group the error messages by source.
@@ -37,7 +37,7 @@ object PublishDiagnosticsParams {
     // Translate each compilation message to a diagnostic.
     errorsBySource.foldLeft(Nil: List[PublishDiagnosticsParams]) {
       case (acc, (source, compilationMessages)) =>
-        val diagnostics = compilationMessages.map(msg => Diagnostic.from(msg, explain, formatter))
+        val diagnostics = compilationMessages.map(msg => Diagnostic.from(msg, formatter))
         PublishDiagnosticsParams(source.name, diagnostics) :: acc
     }
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
@@ -351,11 +351,11 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
       flix.check() match {
         case (Some(r), Nil) =>
           // Case 1: Compilation was successful. Build the reverse index.
-          processSuccessfulCheck(requestId, r, List.empty, flix.options.explain, t)
+          processSuccessfulCheck(requestId, r, List.empty, t)
 
         case (Some(r), errors) =>
           // Case 2: Compilation had non-critical errors. Build the reverse index.
-          processSuccessfulCheck(requestId, r, errors, flix.options.explain, t)
+          processSuccessfulCheck(requestId, r, errors, t)
 
         case (None, errors) =>
           // Case 3: Compilation failed. Send back the error messages.
@@ -364,7 +364,7 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
           this.currentErrors = errors
 
           // Publish diagnostics.
-          val results = PublishDiagnosticsParams.fromMessages(currentErrors, flix.options.explain)
+          val results = PublishDiagnosticsParams.fromMessages(currentErrors)
           ("id" -> requestId) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> results.map(_.toJSON))
       }
     } catch {
@@ -379,7 +379,7 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
   /**
     * Helper function for [[processCheck]] which handles successful and soft failure compilations.
     */
-  private def processSuccessfulCheck(requestId: String, root: Root, errors: List[CompilationMessage], explain: Boolean, t0: Long): JValue = {
+  private def processSuccessfulCheck(requestId: String, root: Root, errors: List[CompilationMessage], t0: Long): JValue = {
     // Update the root and the errors.
     this.root = root
     this.currentErrors = errors
@@ -394,7 +394,7 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
     val codeHints = CodeHinter.run(sources.keysIterator.map(_.toString).toSet)(root)
 
     // Determine the status based on whether there are errors.
-    val results = PublishDiagnosticsParams.fromMessages(currentErrors, explain) ::: PublishDiagnosticsParams.fromCodeHints(codeHints)
+    val results = PublishDiagnosticsParams.fromMessages(currentErrors) ::: PublishDiagnosticsParams.fromCodeHints(codeHints)
     ("id" -> requestId) ~ ("status" -> ResponseStatus.Success) ~ ("time" -> e) ~ ("result" -> results.map(_.toJSON))
   }
 

--- a/main/src/ca/uwaterloo/flix/language/CompilationMessage.scala
+++ b/main/src/ca/uwaterloo/flix/language/CompilationMessage.scala
@@ -66,11 +66,6 @@ trait CompilationMessage {
   def message(formatter: Formatter): String
 
   /**
-    * Returns a formatted string with helpful suggestions.
-    */
-  def explain(formatter: Formatter): Option[String] = None
-
-  /**
     * Returns the error message formatted with source location.
     */
   def messageWithLoc(formatter: Formatter): String = {

--- a/main/src/ca/uwaterloo/flix/language/errors/DerivationError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/DerivationError.scala
@@ -46,13 +46,10 @@ object DerivationError {
       s""">> Illegal derivation '${red(sym.name)}'.
          |
          |${src(loc, "Illegal derivation.")}
+         |
+         |${underline("Tip:")} Only the following traits may be derived: ${legalSyms.map(_.name).mkString(", ")}.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Only the following traits may be derived: ${legalSyms.map(_.name).mkString(", ")}."
-    })
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/EntryPointError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/EntryPointError.scala
@@ -75,8 +75,6 @@ object EntryPointError {
     }
 
     override def loc: SourceLocation = loc1
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -125,8 +123,6 @@ object EntryPointError {
          |${src(loc, "unhandled effect")}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -227,11 +223,9 @@ object EntryPointError {
       s""">> The type: '${red(FormatType.formatType(tpe))}' is not a valid result type for the main function.
          |
          |${src(loc, "Unexpected result type for main.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""A ToString instance must be defined for the result type.
+         |
+         |${underline("Explanation:")}
+         |A ToString instance must be defined for the result type.
          |
          |To define a string representation of '${FormatType.formatType(tpe)}', either:
          |
@@ -243,9 +237,8 @@ object EntryPointError {
          |  enum Color with ToString {
          |    case Red, Green, Blue
          |  }
-         |
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -265,8 +258,6 @@ object EntryPointError {
          |${src(loc, "unexpected entry point argument(s).")}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -281,19 +272,15 @@ object EntryPointError {
 
     // NB: We do not print the symbol source location as it is always Unknown.
     override def message(formatter: Formatter): String = {
+      import formatter.*
       s""">> The entry point $sym cannot be found.
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Change the specified entry point to an existing function.
          |  (2)  Add an entry point function $sym.
-         |
          |""".stripMargin
-    })
+    }
 
     override def loc: SourceLocation = SourceLocation.Unknown
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -72,13 +72,10 @@ object InstanceError {
       s""">> Duplicate type variable '${red(FormatType.formatType(tvar))}' in '${magenta(sym.name)}'.
          |
          |${src(loc, s"The type variable '${FormatType.formatType(tvar)}' occurs more than once.")}
+         |
+         |${underline("Tip:")} Rename one of the instances of the type variable.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Rename one of the instances of the type variable."
-    })
 
   }
 
@@ -99,13 +96,10 @@ object InstanceError {
       s""">> The signature '${red(defnSym.name)}' is not present in the '${magenta(traitSym.name)}' trait.
          |
          |${src(loc, s"extraneous def")}
+         |
+         |${underline("Tip:")} Remove this definition from the instance.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Remove this definition from the instance."
-    })
   }
 
   /**
@@ -198,13 +192,10 @@ object InstanceError {
          |
          |Expected scheme: ${FormatScheme.formatScheme(expected)}
          |Actual scheme:   ${FormatScheme.formatScheme(actual)}
+         |
+         |${underline("Tip:")} Modify the definition to match the signature.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Modify the definition to match the signature."
-    })
   }
 
   /**
@@ -226,13 +217,10 @@ object InstanceError {
          |The constraint ${FormatEqualityConstraint.formatEqualityConstraint(econstr)} is required because it is a constraint on super trait ${superTrait.name}.
          |
          |${src(loc, s"missing equality constraint")}
-      """.stripMargin
+         |
+         |${underline("Tip:")} Add the missing equality constraint.
+         |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Add the missing equality constraint."
-    })
   }
 
   /**
@@ -251,13 +239,10 @@ object InstanceError {
       s""">> Missing implementation of '${red(sig.name)}' required by '${magenta(sig.trt.name)}'.
          |
          |${src(loc, s"missing implementation")}
+         |
+         |${underline("Tip:")} Add an implementation of the signature to the instance.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Add an implementation of the signature to the instance."
-    })
   }
 
   /**
@@ -282,13 +267,10 @@ object InstanceError {
          |The trait '${red(subTrait.name)}' extends the trait '${red(superTrait.name)}'.
          |
          |If you provide an instance for '${red(subTrait.name)}' you must also provide an instance for '${red(superTrait.name)}'.
+         |
+         |${underline("Tip:")} Add an instance of '${superTrait.name}' for '${FormatType.formatType(tpe)}'.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Add an instance of '${superTrait.name}' for '${FormatType.formatType(tpe)}'."
-    })
   }
 
   /**
@@ -310,13 +292,10 @@ object InstanceError {
          |The constraint ${FormatTraitConstraint.formatTraitConstraint(tconstr)} is required because it is a constraint on super trait ${superTrait.name}.
          |
          |${src(loc, s"missing type constraint")}
-      """.stripMargin
+         |
+         |${underline("Tip:")} Add the missing type constraint.
+         |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Add the missing type constraint."
-    })
   }
 
   /**
@@ -361,13 +340,10 @@ object InstanceError {
          |${src(loc1, "the first instance was declared here.")}
          |
          |${src(loc2, "the second instance was declared here.")}
+         |
+         |${underline("Tip:")} Remove or change the type of one of the instances.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip: ")} Remove or change the type of one of the instances."
-    })
 
     def loc: SourceLocation = loc1
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/KindError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/KindError.scala
@@ -93,12 +93,8 @@ object KindError {
          |
          |${src(loc, "uninferred kind.")}
          |
+         |${underline("Tip:")} Add a kind annotation.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip: ")} Add a kind annotation."
-    })
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
@@ -48,8 +48,6 @@ object NameError {
          |${src(loc, "deprecated")}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -71,19 +69,17 @@ object NameError {
          |${src(loc1, "the first definition was here.")}
          |
          |${src(loc2, "the second definition was here.")}
+         |
+         |${underline("Explanation:")}
+         |Flix does not support overloading. For example, you cannot define two
+         |functions with the same name, even if their formal parameters differ.
+         |
+         |If you want two functions to share the same name you have to either:
+         |
+         |    (a) put each function into its own namespace, or
+         |    (b) introduce a trait and implement two instances.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      """Flix does not support overloading. For example, you cannot define two
-        |functions with the same name, even if their formal parameters differ.
-        |
-        |If you want two functions to share the same name you have to either:
-        |
-        |    (a) put each function into its own namespace, or
-        |    (b) introduce a trait and implement two instances.
-        |""".stripMargin
-    })
 
     def loc: SourceLocation = loc1
   }
@@ -193,19 +189,17 @@ object NameError {
       s""">> Suspicious type variable '${red(name)}'. Did you mean: '${cyan(name.capitalize)}'?
          |
          |${src(loc, "suspicious type variable.")}
+         |
+         |${underline("Explanation:")}
+         |Flix uses lowercase variable names.
+         |
+         |The type variable looks suspiciously like the name of a built-in type.
+         |
+         |Perhaps you meant to use the built-in type?
+         |
+         |For example, `Int32` is a built-in type whereas `int32` is a type variable.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      """Flix uses lowercase variable names.
-        |
-        |The type variable looks suspiciously like the name of a built-in type.
-        |
-        |Perhaps you meant to use the built-in type?
-        |
-        |For example, `Int32` is a built-in type whereas `int32` is a type variable.
-        |""".stripMargin
-    })
 
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/NonExhaustiveMatchError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/NonExhaustiveMatchError.scala
@@ -35,17 +35,14 @@ case class NonExhaustiveMatchError(pat: String, loc: SourceLocation) extends Com
     s""">> Non-Exhaustive Pattern. Missing case: ${red(pat)} in match expression.
        |
        |${src(loc, "incomplete pattern.")}
-       |""".stripMargin
-  }
-
-  override def explain(formatter: Formatter): Option[String] = Some({
-    s"""Flix requires every pattern match expression to be exhaustive, i.e. to cover all
+       |
+       |${underline("Explanation:")}
+       |Flix requires every pattern match expression to be exhaustive, i.e. to cover all
        |possible cases. A wild card pattern, written with an underscore, can be used to
        |handle all other cases. For example:
        |
        |    case _ => // handle all other cases.
-       |
        |""".stripMargin
-  })
+  }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
@@ -93,19 +93,13 @@ object RedundancyError {
       s""">> Hidden variable symbol '${red(sym.text)}'. The symbol is marked as unused.
          |
          |${src(loc, "hidden symbol.")}
-         |""".stripMargin
-
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Don't use the variable symbol.
          |  (2)  Rename the underscore prefix from the variable symbol name.
-         |
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -184,17 +178,12 @@ object RedundancyError {
       s""">> Type constraint '${red(FormatTraitConstraint.formatTraitConstraint(redundantTconstr))}' is entailed by type constraint '${green(FormatTraitConstraint.formatTraitConstraint(entailingTconstr))}'.
          |
          |${src(loc, "redundant type constraint.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Remove the type constraint.
-         |
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -326,19 +315,15 @@ object RedundancyError {
       s""">> Unused definition '${red(sym.name)}'. The definition is never referenced.
          |
          |${src(sym.loc, "unused definition.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the definition.
          |  (2)  Remove the definition.
          |  (3)  Mark the definition as public.
          |  (4)  Prefix the definition name with an underscore.
-         |
          |""".stripMargin
-    })
+    }
 
     def loc: SourceLocation = sym.loc
   }
@@ -358,19 +343,15 @@ object RedundancyError {
       s""">> Unused effect '${red(sym.name)}'. The effect is never referenced.
          |
          |${src(sym.loc, "unused effect.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the effect.
          |  (2)  Remove the effect.
          |  (3)  Mark the effect as public.
          |  (4)  Prefix the effect name with an underscore.
-         |
          |""".stripMargin
-    })
+    }
 
     def loc: SourceLocation = sym.loc
   }
@@ -390,20 +371,15 @@ object RedundancyError {
       s""">> Unused enum '${red(sym.name)}'. Neither the enum nor its cases are ever used.
          |
          |${src(sym.loc, "unused enum.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the enum.
          |  (2)  Remove the enum.
          |  (3)  Mark the enum as public.
          |  (4)  Prefix the enum name with an underscore.
-         |
          |""".stripMargin
-    })
+    }
 
     def loc: SourceLocation = sym.loc
   }
@@ -424,20 +400,14 @@ object RedundancyError {
       s""">> Unused case '${red(tag.name)}' in enum '${cyan(sym.name)}'.
          |
          |${src(tag.loc, "unused tag.")}
-         |""".stripMargin
-
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the case.
          |  (2)  Remove the case.
          |  (3)  Prefix the case with an underscore.
-         |
          |""".stripMargin
-    })
+    }
 
     def loc: SourceLocation = tag.loc
   }
@@ -457,20 +427,15 @@ object RedundancyError {
       s""">> Unused struct '${red(sym.name)}'.
          |
          |${src(sym.loc, "unused struct.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the struct.
          |  (2)  Remove the struct.
          |  (3)  Mark the struct as public.
          |  (4)  Prefix the struct name with an underscore.
-         |
          |""".stripMargin
-    })
+    }
 
     def loc: SourceLocation = sym.loc
   }
@@ -490,19 +455,14 @@ object RedundancyError {
       s""">> Unused formal parameter '${red(sym.text)}'. The parameter is not used within its scope.
          |
          |${src(sym.loc, "unused formal parameter.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the formal parameter.
          |  (2)  Remove the formal parameter.
          |  (3)  Prefix the formal parameter name with an underscore.
-         |
          |""".stripMargin
-    })
+    }
 
     def loc: SourceLocation = sym.loc
   }
@@ -522,19 +482,14 @@ object RedundancyError {
       s""">> Unused type parameter '${red(ident.name)}'. The parameter is not referenced anywhere.
          |
          |${src(ident.loc, "unused type parameter.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the type parameter.
          |  (2)  Remove type parameter.
          |  (3)  Prefix the type parameter name with an underscore.
-         |
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -552,19 +507,14 @@ object RedundancyError {
       s""">> Unused type parameter '${red(ident.name)}'. The parameter is not referenced in the signature.
          |
          |${src(ident.loc, "type parameter unused in function signature.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the type parameter in the signature.
          |  (2)  Remove type parameter.
          |  (3)  Prefix the type parameter name with an underscore.
-         |
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -582,19 +532,14 @@ object RedundancyError {
       s""">> Unused local variable '${red(sym.text)}'. The variable is not referenced within its scope.
          |
          |${src(sym.loc, "unused local variable.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the local variable.
          |  (2)  Remove local variable declaration.
          |  (3)  Prefix the variable name with an underscore.
-         |
          |""".stripMargin
-    })
+    }
 
     def loc: SourceLocation = sym.loc
   }
@@ -619,18 +564,13 @@ object RedundancyError {
          |Covered by the following pattern:
          |
          |${src(defaultLoc, "covering pattern.")}
+         |
+         |${underline("Possible fixes:")}
+         |
+         |  (1)  Remove the covered case.
+         |  (2)  Remove the covering '_' case.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      """
-        |Possible fixes:
-        |
-        |  (1)  Remove the covered case.
-        |  (2)  Remove the covering '_' case.
-        |
-        |""".stripMargin
-    })
   }
 
   /**
@@ -651,19 +591,14 @@ object RedundancyError {
          |${src(loc, "useless expression.")}
          |
          |The expression has type '${FormatType.formatType(tpe)}'
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
+         |
+         |${underline("Possible fixes:")}
          |
          |  (1)  Use the result computed by the expression.
          |  (2)  Remove the expression statement.
          |  (3)  Introduce a let-binding with a wildcard name.
-         |
          |""".stripMargin
-    })
+    }
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -119,8 +119,6 @@ object ResolutionError {
          |""".stripMargin
     }
 
-    override def explain(formatter: Formatter): Option[String] = None
-
     val loc: SourceLocation = loc1
   }
 
@@ -144,15 +142,11 @@ object ResolutionError {
          |
          |${src(loc2, "the second occurrence was here.")}
          |
+         |${underline("Tip:")} Remove one of the occurrences.
          |""".stripMargin
     }
 
     override def loc: SourceLocation = loc1
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Remove one of the occurrences."
-    })
 
   }
 
@@ -194,12 +188,11 @@ object ResolutionError {
       s""">> Illegal associated type application.
          |
          |${src(loc, "illegal associated type application.")}
+         |
+         |${underline("Explanation:")}
+         |An associated type may only be applied to a variable.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      "An associated type may only be applied to a variable."
-    })
   }
 
   /**
@@ -240,12 +233,11 @@ object ResolutionError {
       s""">> Unexpected signature '${red(sym.name)}' which does not mention the type variable of the trait.
          |
          |${src(loc, "unexpected signature.")}
+         |
+         |${underline("Explanation:")}
+         |Every signature in a trait must mention the type variable of the trait.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      "Every signature in a trait must mention the type variable of the trait."
-    })
 
   }
 
@@ -265,12 +257,11 @@ object ResolutionError {
       s""">> Illegal wildcard type: '$ident'.
          |
          |${src(loc, "illegal wildcard type.")}
+         |
+         |${underline("Explanation:")}
+         |Wildcard types (types starting with an underscore) are not allowed in this position.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      "Wildcard types (types starting with an underscore) are not allowed in this position."
-    })
   }
 
   /**
@@ -313,14 +304,10 @@ object ResolutionError {
          |
          |${src(loc, "inaccessible trait.")}
          |
+         |${underline("Tip:")} Mark the trait as public.
          |""".stripMargin
 
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Mark the trait as public."
-    })
   }
 
   /**
@@ -341,13 +328,9 @@ object ResolutionError {
          |
          |${src(loc, "inaccessible definition.")}
          |
+         |${underline("Tip:")} Mark the definition as public.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Mark the definition as public."
-    })
 
   }
 
@@ -369,13 +352,9 @@ object ResolutionError {
          |
          |${src(loc, "inaccessible effect.")}
          |
+         |${underline("Tip:")} Mark the effect as public.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Mark the effect as public."
-    })
 
   }
 
@@ -397,13 +376,9 @@ object ResolutionError {
          |
          |${src(loc, "inaccessible enum.")}
          |
+         |${underline("Tip:")} Mark the definition as public.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Mark the definition as public."
-    })
 
   }
 
@@ -425,13 +400,9 @@ object ResolutionError {
          |
          |${src(loc, "inaccessible struct.")}
          |
+         |${underline("Tip:")} Mark the definition as public.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Mark the definition as public."
-    })
   }
 
   /**
@@ -452,13 +423,9 @@ object ResolutionError {
          |
          |${src(loc, "inaccessible enum.")}
          |
+         |${underline("Tip:")} Mark the definition as public.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Mark the definition as public."
-    })
 
   }
 
@@ -479,13 +446,10 @@ object ResolutionError {
       s""">> Definition '${red(sym.toString)}' is not accessible from the namespace '${cyan(ns.toString)}'.
          |
          |${src(loc, "inaccessible definition.")}
+         |
+         |${underline("Tip:")} Mark the definition as public.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Mark the definition as public."
-    })
 
   }
 
@@ -507,13 +471,9 @@ object ResolutionError {
          |
          |${src(loc, "inaccessible type alias.")}
          |
+         |${underline("Tip:")} Mark the type alias as public.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Mark the type alias as public."
-    })
 
   }
 
@@ -645,13 +605,9 @@ object ResolutionError {
          |
          |${src(loc, "sealed trait.")}
          |
+         |${underline("Tip:")} Move the instance or subtrait to the trait's module.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Move the instance or subtrait to the trait's module."
-    })
 
   }
 
@@ -672,13 +628,9 @@ object ResolutionError {
          |
          |${src(loc, "associated type not found.")}
          |
+         |${underline("Tip:")} Possible typo or non-existent associated type?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent associated type?"
-    })
   }
 
   /**
@@ -701,13 +653,9 @@ object ResolutionError {
          |
          |${src(loc, "effect not found")}
          |
+         |${underline("Tip:")} Possible typo or non-existent effect?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent effect?"
-    })
 
   }
 
@@ -755,17 +703,18 @@ object ResolutionError {
          |${src(loc, "undefined class.")}
          |
          |$msg
+         |$nestedClassHint
          |""".stripMargin
     }
 
     /**
       * Returns a formatted string with helpful suggestions.
       */
-    override def explain(formatter: Formatter): Option[String] = {
+    private def nestedClassHint: String = {
       if (raw".*\.[A-Z].*\.[A-Z].*".r matches name)
-        Some(s"Static nested classes should be specified using '$$', e.g. java.util.Locale$$Builder")
+        s"Static nested classes should be specified using '$$', e.g. java.util.Locale$$Builder"
       else
-        None
+        ""
     }
   }
 
@@ -807,13 +756,10 @@ object ResolutionError {
       s""">> Undefined kind '${red(qn.toString)}'.
          |
          |${src(loc, "undefined kind.")}
+         |
+         |${underline("Tip:")} Possible typo or non-existent kind?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent kind?"
-    })
   }
 
   /**
@@ -835,13 +781,9 @@ object ResolutionError {
          |
          |${src(loc, "name not found")}
          |
+         |${underline("Tip:")} Possible typo or non-existent definition?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent definition?"
-    })
 
   }
 
@@ -864,13 +806,9 @@ object ResolutionError {
          |
          |${src(loc, "name not found")}
          |
+         |${underline("Tip:")} Possible typo or non-existent definition?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent definition?"
-    })
 
   }
 
@@ -916,13 +854,9 @@ object ResolutionError {
          |
          |${src(loc, "operation not found")}
          |
+         |${underline("Tip:")} Possible typo or non-existent operation?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent operation?"
-    })
   }
 
   /**
@@ -943,13 +877,9 @@ object ResolutionError {
          |
          |${src(loc, "tag not found.")}
          |
+         |${underline("Tip:")} Possible typo or non-existent tag?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent tag?"
-    })
 
   }
 
@@ -971,13 +901,9 @@ object ResolutionError {
          |
          |${src(loc, "type not found.")}
          |
+         |${underline("Tip:")} Possible typo or non-existent type?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent type?"
-    })
 
   }
 
@@ -999,13 +925,9 @@ object ResolutionError {
          |
          |${src(loc, "tag not found.")}
          |
+         |${underline("Tip:")} Possible typo or non-existent tag?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent tag?"
-    })
 
   }
 
@@ -1030,13 +952,9 @@ object ResolutionError {
          |
          |${src(loc, "trait not found")}
          |
+         |${underline("Tip:")} Possible typo or non-existent trait?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent trait?"
-    })
 
   }
 
@@ -1059,13 +977,9 @@ object ResolutionError {
          |
          |${src(loc, "type not found.")}
          |
+         |${underline("Tip:")} Possible typo or non-existent type?
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Possible typo or non-existent type?"
-    })
 
   }
 
@@ -1085,13 +999,12 @@ object ResolutionError {
       s""">> Undefined type variable '${red(name)}'.
          |
          |${src(loc, "undefined type variable.")}
+         |
+         |${underline("Explanation:")}
+         |Flix cannot find the type variable. Maybe there is a typo?
          |""".stripMargin
 
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      "Flix cannot find the type variable. Maybe there is a typo?"
-    })
   }
 
   /**
@@ -1133,13 +1046,10 @@ object ResolutionError {
       s""">> Under-applied associated type '${red(sym.name)}'.
          |
          |${src(loc, "Under-applied associated type.")}
+         |
+         |${underline("Tip:")} Associated types must be fully applied.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Associated types must be fully applied."
-    })
 
   }
 
@@ -1159,13 +1069,10 @@ object ResolutionError {
       s""">> Under-applied type alias '${red(sym.name)}'.
          |
          |${src(loc, "Under-applied type alias.")}
+         |
+         |${underline("Tip:")} Type aliases must be fully applied.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Type aliases must be fully applied."
-    })
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -296,11 +296,8 @@ object TypeError {
          |
          |${src(loc, s"missing Eq instance")}
          |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""To define equality on '${formatType(tpe, Some(renv))}', either:
+         |${underline("Explanation:")}
+         |To define equality on '${formatType(tpe, Some(renv))}', either:
          |
          |  (a) define an instance of Eq for '${formatType(tpe, Some(renv))}', or
          |  (b) use 'with' to derive an instance of Eq for '${formatType(tpe, Some(renv))}', for example:.
@@ -308,9 +305,8 @@ object TypeError {
          |  enum Color with Eq {
          |    case Red, Green, Blue
          |  }
-         |
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -331,11 +327,8 @@ object TypeError {
          |
          |${src(loc, s"missing Order instance")}
          |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""To define an order on '${formatType(tpe, Some(renv))}', either:
+         |${underline("Explanation:")}
+         |To define an order on '${formatType(tpe, Some(renv))}', either:
          |
          |  (a) define an instance of Order for '${formatType(tpe, Some(renv))}', or
          |  (b) use 'with' to derive an instance of Order for '${formatType(tpe, Some(renv))}', for example:.
@@ -346,7 +339,7 @@ object TypeError {
          |
          |Note: To derive Order you must also derive Eq.
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -367,11 +360,8 @@ object TypeError {
          |
          |${src(loc, s"missing ToString instance")}
          |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""To define a string representation of '${formatType(tpe, Some(renv))}', either:
+         |${underline("Explanation:")}
+         |To define a string representation of '${formatType(tpe, Some(renv))}', either:
          |
          |  (a) define an instance of ToString for '${formatType(tpe, Some(renv))}', or
          |  (b) use 'with' to derive an instance of ToString for '${formatType(tpe, Some(renv))}', for example:.
@@ -379,9 +369,8 @@ object TypeError {
          |  enum Color with ToString {
          |    case Red, Green, Blue
          |  }
-         |
          |""".stripMargin
-    })
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -49,13 +49,9 @@ object WeederError {
          |
          |${src(loc2, "the second occurrence was here.")}
          |
+         |${underline("Tip:")} Remove one of the two annotations.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Remove one of the two annotations."
-    })
 
     def loc: SourceLocation = loc1
 
@@ -81,13 +77,9 @@ object WeederError {
          |
          |${src(loc2, "the second declaration was here.")}
          |
+         |${underline("Tip:")} Remove or rename one of the formal parameters to avoid the name clash.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Remove or rename one of the formal parameters to avoid the name clash."
-    })
 
     def loc: SourceLocation = loc1
 
@@ -142,13 +134,9 @@ object WeederError {
          |
          |${src(field2Loc, "the second occurrence was here")}
          |
+         |${underline("Tip:")} Remove one of the two fields.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Remove one of the two fields."
-    })
   }
 
   /**
@@ -167,18 +155,15 @@ object WeederError {
          |
          |${src(loc, "Loop does not iterate over any collection.")}
          |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""A loop must contain a collection comprehension.
+         |${underline("Explanation:")}
+         |A loop must contain a collection comprehension.
          |
          |A minimal loop is written as follows:
          |
          |    foreach (x <- xs) yield x
          |
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -197,13 +182,9 @@ object WeederError {
          |
          |${src(loc, "empty interpolated expression")}
          |
+         |${underline("Tip:")} Add an expression to the interpolation or remove the interpolation.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Add an expression to the interpolation or remove the interpolation."
-    })
 
   }
 
@@ -225,8 +206,6 @@ object WeederError {
          |
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -265,13 +244,9 @@ object WeederError {
          |
          |${src(loc, "unexpected effect type parameters")}
          |
+         |${underline("Tip:")} Type parameters are not allowed on effects.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Type parameters are not allowed on effects."
-    })
   }
 
   /**
@@ -310,11 +285,8 @@ object WeederError {
          |
          |${src(loc, "unexpected enum format")}
          |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""This enum uses both the singleton syntax and the case syntax.
+         |${underline("Explanation:")}
+         |This enum uses both the singleton syntax and the case syntax.
          |
          |Only one of the enum forms may be used.
          |If you only need one case for the enum, use the singleton syntax:
@@ -329,7 +301,7 @@ object WeederError {
          |    }
          |
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -350,8 +322,6 @@ object WeederError {
          |
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -371,13 +341,9 @@ object WeederError {
          |
          |${src(loc, "invalid escape sequence")}
          |
+         |${underline("Tip:")} The valid escape sequences are '\\t', '\\\\', '\\\'', '\\\"', '\\$$', '\\n', and '\\r'.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")}" + " The valid escape sequences are '\\t', '\\\\', '\\\'', '\\\"', '\\${', '\\n', and '\\r'."
-    })
   }
 
   /**
@@ -396,13 +362,9 @@ object WeederError {
          |
          |${src(loc, "unexpected pattern")}
          |
+         |${underline("Tip:")} Only a default pattern or tags with wild or variable patterns are allowed, e.g., '_' or 'A(x, _, z)', respectively.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      underline("Tip:") + " Only a default pattern or tags with wild or variable patterns are allowed, e.g., '_' or 'A(x, _, z)', respectively."
-    })
   }
 
   /**
@@ -440,11 +402,8 @@ object WeederError {
          |
          |${src(loc, "Loop does not start with collection comprehension.")}
          |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""A loop must start with collection comprehension where the collection
+         |${underline("Explanation:")}
+         |A loop must start with collection comprehension where the collection
          |has an instance of the Iterable trait on it.
          |
          |A minimal loop is written as follows:
@@ -452,7 +411,7 @@ object WeederError {
          |    foreach (x <- xs) yield x
          |
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -612,13 +571,9 @@ object WeederError {
          |
          |${src(loc, "unexpected qualified pattern")}
          |
+         |${underline("Tip:")} Extensible variants can never be qualified, i.e., A.B is not allowed. Consider using just B instead.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      underline("Tip:") + " Extensible variants can never be qualified, i.e., A.B is not allowed. Consider using just B instead."
-    })
   }
 
   /**
@@ -639,8 +594,6 @@ object WeederError {
          |
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -661,8 +614,6 @@ object WeederError {
          |
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -680,16 +631,10 @@ object WeederError {
       s""">> Illegal regex pattern.
          |
          |${src(loc, "regex not allowed here.")}
+         |
+         |${underline("Tip:")} A regex cannot be used as a pattern. It can be used in an `if` guard, e.g using `isMatch` or `isSubmatch`.
          |""".stripMargin
     }
-
-    /**
-      * Returns a formatted string with helpful suggestions.
-      */
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} A regex cannot be used as a pattern. It can be used in an `if` guard, e.g using `isMatch` or `isSubmatch`."
-    })
   }
 
   /**
@@ -785,13 +730,9 @@ object WeederError {
          |
          |${src(loc, "illegal type constraint parameter")}
          |
+         |${underline("Tip:")} Type constraint parameters must be composed only of type variables.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Type constraint parameters must be composed only of type variables."
-    })
 
   }
 
@@ -813,16 +754,13 @@ object WeederError {
          |
          |${src(loc, s"The case of '$fromName' does not match the case of '$toName'.")}
          |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""An alias must match the case of the name it replaces.
+         |${underline("Explanation:")}
+         |An alias must match the case of the name it replaces.
          |
          |If a name is lowercase, the alias must be lowercase.
          |If a name is uppercase, the alias must be uppercase.
          |""".stripMargin
-    })
+    }
   }
 
   /**
@@ -843,8 +781,6 @@ object WeederError {
          |
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -869,8 +805,6 @@ object WeederError {
          |""".stripMargin
     }
 
-    override def explain(formatter: Formatter): Option[String] = None
-
     override def loc: SourceLocation = inlineLoc.min(dontInlineLoc)
   }
 
@@ -891,13 +825,9 @@ object WeederError {
          |
          |${src(loc, "non-single-character literal")}
          |
+         |${underline("Tip:")} A character literal must consist of a single character.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} A character literal must consist of a single character."
-    })
 
   }
 
@@ -917,13 +847,9 @@ object WeederError {
          |
          |${src(loc, "malformed float.")}
          |
+         |${underline("Tip:")} Ensure that the literal is within bounds.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Ensure that the literal is within bounds."
-    })
 
   }
 
@@ -943,13 +869,9 @@ object WeederError {
          |
          |${src(loc, "malformed int.")}
          |
+         |${underline("Tip:")} Ensure that the literal is within bounds.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Ensure that the literal is within bounds."
-    })
 
   }
 
@@ -972,12 +894,11 @@ object WeederError {
          |
          |Pattern compilation error:
          |$err
+         |
+         |${underline("Explanation:")}
+         |A pattern literal must be a valid regular expression.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"A pattern literal must be a valid regular expression."
-    })
   }
 
   /**
@@ -992,17 +913,14 @@ object WeederError {
     def summary: String = s"Malformed unicode escape sequence."
 
     def message(formatter: Formatter): String = {
+      import formatter.*
       s""">> Malformed unicode escape sequence.
          |
-         |${formatter.src(loc, "malformed unicode escape sequence")}
+         |${src(loc, "malformed unicode escape sequence")}
          |
+         |${underline("Tip:")} A Unicode escape sequence must be of the form \\uXXXX where X is a hexadecimal.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")}" + " A Unicode escape sequence must be of the form \\uXXXX where X is a hexadecimal."
-    })
   }
 
   /**
@@ -1042,13 +960,9 @@ object WeederError {
          |
          |${src(loc, "inconsistent type parameters")}
          |
+         |${underline("Tip:")} Either all or none of the type parameters must be annotated with a kind.
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} Either all or none of the type parameters must be annotated with a kind."
-    })
 
   }
 
@@ -1153,12 +1067,9 @@ object WeederError {
          |${src(loc2, "the second occurrence was here.")}
          |
          |A variable may only occur once in a pattern.
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"""${underline("Tip:")} You can replace
+         |
+         |${underline("Explanation:")}
+         |Tip: You can replace
          |
          |  case (x, x) => ...
          |
@@ -1166,7 +1077,7 @@ object WeederError {
          |
          |  case (x, y) if x == y => ...
          |""".stripMargin
-    })
+    }
 
     def loc: SourceLocation = loc1 min loc2
 
@@ -1292,13 +1203,10 @@ object WeederError {
       s""">> Unqualified use.
          |
          |${src(loc, "unqualified use.")}
+         |
+         |${underline("Tip:")} A use must be qualified: It should have the form `use Foo.bar`
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter.*
-      s"${underline("Tip:")} A use must be qualified: It should have the form `use Foo.bar`"
-    })
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/Options.scala
+++ b/main/src/ca/uwaterloo/flix/util/Options.scala
@@ -28,7 +28,6 @@ object Options {
     lib = LibLevel.All,
     build = Build.Development,
     entryPoint = None,
-    explain = false,
     githubToken = None,
     installDeps = false,
     incremental = true,
@@ -76,7 +75,6 @@ object Options {
   * @param lib            selects the level of libraries to include.
   * @param build          selects development or production mode.
   * @param entryPoint     specifies the main entry point.
-  * @param explain        enables additional explanations.
   * @param githubToken    the API key to use for GitHub dependency resolution.
   * @param incremental    enables incremental compilation.
   * @param installDeps    enables automatic installation of dependencies.
@@ -91,7 +89,6 @@ object Options {
 case class Options(lib: LibLevel,
                    build: Build,
                    entryPoint: Option[Symbol.DefnSym],
-                   explain: Boolean,
                    githubToken: Option[String],
                    incremental: Boolean,
                    installDeps: Boolean,

--- a/main/test/ca/uwaterloo/flix/TestMain.scala
+++ b/main/test/ca/uwaterloo/flix/TestMain.scala
@@ -121,12 +121,6 @@ class TestMain extends AnyFunSuite {
     assert(opts.args == Seq("arg1", "arg2"))
   }
 
-  test("--explain foo") {
-    val args = Array("--explain", "p.flix")
-    val opts = Main.parseCmdOpts(args).get
-    assert(opts.explain)
-  }
-
   test("--json") {
     val args = Array("--json")
     val opts = Main.parseCmdOpts(args).get
@@ -197,12 +191,6 @@ class TestMain extends AnyFunSuite {
     val args = Array("--Xlib", "all", "p.flix")
     val opts = Main.parseCmdOpts(args).get
     assert(opts.xlib == LibLevel.All)
-  }
-
-  test("--explain") {
-    val args = Array("--explain")
-    val opts = Main.parseCmdOpts(args).get
-    assert(opts.explain)
   }
 
   test("--Xno-deprecated") {


### PR DESCRIPTION
- Removes `--explain`.
- Move messages into the main error message.

Rationale: 

- Its difficult for new comers to run the compiler with `--explain` from VSCode.
- Its probably easier for us to first have good error messages.