### PR TITLE
fix: report first non-comment location

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -219,8 +219,14 @@ object Parser2 {
 
   /** Get first non-comment previous position of the parser as a [[SourceLocation]]. */
   private def previousSourceLocation()(implicit s: State): SourceLocation = {
-    val token = s.tokens((s.position - previousNonComment(-1)).max(0))
-    token.mkSourceLocation()
+    val prevPos = (s.position - previousNonComment(1)).max(0)
+    if (0 <= prevPos && prevPos < s.tokens.length) {
+      val token = s.tokens(prevPos)
+      token.mkSourceLocation()
+    } else {
+      // This cannot happen.
+      throw InternalCompilerException(s"Parser arrived in impossible case", currentSourceLocation())
+    }
   }
 
   /** Get current position of the parser as a [[SourceLocation]]. */
@@ -501,14 +507,16 @@ object Parser2 {
     }
   }
 
-  /** Returns the distance to the first non-comment token after lookahead. */
+  /**
+    * Returns the distance to the first non-comment token after lookahead.
+    */
   @tailrec
   private def previousNonComment(lookbehind: Int)(implicit s: State): Int = {
-    if (s.position + lookbehind < 1) {
-      Math.abs(lookbehind)
-    } else s.tokens(s.position + lookbehind).kind match {
-      case t if t.isComment => previousNonComment(lookbehind - 1)
-      case _ => Math.abs(lookbehind)
+    if (s.position - lookbehind < 1) {
+      lookbehind
+    } else s.tokens(s.position - lookbehind).kind match {
+      case t if t.isComment => previousNonComment(lookbehind + 1)
+      case _ => lookbehind
     }
   }
 


### PR DESCRIPTION
Together with #12089 this has fixed the bug pointed out in #10197 and reports the correct position, not the comment's position. It does not affect the trailing comma discussion raised in #10197 .

The `Math.abs(lookbehind)` could be replaced with `-lookbehind`, but this seems clearer.