### PR TITLE
fix: `jvmMethod` should not crash on doc-comment

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2847,7 +2847,7 @@ object Parser2 {
         // `new Type { ... }`.
         zeroOrMore(
           namedTokenSet = NamedTokenSet.FromKinds(Set(TokenKind.KeywordDef)),
-          checkForItem = t => t.isComment || t == TokenKind.KeywordDef,
+          checkForItem = _ => nth(nextNonComment(0))  == TokenKind.KeywordDef,
           getItem = jvmMethod,
           breakWhen = _.isRecoverInExpr,
           delimiterL = TokenKind.CurlyL,
@@ -2873,8 +2873,9 @@ object Parser2 {
 
     private def jvmMethod()(implicit s: State): Mark.Closed = {
       implicit val sctx: SyntacticContext = SyntacticContext.Expr.OtherExpr
-      assert(at(TokenKind.KeywordDef))
+      // Have to eat potential comments before the `assert`.
       val mark = open()
+      assert(at(TokenKind.KeywordDef))
       expect(TokenKind.KeywordDef)
       nameUnqualified(NAME_JAVA)
       Decl.parameters()

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -310,4 +310,13 @@ mod Test.Exp.Jvm.NewObject {
     @CompileTest
     def testClassWithProtectedConstructor01(): TestClassWithProtectedConstructor \ IO =
         new TestClassWithProtectedConstructor {}
+
+    @CompileTest
+    def testCommentBeforeJVMMethod01(): Unit \ IO =
+        let _ = new TestBoolInterface {
+            /// We can write comments here.
+            def testMethod(_this: TestBoolInterface, x: Bool): Bool = not x
+        };
+        ()
+
 }


### PR DESCRIPTION
Fixes the bug from the 4. October in #11738