### PR TITLE
chore: extend LoweredAst with TypedAst expressions

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -16,10 +16,13 @@
 
 package ca.uwaterloo.flix.language.ast
 
+import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, TraitEnv}
 import ca.uwaterloo.flix.util.collection.{ListMap, Nel}
+
+import java.lang.reflect.{Constructor, Field, Method}
 
 object LoweredAst {
 
@@ -83,6 +86,20 @@ object LoweredAst {
       def eff: Type = Type.Pure
     }
 
+    case class Hole(sym: Symbol.HoleSym, scp: LocalScope, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class HoleWithExp(exp: Expr, scp: LocalScope, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class OpenAs(symUse: RestrictableEnumSymUse, exp: Expr, tpe: Type, loc: SourceLocation) extends Expr {
+      def eff: Type = exp.eff
+    }
+
+    case class Use(sym: Symbol, alias: Name.Ident, exp: Expr, loc: SourceLocation) extends Expr {
+      def tpe: Type = exp.tpe
+
+      def eff: Type = exp.eff
+    }
+
     case class Lambda(fparam: FormalParam, exp: Expr, tpe: Type, loc: SourceLocation) extends Expr {
       def eff: Type = Type.Pure
     }
@@ -98,6 +115,10 @@ object LoweredAst {
     case class ApplyOp(sym: Symbol.OpSym, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class ApplySig(sym: Symbol.SigSym, exps: List[Expr], targ: Type, targs: List[Type], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Unary(sop: SemanticOp.UnaryOp, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Binary(sop: SemanticOp.BinaryOp, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
@@ -115,9 +136,45 @@ object LoweredAst {
 
     case class Match(exp: Expr, rules: List[MatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
+    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class RestrictableChoose(star: Boolean, exp: Expr, rules: List[RestrictableChooseRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
     case class ExtMatch(exp: Expr, rules: List[ExtMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Tag(symUse: CaseSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class RestrictableTag(symUse: RestrictableCaseSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class ExtTag(label: Name.Label, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Tuple(exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class RecordSelect(exp: Expr, label: Name.Label, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class RecordExtend(label: Name.Label, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class RecordRestrict(label: Name.Label, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class ArrayLit(exps: List[Expr], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class ArrayNew(exp1: Expr, exp2: Expr, exp3: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class ArrayLoad(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class ArrayLength(exp: Expr, eff: Type, loc: SourceLocation) extends Expr {
+      def tpe: Type = Type.Int32
+    }
+
+    case class ArrayStore(exp1: Expr, exp2: Expr, exp3: Expr, eff: Type, loc: SourceLocation) extends Expr {
+      def tpe: Type = Type.Unit
+    }
+
+    case class StructNew(sym: Symbol.StructSym, fields: List[(StructFieldSymUse, Expr)], region: Option[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class StructGet(exp: Expr, symUse: StructFieldSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class StructPut(exp1: Expr, symUse: StructFieldSymUse, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class VectorLit(exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
@@ -131,11 +188,45 @@ object LoweredAst {
 
     case class Ascribe(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
+    case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr {
+      def eff: Type = exp.eff
+
+      def tpe: Type = Type.Bool
+    }
+
+    case class CheckedCast(cast: CheckedCastType, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class UncheckedCast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Unsafe(exp: Expr, runEff: Type, asEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Without(exp: Expr, symUse: EffSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
     case class Cast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
+    case class Throw(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Handler(symUse: EffSymUse, rules: List[HandlerRule], bodyType: Type, bodyEff: Type, handledEff: Type, tpe: Type, loc: SourceLocation) extends Expr {
+      override def eff: Type = Type.Pure
+    }
+
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class InvokeConstructor(constructor: Constructor[?], exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class InvokeMethod(method: Method, exp: Expr, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class InvokeStaticMethod(method: Method, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class GetField(field: Field, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class PutField(field: Field, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class GetStaticField(field: Field, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class PutStaticField(field: Field, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
@@ -147,7 +238,15 @@ object LoweredAst {
 
     case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
+    case class Spawn(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
     case class ParYield(frags: List[ParYieldFragment], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Lazy(exp: Expr, tpe: Type, loc: SourceLocation) extends Expr {
+      def eff: Type = Type.Pure
+    }
+
+    case class Force(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class FixpointConstraintSet(cs: List[Constraint], tpe: Type, loc: SourceLocation) extends Expr {
       def eff: Type = Type.Pure
@@ -164,6 +263,10 @@ object LoweredAst {
     case class FixpointSolveWithProject(exps: List[Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class FixpointInjectInto(exps: List[Expr], predsAndArities: List[PredicateAndArity], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Error(m: CompilationMessage, tpe: Type, eff: Type) extends Expr {
+      override def loc: SourceLocation = m.loc
+    }
 
   }
 
@@ -190,6 +293,22 @@ object LoweredAst {
     object Record {
       case class RecordLabelPattern(label: Name.Label, pat: Pattern, tpe: Type, loc: SourceLocation)
     }
+  }
+
+  sealed trait RestrictableChoosePattern
+
+  object RestrictableChoosePattern {
+
+    sealed trait VarOrWild
+
+    case class Wild(tpe: Type, loc: SourceLocation) extends VarOrWild
+
+    case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends VarOrWild
+
+    case class Tag(symUse: RestrictableCaseSymUse, pat: List[VarOrWild], tpe: Type, loc: SourceLocation) extends RestrictableChoosePattern
+
+    case class Error(tpe: Type, loc: SourceLocation) extends VarOrWild with RestrictableChoosePattern
+
   }
 
   sealed trait ExtPattern {
@@ -265,6 +384,8 @@ object LoweredAst {
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr)
 
   case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr)
+
+  case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
 
   case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/LoweredAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/LoweredAstOps.scala
@@ -2,7 +2,8 @@ package ca.uwaterloo.flix.language.ast.ops
 
 import ca.uwaterloo.flix.language.ast.LoweredAst.*
 import ca.uwaterloo.flix.language.ast.LoweredAst.Predicate.{Body, Head}
-import ca.uwaterloo.flix.language.ast.{Symbol, Type, LoweredAst}
+import ca.uwaterloo.flix.language.ast.{LoweredAst, Symbol, Type}
+import ca.uwaterloo.flix.util.InternalCompilerException
 
 object LoweredAstOps {
 
@@ -156,6 +157,9 @@ object LoweredAstOps {
 
     case Expr.FixpointInjectInto(exps, _, _, _, _) =>
       freeVars(exps)
+
+    case _ =>
+      throw InternalCompilerException(s"Will not be implemented", exp0.loc)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.dbg.printer
 import ca.uwaterloo.flix.language.ast.{LoweredAst, Symbol}
 import ca.uwaterloo.flix.language.ast.LoweredAst.{Expr, ExtPattern, ExtTagPattern, Pattern}
 import ca.uwaterloo.flix.language.dbg.DocAst
+import ca.uwaterloo.flix.util.InternalCompilerException
 
 object LoweredAstPrinter {
 
@@ -138,6 +139,9 @@ object LoweredAstPrinter {
     case LoweredAst.Expr.FixpointSolveWithProject(_, _, _, _, _, _) => DocAst.Expr.Unknown
 
     case LoweredAst.Expr.FixpointInjectInto(_, _, _, _, _) => DocAst.Expr.Unknown
+
+    case _ =>
+      throw InternalCompilerException(s"Will not be implemented", e.loc)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -163,7 +163,22 @@ object Lowering {
     */
   private def lowerExp(exp0: LoweredAst.Expr)(implicit ctx: Context, root: LoweredAst.Root, flix: Flix): MonoAst.Expr = exp0 match {
     case LoweredAst.Expr.Cst(cst, tpe, loc) => MonoAst.Expr.Cst(cst, lowerType(tpe), loc)
+
     case LoweredAst.Expr.Var(sym, tpe, loc) => MonoAst.Expr.Var(sym, lowerType(tpe), loc)
+
+    case LoweredAst.Expr.Hole(sym, _, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.HoleWithExp(_, _, tpe, _, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.OpenAs(_, exp, _, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.Use(_, _, exp, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+
     case LoweredAst.Expr.Lambda(fparam, exp, tpe, loc) =>
       val p = lowerFormalParam(fparam)
       val e = lowerExp(exp)
@@ -210,6 +225,12 @@ object Lowering {
       val t = lowerType(tpe)
       MonoAst.Expr.ApplyOp(sym, es, t, eff, loc)
 
+    case LoweredAst.Expr.Unary(sop, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.Binary(sop, exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
     case LoweredAst.Expr.Let(sym, exp1, exp2, tpe, eff, loc) =>
       val e1 = lowerExp(exp1)
       val e2 = lowerExp(exp2)
@@ -251,11 +272,59 @@ object Lowering {
       val rs = rules.map(visitMatchRule)
       MonoAst.Expr.Match(e, rs, t, eff, loc)
 
+    case LoweredAst.Expr.RestrictableChoose(_, exp, rules, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
     case LoweredAst.Expr.ExtMatch(exp, rules, tpe, eff, loc) =>
       val e = lowerExp(exp)
       val rs = rules.map(lowerExtMatch)
       val t = lowerType(tpe)
       MonoAst.Expr.ExtMatch(e, rs, t, eff, loc)
+
+    case LoweredAst.Expr.Tag(symUse, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.RestrictableTag(symUse, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.ExtTag(label, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.Tuple(exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.RecordSelect(exp, label, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.RecordExtend(label, exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.RecordRestrict(label, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.ArrayLit(exps, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.ArrayNew(exp1, exp2, exp3, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.ArrayLoad(exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.ArrayLength(exp, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.ArrayStore(exp1, exp2, exp3, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.StructNew(sym, fields0, region0, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.StructGet(exp, field, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.StructPut(exp, field, exp1, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
 
     case LoweredAst.Expr.VectorLit(exps, tpe, eff, loc) =>
       val es = exps.map(lowerExp)
@@ -268,7 +337,8 @@ object Lowering {
       val t = lowerType(tpe)
       MonoAst.Expr.VectorLoad(e1, e2, t, eff, loc)
 
-    case LoweredAst.Expr.VectorLength(exp, loc) => MonoAst.Expr.VectorLength(lowerExp(exp), loc)
+    case LoweredAst.Expr.VectorLength(exp, loc) =>
+      MonoAst.Expr.VectorLength(lowerExp(exp), loc)
 
     case LoweredAst.Expr.Ascribe(exp, _, _, _) =>
       lowerExp(exp)
@@ -278,6 +348,24 @@ object Lowering {
       val e = lowerExp(exp)
       val t = lowerType(tpe)
       mkCast(e, t, eff, loc)
+
+    case LoweredAst.Expr.InstanceOf(exp, clazz, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.CheckedCast(_, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.UncheckedCast(exp, _, _, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.Unsafe(exp, _, _, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.Without(exp, _, _, _, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.Throw(exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
 
     case LoweredAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = lowerExp(exp)
@@ -290,6 +378,30 @@ object Lowering {
       val t = lowerType(tpe)
       val rs = rules.map(lowerHandlerRule)
       MonoAst.Expr.RunWith(e, effUse, rs, t, eff, loc)
+
+    case LoweredAst.Expr.Handler(symUse, rules, bodyTpe, bodyEff, handledEff, tpe, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.InvokeConstructor(constructor, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.GetField(field, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.PutField(field, exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.GetStaticField(field, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.PutStaticField(field, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
 
     case LoweredAst.Expr.NewObject(name, clazz, tpe, eff, methods, loc) =>
       val ms = methods.map(lowerJvmMethod)
@@ -319,6 +431,9 @@ object Lowering {
       val t = lowerType(tpe)
       Lowering.mkSelectChannel(rules, default, t, eff, loc)
 
+    case LoweredAst.Expr.Spawn(exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
     case LoweredAst.Expr.ParYield(frags, exp, tpe, eff, loc) =>
       val fs = frags.map {
         case LoweredAst.ParYieldFragment(pat, fragExp, fragLoc) =>
@@ -328,6 +443,12 @@ object Lowering {
       val e = lowerExp(exp)
       val t = lowerType(tpe)
       Lowering.mkParYield(fs, e, t, eff, loc)
+
+    case LoweredAst.Expr.Lazy(exp, tpe, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case LoweredAst.Expr.Force(exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
 
     case LoweredAst.Expr.FixpointConstraintSet(cs, _, loc) =>
       lowerConstraintSet(cs, loc)
@@ -362,6 +483,9 @@ object Lowering {
 
     case LoweredAst.Expr.TypeMatch(_, _, _, _, _) =>
       throw InternalCompilerException(s"Unexpected TypeMatch", exp0.loc)
+
+    case LoweredAst.Expr.Error(m, _, _) =>
+      throw InternalCompilerException(s"Unexpected error expression near", m.loc)
 
   }
 
@@ -1003,24 +1127,24 @@ object Lowering {
     * }}}
     */
   private def lowerSolveWithProject(exps0: List[LoweredAst.Expr], optPreds: Option[List[Name.Pred]], mode: SolveMode, eff: Type, loc: SourceLocation)(implicit ctx: Context, root: LoweredAst.Root, flix: Flix): MonoAst.Expr = {
-      val defn = mode match {
-        case SolveMode.Default => lookup(Defs.Solve, Types.Datalog)
-        case SolveMode.WithProvenance => lookup(Defs.SolveWithProvenance, Types.Datalog)
-      }
-      val exps = exps0.map(lowerExp)
-      val mergedExp = mergeExps(exps, loc)
-      val argExps = mergedExp :: Nil
-      val solvedExp = MonoAst.Expr.ApplyDef(defn, argExps, Types.SolveType, Types.Datalog, eff, loc)
-      val tmpVarSym = Symbol.freshVarSym("tmp%", BoundBy.Let, loc)(Scope.Top, flix)
-      val letBodyExp = optPreds match {
-        case Some(preds) =>
-          mergeExps(preds.map(pred => {
-            val varExp = MonoAst.Expr.Var(tmpVarSym, Types.Datalog, loc)
-            projectSym(mkPredSym(pred), varExp, loc)
-          }), loc)
-        case None => MonoAst.Expr.Var(tmpVarSym, Types.Datalog, loc)
-      }
-      MonoAst.Expr.Let(tmpVarSym, solvedExp, letBodyExp, Types.Datalog, eff, Occur.Unknown, loc)
+    val defn = mode match {
+      case SolveMode.Default => lookup(Defs.Solve, Types.Datalog)
+      case SolveMode.WithProvenance => lookup(Defs.SolveWithProvenance, Types.Datalog)
+    }
+    val exps = exps0.map(lowerExp)
+    val mergedExp = mergeExps(exps, loc)
+    val argExps = mergedExp :: Nil
+    val solvedExp = MonoAst.Expr.ApplyDef(defn, argExps, Types.SolveType, Types.Datalog, eff, loc)
+    val tmpVarSym = Symbol.freshVarSym("tmp%", BoundBy.Let, loc)(Scope.Top, flix)
+    val letBodyExp = optPreds match {
+      case Some(preds) =>
+        mergeExps(preds.map(pred => {
+          val varExp = MonoAst.Expr.Var(tmpVarSym, Types.Datalog, loc)
+          projectSym(mkPredSym(pred), varExp, loc)
+        }), loc)
+      case None => MonoAst.Expr.Var(tmpVarSym, Types.Datalog, loc)
+    }
+    MonoAst.Expr.Let(tmpVarSym, solvedExp, letBodyExp, Types.Datalog, eff, Occur.Unknown, loc)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -473,6 +473,18 @@ object Specialization {
     case Expr.Cst(cst, tpe, loc) =>
       Expr.Cst(cst, subst(tpe), loc)
 
+    case Expr.Hole(sym, scp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.HoleWithExp(exp, scp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.OpenAs(symUse, exp, tpe, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.Use(symbol, alias, exp, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
     case Expr.Lambda(fparam, exp, tpe, loc) =>
       val (p, env1) = specializeFormalParam(fparam, subst)
       val e = specializeExp(exp, env0 ++ env1, subst)
@@ -509,6 +521,12 @@ object Specialization {
       val newSym = specializeSigSym(sym, it)
       val es = exps.map(specializeExp(_, env0, subst))
       Expr.ApplyDef(newSym, es, targs, it, subst(tpe), subst(eff), loc)
+
+    case Expr.Unary(sop, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.Binary(sop, exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
 
     case Expr.Let(sym, exp1, exp2, tpe, eff, loc) =>
       val freshSym = Symbol.freshVarSym(sym)
@@ -596,6 +614,54 @@ object Specialization {
           }
       }.get // This is safe since the last case can always match.
 
+    case Expr.RestrictableChoose(star, exp, rules, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.Tag(symUse, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.RestrictableTag(symUse, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.ExtTag(label, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.Tuple(exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.RecordSelect(exp, label, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.RecordExtend(label, exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.RecordRestrict(label, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.ArrayLit(exps, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.ArrayNew(exp1, exp2, exp3, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.ArrayLoad(exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.ArrayLength(exp, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.ArrayStore(exp1, exp2, exp3, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.StructNew(sym, fields0, region0, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.StructGet(exp, field, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.StructPut(exp1, field, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
     case Expr.VectorLit(exps, tpe, eff, loc) =>
       val es = exps.map(specializeExp(_, env0, subst))
       Expr.VectorLit(es, subst(tpe), subst(eff), loc)
@@ -621,6 +687,21 @@ object Specialization {
       val t = subst(tpe)
       Expr.Cast(e, dType, dEff, t, subst(eff), loc)
 
+    case Expr.InstanceOf(exp, clazz, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.UncheckedCast(exp, declaredType, declaredEff, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.CheckedCast(cast, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.Unsafe(exp, runEff, asEff0, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.Without(exp, symUse, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
     case Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = specializeExp(exp, env0, subst)
       val rs = rules map {
@@ -632,6 +713,12 @@ object Specialization {
       }
       Expr.TryCatch(e, rs, subst(tpe), subst(eff), loc)
 
+    case Expr.Throw(exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.Handler(symUse0, rules0, bodyTpe, bodyEff, handledEff, tpe, loc0) =>
+      throw InternalCompilerException(s"Not implemented", loc0)
+
     case Expr.RunWith(exp, effSymUse, rules, tpe, eff, loc) =>
       val e = specializeExp(exp, env0, subst)
       val rs = rules map {
@@ -642,6 +729,27 @@ object Specialization {
           LoweredAst.HandlerRule(opSymUse, fparams, body)
       }
       Expr.RunWith(e, effSymUse, rs, subst(tpe), subst(eff), loc)
+
+    case Expr.InvokeConstructor(constructor, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.GetField(field, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.PutField(field, exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.GetStaticField(field, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.PutStaticField(field, exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
 
     case Expr.NewObject(name, clazz, tpe, eff, methods0, loc) =>
       val methods = methods0.map(specializeJvmMethod(_, env0, subst))
@@ -672,6 +780,9 @@ object Specialization {
       val default = default0.map { d => specializeExp(d, env0, subst) }
       Expr.SelectChannel(rules, default, subst(tpe), subst(eff), loc0)
 
+    case Expr.Spawn(exp1, exp2, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
     case Expr.ParYield(frags, exp, tpe, eff, loc) =>
       var curEnv = env0
       val fs = frags.map {
@@ -682,6 +793,12 @@ object Specialization {
       }
       val e = specializeExp(exp, curEnv, subst)
       Expr.ParYield(fs, e, subst(tpe), subst(eff), loc)
+
+    case Expr.Lazy(exp, tpe, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
+
+    case Expr.Force(exp, tpe, eff, loc) =>
+      throw InternalCompilerException(s"Not implemented", loc)
 
     case Expr.FixpointConstraintSet(cs0, tpe, loc) =>
       val cs = cs0.map(specializeConstraint(_, env0, subst))
@@ -724,6 +841,9 @@ object Specialization {
       val exps = exps0.map(specializeExp(_, env0, subst))
       val t = subst(tpe)
       Expr.FixpointInjectInto(exps, predsAndArities, t, subst(eff), loc)
+
+    case LoweredAst.Expr.Error(m, _, _) =>
+      throw InternalCompilerException(s"Unexpected error expression near", m.loc)
 
   }
 


### PR DESCRIPTION
The goal is to remove LoweredAstOps and LoweredAstPrinter, so I've just used a wildcard pattern for the new expressions.