### PR TITLE
chore: implement last TypedAst expression in monomorph

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -212,7 +212,9 @@ object LoweredAst {
       override def eff: Type = Type.Pure
     }
 
-    case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class RunWith(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class OldRunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class InvokeConstructor(constructor: Constructor[?], exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/LoweredAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/LoweredAstOps.scala
@@ -102,7 +102,7 @@ object LoweredAstOps {
         case (acc, CatchRule(sym, _, body)) => acc ++ freeVars(body) - sym
       }
 
-    case Expr.RunWith(exp1, _, _, _, _, _) =>
+    case Expr.OldRunWith(exp1, _, _, _, _, _) =>
       freeVars(exp1)
 
     case Expr.NewObject(_, _, _, _, methods, _) =>

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -103,7 +103,7 @@ object LoweredAstPrinter {
         case LoweredAst.CatchRule(sym, clazz, body) => (sym, clazz, print(body))
       }
       DocAst.Expr.TryCatch(expD, rulesD)
-    case Expr.RunWith(exp, effSymUse, rules, _, _, _) =>
+    case Expr.OldRunWith(exp, effSymUse, rules, _, _, _) =>
       val expD = print(exp)
       val effD = effSymUse.sym
       val rulesD = rules.map {

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -663,7 +663,7 @@ object Lowering {
       val bodyThunkType = Type.mkArrowWithEffect(Type.Unit, bodyEff, bt, loc.asSynthetic)
       val bodyVar = LoweredAst.Expr.Var(bodySym, bodyThunkType, loc.asSynthetic)
       val body = LoweredAst.Expr.ApplyClo(bodyVar, LoweredAst.Expr.Cst(Constant.Unit, Type.Unit, loc.asSynthetic), bt, bodyEff, loc.asSynthetic)
-      val RunWith = LoweredAst.Expr.RunWith(body, symUse, rs, bt, handledEff, loc)
+      val RunWith = LoweredAst.Expr.OldRunWith(body, symUse, rs, bt, handledEff, loc)
       val param = LoweredAst.FormalParam(bodySym, bodyThunkType, loc.asSynthetic)
       LoweredAst.Expr.Lambda(param, RunWith, t, loc)
 


### PR DESCRIPTION
I'll remove `LoweredAst` in the next PR. It will involve quite a lot of small changes.

The `RunWith` added is to mimic the `TypedAst` one instead of the `LoweredAst` one.