### PR TITLE
fix: disallow member lookup on primitives

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -138,6 +138,7 @@ object ErrorCode {
   case object E3918 extends ErrorCode
   case object E3952 extends ErrorCode
   case object E4029 extends ErrorCode
+  case object E4038 extends ErrorCode
   case object E4063 extends ErrorCode
   case object E4132 extends ErrorCode
   case object E4176 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -161,6 +161,31 @@ object SafetyError {
   }
 
   /**
+    * An error indicating that a primitive `value` is used in `value.field` or `value.method()`
+    *
+    * @param tpe           the type of `value`.
+    * @param lookupPurpose 'method' or 'field'.
+    * @param loc           the source location of the lookup.
+    */
+  case class IllegalNonJavaPrimitive(tpe: Type, lookupPurpose: String, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+    def code: ErrorCode = ErrorCode.E4038
+
+    def summary: String = s"Cannot perform $lookupPurpose lookup on primitive type."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Cannot perform $lookupPurpose lookup on primitive type.
+         |
+         |${highlight(loc, s"impossible $lookupPurpose lookup", fmt)}
+         |
+         |Type: ${red(FormatType.formatType(tpe))}.
+         |
+         |${underline("Explanation:")} A $lookupPurpose lookup can only be performed on non-primitive Java types.
+         |""".stripMargin
+    }
+  }
+
+  /**
     * An error raised to indicate a cast from a type to a type variable.
     *
     * @param from the source type.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -19,13 +19,19 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.errors.{EntryPointError, SafetyError}
-import ca.uwaterloo.flix.language.errors.SafetyError.{Forbidden, IllegalCatchType, IllegalMethodEffect, IllegalNegativelyBoundWildCard, IllegalNonPositivelyBoundVar, IllegalPatternInBodyAtom, IllegalRelationalUseOfLatticeVar, IllegalThrowType}
+import ca.uwaterloo.flix.language.errors.SafetyError.{Forbidden, IllegalCatchType, IllegalMethodEffect, IllegalNegativelyBoundWildCard, IllegalNonJavaPrimitive, IllegalNonPositivelyBoundVar, IllegalPatternInBodyAtom, IllegalRelationalUseOfLatticeVar, IllegalThrowType}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
 class TestSafety extends AnyFunSuite with TestUtils {
 
   val DefaultOptions: Options = Options.TestWithLibMin
+
+  test("IllegalMemberLookup.01") {
+    val input = """pub def f(): Unit \ IO = println((1).toString())"""
+    val result = check(input, Options.TestWithLibNix)
+    expectError[IllegalNonJavaPrimitive](result)
+  }
 
   test("IllegalCatchType.01") {
     val input =


### PR DESCRIPTION
Fixes #12135

I'm not that deeply into the type system, so I may have missed something. I've gone with a restrictive take disallowing everything that is not known to be safe (assuming `Box.Boxed` is safe).

We could do the reverse (disallowing `Int32`, `Int64` and the other primitives) and build on the assumption that the type system will catch everything else.