### PR TITLE
feat: add `ExpectedThickArrowRGotEqual`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -95,3 +95,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Alexander Friis Sommer](https://github.com/sommerblommer)
 - [Samuel Skovbakke](https://github.com/samuelskovbakke)
 - [Mikkel Sejdelin](https://github.com/Sejder)
+- [Anders Bjerrum Jensen](https://github.com/AndersJensenStudie)

--- a/main/src/library/DnsWithResult.flix
+++ b/main/src/library/DnsWithResult.flix
@@ -75,6 +75,7 @@ pub mod DnsWithResult {
     ///
     /// In other words, re-interprets the `DnsWithResult` effect using the `IO` effect.
     ///
+    @DefaultHandler
     pub def runWithIO(f: Unit -> a \ ef): a \ ef - DnsWithResult + IO = handle(f)()
 
 }

--- a/main/src/library/PingWithResult.flix
+++ b/main/src/library/PingWithResult.flix
@@ -58,7 +58,8 @@ pub mod PingWithResult {
     ///
     /// In other words, re-interprets the `PingWithResult` effect using the `IO` effect.
     ///
-    pub def runWithIO(f: Unit -> a \ ef): a \ ef - PingWithResult + IO = handle(f)()
+    @DefaultHandler
+    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - PingWithResult) + IO = handle(f)()
 
 }
 

--- a/main/src/library/ProcessWithResult.flix
+++ b/main/src/library/ProcessWithResult.flix
@@ -183,6 +183,7 @@ pub mod ProcessWithResult {
     ///
     /// In other words, re-interprets the `Process` effect using the `IO` effect.
     ///
+    @DefaultHandler
     pub def runWithIO(f: Unit -> a \ ef): a \ (ef - ProcessWithResult) + IO = handle(f)()
 
 }

--- a/main/src/library/TcpAcceptWithResult.flix
+++ b/main/src/library/TcpAcceptWithResult.flix
@@ -57,6 +57,7 @@ pub mod TcpAcceptWithResult {
     ///
     /// In other words, re-interprets the `TcpAcceptWithResult` effect using the `IO` effect.
     ///
+    @DefaultHandler
     pub def runWithIO(f: Unit -> a \ ef): a \ ef - TcpAcceptWithResult + IO = handle(f)()
 
 }

--- a/main/src/library/TcpBindWithResult.flix
+++ b/main/src/library/TcpBindWithResult.flix
@@ -58,6 +58,7 @@ pub mod TcpBindWithResult {
     ///
     /// In other words, re-interprets the `TcpBindWithResult` effect using the `IO` effect.
     ///
-    pub def runWithIO(f: Unit -> a \ ef): a \ ef - TcpBindWithResult + IO = handle(f)()
+    @DefaultHandler
+    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - TcpBindWithResult) + IO = handle(f)()
 
 }

--- a/main/src/library/TcpConnectWithResult.flix
+++ b/main/src/library/TcpConnectWithResult.flix
@@ -56,6 +56,7 @@ pub mod TcpConnectWithResult {
     ///
     /// In other words, re-interprets the `TcpConnectWithResult` effect using the `IO` effect.
     ///
-    pub def runWithIO(f: Unit -> a \ ef): a \ ef - TcpConnectWithResult + IO = handle(f)()
+    @DefaultHandler
+    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - TcpConnectWithResult) + IO = handle(f)()
 
 }


### PR DESCRIPTION
I created a new ParseError called ExpectedThickArrowRGotEqual
Added a new ErrorCode to it
Modified CodeActionProvider to take care of this new error
Created a Test for to see that the error is provided.

Furthermore in typematchRule() in Parser2.scala i decided to continue parsing as if no problems occurred to suppress other errors. I don't know whether this is the right approach but it looks nice and comprehensible instead of the entire line giving a harder to read error.
```scala
if (eat(TokenKind.Equal)) {
        closeWithError(open(), ExpectedThickArrowRGotEqual(previousSourceLocation(), sctx, Some("Use => instead of =")))
        // Continue parsing the rule as if we had seen '=>' to suppress other errors.
        statement()
      }
```
<img width="1102" height="206" alt="image" src="https://github.com/user-attachments/assets/36412cd4-c51d-4881-b096-af4800c8772e" />
