### PR TITLE
chore: IO inlay hint add missing spaces with double-clicking

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -79,7 +79,7 @@ object InlayHintProvider {
   private def getInlayHintsFromErrors(errors: List[CompilationMessage]): List[InlayHint] = {
     errors.foldLeft(List(): List[InlayHint]) {
       case (acc, TypeError.ExplicitlyPureFunctionUsesIO(loc, _)) => mkIOHint(Position.from(loc.start), "IO", "IO", Range.from(loc)) :: acc
-      case (acc, TypeError.ImplicitlyPureFunctionUsesIO(loc, _)) => mkIOHint(Position.from(loc.end), "\\ IO", "\\ IO", Range.from(loc)) :: acc
+      case (acc, TypeError.ImplicitlyPureFunctionUsesIO(loc, _)) => mkIOHint(Position.from(loc.end), " \\ IO ", " \\ IO ", Range.from(loc)) :: acc
       case (acc, _) => acc
     }
   }
@@ -151,10 +151,10 @@ object InlayHintProvider {
   private def mkIOHint(pos: Position, lbl: String, ttp: String, rng: Range): InlayHint = {
       InlayHint(
         position = pos,
-        label = s" ${lbl} ",
+        label = lbl,
         kind = Some(InlayHintKind.Type),
-        textEdits = List(TextEdit(rng, s" ${lbl} ")),
-        tooltip = s" ${ttp} ",
+        textEdits = List(TextEdit(rng, lbl)),
+        tooltip = ttp,
       )
   }
 }


### PR DESCRIPTION
This pull request makes minor formatting improvements to the inlay hint in the `InlayHintProvider`. The changes add extra spaces around the IO in implicit case to conform with the Flix style guide.

- Formatting improvements to inlay hints