### PR TITLE
chore: set isPreferred and diagnostic

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -59,21 +59,21 @@ object CodeActionProvider {
     case ResolutionError.UndefinedType(qn, _, ap, _, loc) if overlaps(range, loc) =>
       mkUseType(qn.ident, uri, ap) ++ mkImportJava(qn, uri, ap)
 
-    case TypeError.ExplicitlyPureFunctionUsesIO(loc, _) if overlaps(range, loc) =>
+    case te@TypeError.ExplicitlyPureFunctionUsesIO(loc, _) if overlaps(range, loc) =>
       List(CodeAction(
         title = "Change {} to IO",
         kind = CodeActionKind.QuickFix,
-        diagnostic = Some(Diagnostic.from(CodeHint.Experimental(loc))),
+        diagnostic = Some(Diagnostic.from(te, Some(root))),
         isPreferred = true,
         edit = Some(WorkspaceEdit(Map(uri -> List(TextEdit(Range.from(loc), "IO"))))),
         command = None
       ))
 
-    case TypeError.ImplicitlyPureFunctionUsesIO(loc, _) if overlaps(range, loc) =>
+    case te@TypeError.ImplicitlyPureFunctionUsesIO(loc, _) if overlaps(range, loc) =>
       List(CodeAction(
         title = "add \\ IO to signature",
         kind = CodeActionKind.QuickFix,
-        diagnostic = Some(Diagnostic.from(CodeHint.Experimental(loc))),
+        diagnostic = Some(Diagnostic.from(te, Some(root))),
         isPreferred = true,
         edit = Some(WorkspaceEdit(Map(uri -> List(TextEdit(Range.from(loc), " \\ IO "))))),
         command = None


### PR DESCRIPTION
This pull request enhances the code action suggestions in the Flix LSP by associating diagnostics with quick fixes and marking them as preferred. This provides better integration with editors, enabling users to see more context-aware and prioritized suggestions.

Improvements to quick fix suggestions:

* Added `diagnostic` information to quick fix `CodeAction`s by creating a `Diagnostic` from `CodeHint.Experimental`, improving the context provided for each suggestion. [[1]](diffhunk://#diff-ca6a3fe8ba0d94cfe2c89b80166b36233f2da62084cbf46ba78cf6ae3cad83ddR66-R67) [[2]](diffhunk://#diff-ca6a3fe8ba0d94cfe2c89b80166b36233f2da62084cbf46ba78cf6ae3cad83ddR76-R77)
* Marked relevant quick fixes as `isPreferred = true`, allowing editors to prioritize these actions for users. [[1]](diffhunk://#diff-ca6a3fe8ba0d94cfe2c89b80166b36233f2da62084cbf46ba78cf6ae3cad83ddR66-R67) [[2]](diffhunk://#diff-ca6a3fe8ba0d94cfe2c89b80166b36233f2da62084cbf46ba78cf6ae3cad83ddR76-R77)

Dependency and import updates:

* Updated imports to include `Diagnostic` and `CodeHint` for supporting the new diagnostic functionality.