### PR TITLE
refactor: make Richstring.toPlainString public

### DIFF
--- a/main/src/library/RichString.flix
+++ b/main/src/library/RichString.flix
@@ -301,7 +301,7 @@ pub mod RichString {
     ///
     /// All styling and color information is discarded.
     ///
-    def toPlainString(rs: RichString): String = match rs {
+    pub def toPlainString(rs: RichString): String = match rs {
         case RichString(spans) =>
             Chain.joinWith(match Span.Span(r) -> r#text, "", spans)
     }


### PR DESCRIPTION
It is useful to be able to get a plainstring from a `RichString`, independent from if the current console supports ANSI colors (as is the case with `toString`).