### PR TITLE
feat: add handler to logger that writes to different files

### DIFF
--- a/main/src/library/Logger.flix
+++ b/main/src/library/Logger.flix
@@ -89,22 +89,15 @@ pub mod Logger {
     /// 
     /// Handles the `Logger` effect of the given function `f` with the `FileWrite` effect.
     /// 
-    /// Appends each Severity level to the file given in `files`.
+    /// Appends the logged message to the file obtained by running `file` with the 
+    /// severity of the `log`.
     ///
-    pub def handleWithWriteByLevel(
-        files: {trace = String, debug = String, info = String, warn = String, fatal = String}, 
-            f: a -> b \ ef): a -> b \ (ef - Logger) + FileWrite = 
+    pub def handleWithWriteByLevel(file: Severity -> String, f: a -> b \ ef): a -> b \ (ef - Logger) + FileWrite = 
         x -> run {
             f(x)
         } with handler Logger {
             def log(s, m, k) = 
-                let filename = match s {
-                    case Severity.Trace => files#trace
-                    case Severity.Debug => files#debug
-                    case Severity.Info => files#info
-                    case Severity.Warn => files#warn
-                    case Severity.Fatal => files#fatal
-                };
+                let filename = file(s);
                 let output = "[${ToString.toString(s)}] ${RichString.toString(m)}\n";
                 FileWrite.append({str = output}, filename);
                 k()
@@ -112,9 +105,9 @@ pub mod Logger {
     /// 
     /// Runs the `Logger` effect of the given function `f` with the `FileWrite` effect.
     /// 
-    /// Appends each Severity level to the file given in `files`.
+    /// Appends the logged message to the file obtained by running `file` with the 
+    /// severity of the `log`.
     ///
-    pub def runWithWriteByLevel(files: {trace = String, debug = String, info = String, warn = String, fatal = String}, 
-            f: Unit -> a \ ef): a \ (ef - Logger) + FileWrite = 
-            handleWithWriteByLevel(files, f)()
+    pub def runWithWriteByLevel(file: Severity -> String, f: Unit -> a \ ef): a \ (ef - Logger) + FileWrite = 
+        handleWithWriteByLevel(file, f)()
 }

--- a/main/src/library/Logger.flix
+++ b/main/src/library/Logger.flix
@@ -91,7 +91,7 @@ pub mod Logger {
     /// 
     /// Appends each Severity level to the file given in `files`.
     ///
-    def handleWithWriteByLevel(
+    pub def handleWithWriteByLevel(
         files: {trace = String, debug = String, info = String, warn = String, fatal = String}, 
             f: a -> b \ ef): a -> b \ (ef - Logger) + FileWrite = 
         x -> run {
@@ -114,7 +114,7 @@ pub mod Logger {
     /// 
     /// Appends each Severity level to the file given in `files`.
     ///
-    def runWithWriteByLevel(files: {trace = String, debug = String, info = String, warn = String, fatal = String}, 
+    pub def runWithWriteByLevel(files: {trace = String, debug = String, info = String, warn = String, fatal = String}, 
             f: Unit -> a \ ef): a \ (ef - Logger) + FileWrite = 
             handleWithWriteByLevel(files, f)()
 }

--- a/main/src/library/Logger.flix
+++ b/main/src/library/Logger.flix
@@ -86,4 +86,35 @@ pub mod Logger {
     @DefaultHandler
     pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Logger) + IO = handle(f)()
 
+    /// 
+    /// Handles the `Logger` effect of the given function `f` with the `FileWrite` effect.
+    /// 
+    /// Appends each Severity level to the file given in `files`.
+    ///
+    def handleWithWriteByLevel(
+        files: {trace = String, debug = String, info = String, warn = String, fatal = String}, 
+            f: a -> b \ ef): a -> b \ (ef - Logger) + FileWrite = 
+        x -> run {
+            f(x)
+        } with handler Logger {
+            def log(s, m, k) = 
+                let filename = match s {
+                    case Severity.Trace => files#trace
+                    case Severity.Debug => files#debug
+                    case Severity.Info => files#info
+                    case Severity.Warn => files#warn
+                    case Severity.Fatal => files#fatal
+                };
+                let output = "[${ToString.toString(s)}] ${RichString.toString(m)}\n";
+                FileWrite.append({str = output}, filename);
+                k()
+        }
+    /// 
+    /// Runs the `Logger` effect of the given function `f` with the `FileWrite` effect.
+    /// 
+    /// Appends each Severity level to the file given in `files`.
+    ///
+    def runWithWriteByLevel(files: {trace = String, debug = String, info = String, warn = String, fatal = String}, 
+            f: Unit -> a \ ef): a \ (ef - Logger) + FileWrite = 
+            handleWithWriteByLevel(files, f)()
 }

--- a/main/test/ca/uwaterloo/flix/library/TestLogger.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLogger.flix
@@ -1,6 +1,7 @@
 mod TestLogger {
     use Assert.assertEq
     use Logger.{log, info, fatal, warn, trace, debug, runWithWriteByLevel}
+    use Severity.{Debug, Trace, Fatal, Warn, Info}
 
     /////////////////////////////////////////////////////////////////////////////
     // RunWithWriteLevels                                                      //
@@ -12,7 +13,10 @@ mod TestLogger {
             info("Hello, world");
             ""
         } with runWithWriteByLevel(
-            {trace = "", debug = "", info = "info.txt", warn = "", fatal = ""}
+            s -> match s {
+                case Info => "info.txt"
+                case _ => ""
+            }
         )
         with fileWriteHandlerStub;
         assertEq(expected = "Writing to info.txt: [Info] Hello, world\n", res)
@@ -25,7 +29,12 @@ mod TestLogger {
             fatal("Fatal");
             ""
         } with runWithWriteByLevel(
-            {trace = "trace.txt", debug = "", info = "info.txt", warn = "", fatal = "fatal.txt"}
+            s -> match s {
+                case Info => "info.txt"
+                case Trace => "trace.txt"
+                case Fatal => "fatal.txt"
+                case _ => ""
+            }
         )
         with fileWriteHandlerStub;
         let expected =  "Writing to info.txt: [Info] Info\nWriting to trace.txt: [Trace] Trace\nWriting to fatal.txt: [Fatal] Fatal\n";

--- a/main/test/ca/uwaterloo/flix/library/TestLogger.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLogger.flix
@@ -1,0 +1,56 @@
+mod TestLogger {
+    use Assert.assertEq
+    use Logger.{log, info, fatal, warn, trace, debug, fileWriteHandlerStub}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // RunWithWriteLevels                                                      //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def runWithWriteLevels01(): Unit \ Assert = 
+        let res = run {
+            info("Hello, world");
+            ""
+        } with runWithWriteByLevel(
+            {trace = "", debug = "", info = "info.txt", warn = "", fatal = ""}
+        )
+        with fileWriteHandlerStub;
+        assertEq(expected = "Writing to info.txt: [Info] Hello, world\n", res)
+
+    @Test
+    def runWithWriteLevels02(): Unit \ Assert = 
+        let res = run {
+            info("Info");
+            trace("Trace");
+            fatal("Fatal");
+            ""
+        } with runWithWriteByLevel(
+            {trace = "trace.txt", debug = "", info = "info.txt", warn = "", fatal = "fatal.txt"}
+        )
+        with fileWriteHandlerStub;
+        let expected =  "Writing to info.txt: [Info] Info\nWriting to trace.txt: [Trace] Trace\nWriting to fatal.txt: [Fatal] Fatal\n";
+        assertEq(expected = expected, res)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Helpers                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    def fileWriteHandlerStub(g: Unit -> String \ ef): String \ (ef - FileWrite) = 
+        run {
+            g()
+        } with handler FileWrite {
+            def append(dat, f, k) = {
+                let res = "Writing to " + f + ": " + dat#str + k();
+                res
+            }
+            def write(data, f, k) = unreachable!()
+            def writeLines(data, f, k) = unreachable!()
+            def writeBytes(data, f, k) = unreachable!()
+            def appendLines(data, f, k) = unreachable!()
+            def appendBytes(data, f, k) = unreachable!()
+            def truncate(f, k) = unreachable!()
+            def mkDir(d, k) = unreachable!()
+            def mkDirs(d, k) = unreachable!()
+            def mkTempDir(prefix, k) = unreachable!()
+        }
+}

--- a/main/test/ca/uwaterloo/flix/library/TestLogger.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLogger.flix
@@ -43,14 +43,14 @@ mod TestLogger {
                 let res = "Writing to " + f + ": " + dat#str + k();
                 res
             }
-            def write(data, f, k) = unreachable!()
-            def writeLines(data, f, k) = unreachable!()
-            def writeBytes(data, f, k) = unreachable!()
-            def appendLines(data, f, k) = unreachable!()
-            def appendBytes(data, f, k) = unreachable!()
-            def truncate(f, k) = unreachable!()
-            def mkDir(d, k) = unreachable!()
-            def mkDirs(d, k) = unreachable!()
-            def mkTempDir(prefix, k) = unreachable!()
+            def write(_data, _f, _k) = unreachable!()
+            def writeLines(_data, _f, _k) = unreachable!()
+            def writeBytes(_data, _f, _k) = unreachable!()
+            def appendLines(_data, _f, _k) = unreachable!()
+            def appendBytes(_data, _f, _k) = unreachable!()
+            def truncate(_f, _k) = unreachable!()
+            def mkDir(_d, _k) = unreachable!()
+            def mkDirs(_d, _k) = unreachable!()
+            def mkTempDir(_prefix, _k) = unreachable!()
         }
 }

--- a/main/test/ca/uwaterloo/flix/library/TestLogger.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLogger.flix
@@ -1,6 +1,6 @@
 mod TestLogger {
     use Assert.assertEq
-    use Logger.{log, info, fatal, warn, trace, debug, fileWriteHandlerStub}
+    use Logger.{log, info, fatal, warn, trace, debug}
 
     /////////////////////////////////////////////////////////////////////////////
     // RunWithWriteLevels                                                      //

--- a/main/test/ca/uwaterloo/flix/library/TestLogger.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLogger.flix
@@ -1,6 +1,6 @@
 mod TestLogger {
     use Assert.assertEq
-    use Logger.{log, info, fatal, warn, trace, debug}
+    use Logger.{log, info, fatal, warn, trace, debug, runWithWriteByLevel}
 
     /////////////////////////////////////////////////////////////////////////////
     // RunWithWriteLevels                                                      //


### PR DESCRIPTION
Added `Logger.runWithWriteLevels`, a handler for the `Logger` effect, that writes to different files, based on severity level.

(related to #12355)