### PR TITLE
fix: dead link to docs/STYLE.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,4 +51,4 @@ We are interested in correct, well-documented, and well-tested code.
 
 We expect all pull requests to be maintainable and follow established style.
 
-Please have a look at [STYLE.md](./STYLE.md) for more information on how to structure your code.
+Please have a look at [docs/STYLE.md](docs/STYLE.md) for more information on how to structure your code.


### PR DESCRIPTION
Link to `STYLE.md` goes to [a 404](https://github.com/flix/flix/blob/master/STYLE.md) when pressed on github. 