### PR TITLE
refactor: remove `without` construct from the compiler

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/effectlock/UseGraph.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/UseGraph.scala
@@ -190,8 +190,6 @@ object UseGraph {
     case Expr.Unsafe(exp, _, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Without(exp, _, _, _, _) =>
-      visitExp(exp)
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp))

--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -496,9 +496,6 @@ object Visitor {
         asEff.foreach(visitType)
         visitExpr(exp)
 
-      case Expr.Without(exp, symUse, _, _, _) =>
-        visitExpr(exp)
-        visitEffSymUse(symUse)
 
       case Expr.TryCatch(exp, rules, _, _, _) =>
         visitExpr(exp)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -577,9 +577,6 @@ object SemanticTokensProvider {
     case Expr.Unsafe(exp, runEff, asEff, _, _, _) =>
       visitType(runEff) ++ asEff.map(visitType).getOrElse(Iterator()) ++ visitExp(exp)
 
-    case Expr.Without(exp, symUse, _, _, _) =>
-      val t = SemanticToken(SemanticTokenType.Effect, Nil, symUse.qname.loc)
-      Iterator(t) ++ visitExp(exp)
 
     case Expr.TryCatch(exp1, rules, _, _, _) =>
       rules.foldLeft(visitExp(exp1)) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -142,7 +142,7 @@ object KeywordCompleter {
       Completion.KeywordCompletion("use"         , range, Priority.Lowest(0)),
       // W
       Completion.KeywordCompletion("with"        , range, Priority.Lowest(0)),
-      Completion.KeywordCompletion("without"     , range, Priority.Lowest(1)),
+
       // Y
       Completion.KeywordCompletion("yield"       , range, Priority.Lowest(0))
     ).filter {

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -160,7 +160,6 @@ object DesugaredAst {
 
     case class Unsafe(exp: Expr, eff: Type, asEff: Option[Type], loc: SourceLocation) extends Expr
 
-    case class Without(exp: Expr, eff: Name.QName, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -165,7 +165,6 @@ object KindedAst {
 
     case class Unsafe(exp: Expr, eff: Type, asEff: Option[Type], loc: SourceLocation) extends Expr
 
-    case class Without(exp: Expr, symUse: EffSymUse, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -174,7 +174,6 @@ object NamedAst {
 
     case class Unsafe(exp: Expr, eff: Type, asEff: Option[Type], loc: SourceLocation) extends Expr
 
-    case class Without(exp: Expr, qname: Name.QName, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -181,7 +181,6 @@ object ResolvedAst {
 
     case class Unsafe(exp: Expr, eff: UnkindedType, asEff: Option[UnkindedType], loc: SourceLocation) extends Expr
 
-    case class Without(exp: Expr, symUse: EffSymUse, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -380,7 +380,6 @@ object SyntaxTree {
 
       case object Use extends Expr
 
-      case object Without extends Expr
 
     }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -149,7 +149,7 @@ sealed trait TokenKind {
       case TokenKind.KeywordUse => "'use'"
       case TokenKind.KeywordWhere => "'where'"
       case TokenKind.KeywordWith => "'with'"
-      case TokenKind.KeywordWithout => "'without'"
+
       case TokenKind.KeywordXor => "'xor'"
       case TokenKind.KeywordXvar => "'xvar'"
       case TokenKind.KeywordYield => "'yield'"
@@ -280,7 +280,7 @@ sealed trait TokenKind {
     case TokenKind.KeywordUse => true
     case TokenKind.KeywordWhere => true
     case TokenKind.KeywordWith => true
-    case TokenKind.KeywordWithout => true
+
     case TokenKind.KeywordXor => true
     case TokenKind.KeywordXvar => true
     case TokenKind.KeywordYield => true
@@ -888,7 +888,6 @@ object TokenKind {
 
   case object KeywordWith extends TokenKind
 
-  case object KeywordWithout extends TokenKind
 
   case object KeywordXor extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -213,7 +213,6 @@ object TypedAst {
 
     case class Unsafe(exp: Expr, runEff: Type, asEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class Without(exp: Expr, symUse: EffSymUse, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -180,7 +180,6 @@ object WeededAst {
 
     case class Unsafe(exp: Expr, eff: Type, asEff: Option[Type], loc: SourceLocation) extends Expr
 
-    case class Without(exp: Expr, eff: Name.QName, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, handlers: List[CatchRule], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -84,7 +84,7 @@ object TypedAstOps {
     case Expr.CheckedCast(_, exp, _, _, _) => sigSymsOf(exp)
     case Expr.UncheckedCast(exp, _, _, _, _, _) => sigSymsOf(exp)
     case Expr.Unsafe(exp, _, _, _, _, _) => sigSymsOf(exp)
-    case Expr.Without(exp, _, _, _, _) => sigSymsOf(exp)
+
     case Expr.TryCatch(exp, rules, _, _, _) => sigSymsOf(exp) ++ rules.flatMap(rule => sigSymsOf(rule.exp))
     case Expr.Throw(exp, _, _, _) => sigSymsOf(exp)
     case Expr.Handler(_, rules, _, _, _, _, _) => rules.flatMap(rule => sigSymsOf(rule.exp)).toSet
@@ -305,8 +305,6 @@ object TypedAstOps {
     case Expr.Ascribe(exp, _, _, _, _, _) =>
       freeVars(exp)
 
-    case Expr.Without(exp, _, _, _, _) =>
-      freeVars(exp)
 
     case Expr.InstanceOf(exp, _, _) =>
       freeVars(exp)

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -283,8 +283,6 @@ object DocAst {
     def Box(d: Expr): Expr =
       Keyword("box", d)
 
-    def Without(d: Expr, sym: Symbol.EffSym): Expr =
-      Binary(d, "without", AsIs(sym.toString))
 
     def Cst(cst: Constant): Expr =
       printer.ConstantPrinter.print(cst)

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -94,7 +94,7 @@ object ResolvedAstPrinter {
     case Expr.CheckedCast(cast, exp, _) => DocAst.Expr.CheckedCast(cast, print(exp))
     case Expr.UncheckedCast(exp, tpe, eff, _) => DocAst.Expr.UncheckedCast(print(exp), tpe.map(UnkindedTypePrinter.print), eff.map(UnkindedTypePrinter.print))
     case Expr.Unsafe(exp, runEff, asEff, _) => DocAst.Expr.Unsafe(print(exp), UnkindedTypePrinter.print(runEff), asEff.map(UnkindedTypePrinter.print))
-    case Expr.Without(exp, symUse, _) => DocAst.Expr.Without(print(exp), symUse.sym)
+
     case Expr.TryCatch(exp, rules, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
       case ResolvedAst.CatchRule(sym, clazz, body, _) => (sym, clazz, print(body))
     })

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -73,7 +73,7 @@ object TypedAstPrinter {
     case Expr.CheckedCast(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.UncheckedCast(_, _, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.Unsafe(exp, runEff, asEff, _, _, _) => DocAst.Expr.Unsafe(print(exp), TypePrinter.print(runEff), asEff.map(TypePrinter.print))
-    case Expr.Without(_, _, _, _, _) => DocAst.Expr.Unknown
+
     case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule))
     case Expr.Throw(exp, _, _, _) => DocAst.Expr.Throw(print(exp))
     case Expr.Handler(symUse, rules, _, _, _, _, _) => DocAst.Expr.Handler(symUse.sym, rules.map(printHandlerRule))

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -368,11 +368,6 @@ object Dependencies {
       visitType(tpe)
       visitType(eff)
 
-    case Expr.Without(exp, symUse, tpe, eff, _) =>
-      visitExp(exp)
-      visitSymUse(symUse)
-      visitType(tpe)
-      visitType(eff)
 
     case Expr.TryCatch(exp, rules, tpe, eff, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -697,9 +697,6 @@ object Desugar {
       val asEff = asEff0.map(visitType)
       Expr.Unsafe(e, eff, asEff, loc)
 
-    case WeededAst.Expr.Without(exp, eff, loc) =>
-      val e = visitExp(exp)
-      Expr.Without(e, eff, loc)
 
     case WeededAst.Expr.TryCatch(exp, rules, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -673,9 +673,6 @@ object Kinder {
         val asEff = asEff0.map(visitType(_, Kind.Eff, kenv0, root))
         KindedAst.Expr.Unsafe(exp, eff, asEff, loc)
 
-      case ResolvedAst.Expr.Without(exp0, symUse, loc) =>
-        val exp = visitExp(exp0, kenv0, root)
-        KindedAst.Expr.Without(exp, symUse, loc)
 
       case ResolvedAst.Expr.TryCatch(exp0, rules0, loc) =>
         val exp = visitExp(exp0, kenv0, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -131,7 +131,7 @@ object Lexer {
       ("use", TokenKind.KeywordUse),
       ("where", TokenKind.KeywordWhere),
       ("with", TokenKind.KeywordWith),
-      ("without", TokenKind.KeywordWithout),
+
       ("xor", TokenKind.KeywordXor),
       ("xvar", TokenKind.KeywordXvar),
       ("yield", TokenKind.KeywordYield),

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -915,9 +915,6 @@ object Namer {
       val asEff = asEff0.map(visitType)
       NamedAst.Expr.Unsafe(e, eff, asEff, loc)
 
-    case DesugaredAst.Expr.Without(exp, qname, loc) =>
-      val e = visitExp(exp)
-      NamedAst.Expr.Without(e, qname, loc)
 
     case DesugaredAst.Expr.TryCatch(exp, rules, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1521,8 +1521,7 @@ object Parser2 {
                 // Hence we special case on whether the left token is ::. If it is,
                 // we avoid consuming any fuel.
                 // The next nth lookup will always fail, so we add fuel to account for it.
-                // The lookup for KeywordWithout will always happen so we add fuel to account for it.
-                if (left == BinaryOp.ColonColon) s.fuel += 2
+                if (left == BinaryOp.ColonColon) s.fuel += 1
                 continue = false
               case _ =>
                 val mark = openBefore(lhs)
@@ -1534,36 +1533,11 @@ object Parser2 {
           case None =>
             // Non-operator or EOF.
             // Add fuel for the same reason as above.
-            if (leftOpt.contains(BinaryOp.ColonColon)) s.fuel += 2
+            if (leftOpt.contains(BinaryOp.ColonColon)) s.fuel += 1
             continue = false
         }
       }
-      // Handle without expressions.
-      if (eat(TokenKind.KeywordWithout)) {
-        val mark = open()
-        if (at(TokenKind.CurlyL)) {
-          zeroOrMore(
-            namedTokenSet = NamedTokenSet.Effect,
-            getItem = () => nameAllowQualified(NAME_EFFECT),
-            checkForItem = NAME_EFFECT.contains,
-            breakWhen = _.isRecoverInExpr,
-            delimiterL = TokenKind.CurlyL,
-            delimiterR = TokenKind.CurlyR
-          )
-        } else if (NAME_EFFECT.contains(nth(0))) {
-          nameAllowQualified(NAME_EFFECT)
-        } else {
-          closeWithError(open(), UnexpectedToken(
-            expected = NamedTokenSet.Effect,
-            actual = Some(nth(0)),
-            sctx = sctx,
-            hint = Some(s"supply at least one effect to ${TokenKind.KeywordWithout.display}."),
-            loc = previousSourceLocation()))
-        }
-        close(mark, TreeKind.Type.EffectSet)
-        lhs = close(openBefore(lhs), TreeKind.Expr.Without)
-        lhs = close(openBefore(lhs), TreeKind.Expr.Expr)
-      }
+
       lhs
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -254,7 +254,6 @@ object PatMatch {
 
       case Expr.Unsafe(exp, _, _, _, _, _) => visitExp(exp)
 
-      case Expr.Without(exp, _, _, _, _) => visitExp(exp)
 
       case Expr.TryCatch(exp, rules, _, _, _) =>
         visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -249,8 +249,6 @@ object PredDeps {
     case Expr.Unsafe(exp, _, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Without(exp, _, _, _, _) =>
-      visitExp(exp)
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -734,9 +734,6 @@ object Redundancy {
         case _ => visitExp(exp, env0, rc)
       }
 
-    case Expr.Without(exp, symUse, _, _, _) =>
-      sctx.effSyms.put(symUse.sym, ())
-      visitExp(exp, env0, rc)
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
       val usedExp = visitExp(exp, env0, rc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1151,17 +1151,6 @@ object Resolver {
       val e = resolveExp(exp, scp0)
       ResolvedAst.Expr.Throw(e, loc)
 
-    case NamedAst.Expr.Without(exp, qname, loc) =>
-      lookupEffect(qname, scp0, ns0, root) match {
-        case Result.Ok(decl) =>
-          checkEffectIsAccessible(decl, ns0, qname.loc)
-          val symUse = EffSymUse(decl.sym, qname)
-          val e = resolveExp(exp, scp0)
-          ResolvedAst.Expr.Without(e, symUse, loc)
-        case Result.Err(error) =>
-          sctx.errors.add(error)
-          ResolvedAst.Expr.Error(error)
-      }
 
     case NamedAst.Expr.Handler(qname, rules, loc) =>
       visitHandler(qname, rules, scp0) match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -244,8 +244,6 @@ object Safety {
       checkPermissions(loc.security, loc)
       visitExp(exp)
 
-    case Expr.Without(exp, _, _, _, _) =>
-      visitExp(exp)
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -300,9 +300,6 @@ object Stratifier {
       val e = visitExp(exp)
       Expr.Unsafe(e, runEff, asEff, tpe, eff, loc)
 
-    case Expr.Without(exp, symUse, tpe, eff, loc) =>
-      val e = visitExp(exp)
-      Expr.Without(e, symUse, tpe, eff, loc)
 
     case Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
@@ -213,8 +213,6 @@ object TreeShaker1 {
     case Expr.Unsafe(exp, _, _, _, _, _) =>
       visitExp(exp)
 
-    case Expr.Without(exp, _, _, _, _) =>
-      visitExp(exp)
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp))

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -386,11 +386,6 @@ object TypeReconstruction {
       val eff = Type.mkUnion(Type.mkDifference(e.eff, eff0, loc), asEff0.getOrElse(Type.Pure), loc)
       TypedAst.Expr.Unsafe(e, eff0, asEff0, e.tpe, eff, loc)
 
-    case KindedAst.Expr.Without(exp, symUse, loc) =>
-      val e = visitExp(exp)
-      val tpe = e.tpe
-      val eff = e.eff
-      TypedAst.Expr.Without(e, symUse, tpe, eff, loc)
 
     case KindedAst.Expr.TryCatch(exp, rules, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -446,8 +446,6 @@ object Lowering {
       val t = lowerType(tpe)
       mkCast(e, t, eff, loc)
 
-    case TypedAst.Expr.Without(exp, _, _, _, _) =>
-      lowerExp(exp)
 
     case TypedAst.Expr.Throw(exp, tpe, eff, loc) =>
       val e = lowerExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -813,10 +813,6 @@ object Specialization {
       val asEff = asEff0.map(subst.apply)
       Expr.Unsafe(e, subst(runEff), asEff, t, subst(eff), loc)
 
-    case Expr.Without(exp, symUse, tpe, eff, loc) =>
-      val e = specializeExp(exp, env0, subst)
-      val t = subst(tpe)
-      Expr.Without(e, symUse, t, subst(eff), loc)
 
     case Expr.TryCatch(exp, rules, tpe, eff, loc0) =>
       val e = specializeExp(exp, env0, subst)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -850,18 +850,6 @@ object ConstraintGen {
         val resEff = Type.mkUnion(Type.mkDifference(eff, eff0, loc), asEff0.getOrElse(Type.Pure), loc)
         (resTpe, resEff)
 
-      case Expr.Without(exp, symUse, _) =>
-        //
-        // e: tpe \ eff - symUse
-        // -------------------------
-        // e without symUse : tpe
-        //
-        val (tpe, eff) = visitExp(exp)
-        val effWithoutSym = Type.mkDifference(eff, Type.Cst(TypeConstructor.Effect(symUse.sym, Kind.Eff), symUse.qname.loc), symUse.qname.loc) // TODO EFF-TPARAMS need kind
-        c.unifyType(eff, effWithoutSym, symUse.qname.loc)
-        val resTpe = tpe
-        val resEff = eff
-        (resTpe, resEff)
 
       case Expr.TryCatch(exp, rules, loc) =>
         val (tpe, eff) = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -241,7 +241,7 @@ object Summary {
     case Expr.CheckedCast(CheckedCastType.TypeCast, exp, _, _, _) => countCheckedEcasts(exp)
     case Expr.UncheckedCast(exp, _, _, _, _, _) => countCheckedEcasts(exp)
     case Expr.Unsafe(exp, _, _, _, _, _) => countCheckedEcasts(exp)
-    case Expr.Without(exp, _, _, _, _) => countCheckedEcasts(exp)
+
     case Expr.TryCatch(exp, rules, _, _, _) => countCheckedEcasts(exp) + rules.map {
       case TypedAst.CatchRule(_, _, exp, _) => countCheckedEcasts(exp)
     }.sum

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParserRecovery.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParserRecovery.scala
@@ -609,27 +609,6 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
-  test("BadWithout.01") {
-    val input =
-      """
-        |def foo(): Int32 = 1 without { IO
-        |def main(): Unit = ()
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibMin)
-    expectError[ParseError](result)
-    expectMain(result)
-  }
-
-  test("BadWithout.02") {
-    val input =
-      """
-        |def foo(): Int32 = 1 without
-        |def main(): Unit = ()
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibMin)
-    expectError[ParseError](result)
-    expectMain(result)
-  }
 
   test("BadLambda.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1076,18 +1076,6 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
-  test("Test.MismatchedEff.Without.01") {
-    val input =
-      """
-        |eff E {
-        |    pub def op(): Unit
-        |}
-        |
-        |def foo(): Unit = E.op() without E
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[TypeError](result)
-  }
 
   test("Test.MismatchedEff.Apply.02") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1922,14 +1922,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.EmptyTypeParamList](result)
   }
 
-  test("EmptyEffectSet.01") {
-    val input =
-      """
-        |def without01(): Bool = ??? without { }
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[ParseError.NeedAtleastOne](result)
-  }
 
   test("EmptyEnumCaseType.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
@@ -275,11 +275,8 @@ object EffectVerifier {
       val expected = Type.mkUnion(Type.mkDifference(exp.eff, runEff, loc), Type.Pure, loc)
       val actual = eff
       expectType(expected, actual, loc)
-    case Expr.Without(exp, symUse, tpe, eff, loc) =>
-      visitExp(exp)
-      val expected = exp.eff
-      val actual = eff
-      expectType(expected, actual, loc)
+
+
     case Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       visitExp(exp)
       rules.foreach { r => visitExp(r.exp) }

--- a/main/test/flix/Test.Exp.Effect.flix
+++ b/main/test/flix/Test.Exp.Effect.flix
@@ -49,11 +49,6 @@ mod Test.Exp.Effect {
         }
     })
 
-    @CompileTest
-    def without01(): Bool = true without Fail
-
-    @CompileTest
-    def without02(): Bool = true without {Fail, Console}
 
     @CompileTest
     def singleEffect(): Bool \ Fail = ???


### PR DESCRIPTION
## Summary
- Remove all traces of the `without` expression (e.g., `expr without Effect`) from the Flix compiler
- Follows the same pattern as the recent `typematch` removal (commit ff513f729)
- Deletes keyword, token, parser, AST nodes across all phases, compiler phase handlers, IDE support, and tests (40 files, ~190 lines deleted)

Closes #12400

## Test plan
- [x] `./mill flix.compile` succeeds
- [x] `./mill flix.test.compile` succeeds
- [x] Grep confirms zero remaining references to `KeywordWithout`, `Expr.Without`, `TreeKind.Expr.Without`

🤖 Generated with [Claude Code](https://claude.com/claude-code)