### PR TITLE
refactor: replace ListBuffer with ArrayBuffer

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -38,7 +38,7 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.ForkJoinPool
 import java.util.zip.ZipFile
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 import scala.util.Using
 
@@ -108,7 +108,7 @@ class Flix {
   /**
     * A map to track the time spent in each phase and sub-phase.
     */
-  var phaseTimers: ListBuffer[PhaseTime] = ListBuffer.empty
+  var phaseTimers: ArrayBuffer[PhaseTime] = ArrayBuffer.empty
 
   /**
     * The current phase we are in. Initially null.
@@ -123,7 +123,7 @@ class Flix {
   /**
     * The currently registered event listeners.
     */
-  private val listeners: ListBuffer[FlixListener] = ListBuffer.empty
+  private val listeners: ArrayBuffer[FlixListener] = ArrayBuffer.empty
 
   /**
     * The default assumed charset.
@@ -439,7 +439,7 @@ class Flix {
     initForkJoinPool()
 
     // Reset the phase information.
-    phaseTimers = ListBuffer.empty
+    phaseTimers = ArrayBuffer.empty
 
     // Reset the phase list file if relevant
     if (this.options.xprintphases) {
@@ -457,7 +457,7 @@ class Flix {
     val entryPoint = flix.options.entryPoint
 
     // The global collection of errors
-    val errors = mutable.ListBuffer.empty[CompilationMessage]
+    val errors = mutable.ArrayBuffer.empty[CompilationMessage]
 
     val (afterReader, readerErrors) = Reader.run(getInputs, availableClasses)
     errors ++= readerErrors
@@ -823,7 +823,7 @@ class Flix {
     */
   private def getClassesAndInterfacesOfJar(p: Path): List[String] = {
     Using(new ZipFile(p.toFile)) { zip =>
-      val result = mutable.ListBuffer.empty[String]
+      val result = mutable.ArrayBuffer.empty[String]
       val iterator = zip.entries()
       while (iterator.hasMoreElements) {
         val entry = iterator.nextElement()

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -407,7 +407,7 @@ object Eraser {
 
     /** Returns the entries of `m`. */
     private def toList[A, B](m: ConcurrentHashMap[(A, B), A]): List[(A, B, A)] = {
-      val res = mutable.ListBuffer.empty[(A, B, A)]
+      val res = mutable.ArrayBuffer.empty[(A, B, A)]
       m.forEach(new BiConsumer[(A, B), A] {
         override def accept(t: (A, B), u: A): Unit = res.append((t._1, t._2, u))
       })

--- a/main/src/ca/uwaterloo/flix/language/phase/Reader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reader.scala
@@ -82,7 +82,7 @@ object Reader {
         // Open the zip file.
         Using(new ZipFile(p.toFile)) { zip =>
           // Collect all source and test files.
-          val result = mutable.ListBuffer.empty[Source]
+          val result = mutable.ArrayBuffer.empty[Source]
           val iterator = zip.entries()
           while (iterator.hasMoreElements) {
             val entry = iterator.nextElement()

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -33,7 +33,7 @@ import ca.uwaterloo.flix.util.collection.SeqOps
 import java.util.concurrent.ConcurrentHashMap
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.ArrayBuffer
 
 /**
   * The Redundancy phase checks that declarations and expressions within the AST are used in a meaningful way.
@@ -93,7 +93,7 @@ object Redundancy {
     * Checks for unused definition symbols.
     */
   private def checkUnusedDefs()(implicit sctx: SharedContext, root: Root): List[RedundancyError] = {
-    val result = new ListBuffer[RedundancyError]
+    val result = new ArrayBuffer[RedundancyError]
     for ((_, defn) <- root.defs) {
       if (deadDef(defn)) {
         result += UnusedDefSym(defn.sym)
@@ -106,7 +106,7 @@ object Redundancy {
     * Checks for unused effect symbols.
     */
   private def checkUnusedEffects()(implicit sctx: SharedContext, root: Root): List[RedundancyError] = {
-    val result = new ListBuffer[RedundancyError]
+    val result = new ArrayBuffer[RedundancyError]
     for ((_, eff) <- root.effects) {
       if (deadEffect(eff)) {
         result += UnusedEffSym(eff.sym)
@@ -119,7 +119,7 @@ object Redundancy {
     * Checks for unused enum symbols and tags.
     */
   private def checkUnusedEnumsAndTags()(implicit sctx: SharedContext, root: Root): List[RedundancyError] = {
-    val result = new ListBuffer[RedundancyError]
+    val result = new ArrayBuffer[RedundancyError]
     for ((_, enm) <- root.enums) {
       if (deadEnum(enm)) {
         result += UnusedEnumSym(enm.sym)
@@ -138,7 +138,7 @@ object Redundancy {
     * Checks for unused type parameters in enums.
     */
   private def checkUnusedTypeParamsEnums()(implicit root: Root): List[RedundancyError] = {
-    val result = new ListBuffer[RedundancyError]
+    val result = new ArrayBuffer[RedundancyError]
     for ((_, decl) <- root.enums) {
       val usedTypeVars = decl.cases.foldLeft(Set.empty[Symbol.KindedTypeVarSym]) {
         case (sacc, (_, Case(_, tpes, _, _))) => sacc ++ tpes.flatMap(_.typeVars.map(_.sym))
@@ -157,7 +157,7 @@ object Redundancy {
     * Checks for unused type parameters in enums.
     */
   private def checkUnusedTypeParamsTypeAliases()(implicit root: Root): List[RedundancyError] = {
-    val result = new ListBuffer[RedundancyError]
+    val result = new ArrayBuffer[RedundancyError]
     for ((_, decl) <- root.typeAliases) {
       val usedTypeVars = decl.tpe.typeVars.map(_.sym)
       val unusedTypeParams = decl.tparams.filter {
@@ -174,7 +174,7 @@ object Redundancy {
     * Checks for unused struct symbols and tags.
     */
   private def checkUnusedStructsAndFields()(implicit sctx: SharedContext, root: Root): List[RedundancyError] = {
-    val result = new ListBuffer[RedundancyError]
+    val result = new ArrayBuffer[RedundancyError]
     for ((_, struct) <- root.structs) {
       if (deadStruct(struct)) {
         result += UnusedStructSym(struct.sym)
@@ -188,7 +188,7 @@ object Redundancy {
     * Checks for unused type parameters in structs.
     */
   private def checkUnusedTypeParamsStructs()(implicit root: Root): List[RedundancyError] = {
-    val result = new ListBuffer[RedundancyError]
+    val result = new ArrayBuffer[RedundancyError]
     for ((_, decl) <- root.structs) {
       val usedTypeVars = decl.fields.foldLeft(Set.empty[Symbol.KindedTypeVarSym]) {
         case (acc, (_, field)) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -613,7 +613,7 @@ object Resolver {
         val m = mutable.Map.empty[Symbol.AssocTypeSym, ResolvedAst.Declaration.AssocTypeDef]
 
         // We collect [[DuplicateAssocTypeDef]] and [[DuplicateAssocTypeDef]] errors.
-        val errors = mutable.ListBuffer.empty[ResolutionError]
+        val errors = mutable.ArrayBuffer.empty[ResolutionError]
 
         // Build the map `m` and check for [[DuplicateAssocTypeDef]].
         for (d@ResolvedAst.Declaration.AssocTypeDef(_, _, symUse, _, _, loc1) <- xs) {

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -538,13 +538,13 @@ object Summary {
   class Table {
 
     /** The rows collected so far */
-    private val rows: mutable.ListBuffer[List[String]] = mutable.ListBuffer.empty
+    private val rows: mutable.ArrayBuffer[List[String]] = mutable.ArrayBuffer.empty
 
     /**
       * Has the length of the longest list in rows. Each integer contains the
       * max length of any string in that column.
       */
-    private val maxLens: mutable.ListBuffer[Int] = mutable.ListBuffer.empty
+    private val maxLens: mutable.ArrayBuffer[Int] = mutable.ArrayBuffer.empty
 
     /** Adds a row to the builder. The rows can have different lengths */
     def addRow(row: List[String]): Unit = insertRow(rows.length, row)

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.util.collection
 
 import scala.annotation.tailrec
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.ArrayBuffer
 
 /**
   * A linear data structure that allows fast concatenation.
@@ -114,7 +114,7 @@ sealed trait Chain[+A] {
     * Returns `this` as a [[List]].
     */
   final def toList: List[A] = {
-    val buf = new ListBuffer[A]
+    val buf = new ArrayBuffer[A]
     this.foreach(buf.addOne)
     buf.toList
   }

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -408,7 +408,7 @@ class TestCompletionProvider extends AnyFunSuite {
   private def cutHoles(prg: String, loc: SourceLocation): List[ProgramWithHole] = {
     assert(loc.isSingleLine)
 
-    val result = mutable.ListBuffer.empty[ProgramWithHole]
+    val result = mutable.ArrayBuffer.empty[ProgramWithHole]
     val bOffset = indexOf(Position.fromBegin(loc), prg)
     val eOffset = indexOf(Position.fromEnd(loc), prg)
     val length = loc.end.colOneIndexed - loc.start.colOneIndexed


### PR DESCRIPTION
## Summary
- Replaces all uses of `ListBuffer` with `ArrayBuffer` across the compiler (8 files).
- `ArrayBuffer` provides better cache locality and amortized O(1) indexed access compared to `ListBuffer`.

Resolves #9614

## Test plan
- [x] Verify the project compiles successfully
- [x] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)