### PR TITLE
fix: match completions to preserve scrutinee

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2298,16 +2298,9 @@ object Parser2 {
           case TokenKind.ParenL => parenNestingLevel += 1; lookAhead += 1
           case TokenKind.ParenR => parenNestingLevel -= 1; lookAhead += 1
           case TokenKind.Eof =>
-            val error = UnexpectedToken(expected = NamedTokenSet.Expression, actual = None, sctx, loc = currentSourceLocation())
-            return Result.Err(closeWithError(mark, error))
+            continue = false
           case t if t.isFirstInDecl =>
-            // Advance past the erroneous region to the next stable token
-            // (the start of the declaration).
-            for (_ <- 0 until lookAhead) {
-              advance()
-            }
-            val error = UnexpectedToken(expected = NamedTokenSet.Expression, actual = Some(t), sctx, loc = currentSourceLocation())
-            return Result.Err(closeWithError(mark, error))
+            continue = false
           case _ => lookAhead += 1
         }
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1421,8 +1421,9 @@ object Weeder2 {
         case (expr, Nil) =>
           val error = NeedAtleastOne(NamedTokenSet.MatchRule, SyntacticContext.Expr.OtherExpr, loc = expr.loc)
           sctx.errors.add(error)
-          // Fall back on Expr.Error.
-          Validation.Success(Expr.Error(error))
+          // Preserve the scrutinee so name resolution can process it.
+          val dummyRule = MatchRule(Pattern.Wild(tree.loc.asSynthetic), None, Expr.Error(error), tree.loc.asSynthetic)
+          Validation.Success(Expr.Match(expr, dummyRule :: Nil, tree.loc))
         case (expr, rules) => Validation.Success(Expr.Match(expr, rules, tree.loc))
       }
     }


### PR DESCRIPTION
I have updated Parser2 to not create any early errors, if not finding the rest of the match expression, and updated the weeder to use a dummy rule such that the completions can still be suggested while the actual match expression is incomplete. 

Fixes #10195.