### PR TITLE
ci: add chalk to community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -38,6 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         repo:
+          - "flix/chalk"
           - "flix/datalog2"
           - "flix/test-pkg-trust-plain"
           - "flix/test-pkg-trust-unchecked-cast"


### PR DESCRIPTION
So we know when Flix-owned projects break.