### PR TITLE
ci: add Flix-ANSI-Terminal to community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -41,6 +41,7 @@ jobs:
           - "flix/datalog2"
           - "flix/test-pkg-trust-plain"
           - "flix/test-pkg-trust-unchecked-cast"
+          - "JonathanStarup/Flix-ANSI-Terminal"
           - "JonathanStarup/ListSet"
           - "JonathanStarup/talpin1992-in-flix"
           - "magnus-madsen/bibblitz"


### PR DESCRIPTION
IMO the community build needs to include the transitive closure of dependencies, so we easily see everything that needs to be fixed, not just the leaves.