### PR TITLE
fix: resolve effect declarations in DefCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.DefCompletion
 import ca.uwaterloo.flix.api.lsp.{Position, Range}
-import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Def, Mod}
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Def, Effect, Mod}
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
 import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
@@ -63,6 +63,7 @@ object DefCompleter {
   private def partiallyQualifiedCompletions(qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope, ectx: ExprContext)(implicit root: Root): Iterable[Completion] = {
     val fullyQualifiedNamespaceHead = scp.resolve(qn.namespace.idents.head.name) match {
       case Some(Resolution.Declaration(Mod(_, _, name, _, _, _))) => name.toString
+      case Some(Resolution.Declaration(Effect(_, _, _, name, _, _, _))) => name.toString
       case _ => return Nil
     }
     val namespaceTail = qn.namespace.idents.tail.map(_.name).mkString(".")


### PR DESCRIPTION
## Summary
- `DefCompleter.partiallyQualifiedCompletions` only accepted `Mod` resolutions when resolving the namespace head, so it returned no completions when the name resolved as an `Effect` (e.g. `Process.exec` after `use Sys.Process`).
- Added `Effect` as an accepted resolution, matching how `OpCompleter` already handles both `Effect` and `Mod` cases. Since effects and their companion modules share a namespace, the fully qualified name is identical either way.

## Test plan
- [x] Verify that `Process.e` now completes both `exec` (from `mod Sys.Process`) and `execWithCwdAndEnv` (from `eff Process`)
- [x] Verify existing completion behavior is unchanged for module-qualified defs

🤖 Generated with [Claude Code](https://claude.com/claude-code)