### PR TITLE
refactor: extract Java interop from Fs handlers into FsClient

### DIFF
--- a/main/src/library/Fs/AccessTime.flix
+++ b/main/src/library/Fs/AccessTime.flix
@@ -16,18 +16,7 @@
 
 pub mod Fs.AccessTime {
 
-    import java.io.IOException
-    import java.lang.Class
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.LinkOption
-    import java.nio.file.Path
-    import java.nio.file.Paths
-    import java.nio.file.attribute.BasicFileAttributes
-
     use Fs.FileTime
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `AccessTime` effect of the given function `f`.
@@ -35,18 +24,8 @@ pub mod Fs.AccessTime {
     /// In other words, re-interprets the `AccessTime` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - AccessTime) + IO = x ->
-        run {
-            f(x)
-        } with handler AccessTime {
-            def accessTime(filename, k) = {
-                let res = try {
-                    Ok(fileAttributes(Paths.get(filename)).lastAccessTime().toMillis())
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler AccessTime {
+            def accessTime(filename, k) = k(Fs.FsClient.accessTime(filename))
         }
 
     ///
@@ -64,16 +43,5 @@ pub mod Fs.AccessTime {
         run { f(x) } with handler AccessTime {
             def accessTime(filename, k) = k(Fs.FileTime.accessTime(filename))
         }
-
-    ///
-    /// Returns the attributes of the given file `f`.
-    /// May throw `IOException` and `SecurityException`.
-    ///
-    def fileAttributes(path: Path): BasicFileAttributes \ IO =
-        Files.readAttributes(
-            path,
-            Class.forName("java.nio.file.attribute.BasicFileAttributes"),
-            (...{}: Vector[LinkOption])
-        )
 
 }

--- a/main/src/library/Fs/AppendBytes.flix
+++ b/main/src/library/Fs/AppendBytes.flix
@@ -16,17 +16,7 @@
 
 pub mod Fs.AppendBytes {
 
-    import java.io.IOException
-    import java.lang.UnsupportedOperationException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.OpenOption
-    import java.nio.file.Paths
-    import java.nio.file.StandardOpenOption
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `AppendBytes` effect of the given function `f`.
@@ -34,27 +24,8 @@ pub mod Fs.AppendBytes {
     /// In other words, re-interprets the `AppendBytes` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - AppendBytes) + IO = x ->
-        run {
-            f(x)
-        } with handler AppendBytes {
-            def appendBytes(data, file, k) = {
-                let res = try {
-                    region rc {
-                        let bytes = Vector.toArray(rc, data);
-                        let opts: Vector[OpenOption] = ...{
-                            checked_cast(StandardOpenOption.APPEND),
-                            checked_cast(StandardOpenOption.CREATE)
-                        };
-                        Files.write(Paths.get(file), bytes, opts);
-                        Ok(())
-                    }
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler AppendBytes {
+            def appendBytes(data, file, k) = k(Fs.FsClient.appendBytes(data, file))
         }
 
     ///

--- a/main/src/library/Fs/AppendFile.flix
+++ b/main/src/library/Fs/AppendFile.flix
@@ -16,18 +16,7 @@
 
 pub mod Fs.AppendFile {
 
-    import java.io.IOException
-    import java.lang.UnsupportedOperationException
-    import java.nio.charset.StandardCharsets
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.OpenOption
-    import java.nio.file.Paths
-    import java.nio.file.StandardOpenOption
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `AppendFile` effect of the given function `f`.
@@ -35,25 +24,8 @@ pub mod Fs.AppendFile {
     /// In other words, re-interprets the `AppendFile` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - AppendFile) + IO = x ->
-        run {
-            f(x)
-        } with handler AppendFile {
-            def append(data, file, k) = {
-                let res = try {
-                    let bytes = data#str.getBytes(StandardCharsets.UTF_8);
-                    let opts: Vector[OpenOption] = ...{
-                        checked_cast(StandardOpenOption.APPEND),
-                        checked_cast(StandardOpenOption.CREATE)
-                    };
-                    Files.write(Paths.get(file), bytes, opts);
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler AppendFile {
+            def append(data, file, k) = k(Fs.FsClient.append(data, file))
         }
 
     ///

--- a/main/src/library/Fs/AppendLines.flix
+++ b/main/src/library/Fs/AppendLines.flix
@@ -16,17 +16,7 @@
 
 pub mod Fs.AppendLines {
 
-    import java.io.IOException
-    import java.lang.UnsupportedOperationException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.OpenOption
-    import java.nio.file.Paths
-    import java.nio.file.StandardOpenOption
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `AppendLines` effect of the given function `f`.
@@ -34,29 +24,8 @@ pub mod Fs.AppendLines {
     /// In other words, re-interprets the `AppendLines` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - AppendLines) + IO = x ->
-        run {
-            f(x)
-        } with handler AppendLines {
-            def appendLines(data, file, k) = {
-                let res = try {
-                    let opts: Vector[OpenOption] = ...{
-                        checked_cast(StandardOpenOption.APPEND),
-                        checked_cast(StandardOpenOption.CREATE)
-                    };
-                    let bf = Files.newBufferedWriter(Paths.get(file), opts);
-                    List.forEach(line -> {
-                        bf.write(line, 0, String.length(line));
-                        bf.newLine()
-                    }, data#lines);
-                    bf.close();
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler AppendLines {
+            def appendLines(data, file, k) = k(Fs.FsClient.appendLines(data, file))
         }
 
     ///

--- a/main/src/library/Fs/CreationTime.flix
+++ b/main/src/library/Fs/CreationTime.flix
@@ -16,18 +16,7 @@
 
 pub mod Fs.CreationTime {
 
-    import java.io.IOException
-    import java.lang.Class
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.LinkOption
-    import java.nio.file.Path
-    import java.nio.file.Paths
-    import java.nio.file.attribute.BasicFileAttributes
-
     use Fs.FileTime
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `CreationTime` effect of the given function `f`.
@@ -35,18 +24,8 @@ pub mod Fs.CreationTime {
     /// In other words, re-interprets the `CreationTime` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - CreationTime) + IO = x ->
-        run {
-            f(x)
-        } with handler CreationTime {
-            def creationTime(filename, k) = {
-                let res = try {
-                    Ok(fileAttributes(Paths.get(filename)).creationTime().toMillis())
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler CreationTime {
+            def creationTime(filename, k) = k(Fs.FsClient.creationTime(filename))
         }
 
     ///
@@ -64,16 +43,5 @@ pub mod Fs.CreationTime {
         run { f(x) } with handler CreationTime {
             def creationTime(filename, k) = k(Fs.FileTime.creationTime(filename))
         }
-
-    ///
-    /// Returns the attributes of the given file `f`.
-    /// May throw `IOException` and `SecurityException`.
-    ///
-    def fileAttributes(path: Path): BasicFileAttributes \ IO =
-        Files.readAttributes(
-            path,
-            Class.forName("java.nio.file.attribute.BasicFileAttributes"),
-            (...{}: Vector[LinkOption])
-        )
 
 }

--- a/main/src/library/Fs/DirList.flix
+++ b/main/src/library/Fs/DirList.flix
@@ -16,16 +16,9 @@
 
 pub mod Fs.DirList {
 
-    import java.io.File
-    import java.io.IOException
-    import java.nio.file.InvalidPathException
-    import java.nio.file.NotDirectoryException
-
     use Fs.DirList
     use Fs.FileSystem
     use Fs.FsClient.{logPre, logPost}
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `DirList` effect of the given function `f`.
@@ -33,20 +26,8 @@ pub mod Fs.DirList {
     /// In other words, re-interprets the `DirList` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - DirList) + IO = x ->
-        run {
-            f(x)
-        } with handler DirList {
-            def list(filename, k) = {
-                let res = try {
-                    let file = new File(filename);
-                    Ok(Array.toList(file.list()))
-                } catch {
-                    case ex: InvalidPathException  => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: NotDirectoryException => Err(IoError(ErrorKind.NotDirectory, ex.getMessage()))
-                    case ex: IOException           => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler DirList {
+            def list(filename, k) = k(Fs.FsClient.list(filename))
         }
 
     ///

--- a/main/src/library/Fs/FileExists.flix
+++ b/main/src/library/Fs/FileExists.flix
@@ -16,14 +16,7 @@
 
 pub mod Fs.FileExists {
 
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.LinkOption
-    import java.nio.file.Paths
-
     use Fs.FileTest
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `FileExists` effect of the given function `f`.
@@ -31,17 +24,8 @@ pub mod Fs.FileExists {
     /// In other words, re-interprets the `FileExists` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - FileExists) + IO = x ->
-        run {
-            f(x)
-        } with handler FileExists {
-            def exists(filename, k) = {
-                let res = try {
-                    Ok(Files.exists(Paths.get(filename), (...{}: Vector[LinkOption])))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler FileExists {
+            def exists(filename, k) = k(Fs.FsClient.exists(filename))
         }
 
     ///

--- a/main/src/library/Fs/FileSize.flix
+++ b/main/src/library/Fs/FileSize.flix
@@ -16,14 +16,7 @@
 
 pub mod Fs.FileSize {
 
-    import java.io.IOException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FileStat
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `FileSize` effect of the given function `f`.
@@ -31,18 +24,8 @@ pub mod Fs.FileSize {
     /// In other words, re-interprets the `FileSize` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - FileSize) + IO = x ->
-        run {
-            f(x)
-        } with handler FileSize {
-            def size(filename, k) = {
-                let res = try {
-                    Ok(Files.size(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler FileSize {
+            def size(filename, k) = k(Fs.FsClient.size(filename))
         }
 
     ///

--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -16,28 +16,9 @@
 
 pub mod Fs.FileSystem {
 
-    import java.io.File
-    import java.io.IOException
-    import java.lang.Class
-    import java.lang.IllegalArgumentException
-    import java.lang.UnsupportedOperationException
-    import java.nio.charset.StandardCharsets
-    import java.nio.file.attribute.BasicFileAttributes
-    import java.nio.file.attribute.FileAttribute
-    import java.nio.file.FileAlreadyExistsException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.LinkOption
-    import java.nio.file.NotDirectoryException
-    import java.nio.file.OpenOption
-    import java.nio.file.Path
-    import java.nio.file.Paths
-    import java.nio.file.StandardOpenOption
-
     use Fs.FileSystem
     use Fs.FsClient.{logPre, logPost}
     use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `FileSystem` effect of the given function `f`.
@@ -48,306 +29,31 @@ pub mod Fs.FileSystem {
         run {
             f(x)
         } with handler FileSystem {
-            def exists(filename, k) = {
-                let res = try {
-                    Ok(Files.exists(Paths.get(filename), (...{}: Vector[LinkOption])))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def isDirectory(filename, k) = {
-                let res = try {
-                    Ok(Files.isDirectory(Paths.get(filename), (...{}: Vector[LinkOption])))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def isRegularFile(filename, k) = {
-                let res = try {
-                    Ok(Files.isRegularFile(Paths.get(filename), (...{}: Vector[LinkOption])))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def isSymbolicLink(filename, k) = {
-                let res = try {
-                    Ok(Files.isSymbolicLink(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def isReadable(filename, k) = {
-                let res = try {
-                    Ok(Files.isReadable(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def isWritable(filename, k) = {
-                let res = try {
-                    Ok(Files.isWritable(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def isExecutable(filename, k) = {
-                let res = try {
-                    Ok(Files.isExecutable(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def accessTime(filename, k) = {
-                let res = try {
-                    Ok(fileAttributes(Paths.get(filename)).lastAccessTime().toMillis())
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def creationTime(filename, k) = {
-                let res = try {
-                    Ok(fileAttributes(Paths.get(filename)).creationTime().toMillis())
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def modificationTime(filename, k) = {
-                let res = try {
-                    Ok(fileAttributes(Paths.get(filename)).lastModifiedTime().toMillis())
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def size(filename, k) = {
-                let res = try {
-                    Ok(Files.size(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def read(filename, k) = {
-                let res = try {
-                    Ok(String.fromBytes(Array.toVector(Files.readAllBytes(Paths.get(filename)))))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def readLines(filename, k) = {
-                let res = try {
-                    Ok(ToFlix.toFlix(Files.readAllLines(Paths.get(filename))))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def readBytes(filename, k) = {
-                let res = try {
-                    Ok(Array.toVector(Files.readAllBytes(Paths.get(filename))))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def list(filename, k) = {
-                let res = try {
-                    let file = new File(filename);
-                    Ok(Array.toList(file.list()))
-                } catch {
-                    case ex: InvalidPathException  => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: NotDirectoryException => Err(IoError(ErrorKind.NotDirectory, ex.getMessage()))
-                    case ex: IOException           => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def write(data, file, k) = {
-                let res = try {
-                    let bytes = data#str.getBytes(StandardCharsets.UTF_8);
-                    Files.write(Paths.get(file), bytes, (...{}: Vector[OpenOption]));
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def writeLines(data, file, k) = {
-                let res = try {
-                    let bf = Files.newBufferedWriter(Paths.get(file), (...{}: Vector[OpenOption]));
-                    List.forEach(line -> {
-                        bf.write(line, 0, String.length(line));
-                        bf.newLine()
-                    }, data#lines);
-                    bf.close();
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def writeBytes(data, file, k) = {
-                let res = try {
-                    region rc {
-                        let bytes = Vector.toArray(rc, data);
-                        Files.write(Paths.get(file), bytes, (...{}: Vector[OpenOption]));
-                        Ok(())
-                    }
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def append(data, file, k) = {
-                let res = try {
-                    let bytes = data#str.getBytes(StandardCharsets.UTF_8);
-                    let opts: Vector[OpenOption] = ...{
-                        checked_cast(StandardOpenOption.APPEND),
-                        checked_cast(StandardOpenOption.CREATE)
-                    };
-                    Files.write(Paths.get(file), bytes, opts);
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def appendLines(data, file, k) = {
-                let res = try {
-                    let opts: Vector[OpenOption] = ...{
-                        checked_cast(StandardOpenOption.APPEND),
-                        checked_cast(StandardOpenOption.CREATE)
-                    };
-                    let bf = Files.newBufferedWriter(Paths.get(file), opts);
-                    List.forEach(line -> {
-                        bf.write(line, 0, String.length(line));
-                        bf.newLine()
-                    }, data#lines);
-                    bf.close();
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def appendBytes(data, file, k) = {
-                let res = try {
-                    region rc {
-                        let bytes = Vector.toArray(rc, data);
-                        let opts: Vector[OpenOption] = ...{
-                            checked_cast(StandardOpenOption.APPEND),
-                            checked_cast(StandardOpenOption.CREATE)
-                        };
-                        Files.write(Paths.get(file), bytes, opts);
-                        Ok(())
-                    }
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def truncate(file, k) = {
-                let res = try {
-                    region rc {
-                        let opt: OpenOption = checked_cast(StandardOpenOption.TRUNCATE_EXISTING);
-                        let arr: Array[Int8, rc] = Array#{} @ rc;
-                        Files.write(Paths.get(file), arr, ...{opt});
-                        Ok(())
-                    }
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def mkDir(d, k) = {
-                let res = try {
-                    Files.createDirectory(Paths.get(d), (...{}: Vector[FileAttribute]));
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: FileAlreadyExistsException    => Err(IoError(ErrorKind.AlreadyExists, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def mkDirs(d, k) = {
-                let res = try {
-                    Files.createDirectories(Paths.get(d), (...{}: Vector[FileAttribute]));
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: FileAlreadyExistsException    => Err(IoError(ErrorKind.AlreadyExists, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
-
-            def mkTempDir(prefix, k) = {
-                let res = try {
-                    let path = Files.createTempDirectory(prefix, (...{}: Vector[FileAttribute]));
-                    Ok(path.toString())
-                } catch {
-                    case ex: IllegalArgumentException      => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+            def exists(filename, k)           = k(Fs.FsClient.exists(filename))
+            def isDirectory(filename, k)      = k(Fs.FsClient.isDirectory(filename))
+            def isRegularFile(filename, k)    = k(Fs.FsClient.isRegularFile(filename))
+            def isSymbolicLink(filename, k)   = k(Fs.FsClient.isSymbolicLink(filename))
+            def isReadable(filename, k)       = k(Fs.FsClient.isReadable(filename))
+            def isWritable(filename, k)       = k(Fs.FsClient.isWritable(filename))
+            def isExecutable(filename, k)     = k(Fs.FsClient.isExecutable(filename))
+            def accessTime(filename, k)       = k(Fs.FsClient.accessTime(filename))
+            def creationTime(filename, k)     = k(Fs.FsClient.creationTime(filename))
+            def modificationTime(filename, k) = k(Fs.FsClient.modificationTime(filename))
+            def size(filename, k)             = k(Fs.FsClient.size(filename))
+            def read(filename, k)             = k(Fs.FsClient.read(filename))
+            def readLines(filename, k)        = k(Fs.FsClient.readLines(filename))
+            def readBytes(filename, k)        = k(Fs.FsClient.readBytes(filename))
+            def list(filename, k)             = k(Fs.FsClient.list(filename))
+            def write(data, file, k)          = k(Fs.FsClient.write(data, file))
+            def writeLines(data, file, k)     = k(Fs.FsClient.writeLines(data, file))
+            def writeBytes(data, file, k)     = k(Fs.FsClient.writeBytes(data, file))
+            def append(data, file, k)         = k(Fs.FsClient.append(data, file))
+            def appendLines(data, file, k)    = k(Fs.FsClient.appendLines(data, file))
+            def appendBytes(data, file, k)    = k(Fs.FsClient.appendBytes(data, file))
+            def truncate(file, k)             = k(Fs.FsClient.truncate(file))
+            def mkDir(d, k)                   = k(Fs.FsClient.mkDir(d))
+            def mkDirs(d, k)                  = k(Fs.FsClient.mkDirs(d))
+            def mkTempDir(prefix, k)          = k(Fs.FsClient.mkTempDir(prefix))
         }
 
     ///
@@ -517,16 +223,5 @@ pub mod Fs.FileSystem {
                 k(result)
             }
         }
-
-    ///
-    /// Returns the attributes of the given file `f`.
-    /// May throw `IOException` and `SecurityException`.
-    ///
-    def fileAttributes(path: Path): BasicFileAttributes \ IO =
-        Files.readAttributes(
-            path,
-            Class.forName("java.nio.file.attribute.BasicFileAttributes"),
-            (...{}: Vector[LinkOption])
-        )
 
 }

--- a/main/src/library/Fs/FsClient.flix
+++ b/main/src/library/Fs/FsClient.flix
@@ -16,8 +16,29 @@
 
 mod Fs.FsClient {
 
+    import java.io.File
+    import java.io.IOException
+    import java.lang.Class
+    import java.lang.IllegalArgumentException
+    import java.lang.UnsupportedOperationException
+    import java.nio.charset.StandardCharsets
+    import java.nio.file.attribute.BasicFileAttributes
+    import java.nio.file.attribute.FileAttribute
+    import java.nio.file.FileAlreadyExistsException
+    import java.nio.file.Files
+    import java.nio.file.InvalidPathException
+    import java.nio.file.LinkOption
+    import java.nio.file.NotDirectoryException
+    import java.nio.file.OpenOption
+    import java.nio.file.Path
+    import java.nio.file.Paths
+    import java.nio.file.StandardOpenOption
+
     use IoError.IoError
+    use IoError.ErrorKind
     use RichString.{text, bold, cyan, green, red, gray}
+
+    // ─── Logging helpers ───────────────────────────────────────────────
 
     ///
     /// Logs a pre-operation message at `Debug` level.
@@ -42,5 +63,287 @@ mod Fs.FsClient {
                     bold(op) + text(" ") + cyan(path) +
                     text(" ") + red("${err}"))
         }
+
+    // ─── File-test operations ──────────────────────────────────────────
+
+    pub def exists(f: String): Result[IoError, Bool] \ IO =
+        try {
+            Ok(Files.exists(Paths.get(f), (...{}: Vector[LinkOption])))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+        }
+
+    pub def isDirectory(f: String): Result[IoError, Bool] \ IO =
+        try {
+            Ok(Files.isDirectory(Paths.get(f), (...{}: Vector[LinkOption])))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+        }
+
+    pub def isRegularFile(f: String): Result[IoError, Bool] \ IO =
+        try {
+            Ok(Files.isRegularFile(Paths.get(f), (...{}: Vector[LinkOption])))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+        }
+
+    pub def isSymbolicLink(f: String): Result[IoError, Bool] \ IO =
+        try {
+            Ok(Files.isSymbolicLink(Paths.get(f)))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+        }
+
+    pub def isReadable(f: String): Result[IoError, Bool] \ IO =
+        try {
+            Ok(Files.isReadable(Paths.get(f)))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+        }
+
+    pub def isWritable(f: String): Result[IoError, Bool] \ IO =
+        try {
+            Ok(Files.isWritable(Paths.get(f)))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+        }
+
+    pub def isExecutable(f: String): Result[IoError, Bool] \ IO =
+        try {
+            Ok(Files.isExecutable(Paths.get(f)))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+        }
+
+    // ─── File-time operations ──────────────────────────────────────────
+
+    pub def accessTime(f: String): Result[IoError, Int64] \ IO =
+        try {
+            Ok(fileAttributes(Paths.get(f)).lastAccessTime().toMillis())
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def creationTime(f: String): Result[IoError, Int64] \ IO =
+        try {
+            Ok(fileAttributes(Paths.get(f)).creationTime().toMillis())
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def modificationTime(f: String): Result[IoError, Int64] \ IO =
+        try {
+            Ok(fileAttributes(Paths.get(f)).lastModifiedTime().toMillis())
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    // ─── File-stat operations ──────────────────────────────────────────
+
+    pub def size(f: String): Result[IoError, Int64] \ IO =
+        try {
+            Ok(Files.size(Paths.get(f)))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    // ─── Read operations ───────────────────────────────────────────────
+
+    pub def read(f: String): Result[IoError, String] \ IO =
+        try {
+            Ok(String.fromBytes(Array.toVector(Files.readAllBytes(Paths.get(f)))))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def readLines(f: String): Result[IoError, List[String]] \ IO =
+        try {
+            Ok(ToFlix.toFlix(Files.readAllLines(Paths.get(f))))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def readBytes(f: String): Result[IoError, Vector[Int8]] \ IO =
+        try {
+            Ok(Array.toVector(Files.readAllBytes(Paths.get(f))))
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    // ─── Directory listing ─────────────────────────────────────────────
+
+    pub def list(f: String): Result[IoError, List[String]] \ IO =
+        try {
+            let file = new File(f);
+            Ok(Array.toList(file.list()))
+        } catch {
+            case ex: InvalidPathException  => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: NotDirectoryException => Err(IoError(ErrorKind.NotDirectory, ex.getMessage()))
+            case ex: IOException           => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    // ─── Write operations ──────────────────────────────────────────────
+
+    pub def write(data: {str = String}, f: String): Result[IoError, Unit] \ IO =
+        try {
+            let bytes = data#str.getBytes(StandardCharsets.UTF_8);
+            Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
+            Ok(())
+        } catch {
+            case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def writeLines(data: {lines = List[String]}, f: String): Result[IoError, Unit] \ IO =
+        try {
+            let bf = Files.newBufferedWriter(Paths.get(f), (...{}: Vector[OpenOption]));
+            List.forEach(line -> {
+                bf.write(line, 0, String.length(line));
+                bf.newLine()
+            }, data#lines);
+            bf.close();
+            Ok(())
+        } catch {
+            case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def writeBytes(data: Vector[Int8], f: String): Result[IoError, Unit] \ IO =
+        try {
+            region rc {
+                let bytes = Vector.toArray(rc, data);
+                Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
+                Ok(())
+            }
+        } catch {
+            case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    // ─── Append operations ─────────────────────────────────────────────
+
+    pub def append(data: {str = String}, f: String): Result[IoError, Unit] \ IO =
+        try {
+            let bytes = data#str.getBytes(StandardCharsets.UTF_8);
+            let opts: Vector[OpenOption] = ...{
+                checked_cast(StandardOpenOption.APPEND),
+                checked_cast(StandardOpenOption.CREATE)
+            };
+            Files.write(Paths.get(f), bytes, opts);
+            Ok(())
+        } catch {
+            case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def appendLines(data: {lines = List[String]}, f: String): Result[IoError, Unit] \ IO =
+        try {
+            let opts: Vector[OpenOption] = ...{
+                checked_cast(StandardOpenOption.APPEND),
+                checked_cast(StandardOpenOption.CREATE)
+            };
+            let bf = Files.newBufferedWriter(Paths.get(f), opts);
+            List.forEach(line -> {
+                bf.write(line, 0, String.length(line));
+                bf.newLine()
+            }, data#lines);
+            bf.close();
+            Ok(())
+        } catch {
+            case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def appendBytes(data: Vector[Int8], f: String): Result[IoError, Unit] \ IO =
+        try {
+            region rc {
+                let bytes = Vector.toArray(rc, data);
+                let opts: Vector[OpenOption] = ...{
+                    checked_cast(StandardOpenOption.APPEND),
+                    checked_cast(StandardOpenOption.CREATE)
+                };
+                Files.write(Paths.get(f), bytes, opts);
+                Ok(())
+            }
+        } catch {
+            case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    // ─── Truncate ──────────────────────────────────────────────────────
+
+    pub def truncate(f: String): Result[IoError, Unit] \ IO =
+        try {
+            region rc {
+                let opt: OpenOption = checked_cast(StandardOpenOption.TRUNCATE_EXISTING);
+                let arr: Array[Int8, rc] = Array#{} @ rc;
+                Files.write(Paths.get(f), arr, ...{opt});
+                Ok(())
+            }
+        } catch {
+            case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    // ─── Directory operations ──────────────────────────────────────────
+
+    pub def mkDir(d: String): Result[IoError, Unit] \ IO =
+        try {
+            Files.createDirectory(Paths.get(d), (...{}: Vector[FileAttribute]));
+            Ok(())
+        } catch {
+            case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: FileAlreadyExistsException    => Err(IoError(ErrorKind.AlreadyExists, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def mkDirs(d: String): Result[IoError, Unit] \ IO =
+        try {
+            Files.createDirectories(Paths.get(d), (...{}: Vector[FileAttribute]));
+            Ok(())
+        } catch {
+            case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: FileAlreadyExistsException    => Err(IoError(ErrorKind.AlreadyExists, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    pub def mkTempDir(prefix: String): Result[IoError, String] \ IO =
+        try {
+            let path = Files.createTempDirectory(prefix, (...{}: Vector[FileAttribute]));
+            Ok(path.toString())
+        } catch {
+            case ex: IllegalArgumentException      => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
+            case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    // ─── Private helper ────────────────────────────────────────────────
+
+    ///
+    /// Returns the attributes of the given file `f`.
+    /// May throw `IOException` and `SecurityException`.
+    ///
+    def fileAttributes(path: Path): BasicFileAttributes \ IO =
+        Files.readAttributes(
+            path,
+            Class.forName("java.nio.file.attribute.BasicFileAttributes"),
+            (...{}: Vector[LinkOption])
+        )
 
 }

--- a/main/src/library/Fs/IsDirectory.flix
+++ b/main/src/library/Fs/IsDirectory.flix
@@ -16,14 +16,7 @@
 
 pub mod Fs.IsDirectory {
 
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.LinkOption
-    import java.nio.file.Paths
-
     use Fs.FileTest
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `IsDirectory` effect of the given function `f`.
@@ -31,17 +24,8 @@ pub mod Fs.IsDirectory {
     /// In other words, re-interprets the `IsDirectory` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - IsDirectory) + IO = x ->
-        run {
-            f(x)
-        } with handler IsDirectory {
-            def isDirectory(filename, k) = {
-                let res = try {
-                    Ok(Files.isDirectory(Paths.get(filename), (...{}: Vector[LinkOption])))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler IsDirectory {
+            def isDirectory(filename, k) = k(Fs.FsClient.isDirectory(filename))
         }
 
     ///

--- a/main/src/library/Fs/IsExecutable.flix
+++ b/main/src/library/Fs/IsExecutable.flix
@@ -16,13 +16,7 @@
 
 pub mod Fs.IsExecutable {
 
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FilePermission
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `IsExecutable` effect of the given function `f`.
@@ -30,17 +24,8 @@ pub mod Fs.IsExecutable {
     /// In other words, re-interprets the `IsExecutable` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - IsExecutable) + IO = x ->
-        run {
-            f(x)
-        } with handler IsExecutable {
-            def isExecutable(filename, k) = {
-                let res = try {
-                    Ok(Files.isExecutable(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler IsExecutable {
+            def isExecutable(filename, k) = k(Fs.FsClient.isExecutable(filename))
         }
 
     ///

--- a/main/src/library/Fs/IsReadable.flix
+++ b/main/src/library/Fs/IsReadable.flix
@@ -16,13 +16,7 @@
 
 pub mod Fs.IsReadable {
 
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FilePermission
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `IsReadable` effect of the given function `f`.
@@ -30,17 +24,8 @@ pub mod Fs.IsReadable {
     /// In other words, re-interprets the `IsReadable` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - IsReadable) + IO = x ->
-        run {
-            f(x)
-        } with handler IsReadable {
-            def isReadable(filename, k) = {
-                let res = try {
-                    Ok(Files.isReadable(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler IsReadable {
+            def isReadable(filename, k) = k(Fs.FsClient.isReadable(filename))
         }
 
     ///

--- a/main/src/library/Fs/IsRegularFile.flix
+++ b/main/src/library/Fs/IsRegularFile.flix
@@ -16,14 +16,7 @@
 
 pub mod Fs.IsRegularFile {
 
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.LinkOption
-    import java.nio.file.Paths
-
     use Fs.FileTest
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `IsRegularFile` effect of the given function `f`.
@@ -31,17 +24,8 @@ pub mod Fs.IsRegularFile {
     /// In other words, re-interprets the `IsRegularFile` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - IsRegularFile) + IO = x ->
-        run {
-            f(x)
-        } with handler IsRegularFile {
-            def isRegularFile(filename, k) = {
-                let res = try {
-                    Ok(Files.isRegularFile(Paths.get(filename), (...{}: Vector[LinkOption])))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler IsRegularFile {
+            def isRegularFile(filename, k) = k(Fs.FsClient.isRegularFile(filename))
         }
 
     ///

--- a/main/src/library/Fs/IsSymbolicLink.flix
+++ b/main/src/library/Fs/IsSymbolicLink.flix
@@ -16,13 +16,7 @@
 
 pub mod Fs.IsSymbolicLink {
 
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FileTest
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `IsSymbolicLink` effect of the given function `f`.
@@ -30,17 +24,8 @@ pub mod Fs.IsSymbolicLink {
     /// In other words, re-interprets the `IsSymbolicLink` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - IsSymbolicLink) + IO = x ->
-        run {
-            f(x)
-        } with handler IsSymbolicLink {
-            def isSymbolicLink(filename, k) = {
-                let res = try {
-                    Ok(Files.isSymbolicLink(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler IsSymbolicLink {
+            def isSymbolicLink(filename, k) = k(Fs.FsClient.isSymbolicLink(filename))
         }
 
     ///

--- a/main/src/library/Fs/IsWritable.flix
+++ b/main/src/library/Fs/IsWritable.flix
@@ -16,13 +16,7 @@
 
 pub mod Fs.IsWritable {
 
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FilePermission
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `IsWritable` effect of the given function `f`.
@@ -30,17 +24,8 @@ pub mod Fs.IsWritable {
     /// In other words, re-interprets the `IsWritable` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - IsWritable) + IO = x ->
-        run {
-            f(x)
-        } with handler IsWritable {
-            def isWritable(filename, k) = {
-                let res = try {
-                    Ok(Files.isWritable(Paths.get(filename)))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler IsWritable {
+            def isWritable(filename, k) = k(Fs.FsClient.isWritable(filename))
         }
 
     ///

--- a/main/src/library/Fs/MkDir.flix
+++ b/main/src/library/Fs/MkDir.flix
@@ -16,17 +16,7 @@
 
 pub mod Fs.MkDir {
 
-    import java.io.IOException
-    import java.lang.UnsupportedOperationException
-    import java.nio.file.attribute.FileAttribute
-    import java.nio.file.FileAlreadyExistsException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `MkDir` effect of the given function `f`.
@@ -34,21 +24,8 @@ pub mod Fs.MkDir {
     /// In other words, re-interprets the `MkDir` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - MkDir) + IO = x ->
-        run {
-            f(x)
-        } with handler MkDir {
-            def mkDir(d, k) = {
-                let res = try {
-                    Files.createDirectory(Paths.get(d), (...{}: Vector[FileAttribute]));
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: FileAlreadyExistsException    => Err(IoError(ErrorKind.AlreadyExists, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler MkDir {
+            def mkDir(d, k) = k(Fs.FsClient.mkDir(d))
         }
 
     ///

--- a/main/src/library/Fs/MkDirs.flix
+++ b/main/src/library/Fs/MkDirs.flix
@@ -16,17 +16,7 @@
 
 pub mod Fs.MkDirs {
 
-    import java.io.IOException
-    import java.lang.UnsupportedOperationException
-    import java.nio.file.attribute.FileAttribute
-    import java.nio.file.FileAlreadyExistsException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `MkDirs` effect of the given function `f`.
@@ -34,21 +24,8 @@ pub mod Fs.MkDirs {
     /// In other words, re-interprets the `MkDirs` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - MkDirs) + IO = x ->
-        run {
-            f(x)
-        } with handler MkDirs {
-            def mkDirs(d, k) = {
-                let res = try {
-                    Files.createDirectories(Paths.get(d), (...{}: Vector[FileAttribute]));
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: FileAlreadyExistsException    => Err(IoError(ErrorKind.AlreadyExists, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler MkDirs {
+            def mkDirs(d, k) = k(Fs.FsClient.mkDirs(d))
         }
 
     ///

--- a/main/src/library/Fs/MkTempDir.flix
+++ b/main/src/library/Fs/MkTempDir.flix
@@ -16,17 +16,7 @@
 
 pub mod Fs.MkTempDir {
 
-    import java.io.IOException
-    import java.lang.IllegalArgumentException
-    import java.lang.UnsupportedOperationException
-    import java.nio.file.attribute.FileAttribute
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `MkTempDir` effect of the given function `f`.
@@ -34,20 +24,8 @@ pub mod Fs.MkTempDir {
     /// In other words, re-interprets the `MkTempDir` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - MkTempDir) + IO = x ->
-        run {
-            f(x)
-        } with handler MkTempDir {
-            def mkTempDir(prefix, k) = {
-                let res = try {
-                    let path = Files.createTempDirectory(prefix, (...{}: Vector[FileAttribute]));
-                    Ok(path.toString())
-                } catch {
-                    case ex: IllegalArgumentException      => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler MkTempDir {
+            def mkTempDir(prefix, k) = k(Fs.FsClient.mkTempDir(prefix))
         }
 
     ///

--- a/main/src/library/Fs/ModificationTime.flix
+++ b/main/src/library/Fs/ModificationTime.flix
@@ -16,18 +16,7 @@
 
 pub mod Fs.ModificationTime {
 
-    import java.io.IOException
-    import java.lang.Class
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.LinkOption
-    import java.nio.file.Path
-    import java.nio.file.Paths
-    import java.nio.file.attribute.BasicFileAttributes
-
     use Fs.FileTime
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `ModificationTime` effect of the given function `f`.
@@ -35,18 +24,8 @@ pub mod Fs.ModificationTime {
     /// In other words, re-interprets the `ModificationTime` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - ModificationTime) + IO = x ->
-        run {
-            f(x)
-        } with handler ModificationTime {
-            def modificationTime(filename, k) = {
-                let res = try {
-                    Ok(fileAttributes(Paths.get(filename)).lastModifiedTime().toMillis())
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler ModificationTime {
+            def modificationTime(filename, k) = k(Fs.FsClient.modificationTime(filename))
         }
 
     ///
@@ -64,16 +43,5 @@ pub mod Fs.ModificationTime {
         run { f(x) } with handler ModificationTime {
             def modificationTime(filename, k) = k(Fs.FileTime.modificationTime(filename))
         }
-
-    ///
-    /// Returns the attributes of the given file `f`.
-    /// May throw `IOException` and `SecurityException`.
-    ///
-    def fileAttributes(path: Path): BasicFileAttributes \ IO =
-        Files.readAttributes(
-            path,
-            Class.forName("java.nio.file.attribute.BasicFileAttributes"),
-            (...{}: Vector[LinkOption])
-        )
 
 }

--- a/main/src/library/Fs/ReadBytes.flix
+++ b/main/src/library/Fs/ReadBytes.flix
@@ -16,14 +16,7 @@
 
 pub mod Fs.ReadBytes {
 
-    import java.io.IOException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FileRead
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `ReadBytes` effect of the given function `f`.
@@ -31,18 +24,8 @@ pub mod Fs.ReadBytes {
     /// In other words, re-interprets the `ReadBytes` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - ReadBytes) + IO = x ->
-        run {
-            f(x)
-        } with handler ReadBytes {
-            def readBytes(filename, k) = {
-                let res = try {
-                    Ok(Array.toVector(Files.readAllBytes(Paths.get(filename))))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler ReadBytes {
+            def readBytes(filename, k) = k(Fs.FsClient.readBytes(filename))
         }
 
     ///

--- a/main/src/library/Fs/ReadFile.flix
+++ b/main/src/library/Fs/ReadFile.flix
@@ -16,14 +16,7 @@
 
 pub mod Fs.ReadFile {
 
-    import java.io.IOException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FileRead
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `ReadFile` effect of the given function `f`.
@@ -31,18 +24,8 @@ pub mod Fs.ReadFile {
     /// In other words, re-interprets the `ReadFile` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - ReadFile) + IO = x ->
-        run {
-            f(x)
-        } with handler ReadFile {
-            def read(filename, k) = {
-                let res = try {
-                    Ok(String.fromBytes(Array.toVector(Files.readAllBytes(Paths.get(filename)))))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler ReadFile {
+            def read(filename, k) = k(Fs.FsClient.read(filename))
         }
 
     ///

--- a/main/src/library/Fs/ReadLines.flix
+++ b/main/src/library/Fs/ReadLines.flix
@@ -16,14 +16,7 @@
 
 pub mod Fs.ReadLines {
 
-    import java.io.IOException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.Paths
-
     use Fs.FileRead
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `ReadLines` effect of the given function `f`.
@@ -31,18 +24,8 @@ pub mod Fs.ReadLines {
     /// In other words, re-interprets the `ReadLines` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - ReadLines) + IO = x ->
-        run {
-            f(x)
-        } with handler ReadLines {
-            def readLines(filename, k) = {
-                let res = try {
-                    Ok(ToFlix.toFlix(Files.readAllLines(Paths.get(filename))))
-                } catch {
-                    case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler ReadLines {
+            def readLines(filename, k) = k(Fs.FsClient.readLines(filename))
         }
 
     ///

--- a/main/src/library/Fs/Truncate.flix
+++ b/main/src/library/Fs/Truncate.flix
@@ -16,17 +16,7 @@
 
 pub mod Fs.Truncate {
 
-    import java.io.IOException
-    import java.lang.UnsupportedOperationException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.OpenOption
-    import java.nio.file.Paths
-    import java.nio.file.StandardOpenOption
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `Truncate` effect of the given function `f`.
@@ -34,24 +24,8 @@ pub mod Fs.Truncate {
     /// In other words, re-interprets the `Truncate` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - Truncate) + IO = x ->
-        run {
-            f(x)
-        } with handler Truncate {
-            def truncate(file, k) = {
-                let res = try {
-                    region rc {
-                        let opt: OpenOption = checked_cast(StandardOpenOption.TRUNCATE_EXISTING);
-                        let arr: Array[Int8, rc] = Array#{} @ rc;
-                        Files.write(Paths.get(file), arr, ...{opt});
-                        Ok(())
-                    }
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler Truncate {
+            def truncate(file, k) = k(Fs.FsClient.truncate(file))
         }
 
     ///

--- a/main/src/library/Fs/WriteBytes.flix
+++ b/main/src/library/Fs/WriteBytes.flix
@@ -16,16 +16,7 @@
 
 pub mod Fs.WriteBytes {
 
-    import java.io.IOException
-    import java.lang.UnsupportedOperationException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.OpenOption
-    import java.nio.file.Paths
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `WriteBytes` effect of the given function `f`.
@@ -33,23 +24,8 @@ pub mod Fs.WriteBytes {
     /// In other words, re-interprets the `WriteBytes` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - WriteBytes) + IO = x ->
-        run {
-            f(x)
-        } with handler WriteBytes {
-            def writeBytes(data, file, k) = {
-                let res = try {
-                    region rc {
-                        let bytes = Vector.toArray(rc, data);
-                        Files.write(Paths.get(file), bytes, (...{}: Vector[OpenOption]));
-                        Ok(())
-                    }
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler WriteBytes {
+            def writeBytes(data, file, k) = k(Fs.FsClient.writeBytes(data, file))
         }
 
     ///

--- a/main/src/library/Fs/WriteFile.flix
+++ b/main/src/library/Fs/WriteFile.flix
@@ -16,17 +16,7 @@
 
 pub mod Fs.WriteFile {
 
-    import java.io.IOException
-    import java.lang.UnsupportedOperationException
-    import java.nio.charset.StandardCharsets
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.OpenOption
-    import java.nio.file.Paths
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `WriteFile` effect of the given function `f`.
@@ -34,21 +24,8 @@ pub mod Fs.WriteFile {
     /// In other words, re-interprets the `WriteFile` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - WriteFile) + IO = x ->
-        run {
-            f(x)
-        } with handler WriteFile {
-            def write(data, file, k) = {
-                let res = try {
-                    let bytes = data#str.getBytes(StandardCharsets.UTF_8);
-                    Files.write(Paths.get(file), bytes, (...{}: Vector[OpenOption]));
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler WriteFile {
+            def write(data, file, k) = k(Fs.FsClient.write(data, file))
         }
 
     ///

--- a/main/src/library/Fs/WriteLines.flix
+++ b/main/src/library/Fs/WriteLines.flix
@@ -16,16 +16,7 @@
 
 pub mod Fs.WriteLines {
 
-    import java.io.IOException
-    import java.lang.UnsupportedOperationException
-    import java.nio.file.Files
-    import java.nio.file.InvalidPathException
-    import java.nio.file.OpenOption
-    import java.nio.file.Paths
-
     use Fs.FileWrite
-    use IoError.IoError
-    use IoError.ErrorKind
 
     ///
     /// Handles the `WriteLines` effect of the given function `f`.
@@ -33,25 +24,8 @@ pub mod Fs.WriteLines {
     /// In other words, re-interprets the `WriteLines` effect using the `IO` effect.
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - WriteLines) + IO = x ->
-        run {
-            f(x)
-        } with handler WriteLines {
-            def writeLines(data, file, k) = {
-                let res = try {
-                    let bf = Files.newBufferedWriter(Paths.get(file), (...{}: Vector[OpenOption]));
-                    List.forEach(line -> {
-                        bf.write(line, 0, String.length(line));
-                        bf.newLine()
-                    }, data#lines);
-                    bf.close();
-                    Ok(())
-                } catch {
-                    case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
-                    case ex: UnsupportedOperationException => Err(IoError(ErrorKind.Unsupported, ex.getMessage()))
-                    case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                };
-                k(res)
-            }
+        run { f(x) } with handler WriteLines {
+            def writeLines(data, file, k) = k(Fs.FsClient.writeLines(data, file))
         }
 
     ///


### PR DESCRIPTION
## Summary
- Consolidate all 25 Fs operation implementations (try-catch blocks, exception mapping, Java imports) into `FsClient.flix` as the single source of truth
- Simplify `FileSystem.handle` and all 25 leaf handler `handle` functions to one-liner delegations to `FsClient`
- Move the duplicated `fileAttributes` helper (previously in 3 leaf files + FileSystem) into `FsClient`
- Net reduction of ~550 lines of duplicated Java interop code

## Test plan
- [x] Compile the project
- [x] Run `foo.flix` with `FileRead.withLogging` to verify logging middleware still works end-to-end
- [x] Verify behavior is identical — only code organization changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)