### PR TITLE
feat: add withBaseDir middleware for Fs effect hierarchy

### DIFF
--- a/main/src/library/Fs/DirList.flix
+++ b/main/src/library/Fs/DirList.flix
@@ -62,4 +62,16 @@ pub mod Fs.DirList {
             }
         }
 
+    ///
+    /// Middleware that intercepts the `DirList` effect, resolving all file paths
+    /// relative to the given `baseDir` using Java's `Path.resolve` semantics.
+    ///
+    /// Absolute paths are passed through unchanged.
+    ///
+    pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - DirList) + DirList =
+        let r = p -> Fs.FsLayer.resolve(baseDir, p);
+        run { f() } with handler DirList {
+            def list(filename, k) = k(DirList.list(r(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FilePermission.flix
+++ b/main/src/library/Fs/FilePermission.flix
@@ -82,4 +82,18 @@ pub mod Fs.FilePermission {
             }
         }
 
+    ///
+    /// Middleware that intercepts the `FilePermission` effect, resolving all file paths
+    /// relative to the given `baseDir` using Java's `Path.resolve` semantics.
+    ///
+    /// Absolute paths are passed through unchanged.
+    ///
+    pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - FilePermission) + FilePermission =
+        let r = p -> Fs.FsLayer.resolve(baseDir, p);
+        run { f() } with handler FilePermission {
+            def isReadable(filename, k)   = k(FilePermission.isReadable(r(filename)))
+            def isWritable(filename, k)   = k(FilePermission.isWritable(r(filename)))
+            def isExecutable(filename, k) = k(FilePermission.isExecutable(r(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FileRead.flix
+++ b/main/src/library/Fs/FileRead.flix
@@ -78,4 +78,18 @@ pub mod Fs.FileRead {
             }
         }
 
+    ///
+    /// Middleware that intercepts the `FileRead` effect, resolving all file paths
+    /// relative to the given `baseDir` using Java's `Path.resolve` semantics.
+    ///
+    /// Absolute paths are passed through unchanged.
+    ///
+    pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - FileRead) + FileRead =
+        let r = p -> Fs.FsLayer.resolve(baseDir, p);
+        run { f() } with handler FileRead {
+            def read(filename, k)      = k(FileRead.read(r(filename)))
+            def readLines(filename, k) = k(FileRead.readLines(r(filename)))
+            def readBytes(filename, k) = k(FileRead.readBytes(r(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FileStat.flix
+++ b/main/src/library/Fs/FileStat.flix
@@ -134,4 +134,26 @@ pub mod Fs.FileStat {
             }
         }
 
+    ///
+    /// Middleware that intercepts the `FileStat` effect, resolving all file paths
+    /// relative to the given `baseDir` using Java's `Path.resolve` semantics.
+    ///
+    /// Absolute paths are passed through unchanged.
+    ///
+    pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - FileStat) + FileStat =
+        let r = p -> Fs.FsLayer.resolve(baseDir, p);
+        run { f() } with handler FileStat {
+            def exists(filename, k)           = k(FileStat.exists(r(filename)))
+            def isDirectory(filename, k)      = k(FileStat.isDirectory(r(filename)))
+            def isRegularFile(filename, k)    = k(FileStat.isRegularFile(r(filename)))
+            def isSymbolicLink(filename, k)   = k(FileStat.isSymbolicLink(r(filename)))
+            def isReadable(filename, k)       = k(FileStat.isReadable(r(filename)))
+            def isWritable(filename, k)       = k(FileStat.isWritable(r(filename)))
+            def isExecutable(filename, k)     = k(FileStat.isExecutable(r(filename)))
+            def accessTime(filename, k)       = k(FileStat.accessTime(r(filename)))
+            def creationTime(filename, k)     = k(FileStat.creationTime(r(filename)))
+            def modificationTime(filename, k) = k(FileStat.modificationTime(r(filename)))
+            def size(filename, k)             = k(FileStat.size(r(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -224,4 +224,40 @@ pub mod Fs.FileSystem {
             }
         }
 
+    ///
+    /// Middleware that intercepts the `FileSystem` effect, resolving all file paths
+    /// relative to the given `baseDir` using Java's `Path.resolve` semantics.
+    ///
+    /// Absolute paths are passed through unchanged. The `mkTempDir` prefix is not resolved.
+    ///
+    pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - FileSystem) + FileSystem =
+        let r = p -> Fs.FsLayer.resolve(baseDir, p);
+        run { f() } with handler FileSystem {
+            def exists(filename, k)           = k(FileSystem.exists(r(filename)))
+            def isDirectory(filename, k)      = k(FileSystem.isDirectory(r(filename)))
+            def isRegularFile(filename, k)    = k(FileSystem.isRegularFile(r(filename)))
+            def isSymbolicLink(filename, k)   = k(FileSystem.isSymbolicLink(r(filename)))
+            def isReadable(filename, k)       = k(FileSystem.isReadable(r(filename)))
+            def isWritable(filename, k)       = k(FileSystem.isWritable(r(filename)))
+            def isExecutable(filename, k)     = k(FileSystem.isExecutable(r(filename)))
+            def accessTime(filename, k)       = k(FileSystem.accessTime(r(filename)))
+            def creationTime(filename, k)     = k(FileSystem.creationTime(r(filename)))
+            def modificationTime(filename, k) = k(FileSystem.modificationTime(r(filename)))
+            def size(filename, k)             = k(FileSystem.size(r(filename)))
+            def read(filename, k)             = k(FileSystem.read(r(filename)))
+            def readLines(filename, k)        = k(FileSystem.readLines(r(filename)))
+            def readBytes(filename, k)        = k(FileSystem.readBytes(r(filename)))
+            def list(filename, k)             = k(FileSystem.list(r(filename)))
+            def write(data, file, k)          = k(FileSystem.write(data, r(file)))
+            def writeLines(data, file, k)     = k(FileSystem.writeLines(data, r(file)))
+            def writeBytes(data, file, k)     = k(FileSystem.writeBytes(data, r(file)))
+            def append(data, file, k)         = k(FileSystem.append(data, r(file)))
+            def appendLines(data, file, k)    = k(FileSystem.appendLines(data, r(file)))
+            def appendBytes(data, file, k)    = k(FileSystem.appendBytes(data, r(file)))
+            def truncate(file, k)             = k(FileSystem.truncate(r(file)))
+            def mkDir(d, k)                   = k(FileSystem.mkDir(r(d)))
+            def mkDirs(d, k)                  = k(FileSystem.mkDirs(r(d)))
+            def mkTempDir(prefix, k)          = k(FileSystem.mkTempDir(prefix))
+        }
+
 }

--- a/main/src/library/Fs/FileTest.flix
+++ b/main/src/library/Fs/FileTest.flix
@@ -89,4 +89,19 @@ pub mod Fs.FileTest {
             }
         }
 
+    ///
+    /// Middleware that intercepts the `FileTest` effect, resolving all file paths
+    /// relative to the given `baseDir` using Java's `Path.resolve` semantics.
+    ///
+    /// Absolute paths are passed through unchanged.
+    ///
+    pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - FileTest) + FileTest =
+        let r = p -> Fs.FsLayer.resolve(baseDir, p);
+        run { f() } with handler FileTest {
+            def exists(filename, k)         = k(FileTest.exists(r(filename)))
+            def isDirectory(filename, k)    = k(FileTest.isDirectory(r(filename)))
+            def isRegularFile(filename, k)  = k(FileTest.isRegularFile(r(filename)))
+            def isSymbolicLink(filename, k) = k(FileTest.isSymbolicLink(r(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FileTime.flix
+++ b/main/src/library/Fs/FileTime.flix
@@ -82,4 +82,18 @@ pub mod Fs.FileTime {
             }
         }
 
+    ///
+    /// Middleware that intercepts the `FileTime` effect, resolving all file paths
+    /// relative to the given `baseDir` using Java's `Path.resolve` semantics.
+    ///
+    /// Absolute paths are passed through unchanged.
+    ///
+    pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - FileTime) + FileTime =
+        let r = p -> Fs.FsLayer.resolve(baseDir, p);
+        run { f() } with handler FileTime {
+            def accessTime(filename, k)       = k(FileTime.accessTime(r(filename)))
+            def creationTime(filename, k)     = k(FileTime.creationTime(r(filename)))
+            def modificationTime(filename, k) = k(FileTime.modificationTime(r(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FileWrite.flix
+++ b/main/src/library/Fs/FileWrite.flix
@@ -127,4 +127,25 @@ pub mod Fs.FileWrite {
             }
         }
 
+    ///
+    /// Middleware that intercepts the `FileWrite` effect, resolving all file paths
+    /// relative to the given `baseDir` using Java's `Path.resolve` semantics.
+    ///
+    /// Absolute paths are passed through unchanged. The `mkTempDir` prefix is not resolved.
+    ///
+    pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - FileWrite) + FileWrite =
+        let r = p -> Fs.FsLayer.resolve(baseDir, p);
+        run { f() } with handler FileWrite {
+            def write(data, file, k)       = k(FileWrite.write(data, r(file)))
+            def writeLines(data, file, k)  = k(FileWrite.writeLines(data, r(file)))
+            def writeBytes(data, file, k)  = k(FileWrite.writeBytes(data, r(file)))
+            def append(data, file, k)      = k(FileWrite.append(data, r(file)))
+            def appendLines(data, file, k) = k(FileWrite.appendLines(data, r(file)))
+            def appendBytes(data, file, k) = k(FileWrite.appendBytes(data, r(file)))
+            def truncate(file, k)          = k(FileWrite.truncate(r(file)))
+            def mkDir(d, k)                = k(FileWrite.mkDir(r(d)))
+            def mkDirs(d, k)               = k(FileWrite.mkDirs(r(d)))
+            def mkTempDir(prefix, k)       = k(FileWrite.mkTempDir(prefix))
+        }
+
 }

--- a/main/src/library/Fs/FsLayer.flix
+++ b/main/src/library/Fs/FsLayer.flix
@@ -333,6 +333,17 @@ mod Fs.FsLayer {
             case ex: IOException                   => Err(IoError(ErrorKind.Other, ex.getMessage()))
         }
 
+    // ─── Path helper ────────────────────────────────────────────────────
+
+    ///
+    /// Resolves `path` against `baseDir` using Java's `Path.resolve` semantics:
+    ///
+    ///   - If `path` is absolute, it is returned as-is.
+    ///   - If `path` is relative, it is joined to `baseDir`.
+    ///
+    pub def resolve(baseDir: String, path: String): String =
+        unsafe IO { Paths.get(baseDir).resolve(path).toString() }
+
     // ─── Private helper ────────────────────────────────────────────────
 
     ///


### PR DESCRIPTION
## Summary
- Add `Fs.FsLayer.resolve` helper using Java's `Path.resolve` semantics (absolute paths pass through, relative paths are joined to base dir)
- Add `withBaseDir` middleware to all 8 grouped effects: `FileSystem`, `FileStat`, `FileTest`, `FilePermission`, `FileTime`, `FileRead`, `FileWrite`, `DirList`
- `mkTempDir` prefix is intentionally not resolved (it's a name prefix, not a path)

## Test plan
- [x] Verify relative paths are resolved against the base directory
- [x] Verify absolute paths pass through unchanged
- [x] Verify `mkTempDir` prefix is not resolved
- [x] Verify `withBaseDir` composes with `withLogging` via `with` chaining
- [x] Verify each grouped effect's `withBaseDir` works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)