### PR TITLE
feat: add withAllowList and withDenyList middleware for Fs effect hierarchy

### DIFF
--- a/main/src/library/Fs/FileRead.flix
+++ b/main/src/library/Fs/FileRead.flix
@@ -105,4 +105,30 @@ pub mod Fs.FileRead {
             def readBytes(filename, k) = k(Result.flatMap(p -> FileRead.readBytes(p), c(filename)))
         }
 
+    ///
+    /// Middleware that intercepts the `FileRead` effect, validating that all file paths
+    /// resolve within one of the given `allowedDirs`. Rejects paths outside the
+    /// allow list with a `PermissionDenied` error.
+    ///
+    pub def withAllowList(allowedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileRead) + FileRead =
+        let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
+        run { f() } with handler FileRead {
+            def read(filename, k)      = k(Result.flatMap(p -> FileRead.read(p), c(filename)))
+            def readLines(filename, k) = k(Result.flatMap(p -> FileRead.readLines(p), c(filename)))
+            def readBytes(filename, k) = k(Result.flatMap(p -> FileRead.readBytes(p), c(filename)))
+        }
+
+    ///
+    /// Middleware that intercepts the `FileRead` effect, validating that all file paths
+    /// do not resolve within any of the given `deniedDirs`. Rejects paths inside a
+    /// denied directory with a `PermissionDenied` error.
+    ///
+    pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileRead) + FileRead =
+        let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
+        run { f() } with handler FileRead {
+            def read(filename, k)      = k(Result.flatMap(p -> FileRead.read(p), c(filename)))
+            def readLines(filename, k) = k(Result.flatMap(p -> FileRead.readLines(p), c(filename)))
+            def readBytes(filename, k) = k(Result.flatMap(p -> FileRead.readBytes(p), c(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FileStat.flix
+++ b/main/src/library/Fs/FileStat.flix
@@ -177,4 +177,46 @@ pub mod Fs.FileStat {
             def size(filename, k)             = k(Result.flatMap(p -> FileStat.size(p), c(filename)))
         }
 
+    ///
+    /// Middleware that intercepts the `FileStat` effect, validating that all file paths
+    /// resolve within one of the given `allowedDirs`. Rejects paths outside the
+    /// allow list with a `PermissionDenied` error.
+    ///
+    pub def withAllowList(allowedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileStat) + FileStat =
+        let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
+        run { f() } with handler FileStat {
+            def exists(filename, k)           = k(Result.flatMap(p -> FileStat.exists(p), c(filename)))
+            def isDirectory(filename, k)      = k(Result.flatMap(p -> FileStat.isDirectory(p), c(filename)))
+            def isRegularFile(filename, k)    = k(Result.flatMap(p -> FileStat.isRegularFile(p), c(filename)))
+            def isSymbolicLink(filename, k)   = k(Result.flatMap(p -> FileStat.isSymbolicLink(p), c(filename)))
+            def isReadable(filename, k)       = k(Result.flatMap(p -> FileStat.isReadable(p), c(filename)))
+            def isWritable(filename, k)       = k(Result.flatMap(p -> FileStat.isWritable(p), c(filename)))
+            def isExecutable(filename, k)     = k(Result.flatMap(p -> FileStat.isExecutable(p), c(filename)))
+            def accessTime(filename, k)       = k(Result.flatMap(p -> FileStat.accessTime(p), c(filename)))
+            def creationTime(filename, k)     = k(Result.flatMap(p -> FileStat.creationTime(p), c(filename)))
+            def modificationTime(filename, k) = k(Result.flatMap(p -> FileStat.modificationTime(p), c(filename)))
+            def size(filename, k)             = k(Result.flatMap(p -> FileStat.size(p), c(filename)))
+        }
+
+    ///
+    /// Middleware that intercepts the `FileStat` effect, validating that all file paths
+    /// do not resolve within any of the given `deniedDirs`. Rejects paths inside a
+    /// denied directory with a `PermissionDenied` error.
+    ///
+    pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileStat) + FileStat =
+        let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
+        run { f() } with handler FileStat {
+            def exists(filename, k)           = k(Result.flatMap(p -> FileStat.exists(p), c(filename)))
+            def isDirectory(filename, k)      = k(Result.flatMap(p -> FileStat.isDirectory(p), c(filename)))
+            def isRegularFile(filename, k)    = k(Result.flatMap(p -> FileStat.isRegularFile(p), c(filename)))
+            def isSymbolicLink(filename, k)   = k(Result.flatMap(p -> FileStat.isSymbolicLink(p), c(filename)))
+            def isReadable(filename, k)       = k(Result.flatMap(p -> FileStat.isReadable(p), c(filename)))
+            def isWritable(filename, k)       = k(Result.flatMap(p -> FileStat.isWritable(p), c(filename)))
+            def isExecutable(filename, k)     = k(Result.flatMap(p -> FileStat.isExecutable(p), c(filename)))
+            def accessTime(filename, k)       = k(Result.flatMap(p -> FileStat.accessTime(p), c(filename)))
+            def creationTime(filename, k)     = k(Result.flatMap(p -> FileStat.creationTime(p), c(filename)))
+            def modificationTime(filename, k) = k(Result.flatMap(p -> FileStat.modificationTime(p), c(filename)))
+            def size(filename, k)             = k(Result.flatMap(p -> FileStat.size(p), c(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -299,4 +299,80 @@ pub mod Fs.FileSystem {
             def mkTempDir(_prefix, k)         = k(Err(IoError(ErrorKind.PermissionDenied, "mkTempDir is not permitted inside a chroot")))
         }
 
+    ///
+    /// Middleware that intercepts the `FileSystem` effect, validating that all file paths
+    /// resolve within one of the given `allowedDirs`. Rejects paths outside the
+    /// allow list with a `PermissionDenied` error.
+    ///
+    /// The `mkTempDir` operation is blocked since the temp directory location cannot be verified.
+    ///
+    pub def withAllowList(allowedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileSystem) + FileSystem =
+        use IoError.IoError;
+        use IoError.ErrorKind;
+        let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
+        run { f() } with handler FileSystem {
+            def exists(filename, k)           = k(Result.flatMap(p -> FileSystem.exists(p), c(filename)))
+            def isDirectory(filename, k)      = k(Result.flatMap(p -> FileSystem.isDirectory(p), c(filename)))
+            def isRegularFile(filename, k)    = k(Result.flatMap(p -> FileSystem.isRegularFile(p), c(filename)))
+            def isSymbolicLink(filename, k)   = k(Result.flatMap(p -> FileSystem.isSymbolicLink(p), c(filename)))
+            def isReadable(filename, k)       = k(Result.flatMap(p -> FileSystem.isReadable(p), c(filename)))
+            def isWritable(filename, k)       = k(Result.flatMap(p -> FileSystem.isWritable(p), c(filename)))
+            def isExecutable(filename, k)     = k(Result.flatMap(p -> FileSystem.isExecutable(p), c(filename)))
+            def accessTime(filename, k)       = k(Result.flatMap(p -> FileSystem.accessTime(p), c(filename)))
+            def creationTime(filename, k)     = k(Result.flatMap(p -> FileSystem.creationTime(p), c(filename)))
+            def modificationTime(filename, k) = k(Result.flatMap(p -> FileSystem.modificationTime(p), c(filename)))
+            def size(filename, k)             = k(Result.flatMap(p -> FileSystem.size(p), c(filename)))
+            def read(filename, k)             = k(Result.flatMap(p -> FileSystem.read(p), c(filename)))
+            def readLines(filename, k)        = k(Result.flatMap(p -> FileSystem.readLines(p), c(filename)))
+            def readBytes(filename, k)        = k(Result.flatMap(p -> FileSystem.readBytes(p), c(filename)))
+            def list(filename, k)             = k(Result.flatMap(p -> FileSystem.list(p), c(filename)))
+            def write(data, file, k)          = k(Result.flatMap(p -> FileSystem.write(data, p), c(file)))
+            def writeLines(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeLines(data, p), c(file)))
+            def writeBytes(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeBytes(data, p), c(file)))
+            def append(data, file, k)         = k(Result.flatMap(p -> FileSystem.append(data, p), c(file)))
+            def appendLines(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendLines(data, p), c(file)))
+            def appendBytes(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendBytes(data, p), c(file)))
+            def truncate(file, k)             = k(Result.flatMap(p -> FileSystem.truncate(p), c(file)))
+            def mkDir(d, k)                   = k(Result.flatMap(p -> FileSystem.mkDir(p), c(d)))
+            def mkDirs(d, k)                  = k(Result.flatMap(p -> FileSystem.mkDirs(p), c(d)))
+            def mkTempDir(_prefix, k)         = k(Err(IoError(ErrorKind.PermissionDenied, "mkTempDir is not permitted with an allow list")))
+        }
+
+    ///
+    /// Middleware that intercepts the `FileSystem` effect, validating that all file paths
+    /// do not resolve within any of the given `deniedDirs`. Rejects paths inside a
+    /// denied directory with a `PermissionDenied` error.
+    ///
+    /// The `mkTempDir` operation is allowed since deny lists are default-allow.
+    ///
+    pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileSystem) + FileSystem =
+        let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
+        run { f() } with handler FileSystem {
+            def exists(filename, k)           = k(Result.flatMap(p -> FileSystem.exists(p), c(filename)))
+            def isDirectory(filename, k)      = k(Result.flatMap(p -> FileSystem.isDirectory(p), c(filename)))
+            def isRegularFile(filename, k)    = k(Result.flatMap(p -> FileSystem.isRegularFile(p), c(filename)))
+            def isSymbolicLink(filename, k)   = k(Result.flatMap(p -> FileSystem.isSymbolicLink(p), c(filename)))
+            def isReadable(filename, k)       = k(Result.flatMap(p -> FileSystem.isReadable(p), c(filename)))
+            def isWritable(filename, k)       = k(Result.flatMap(p -> FileSystem.isWritable(p), c(filename)))
+            def isExecutable(filename, k)     = k(Result.flatMap(p -> FileSystem.isExecutable(p), c(filename)))
+            def accessTime(filename, k)       = k(Result.flatMap(p -> FileSystem.accessTime(p), c(filename)))
+            def creationTime(filename, k)     = k(Result.flatMap(p -> FileSystem.creationTime(p), c(filename)))
+            def modificationTime(filename, k) = k(Result.flatMap(p -> FileSystem.modificationTime(p), c(filename)))
+            def size(filename, k)             = k(Result.flatMap(p -> FileSystem.size(p), c(filename)))
+            def read(filename, k)             = k(Result.flatMap(p -> FileSystem.read(p), c(filename)))
+            def readLines(filename, k)        = k(Result.flatMap(p -> FileSystem.readLines(p), c(filename)))
+            def readBytes(filename, k)        = k(Result.flatMap(p -> FileSystem.readBytes(p), c(filename)))
+            def list(filename, k)             = k(Result.flatMap(p -> FileSystem.list(p), c(filename)))
+            def write(data, file, k)          = k(Result.flatMap(p -> FileSystem.write(data, p), c(file)))
+            def writeLines(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeLines(data, p), c(file)))
+            def writeBytes(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeBytes(data, p), c(file)))
+            def append(data, file, k)         = k(Result.flatMap(p -> FileSystem.append(data, p), c(file)))
+            def appendLines(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendLines(data, p), c(file)))
+            def appendBytes(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendBytes(data, p), c(file)))
+            def truncate(file, k)             = k(Result.flatMap(p -> FileSystem.truncate(p), c(file)))
+            def mkDir(d, k)                   = k(Result.flatMap(p -> FileSystem.mkDir(p), c(d)))
+            def mkDirs(d, k)                  = k(Result.flatMap(p -> FileSystem.mkDirs(p), c(d)))
+            def mkTempDir(prefix, k)          = k(FileSystem.mkTempDir(prefix))
+        }
+
 }

--- a/main/src/library/Fs/FileTest.flix
+++ b/main/src/library/Fs/FileTest.flix
@@ -118,4 +118,32 @@ pub mod Fs.FileTest {
             def isSymbolicLink(filename, k) = k(Result.flatMap(p -> FileTest.isSymbolicLink(p), c(filename)))
         }
 
+    ///
+    /// Middleware that intercepts the `FileTest` effect, validating that all file paths
+    /// resolve within one of the given `allowedDirs`. Rejects paths outside the
+    /// allow list with a `PermissionDenied` error.
+    ///
+    pub def withAllowList(allowedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileTest) + FileTest =
+        let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
+        run { f() } with handler FileTest {
+            def exists(filename, k)         = k(Result.flatMap(p -> FileTest.exists(p), c(filename)))
+            def isDirectory(filename, k)    = k(Result.flatMap(p -> FileTest.isDirectory(p), c(filename)))
+            def isRegularFile(filename, k)  = k(Result.flatMap(p -> FileTest.isRegularFile(p), c(filename)))
+            def isSymbolicLink(filename, k) = k(Result.flatMap(p -> FileTest.isSymbolicLink(p), c(filename)))
+        }
+
+    ///
+    /// Middleware that intercepts the `FileTest` effect, validating that all file paths
+    /// do not resolve within any of the given `deniedDirs`. Rejects paths inside a
+    /// denied directory with a `PermissionDenied` error.
+    ///
+    pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileTest) + FileTest =
+        let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
+        run { f() } with handler FileTest {
+            def exists(filename, k)         = k(Result.flatMap(p -> FileTest.exists(p), c(filename)))
+            def isDirectory(filename, k)    = k(Result.flatMap(p -> FileTest.isDirectory(p), c(filename)))
+            def isRegularFile(filename, k)  = k(Result.flatMap(p -> FileTest.isRegularFile(p), c(filename)))
+            def isSymbolicLink(filename, k) = k(Result.flatMap(p -> FileTest.isSymbolicLink(p), c(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FileWrite.flix
+++ b/main/src/library/Fs/FileWrite.flix
@@ -172,4 +172,50 @@ pub mod Fs.FileWrite {
             def mkTempDir(_prefix, k)      = k(Err(IoError(ErrorKind.PermissionDenied, "mkTempDir is not permitted inside a chroot")))
         }
 
+    ///
+    /// Middleware that intercepts the `FileWrite` effect, validating that all file paths
+    /// resolve within one of the given `allowedDirs`. Rejects paths outside the
+    /// allow list with a `PermissionDenied` error.
+    ///
+    /// The `mkTempDir` operation is blocked since the temp directory location cannot be verified.
+    ///
+    pub def withAllowList(allowedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileWrite) + FileWrite =
+        use IoError.IoError;
+        use IoError.ErrorKind;
+        let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
+        run { f() } with handler FileWrite {
+            def write(data, file, k)       = k(Result.flatMap(p -> FileWrite.write(data, p), c(file)))
+            def writeLines(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeLines(data, p), c(file)))
+            def writeBytes(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeBytes(data, p), c(file)))
+            def append(data, file, k)      = k(Result.flatMap(p -> FileWrite.append(data, p), c(file)))
+            def appendLines(data, file, k) = k(Result.flatMap(p -> FileWrite.appendLines(data, p), c(file)))
+            def appendBytes(data, file, k) = k(Result.flatMap(p -> FileWrite.appendBytes(data, p), c(file)))
+            def truncate(file, k)          = k(Result.flatMap(p -> FileWrite.truncate(p), c(file)))
+            def mkDir(d, k)                = k(Result.flatMap(p -> FileWrite.mkDir(p), c(d)))
+            def mkDirs(d, k)               = k(Result.flatMap(p -> FileWrite.mkDirs(p), c(d)))
+            def mkTempDir(_prefix, k)      = k(Err(IoError(ErrorKind.PermissionDenied, "mkTempDir is not permitted with an allow list")))
+        }
+
+    ///
+    /// Middleware that intercepts the `FileWrite` effect, validating that all file paths
+    /// do not resolve within any of the given `deniedDirs`. Rejects paths inside a
+    /// denied directory with a `PermissionDenied` error.
+    ///
+    /// The `mkTempDir` operation is allowed since deny lists are default-allow.
+    ///
+    pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileWrite) + FileWrite =
+        let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
+        run { f() } with handler FileWrite {
+            def write(data, file, k)       = k(Result.flatMap(p -> FileWrite.write(data, p), c(file)))
+            def writeLines(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeLines(data, p), c(file)))
+            def writeBytes(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeBytes(data, p), c(file)))
+            def append(data, file, k)      = k(Result.flatMap(p -> FileWrite.append(data, p), c(file)))
+            def appendLines(data, file, k) = k(Result.flatMap(p -> FileWrite.appendLines(data, p), c(file)))
+            def appendBytes(data, file, k) = k(Result.flatMap(p -> FileWrite.appendBytes(data, p), c(file)))
+            def truncate(file, k)          = k(Result.flatMap(p -> FileWrite.truncate(p), c(file)))
+            def mkDir(d, k)                = k(Result.flatMap(p -> FileWrite.mkDir(p), c(d)))
+            def mkDirs(d, k)               = k(Result.flatMap(p -> FileWrite.mkDirs(p), c(d)))
+            def mkTempDir(prefix, k)       = k(FileWrite.mkTempDir(prefix))
+        }
+
 }

--- a/main/src/library/Fs/FsLayer.flix
+++ b/main/src/library/Fs/FsLayer.flix
@@ -362,6 +362,50 @@ mod Fs.FsLayer {
                     "Path '${path}' escapes chroot '${chrootDir}'"))
         }
 
+    ///
+    /// Resolves `path` to an absolute, normalized form and checks that it falls within
+    /// at least one of the `allowedDirs`. Returns `Ok(resolvedPath)` if allowed,
+    /// or `Err(PermissionDenied)` if the path is outside every allowed directory.
+    ///
+    pub def allowList(allowedDirs: Nel[String], path: String): Result[IoError, String] =
+        unsafe IO {
+            let resolved = Paths.get(path).toAbsolutePath().normalize();
+            let allowed = Nel.exists(
+                dir -> {
+                    let base = Paths.get(dir).toAbsolutePath().normalize();
+                    resolved.startsWith(base)
+                },
+                allowedDirs
+            );
+            if (allowed)
+                Ok(resolved.toString())
+            else
+                Err(IoError(ErrorKind.PermissionDenied,
+                    "Path '${path}' is not within any allowed directory"))
+        }
+
+    ///
+    /// Resolves `path` to an absolute, normalized form and checks that it does not fall
+    /// within any of the `deniedDirs`. Returns `Ok(resolvedPath)` if permitted,
+    /// or `Err(PermissionDenied)` if the path is within a denied directory.
+    ///
+    pub def denyList(deniedDirs: Nel[String], path: String): Result[IoError, String] =
+        unsafe IO {
+            let resolved = Paths.get(path).toAbsolutePath().normalize();
+            let denied = Nel.exists(
+                dir -> {
+                    let base = Paths.get(dir).toAbsolutePath().normalize();
+                    resolved.startsWith(base)
+                },
+                deniedDirs
+            );
+            if (denied)
+                Err(IoError(ErrorKind.PermissionDenied,
+                    "Path '${path}' is within a denied directory"))
+            else
+                Ok(resolved.toString())
+        }
+
     // ─── Private helper ────────────────────────────────────────────────
 
     ///


### PR DESCRIPTION
## Summary
- Add `withAllowList` and `withDenyList` middleware to all 5 Fs modules (FileSystem, FileRead, FileWrite, FileStat, FileTest)
- Add `allowList` and `denyList` helper functions in `FsLayer` using the same `startsWith` prefix matching as `chroot`
- `withAllowList` blocks `mkTempDir` (can't verify location); `withDenyList` passes it through (default-allow)
- Parameter type is `Nel[String]` to eliminate the confusing empty-list case

## Test plan
- [x] Verified `withAllowList` permits reads from allowed directory
- [x] Verified `withAllowList` rejects reads from non-allowed paths with `PermissionDenied`
- [x] Verified `withDenyList` permits reads from non-denied paths
- [x] Verified `withDenyList` rejects reads from denied directories with `PermissionDenied`
- [x] Verified `withAllowList` blocks `mkTempDir` with `PermissionDenied`
- [x] Verified `withDenyList` allows `mkTempDir` to pass through

🤖 Generated with [Claude Code](https://claude.com/claude-code)