### PR TITLE
feat: add withDryRun middleware for Fs effect hierarchy

### DIFF
--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -375,4 +375,74 @@ pub mod Fs.FileSystem {
             def mkTempDir(prefix, k)          = k(FileSystem.mkTempDir(prefix))
         }
 
+    ///
+    /// Middleware that intercepts the `FileSystem` effect, logging each write
+    /// operation via the `Logger` effect at `Debug` level without performing
+    /// the actual filesystem modification. All write operations return `Ok(())`;
+    /// `mkTempDir` returns `Ok("<dry-run>")`. Read, stat, and test operations
+    /// are passed through to the underlying `FileSystem` effect unchanged.
+    ///
+    pub def withDryRun(f: Unit -> a \ ef): a \ (ef - FileSystem) + {FileSystem, Logger} =
+        use RichString.{text, bold, cyan, yellow, gray};
+        let tag = yellow("[dry-run]");
+        run { f() } with handler FileSystem {
+            // Read/stat/test ops — pass through
+            def exists(filename, k)           = k(FileSystem.exists(filename))
+            def isDirectory(filename, k)      = k(FileSystem.isDirectory(filename))
+            def isRegularFile(filename, k)    = k(FileSystem.isRegularFile(filename))
+            def isSymbolicLink(filename, k)   = k(FileSystem.isSymbolicLink(filename))
+            def isReadable(filename, k)       = k(FileSystem.isReadable(filename))
+            def isWritable(filename, k)       = k(FileSystem.isWritable(filename))
+            def isExecutable(filename, k)     = k(FileSystem.isExecutable(filename))
+            def accessTime(filename, k)       = k(FileSystem.accessTime(filename))
+            def creationTime(filename, k)     = k(FileSystem.creationTime(filename))
+            def modificationTime(filename, k) = k(FileSystem.modificationTime(filename))
+            def size(filename, k)             = k(FileSystem.size(filename))
+            def read(filename, k)             = k(FileSystem.read(filename))
+            def readLines(filename, k)        = k(FileSystem.readLines(filename))
+            def readBytes(filename, k)        = k(FileSystem.readBytes(filename))
+            def list(filename, k)             = k(FileSystem.list(filename))
+            // Write ops — dry-run (log + return Ok)
+            def write(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("write") + text(" ") + cyan(file) + gray(" (${String.length(data#str)} chars)"));
+                k(Ok(()))
+            }
+            def writeLines(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("writeLines") + text(" ") + cyan(file) + gray(" (${List.length(data#lines)} lines)"));
+                k(Ok(()))
+            }
+            def writeBytes(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("writeBytes") + text(" ") + cyan(file) + gray(" (${Vector.length(data)} bytes)"));
+                k(Ok(()))
+            }
+            def append(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("append") + text(" ") + cyan(file) + gray(" (${String.length(data#str)} chars)"));
+                k(Ok(()))
+            }
+            def appendLines(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("appendLines") + text(" ") + cyan(file) + gray(" (${List.length(data#lines)} lines)"));
+                k(Ok(()))
+            }
+            def appendBytes(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("appendBytes") + text(" ") + cyan(file) + gray(" (${Vector.length(data)} bytes)"));
+                k(Ok(()))
+            }
+            def truncate(file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("truncate") + text(" ") + cyan(file));
+                k(Ok(()))
+            }
+            def mkDir(d, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("mkDir") + text(" ") + cyan(d));
+                k(Ok(()))
+            }
+            def mkDirs(d, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("mkDirs") + text(" ") + cyan(d));
+                k(Ok(()))
+            }
+            def mkTempDir(prefix, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("mkTempDir") + text(" ") + cyan(prefix));
+                k(Ok("<dry-run>"))
+            }
+        }
+
 }

--- a/main/src/library/Fs/FileWrite.flix
+++ b/main/src/library/Fs/FileWrite.flix
@@ -218,4 +218,56 @@ pub mod Fs.FileWrite {
             def mkTempDir(prefix, k)       = k(FileWrite.mkTempDir(prefix))
         }
 
+    ///
+    /// Middleware that intercepts the `FileWrite` effect, logging each write
+    /// operation via the `Logger` effect at `Debug` level without performing
+    /// the actual filesystem modification. All write operations return `Ok(())`;
+    /// `mkTempDir` returns `Ok("<dry-run>")`.
+    ///
+    pub def withDryRun(f: Unit -> a \ ef): a \ (ef - FileWrite) + Logger =
+        use RichString.{text, bold, cyan, yellow, gray};
+        let tag = yellow("[dry-run]");
+        run { f() } with handler FileWrite {
+            def write(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("write") + text(" ") + cyan(file) + gray(" (${String.length(data#str)} chars)"));
+                k(Ok(()))
+            }
+            def writeLines(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("writeLines") + text(" ") + cyan(file) + gray(" (${List.length(data#lines)} lines)"));
+                k(Ok(()))
+            }
+            def writeBytes(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("writeBytes") + text(" ") + cyan(file) + gray(" (${Vector.length(data)} bytes)"));
+                k(Ok(()))
+            }
+            def append(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("append") + text(" ") + cyan(file) + gray(" (${String.length(data#str)} chars)"));
+                k(Ok(()))
+            }
+            def appendLines(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("appendLines") + text(" ") + cyan(file) + gray(" (${List.length(data#lines)} lines)"));
+                k(Ok(()))
+            }
+            def appendBytes(data, file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("appendBytes") + text(" ") + cyan(file) + gray(" (${Vector.length(data)} bytes)"));
+                k(Ok(()))
+            }
+            def truncate(file, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("truncate") + text(" ") + cyan(file));
+                k(Ok(()))
+            }
+            def mkDir(d, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("mkDir") + text(" ") + cyan(d));
+                k(Ok(()))
+            }
+            def mkDirs(d, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("mkDirs") + text(" ") + cyan(d));
+                k(Ok(()))
+            }
+            def mkTempDir(prefix, k) = {
+                Logger.log(Severity.Debug, tag + text(" ") + bold("mkTempDir") + text(" ") + cyan(prefix));
+                k(Ok("<dry-run>"))
+            }
+        }
+
 }


### PR DESCRIPTION
## Summary
- Add `withDryRun` middleware to `FileWrite` and `FileSystem` that intercepts write operations, logs what they would do via `Logger` at `Debug` level, and returns `Ok(())` without touching disk
- `mkTempDir` returns `Ok("<dry-run>")` since callers may use the returned path
- Read/stat/test operations in `FileSystem.withDryRun` are passed through unchanged
- Log output uses colorful `RichString`: yellow `[dry-run]` tag, bold op name, cyan path, gray data size

## Test plan
- [x] Build with `./mill.bat flix.test`
- [x] Run `foo.flix` test program to verify write ops are logged but not performed, and reads still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)