### PR TITLE
feat: add Glob effect to Fs effect hierarchy

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Library.scala
+++ b/main/src/ca/uwaterloo/flix/api/Library.scala
@@ -98,6 +98,7 @@ object Library {
     "Fs/AccessTime.flix" -> LocalResource.get("/src/library/Fs/AccessTime.flix"),
     "Fs/CreationTime.flix" -> LocalResource.get("/src/library/Fs/CreationTime.flix"),
     "Fs/DirList.flix" -> LocalResource.get("/src/library/Fs/DirList.flix"),
+    "Fs/Glob.flix" -> LocalResource.get("/src/library/Fs/Glob.flix"),
     "Fs/FsLayer.flix" -> LocalResource.get("/src/library/Fs/FsLayer.flix"),
     "Fs/FileExists.flix" -> LocalResource.get("/src/library/Fs/FileExists.flix"),
     "Fs/FilePermission.flix" -> LocalResource.get("/src/library/Fs/FilePermission.flix"),

--- a/main/src/library/Fs.flix
+++ b/main/src/library/Fs.flix
@@ -18,7 +18,7 @@ pub mod Fs {
 
     // Effect Hierarchy:
     //
-    // FileSystem                          (27 ops — unified root)
+    // FileSystem                          (28 ops — unified root)
     // ├── FileStat                        (11 ops)
     // │   ├── FileTest                    (4 ops)
     // │   │   ├── FileExists                    — exists
@@ -39,6 +39,7 @@ pub mod Fs {
     // │   ├── ReadLines                         — readLines
     // │   └── ReadBytes                         — readBytes
     // ├── DirList                               — list
+    // ├── Glob                                — glob
     // └── FileWrite                       (12 ops)
     //     ├── WriteFile                         — write
     //     ├── WriteLines                        — writeLines
@@ -230,6 +231,18 @@ pub mod Fs {
         /// Returns a list with the names of all files and directories in the given directory `f`.
         ///
         def list(f: String): Result[IoError, List[String]]
+
+    }
+
+    ///
+    /// An effect used to find files matching a glob pattern.
+    ///
+    pub eff Glob {
+
+        ///
+        /// Returns a list of paths under `base` that match the given glob `pattern`.
+        ///
+        def glob(base: String, pattern: String): Result[IoError, List[String]]
 
     }
 
@@ -714,6 +727,11 @@ pub mod Fs {
         /// Returns a list with the names of all files and directories in the given directory `f`.
         ///
         def list(f: String): Result[IoError, List[String]]
+
+        ///
+        /// Returns a list of paths under `base` that match the given glob `pattern`.
+        ///
+        def glob(base: String, pattern: String): Result[IoError, List[String]]
 
         ///
         /// Writes `str` to the given file `f`.

--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -44,6 +44,7 @@ pub mod Fs.FileSystem {
             def readLines(filename, k)        = k(Fs.FsLayer.readLines(filename))
             def readBytes(filename, k)        = k(Fs.FsLayer.readBytes(filename))
             def list(filename, k)             = k(Fs.FsLayer.list(filename))
+            def glob(base, pattern, k)        = k(Fs.FsLayer.glob(base, pattern))
             def write(data, file, k)          = k(Fs.FsLayer.write(data, file))
             def writeLines(data, file, k)     = k(Fs.FsLayer.writeLines(data, file))
             def writeBytes(data, file, k)     = k(Fs.FsLayer.writeBytes(data, file))
@@ -164,6 +165,12 @@ pub mod Fs.FileSystem {
                 logPost("list", filename, ls -> "${List.length(ls)} entries", result);
                 k(result)
             }
+            def glob(base, pattern, k) = {
+                logPre("glob", base);
+                let result = FileSystem.glob(base, pattern);
+                logPost("glob", base, ls -> "${List.length(ls)} matches", result);
+                k(result)
+            }
             def write(data, file, k) = {
                 logPre("write", file);
                 let result = FileSystem.write(data, file);
@@ -262,6 +269,7 @@ pub mod Fs.FileSystem {
             def readLines(filename, k)        = k(FileSystem.readLines(r(filename)))
             def readBytes(filename, k)        = k(FileSystem.readBytes(r(filename)))
             def list(filename, k)             = k(FileSystem.list(r(filename)))
+            def glob(base, pattern, k)        = k(FileSystem.glob(r(base), pattern))
             def write(data, file, k)          = k(FileSystem.write(data, r(file)))
             def writeLines(data, file, k)     = k(FileSystem.writeLines(data, r(file)))
             def writeBytes(data, file, k)     = k(FileSystem.writeBytes(data, r(file)))
@@ -303,6 +311,7 @@ pub mod Fs.FileSystem {
             def readLines(filename, k)        = k(Result.flatMap(p -> FileSystem.readLines(p), c(filename)))
             def readBytes(filename, k)        = k(Result.flatMap(p -> FileSystem.readBytes(p), c(filename)))
             def list(filename, k)             = k(Result.flatMap(p -> FileSystem.list(p), c(filename)))
+            def glob(base, pattern, k)        = k(Result.flatMap(p -> FileSystem.glob(p, pattern), c(base)))
             def write(data, file, k)          = k(Result.flatMap(p -> FileSystem.write(data, p), c(file)))
             def writeLines(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeLines(data, p), c(file)))
             def writeBytes(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeBytes(data, p), c(file)))
@@ -344,6 +353,7 @@ pub mod Fs.FileSystem {
             def readLines(filename, k)        = k(Result.flatMap(p -> FileSystem.readLines(p), c(filename)))
             def readBytes(filename, k)        = k(Result.flatMap(p -> FileSystem.readBytes(p), c(filename)))
             def list(filename, k)             = k(Result.flatMap(p -> FileSystem.list(p), c(filename)))
+            def glob(base, pattern, k)        = k(Result.flatMap(p -> FileSystem.glob(p, pattern), c(base)))
             def write(data, file, k)          = k(Result.flatMap(p -> FileSystem.write(data, p), c(file)))
             def writeLines(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeLines(data, p), c(file)))
             def writeBytes(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeBytes(data, p), c(file)))
@@ -383,6 +393,7 @@ pub mod Fs.FileSystem {
             def readLines(filename, k)        = k(Result.flatMap(p -> FileSystem.readLines(p), c(filename)))
             def readBytes(filename, k)        = k(Result.flatMap(p -> FileSystem.readBytes(p), c(filename)))
             def list(filename, k)             = k(Result.flatMap(p -> FileSystem.list(p), c(filename)))
+            def glob(base, pattern, k)        = k(Result.flatMap(p -> FileSystem.glob(p, pattern), c(base)))
             def write(data, file, k)          = k(Result.flatMap(p -> FileSystem.write(data, p), c(file)))
             def writeLines(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeLines(data, p), c(file)))
             def writeBytes(data, file, k)     = k(Result.flatMap(p -> FileSystem.writeBytes(data, p), c(file)))
@@ -424,6 +435,7 @@ pub mod Fs.FileSystem {
             def readLines(filename, k)        = k(FileSystem.readLines(filename))
             def readBytes(filename, k)        = k(FileSystem.readBytes(filename))
             def list(filename, k)             = k(FileSystem.list(filename))
+            def glob(base, pattern, k)        = k(FileSystem.glob(base, pattern))
             // Write ops — dry-run (log + return Ok)
             def write(data, file, k) = {
                 Logger.log(Severity.Debug, tag + text(" ") + bold("write") + text(" ") + cyan(file) + gray(" (${String.length(data#str)} chars)"));
@@ -503,6 +515,7 @@ pub mod Fs.FileSystem {
             def readLines(filename, k)        = k(FileSystem.readLines(filename))
             def readBytes(filename, k)        = k(FileSystem.readBytes(filename))
             def list(filename, k)             = k(FileSystem.list(filename))
+            def glob(base, pattern, k)        = k(FileSystem.glob(base, pattern))
             // Write ops — blocked
             def write(_data, _file, k)        = k(denied("write"))
             def writeLines(_data, _file, k)   = k(denied("writeLines"))

--- a/main/src/library/Fs/FsLayer.flix
+++ b/main/src/library/Fs/FsLayer.flix
@@ -33,8 +33,13 @@ mod Fs.FsLayer {
     import java.nio.file.Path
     import java.nio.file.Paths
     import java.nio.file.CopyOption
+    import java.nio.file.FileSystems
+    import java.nio.file.FileVisitOption
     import java.nio.file.NoSuchFileException
+    import java.nio.file.PathMatcher
     import java.nio.file.StandardOpenOption
+    import java.util.stream.BaseStream
+    import java.util.stream.Stream
 
     use IoError.IoError
     use IoError.ErrorKind
@@ -189,6 +194,33 @@ mod Fs.FsLayer {
             case ex: InvalidPathException  => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
             case ex: NotDirectoryException => Err(IoError(ErrorKind.NotDirectory, ex.getMessage()))
             case ex: IOException           => Err(IoError(ErrorKind.Other, ex.getMessage()))
+        }
+
+    // ─── Glob operation ─────────────────────────────────────────────────
+
+    pub def glob(base: String, pattern: String): Result[IoError, List[String]] \ IO =
+        try {
+            region rc {
+                let basePath = Paths.get(base);
+                let matcher = FileSystems.getDefault().getPathMatcher("glob:${pattern}");
+                let stream = Files.walk(basePath, (...{}: Vector[FileVisitOption]));
+                let iter = Adaptor.fromStreamToIterator(rc, (Proxy.Proxy: Proxy[Path]), stream);
+                let result = iter
+                    |> Iterator.filterMap(path -> {
+                        let rel = basePath.relativize(path);
+                        if (matcher.matches(rel))
+                            Some(path.toString())
+                        else
+                            None
+                    })
+                    |> Iterator.toList;
+                let bs: BaseStream = checked_cast(stream);
+                bs.close();
+                Ok(result)
+            }
+        } catch {
+            case ex: InvalidPathException => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
+            case ex: IOException          => Err(IoError(ErrorKind.Other, ex.getMessage()))
         }
 
     // ─── Write operations ──────────────────────────────────────────────

--- a/main/src/library/Fs/Glob.flix
+++ b/main/src/library/Fs/Glob.flix
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod Fs.Glob {
+
+    use Fs.Glob
+    use Fs.FileSystem
+    use Fs.FsLayer.{logPre, logPost}
+
+    ///
+    /// Handles the `Glob` effect of the given function `f`.
+    ///
+    /// In other words, re-interprets the `Glob` effect using the `IO` effect.
+    ///
+    pub def handle(f: a -> b \ ef): a -> b \ (ef - Glob) + IO = x ->
+        run { f(x) } with handler Glob {
+            def glob(base, pattern, k) = k(Fs.FsLayer.glob(base, pattern))
+        }
+
+    ///
+    /// Runs the `Glob` effect of the given function `f`.
+    ///
+    /// In other words, re-interprets the `Glob` effect using the `IO` effect.
+    ///
+    @DefaultHandler
+    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Glob) + IO = handle(f)()
+
+    ///
+    /// Handles the `Glob` effect of the given function `f` using the `FileSystem` effect.
+    ///
+    pub def handleWithFileSystem(f: a -> b \ ef): a -> b \ (ef - Glob) + FileSystem = x ->
+        run { f(x) } with handler Glob {
+            def glob(base, pattern, k) = k(Fs.FileSystem.glob(base, pattern))
+        }
+
+    ///
+    /// Middleware that intercepts the `Glob` effect, logging each operation
+    /// and its result via the `Logger` effect.
+    ///
+    /// Successful operations are logged at `Debug` level; errors at `Warn`.
+    ///
+    pub def withLogging(f: Unit -> a \ ef): a \ (ef - Glob) + {Glob, Logger} =
+        run { f() } with handler Glob {
+            def glob(base, pattern, k) = {
+                logPre("glob", base);
+                let result = Glob.glob(base, pattern);
+                logPost("glob", base, ls -> "${List.length(ls)} matches", result);
+                k(result)
+            }
+        }
+
+    ///
+    /// Middleware that intercepts the `Glob` effect, resolving all file paths
+    /// relative to the given `baseDir` using Java's `Path.resolve` semantics.
+    ///
+    /// Absolute paths are passed through unchanged.
+    ///
+    pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - Glob) + Glob =
+        let r = p -> Fs.FsLayer.resolve(baseDir, p);
+        run { f() } with handler Glob {
+            def glob(base, pattern, k) = k(Glob.glob(r(base), pattern))
+        }
+
+}


### PR DESCRIPTION
## Summary
- Add new `Glob` leaf effect with a `glob(base, pattern)` operation using Java's glob syntax (`*`, `**`, `?`, `{a,b}`)
- Add `Glob` handler module (`Fs/Glob.flix`) with `handle`, `runWithIO`, `handleWithFileSystem`, `withLogging`, and `withBaseDir`
- Wire `glob` into all 8 `FileSystem` handlers (handle, withLogging, withBaseDir, withChroot, withAllowList, withDenyList, withDryRun, withReadOnly)

## Test plan
- [x] Smoke test: `Fs.Glob.glob(".", "*.flix")` returns matching files
- [x] Verify `**` recursive patterns work (e.g. `**/*.flix`)
- [ ] Verify middleware composition (withChroot, withAllowList, etc.) validates the `base` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)