### PR TITLE
feat: add MoveOption enum and moveWith operation for Fs effect hierarchy

### DIFF
--- a/main/src/library/Fs.flix
+++ b/main/src/library/Fs.flix
@@ -48,11 +48,19 @@ pub mod Fs {
     //     ├── AppendLines                       — appendLines
     //     ├── AppendBytes                       — appendBytes
     //     ├── Truncate                          — truncate
-    //     ├── MoveFile                          — move
+    //     ├── MoveFile                          — moveWith
     //     ├── DeleteFile                        — delete
     //     ├── MkDir                             — mkDir
     //     ├── MkDirs                            — mkDirs
     //     └── MkTempDir                         — mkTempDir
+
+    ///
+    /// Options for the `moveWith` operation.
+    ///
+    pub enum MoveOption with Eq, Order, ToString {
+        case AtomicMove
+        case ReplaceExisting
+    }
 
     ///
     /// An effect used to check if a file exists.
@@ -348,11 +356,9 @@ pub mod Fs {
     pub eff MoveFile {
 
         ///
-        /// Moves (renames) the file or directory `src` to `dst`.
+        /// Moves (renames) the file or directory `src` to `dst` with the given `options`.
         ///
-        /// Fails if `dst` already exists.
-        ///
-        def move(src: {src = String}, dst: String): Result[IoError, Unit]
+        def moveWith(src: {src = String}, dst: String, opts: Set[MoveOption]): Result[IoError, Unit]
 
     }
 
@@ -616,11 +622,9 @@ pub mod Fs {
         def truncate(f: String): Result[IoError, Unit]
 
         ///
-        /// Moves (renames) the file or directory `src` to `dst`.
+        /// Moves (renames) the file or directory `src` to `dst` with the given `options`.
         ///
-        /// Fails if `dst` already exists.
-        ///
-        def move(src: {src = String}, dst: String): Result[IoError, Unit]
+        def moveWith(src: {src = String}, dst: String, opts: Set[MoveOption]): Result[IoError, Unit]
 
         ///
         /// Deletes the given file `f`.
@@ -781,11 +785,9 @@ pub mod Fs {
         def truncate(f: String): Result[IoError, Unit]
 
         ///
-        /// Moves (renames) the file or directory `src` to `dst`.
+        /// Moves (renames) the file or directory `src` to `dst` with the given `options`.
         ///
-        /// Fails if `dst` already exists.
-        ///
-        def move(src: {src = String}, dst: String): Result[IoError, Unit]
+        def moveWith(src: {src = String}, dst: String, opts: Set[MoveOption]): Result[IoError, Unit]
 
         ///
         /// Deletes the given file `f`.

--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -21,6 +21,12 @@ pub mod Fs.FileSystem {
     use IoError.IoError
 
     ///
+    /// Convenience function: moves `src` to `dst` with no options.
+    ///
+    pub def move(src: {src = String}, dst: String): Result[IoError, Unit] \ FileSystem =
+        Fs.FileSystem.moveWith(src, dst, Set.empty())
+
+    ///
     /// Handles the `FileSystem` effect of the given function `f`.
     ///
     /// In other words, re-interprets the `FileSystem` effect using the `IO` effect.
@@ -52,7 +58,7 @@ pub mod Fs.FileSystem {
             def appendLines(data, file, k)    = k(Fs.FsLayer.appendLines(data, file))
             def appendBytes(data, file, k)    = k(Fs.FsLayer.appendBytes(data, file))
             def truncate(file, k)             = k(Fs.FsLayer.truncate(file))
-            def move(src, dst, k)             = k(Fs.FsLayer.move(src, dst))
+            def moveWith(src, dst, opts, k)   = k(Fs.FsLayer.moveWith(src, dst, opts))
             def delete(file, k)               = k(Fs.FsLayer.delete(file))
             def mkDir(d, k)                   = k(Fs.FsLayer.mkDir(d))
             def mkDirs(d, k)                  = k(Fs.FsLayer.mkDirs(d))
@@ -213,9 +219,9 @@ pub mod Fs.FileSystem {
                 logPost("truncate", file, _ -> "done", result);
                 k(result)
             }
-            def move(src, dst, k) = {
+            def moveWith(src, dst, opts, k) = {
                 logPre("move", src#src);
-                let result = FileSystem.move(src, dst);
+                let result = FileSystem.moveWith(src, dst, opts);
                 logPost("move", src#src, _ -> dst, result);
                 k(result)
             }
@@ -277,7 +283,7 @@ pub mod Fs.FileSystem {
             def appendLines(data, file, k)    = k(FileSystem.appendLines(data, r(file)))
             def appendBytes(data, file, k)    = k(FileSystem.appendBytes(data, r(file)))
             def truncate(file, k)             = k(FileSystem.truncate(r(file)))
-            def move(src, dst, k)             = k(FileSystem.move(src = r(src#src), r(dst)))
+            def moveWith(src, dst, opts, k)   = k(FileSystem.moveWith(src = r(src#src), r(dst), opts))
             def delete(file, k)               = k(FileSystem.delete(r(file)))
             def mkDir(d, k)                   = k(FileSystem.mkDir(r(d)))
             def mkDirs(d, k)                  = k(FileSystem.mkDirs(r(d)))
@@ -319,7 +325,7 @@ pub mod Fs.FileSystem {
             def appendLines(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendLines(data, p), c(file)))
             def appendBytes(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendBytes(data, p), c(file)))
             def truncate(file, k)             = k(Result.flatMap(p -> FileSystem.truncate(p), c(file)))
-            def move(src, dst, k)             = k(Result.flatMap(s -> Result.flatMap(d -> FileSystem.move(src = s, d), c(dst)), c(src#src)))
+            def moveWith(src, dst, opts, k)   = k(Result.flatMap(s -> Result.flatMap(d -> FileSystem.moveWith(src = s, d, opts), c(dst)), c(src#src)))
             def delete(file, k)               = k(Result.flatMap(p -> FileSystem.delete(p), c(file)))
             def mkDir(d, k)                   = k(Result.flatMap(p -> FileSystem.mkDir(p), c(d)))
             def mkDirs(d, k)                  = k(Result.flatMap(p -> FileSystem.mkDirs(p), c(d)))
@@ -361,7 +367,7 @@ pub mod Fs.FileSystem {
             def appendLines(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendLines(data, p), c(file)))
             def appendBytes(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendBytes(data, p), c(file)))
             def truncate(file, k)             = k(Result.flatMap(p -> FileSystem.truncate(p), c(file)))
-            def move(src, dst, k)             = k(Result.flatMap(s -> Result.flatMap(d -> FileSystem.move(src = s, d), c(dst)), c(src#src)))
+            def moveWith(src, dst, opts, k)   = k(Result.flatMap(s -> Result.flatMap(d -> FileSystem.moveWith(src = s, d, opts), c(dst)), c(src#src)))
             def delete(file, k)               = k(Result.flatMap(p -> FileSystem.delete(p), c(file)))
             def mkDir(d, k)                   = k(Result.flatMap(p -> FileSystem.mkDir(p), c(d)))
             def mkDirs(d, k)                  = k(Result.flatMap(p -> FileSystem.mkDirs(p), c(d)))
@@ -401,7 +407,7 @@ pub mod Fs.FileSystem {
             def appendLines(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendLines(data, p), c(file)))
             def appendBytes(data, file, k)    = k(Result.flatMap(p -> FileSystem.appendBytes(data, p), c(file)))
             def truncate(file, k)             = k(Result.flatMap(p -> FileSystem.truncate(p), c(file)))
-            def move(src, dst, k)             = k(Result.flatMap(s -> Result.flatMap(d -> FileSystem.move(src = s, d), c(dst)), c(src#src)))
+            def moveWith(src, dst, opts, k)   = k(Result.flatMap(s -> Result.flatMap(d -> FileSystem.moveWith(src = s, d, opts), c(dst)), c(src#src)))
             def delete(file, k)               = k(Result.flatMap(p -> FileSystem.delete(p), c(file)))
             def mkDir(d, k)                   = k(Result.flatMap(p -> FileSystem.mkDir(p), c(d)))
             def mkDirs(d, k)                  = k(Result.flatMap(p -> FileSystem.mkDirs(p), c(d)))
@@ -465,7 +471,7 @@ pub mod Fs.FileSystem {
                 Logger.log(Severity.Debug, tag + text(" ") + bold("truncate") + text(" ") + cyan(file));
                 k(Ok(()))
             }
-            def move(src, dst, k) = {
+            def moveWith(src, dst, _opts, k) = {
                 Logger.log(Severity.Debug, tag + text(" ") + bold("move") + text(" ") + cyan(src#src) + gray(" -> ") + cyan(dst));
                 k(Ok(()))
             }
@@ -517,18 +523,18 @@ pub mod Fs.FileSystem {
             def list(filename, k)             = k(FileSystem.list(filename))
             def glob(base, pattern, k)        = k(FileSystem.glob(base, pattern))
             // Write ops — blocked
-            def write(_data, _file, k)        = k(denied("write"))
-            def writeLines(_data, _file, k)   = k(denied("writeLines"))
-            def writeBytes(_data, _file, k)   = k(denied("writeBytes"))
-            def append(_data, _file, k)       = k(denied("append"))
-            def appendLines(_data, _file, k)  = k(denied("appendLines"))
-            def appendBytes(_data, _file, k)  = k(denied("appendBytes"))
-            def truncate(_file, k)            = k(denied("truncate"))
-            def move(_src, _dst, k)           = k(denied("move"))
-            def delete(_file, k)              = k(denied("delete"))
-            def mkDir(_d, k)                  = k(denied("mkDir"))
-            def mkDirs(_d, k)                 = k(denied("mkDirs"))
-            def mkTempDir(_prefix, k)         = k(Err(IoError(ErrorKind.PermissionDenied, "read-only: mkTempDir is not permitted")))
+            def write(_data, _file, k)          = k(denied("write"))
+            def writeLines(_data, _file, k)     = k(denied("writeLines"))
+            def writeBytes(_data, _file, k)     = k(denied("writeBytes"))
+            def append(_data, _file, k)         = k(denied("append"))
+            def appendLines(_data, _file, k)    = k(denied("appendLines"))
+            def appendBytes(_data, _file, k)    = k(denied("appendBytes"))
+            def truncate(_file, k)              = k(denied("truncate"))
+            def moveWith(_src, _dst, _opts, k)  = k(denied("move"))
+            def delete(_file, k)                = k(denied("delete"))
+            def mkDir(_d, k)                    = k(denied("mkDir"))
+            def mkDirs(_d, k)                   = k(denied("mkDirs"))
+            def mkTempDir(_prefix, k)           = k(Err(IoError(ErrorKind.PermissionDenied, "read-only: mkTempDir is not permitted")))
         }
 
 }

--- a/main/src/library/Fs/FileWrite.flix
+++ b/main/src/library/Fs/FileWrite.flix
@@ -21,6 +21,12 @@ pub mod Fs.FileWrite {
     use Fs.FsLayer.{logPre, logPost}
 
     ///
+    /// Convenience function: moves `src` to `dst` with no options.
+    ///
+    pub def move(src: {src = String}, dst: String): Result[IoError, Unit] \ FileWrite =
+        Fs.FileWrite.moveWith(src, dst, Set.empty())
+
+    ///
     /// Handles the `FileWrite` effect of the given function `f`.
     ///
     /// In other words, re-interprets the `FileWrite` effect using the `IO` effect.
@@ -45,18 +51,18 @@ pub mod Fs.FileWrite {
     ///
     pub def handleWithFileSystem(f: a -> b \ ef): a -> b \ (ef - FileWrite) + FileSystem = x ->
         run { f(x) } with handler FileWrite {
-            def write(data, file, k)       = k(Fs.FileSystem.write(data, file))
-            def writeLines(data, file, k)  = k(Fs.FileSystem.writeLines(data, file))
-            def writeBytes(data, file, k)  = k(Fs.FileSystem.writeBytes(data, file))
-            def append(data, file, k)      = k(Fs.FileSystem.append(data, file))
-            def appendLines(data, file, k) = k(Fs.FileSystem.appendLines(data, file))
-            def appendBytes(data, file, k) = k(Fs.FileSystem.appendBytes(data, file))
-            def truncate(file, k)          = k(Fs.FileSystem.truncate(file))
-            def move(src, dst, k)          = k(Fs.FileSystem.move(src, dst))
-            def delete(file, k)            = k(Fs.FileSystem.delete(file))
-            def mkDir(d, k)                = k(Fs.FileSystem.mkDir(d))
-            def mkDirs(d, k)               = k(Fs.FileSystem.mkDirs(d))
-            def mkTempDir(prefix, k)       = k(Fs.FileSystem.mkTempDir(prefix))
+            def write(data, file, k)        = k(Fs.FileSystem.write(data, file))
+            def writeLines(data, file, k)   = k(Fs.FileSystem.writeLines(data, file))
+            def writeBytes(data, file, k)   = k(Fs.FileSystem.writeBytes(data, file))
+            def append(data, file, k)       = k(Fs.FileSystem.append(data, file))
+            def appendLines(data, file, k)  = k(Fs.FileSystem.appendLines(data, file))
+            def appendBytes(data, file, k)  = k(Fs.FileSystem.appendBytes(data, file))
+            def truncate(file, k)           = k(Fs.FileSystem.truncate(file))
+            def moveWith(src, dst, opts, k) = k(Fs.FileSystem.moveWith(src, dst, opts))
+            def delete(file, k)             = k(Fs.FileSystem.delete(file))
+            def mkDir(d, k)                 = k(Fs.FileSystem.mkDir(d))
+            def mkDirs(d, k)                = k(Fs.FileSystem.mkDirs(d))
+            def mkTempDir(prefix, k)        = k(Fs.FileSystem.mkTempDir(prefix))
         }
 
     ///
@@ -109,9 +115,9 @@ pub mod Fs.FileWrite {
                 logPost("truncate", file, _ -> "done", result);
                 k(result)
             }
-            def move(src, dst, k) = {
+            def moveWith(src, dst, opts, k) = {
                 logPre("move", src#src);
-                let result = FileWrite.move(src, dst);
+                let result = FileWrite.moveWith(src, dst, opts);
                 logPost("move", src#src, _ -> dst, result);
                 k(result)
             }
@@ -150,18 +156,18 @@ pub mod Fs.FileWrite {
     pub def withBaseDir(baseDir: String, f: Unit -> a \ ef): a \ (ef - FileWrite) + FileWrite =
         let r = p -> Fs.FsLayer.resolve(baseDir, p);
         run { f() } with handler FileWrite {
-            def write(data, file, k)       = k(FileWrite.write(data, r(file)))
-            def writeLines(data, file, k)  = k(FileWrite.writeLines(data, r(file)))
-            def writeBytes(data, file, k)  = k(FileWrite.writeBytes(data, r(file)))
-            def append(data, file, k)      = k(FileWrite.append(data, r(file)))
-            def appendLines(data, file, k) = k(FileWrite.appendLines(data, r(file)))
-            def appendBytes(data, file, k) = k(FileWrite.appendBytes(data, r(file)))
-            def truncate(file, k)          = k(FileWrite.truncate(r(file)))
-            def move(src, dst, k)          = k(FileWrite.move(src = r(src#src), r(dst)))
-            def delete(file, k)            = k(FileWrite.delete(r(file)))
-            def mkDir(d, k)                = k(FileWrite.mkDir(r(d)))
-            def mkDirs(d, k)               = k(FileWrite.mkDirs(r(d)))
-            def mkTempDir(prefix, k)       = k(FileWrite.mkTempDir(prefix))
+            def write(data, file, k)        = k(FileWrite.write(data, r(file)))
+            def writeLines(data, file, k)   = k(FileWrite.writeLines(data, r(file)))
+            def writeBytes(data, file, k)   = k(FileWrite.writeBytes(data, r(file)))
+            def append(data, file, k)       = k(FileWrite.append(data, r(file)))
+            def appendLines(data, file, k)  = k(FileWrite.appendLines(data, r(file)))
+            def appendBytes(data, file, k)  = k(FileWrite.appendBytes(data, r(file)))
+            def truncate(file, k)           = k(FileWrite.truncate(r(file)))
+            def moveWith(src, dst, opts, k) = k(FileWrite.moveWith(src = r(src#src), r(dst), opts))
+            def delete(file, k)             = k(FileWrite.delete(r(file)))
+            def mkDir(d, k)                 = k(FileWrite.mkDir(r(d)))
+            def mkDirs(d, k)                = k(FileWrite.mkDirs(r(d)))
+            def mkTempDir(prefix, k)        = k(FileWrite.mkTempDir(prefix))
         }
 
     ///
@@ -176,18 +182,18 @@ pub mod Fs.FileWrite {
         use IoError.ErrorKind;
         let c = p -> Fs.FsLayer.chroot(chrootDir, p);
         run { f() } with handler FileWrite {
-            def write(data, file, k)       = k(Result.flatMap(p -> FileWrite.write(data, p), c(file)))
-            def writeLines(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeLines(data, p), c(file)))
-            def writeBytes(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeBytes(data, p), c(file)))
-            def append(data, file, k)      = k(Result.flatMap(p -> FileWrite.append(data, p), c(file)))
-            def appendLines(data, file, k) = k(Result.flatMap(p -> FileWrite.appendLines(data, p), c(file)))
-            def appendBytes(data, file, k) = k(Result.flatMap(p -> FileWrite.appendBytes(data, p), c(file)))
-            def truncate(file, k)          = k(Result.flatMap(p -> FileWrite.truncate(p), c(file)))
-            def move(src, dst, k)          = k(Result.flatMap(s -> Result.flatMap(d -> FileWrite.move(src = s, d), c(dst)), c(src#src)))
-            def delete(file, k)            = k(Result.flatMap(p -> FileWrite.delete(p), c(file)))
-            def mkDir(d, k)                = k(Result.flatMap(p -> FileWrite.mkDir(p), c(d)))
-            def mkDirs(d, k)               = k(Result.flatMap(p -> FileWrite.mkDirs(p), c(d)))
-            def mkTempDir(_prefix, k)      = k(Err(IoError(ErrorKind.PermissionDenied, "mkTempDir is not permitted inside a chroot")))
+            def write(data, file, k)        = k(Result.flatMap(p -> FileWrite.write(data, p), c(file)))
+            def writeLines(data, file, k)   = k(Result.flatMap(p -> FileWrite.writeLines(data, p), c(file)))
+            def writeBytes(data, file, k)   = k(Result.flatMap(p -> FileWrite.writeBytes(data, p), c(file)))
+            def append(data, file, k)       = k(Result.flatMap(p -> FileWrite.append(data, p), c(file)))
+            def appendLines(data, file, k)  = k(Result.flatMap(p -> FileWrite.appendLines(data, p), c(file)))
+            def appendBytes(data, file, k)  = k(Result.flatMap(p -> FileWrite.appendBytes(data, p), c(file)))
+            def truncate(file, k)           = k(Result.flatMap(p -> FileWrite.truncate(p), c(file)))
+            def moveWith(src, dst, opts, k) = k(Result.flatMap(s -> Result.flatMap(d -> FileWrite.moveWith(src = s, d, opts), c(dst)), c(src#src)))
+            def delete(file, k)             = k(Result.flatMap(p -> FileWrite.delete(p), c(file)))
+            def mkDir(d, k)                 = k(Result.flatMap(p -> FileWrite.mkDir(p), c(d)))
+            def mkDirs(d, k)                = k(Result.flatMap(p -> FileWrite.mkDirs(p), c(d)))
+            def mkTempDir(_prefix, k)       = k(Err(IoError(ErrorKind.PermissionDenied, "mkTempDir is not permitted inside a chroot")))
         }
 
     ///
@@ -202,18 +208,18 @@ pub mod Fs.FileWrite {
         use IoError.ErrorKind;
         let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
         run { f() } with handler FileWrite {
-            def write(data, file, k)       = k(Result.flatMap(p -> FileWrite.write(data, p), c(file)))
-            def writeLines(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeLines(data, p), c(file)))
-            def writeBytes(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeBytes(data, p), c(file)))
-            def append(data, file, k)      = k(Result.flatMap(p -> FileWrite.append(data, p), c(file)))
-            def appendLines(data, file, k) = k(Result.flatMap(p -> FileWrite.appendLines(data, p), c(file)))
-            def appendBytes(data, file, k) = k(Result.flatMap(p -> FileWrite.appendBytes(data, p), c(file)))
-            def truncate(file, k)          = k(Result.flatMap(p -> FileWrite.truncate(p), c(file)))
-            def move(src, dst, k)          = k(Result.flatMap(s -> Result.flatMap(d -> FileWrite.move(src = s, d), c(dst)), c(src#src)))
-            def delete(file, k)            = k(Result.flatMap(p -> FileWrite.delete(p), c(file)))
-            def mkDir(d, k)                = k(Result.flatMap(p -> FileWrite.mkDir(p), c(d)))
-            def mkDirs(d, k)               = k(Result.flatMap(p -> FileWrite.mkDirs(p), c(d)))
-            def mkTempDir(_prefix, k)      = k(Err(IoError(ErrorKind.PermissionDenied, "mkTempDir is not permitted with an allow list")))
+            def write(data, file, k)        = k(Result.flatMap(p -> FileWrite.write(data, p), c(file)))
+            def writeLines(data, file, k)   = k(Result.flatMap(p -> FileWrite.writeLines(data, p), c(file)))
+            def writeBytes(data, file, k)   = k(Result.flatMap(p -> FileWrite.writeBytes(data, p), c(file)))
+            def append(data, file, k)       = k(Result.flatMap(p -> FileWrite.append(data, p), c(file)))
+            def appendLines(data, file, k)  = k(Result.flatMap(p -> FileWrite.appendLines(data, p), c(file)))
+            def appendBytes(data, file, k)  = k(Result.flatMap(p -> FileWrite.appendBytes(data, p), c(file)))
+            def truncate(file, k)           = k(Result.flatMap(p -> FileWrite.truncate(p), c(file)))
+            def moveWith(src, dst, opts, k) = k(Result.flatMap(s -> Result.flatMap(d -> FileWrite.moveWith(src = s, d, opts), c(dst)), c(src#src)))
+            def delete(file, k)             = k(Result.flatMap(p -> FileWrite.delete(p), c(file)))
+            def mkDir(d, k)                 = k(Result.flatMap(p -> FileWrite.mkDir(p), c(d)))
+            def mkDirs(d, k)                = k(Result.flatMap(p -> FileWrite.mkDirs(p), c(d)))
+            def mkTempDir(_prefix, k)       = k(Err(IoError(ErrorKind.PermissionDenied, "mkTempDir is not permitted with an allow list")))
         }
 
     ///
@@ -226,18 +232,18 @@ pub mod Fs.FileWrite {
     pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileWrite) + FileWrite =
         let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
         run { f() } with handler FileWrite {
-            def write(data, file, k)       = k(Result.flatMap(p -> FileWrite.write(data, p), c(file)))
-            def writeLines(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeLines(data, p), c(file)))
-            def writeBytes(data, file, k)  = k(Result.flatMap(p -> FileWrite.writeBytes(data, p), c(file)))
-            def append(data, file, k)      = k(Result.flatMap(p -> FileWrite.append(data, p), c(file)))
-            def appendLines(data, file, k) = k(Result.flatMap(p -> FileWrite.appendLines(data, p), c(file)))
-            def appendBytes(data, file, k) = k(Result.flatMap(p -> FileWrite.appendBytes(data, p), c(file)))
-            def truncate(file, k)          = k(Result.flatMap(p -> FileWrite.truncate(p), c(file)))
-            def move(src, dst, k)          = k(Result.flatMap(s -> Result.flatMap(d -> FileWrite.move(src = s, d), c(dst)), c(src#src)))
-            def delete(file, k)            = k(Result.flatMap(p -> FileWrite.delete(p), c(file)))
-            def mkDir(d, k)                = k(Result.flatMap(p -> FileWrite.mkDir(p), c(d)))
-            def mkDirs(d, k)               = k(Result.flatMap(p -> FileWrite.mkDirs(p), c(d)))
-            def mkTempDir(prefix, k)       = k(FileWrite.mkTempDir(prefix))
+            def write(data, file, k)        = k(Result.flatMap(p -> FileWrite.write(data, p), c(file)))
+            def writeLines(data, file, k)   = k(Result.flatMap(p -> FileWrite.writeLines(data, p), c(file)))
+            def writeBytes(data, file, k)   = k(Result.flatMap(p -> FileWrite.writeBytes(data, p), c(file)))
+            def append(data, file, k)       = k(Result.flatMap(p -> FileWrite.append(data, p), c(file)))
+            def appendLines(data, file, k)  = k(Result.flatMap(p -> FileWrite.appendLines(data, p), c(file)))
+            def appendBytes(data, file, k)  = k(Result.flatMap(p -> FileWrite.appendBytes(data, p), c(file)))
+            def truncate(file, k)           = k(Result.flatMap(p -> FileWrite.truncate(p), c(file)))
+            def moveWith(src, dst, opts, k) = k(Result.flatMap(s -> Result.flatMap(d -> FileWrite.moveWith(src = s, d, opts), c(dst)), c(src#src)))
+            def delete(file, k)             = k(Result.flatMap(p -> FileWrite.delete(p), c(file)))
+            def mkDir(d, k)                 = k(Result.flatMap(p -> FileWrite.mkDir(p), c(d)))
+            def mkDirs(d, k)                = k(Result.flatMap(p -> FileWrite.mkDirs(p), c(d)))
+            def mkTempDir(prefix, k)        = k(FileWrite.mkTempDir(prefix))
         }
 
     ///
@@ -278,7 +284,7 @@ pub mod Fs.FileWrite {
                 Logger.log(Severity.Debug, tag + text(" ") + bold("truncate") + text(" ") + cyan(file));
                 k(Ok(()))
             }
-            def move(src, dst, k) = {
+            def moveWith(src, dst, _opts, k) = {
                 Logger.log(Severity.Debug, tag + text(" ") + bold("move") + text(" ") + cyan(src#src) + gray(" -> ") + cyan(dst));
                 k(Ok(()))
             }
@@ -310,18 +316,18 @@ pub mod Fs.FileWrite {
         use IoError.ErrorKind;
         let denied = op -> Err(IoError(ErrorKind.PermissionDenied, "read-only: ${op} is not permitted"));
         run { f() } with handler FileWrite {
-            def write(_data, _file, k)       = k(denied("write"))
-            def writeLines(_data, _file, k)  = k(denied("writeLines"))
-            def writeBytes(_data, _file, k)  = k(denied("writeBytes"))
-            def append(_data, _file, k)      = k(denied("append"))
-            def appendLines(_data, _file, k) = k(denied("appendLines"))
-            def appendBytes(_data, _file, k) = k(denied("appendBytes"))
-            def truncate(_file, k)           = k(denied("truncate"))
-            def move(_src, _dst, k)          = k(denied("move"))
-            def delete(_file, k)             = k(denied("delete"))
-            def mkDir(_d, k)                 = k(denied("mkDir"))
-            def mkDirs(_d, k)                = k(denied("mkDirs"))
-            def mkTempDir(_prefix, k)        = k(Err(IoError(ErrorKind.PermissionDenied, "read-only: mkTempDir is not permitted")))
+            def write(_data, _file, k)         = k(denied("write"))
+            def writeLines(_data, _file, k)    = k(denied("writeLines"))
+            def writeBytes(_data, _file, k)    = k(denied("writeBytes"))
+            def append(_data, _file, k)        = k(denied("append"))
+            def appendLines(_data, _file, k)   = k(denied("appendLines"))
+            def appendBytes(_data, _file, k)   = k(denied("appendBytes"))
+            def truncate(_file, k)             = k(denied("truncate"))
+            def moveWith(_src, _dst, _opts, k) = k(denied("move"))
+            def delete(_file, k)               = k(denied("delete"))
+            def mkDir(_d, k)                   = k(denied("mkDir"))
+            def mkDirs(_d, k)                  = k(denied("mkDirs"))
+            def mkTempDir(_prefix, k)          = k(Err(IoError(ErrorKind.PermissionDenied, "read-only: mkTempDir is not permitted")))
         }
 
 }

--- a/main/src/library/Fs/FsLayer.flix
+++ b/main/src/library/Fs/FsLayer.flix
@@ -33,6 +33,7 @@ mod Fs.FsLayer {
     import java.nio.file.Path
     import java.nio.file.Paths
     import java.nio.file.CopyOption
+    import java.nio.file.StandardCopyOption
     import java.nio.file.FileSystems
     import java.nio.file.FileVisitOption
     import java.nio.file.NoSuchFileException
@@ -335,15 +336,22 @@ mod Fs.FsLayer {
 
     // ─── Move operation ────────────────────────────────────────────────
 
-    pub def move(src: {src = String}, dst: String): Result[IoError, Unit] \ IO =
+    pub def moveWith(src: {src = String}, dst: String, opts: Set[Fs.MoveOption]): Result[IoError, Unit] \ IO =
         try {
-            discard Files.move(Paths.get(src#src), Paths.get(dst), (...{}: Vector[CopyOption]));
+            let copyOpts: Vector[CopyOption] = Set.foldLeft((acc, opt) -> match opt {
+                case Fs.MoveOption.AtomicMove      => Vector.append(acc, Vector#{checked_cast(StandardCopyOption.ATOMIC_MOVE)})
+                case Fs.MoveOption.ReplaceExisting => Vector.append(acc, Vector#{checked_cast(StandardCopyOption.REPLACE_EXISTING)})
+            }, (Vector#{}: Vector[CopyOption]), opts);
+            discard Files.move(Paths.get(src#src), Paths.get(dst), copyOpts);
             Ok(())
         } catch {
             case ex: InvalidPathException       => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
             case ex: FileAlreadyExistsException => Err(IoError(ErrorKind.AlreadyExists, ex.getMessage()))
             case ex: IOException                => Err(IoError(ErrorKind.Other, ex.getMessage()))
         }
+
+    pub def move(src: {src = String}, dst: String): Result[IoError, Unit] \ IO =
+        moveWith(src, dst, Set.empty())
 
     // ─── Delete operation ────────────────────────────────────────────────
 

--- a/main/src/library/Fs/MoveFile.flix
+++ b/main/src/library/Fs/MoveFile.flix
@@ -17,6 +17,13 @@
 pub mod Fs.MoveFile {
 
     use Fs.FileWrite
+    use Fs.MoveFile
+
+    ///
+    /// Convenience function: moves `src` to `dst` with no options.
+    ///
+    pub def move(src: {src = String}, dst: String): Result[IoError, Unit] \ MoveFile =
+        Fs.MoveFile.moveWith(src, dst, Set.empty())
 
     ///
     /// Handles the `MoveFile` effect of the given function `f`.
@@ -25,7 +32,7 @@ pub mod Fs.MoveFile {
     ///
     pub def handle(f: a -> b \ ef): a -> b \ (ef - MoveFile) + IO = x ->
         run { f(x) } with handler MoveFile {
-            def move(src, dst, k) = k(Fs.FsLayer.move(src, dst))
+            def moveWith(src, dst, opts, k) = k(Fs.FsLayer.moveWith(src, dst, opts))
         }
 
     ///
@@ -41,7 +48,7 @@ pub mod Fs.MoveFile {
     ///
     pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - MoveFile) + FileWrite = x ->
         run { f(x) } with handler MoveFile {
-            def move(src, dst, k) = k(Fs.FileWrite.move(src, dst))
+            def moveWith(src, dst, opts, k) = k(Fs.FileWrite.moveWith(src, dst, opts))
         }
 
 }


### PR DESCRIPTION
## Summary
- Add `Fs.MoveOption` enum (`AtomicMove`, `ReplaceExisting`) mapping to Java's `StandardCopyOption`
- Replace `move` effect operation with `moveWith(src, dst, opts: Set[MoveOption])` across `MoveFile`, `FileWrite`, and `FileSystem` effects
- Retain backward-compatible `move` convenience functions that delegate with `Set.empty()`
- Update all handlers and middleware (logging, baseDir, chroot, allowList, denyList, dryRun, readOnly) to pass through the new `opts` parameter

## Test plan
- [x] Verified `Fs.FileSystem.move(src, dst)` convenience works (backward compat)
- [x] Verified `Fs.FileSystem.moveWith(src, dst, Set#{AtomicMove, ReplaceExisting})` compiles and runs
- [x] Test atomic move behavior on supported filesystems
- [x] Test ReplaceExisting overwrites destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)