### PR TITLE
feat: add withAtomicWrite middleware for Fs effect hierarchy

### DIFF
--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -559,4 +559,53 @@ pub mod Fs.FileSystem {
             def mkTempDir(_prefix, k)           = k(Err(IoError(ErrorKind.PermissionDenied, "read-only: mkTempDir is not permitted")))
         }
 
+    ///
+    /// Middleware that intercepts the `FileSystem` effect, making `write`,
+    /// `writeLines`, and `writeBytes` atomic. Data is first written to a
+    /// temporary file in the same directory, then atomically moved into place.
+    /// On failure the temporary file is cleaned up.
+    ///
+    /// All other operations (read, stat, test, list, glob, append, truncate,
+    /// copy, move, delete, mkdir) are passed through unchanged.
+    ///
+    pub def withAtomicWrite(f: Unit -> a \ ef): a \ (ef - FileSystem) + FileSystem =
+        let mv  = (tmp, dst) -> FileSystem.moveWith(src = tmp, dst, Set#{Fs.MoveOption.AtomicMove, Fs.MoveOption.ReplaceExisting});
+        let del = tmp -> FileSystem.delete(tmp);
+        run { f() } with handler FileSystem {
+            // Read/stat/test ops — pass through
+            def exists(filename, k)           = k(FileSystem.exists(filename))
+            def isDirectory(filename, k)      = k(FileSystem.isDirectory(filename))
+            def isRegularFile(filename, k)    = k(FileSystem.isRegularFile(filename))
+            def isSymbolicLink(filename, k)   = k(FileSystem.isSymbolicLink(filename))
+            def isReadable(filename, k)       = k(FileSystem.isReadable(filename))
+            def isWritable(filename, k)       = k(FileSystem.isWritable(filename))
+            def isExecutable(filename, k)     = k(FileSystem.isExecutable(filename))
+            def accessTime(filename, k)       = k(FileSystem.accessTime(filename))
+            def creationTime(filename, k)     = k(FileSystem.creationTime(filename))
+            def modificationTime(filename, k) = k(FileSystem.modificationTime(filename))
+            def size(filename, k)             = k(FileSystem.size(filename))
+            def read(filename, k)             = k(FileSystem.read(filename))
+            def readLines(filename, k)        = k(FileSystem.readLines(filename))
+            def readBytes(filename, k)        = k(FileSystem.readBytes(filename))
+            def list(filename, k)             = k(FileSystem.list(filename))
+            def glob(base, pattern, k)        = k(FileSystem.glob(base, pattern))
+
+            // Overwrite ops — atomic write-to-temp then rename
+            def write(data, file, k)          = k(Fs.FsLayer.atomicWrite(file, tmp -> FileSystem.write(data, tmp), mv, del))
+            def writeLines(data, file, k)     = k(Fs.FsLayer.atomicWrite(file, tmp -> FileSystem.writeLines(data, tmp), mv, del))
+            def writeBytes(data, file, k)     = k(Fs.FsLayer.atomicWrite(file, tmp -> FileSystem.writeBytes(data, tmp), mv, del))
+
+            // Other write ops — pass through
+            def append(data, file, k)         = k(FileSystem.append(data, file))
+            def appendLines(data, file, k)    = k(FileSystem.appendLines(data, file))
+            def appendBytes(data, file, k)    = k(FileSystem.appendBytes(data, file))
+            def truncate(file, k)             = k(FileSystem.truncate(file))
+            def copyWith(src, dst, opts, k)   = k(FileSystem.copyWith(src, dst, opts))
+            def moveWith(src, dst, opts, k)   = k(FileSystem.moveWith(src, dst, opts))
+            def delete(file, k)               = k(FileSystem.delete(file))
+            def mkDir(d, k)                   = k(FileSystem.mkDir(d))
+            def mkDirs(d, k)                  = k(FileSystem.mkDirs(d))
+            def mkTempDir(prefix, k)          = k(FileSystem.mkTempDir(prefix))
+        }
+
 }

--- a/main/src/library/Fs/FileWrite.flix
+++ b/main/src/library/Fs/FileWrite.flix
@@ -352,4 +352,32 @@ pub mod Fs.FileWrite {
             def mkTempDir(_prefix, k)          = k(Err(IoError(ErrorKind.PermissionDenied, "read-only: mkTempDir is not permitted")))
         }
 
+    ///
+    /// Middleware that intercepts the `FileWrite` effect, making `write`,
+    /// `writeLines`, and `writeBytes` atomic. Data is first written to a
+    /// temporary file in the same directory, then atomically moved into place.
+    /// On failure the temporary file is cleaned up.
+    ///
+    /// All other operations (append, truncate, copy, move, delete, mkdir) are
+    /// passed through unchanged.
+    ///
+    pub def withAtomicWrite(f: Unit -> a \ ef): a \ (ef - FileWrite) + FileWrite =
+        let mv  = (tmp, dst) -> FileWrite.moveWith(src = tmp, dst, Set#{Fs.MoveOption.AtomicMove, Fs.MoveOption.ReplaceExisting});
+        let del = tmp -> FileWrite.delete(tmp);
+        run { f() } with handler FileWrite {
+            def write(data, file, k)        = k(Fs.FsLayer.atomicWrite(file, tmp -> FileWrite.write(data, tmp), mv, del))
+            def writeLines(data, file, k)   = k(Fs.FsLayer.atomicWrite(file, tmp -> FileWrite.writeLines(data, tmp), mv, del))
+            def writeBytes(data, file, k)   = k(Fs.FsLayer.atomicWrite(file, tmp -> FileWrite.writeBytes(data, tmp), mv, del))
+            def append(data, file, k)       = k(FileWrite.append(data, file))
+            def appendLines(data, file, k)  = k(FileWrite.appendLines(data, file))
+            def appendBytes(data, file, k)  = k(FileWrite.appendBytes(data, file))
+            def truncate(file, k)           = k(FileWrite.truncate(file))
+            def copyWith(src, dst, opts, k) = k(FileWrite.copyWith(src, dst, opts))
+            def moveWith(src, dst, opts, k) = k(FileWrite.moveWith(src, dst, opts))
+            def delete(file, k)             = k(FileWrite.delete(file))
+            def mkDir(d, k)                 = k(FileWrite.mkDir(d))
+            def mkDirs(d, k)                = k(FileWrite.mkDirs(d))
+            def mkTempDir(prefix, k)        = k(FileWrite.mkTempDir(prefix))
+        }
+
 }

--- a/main/src/library/Fs/FsLayer.flix
+++ b/main/src/library/Fs/FsLayer.flix
@@ -40,6 +40,7 @@ mod Fs.FsLayer {
     import java.nio.file.PathMatcher
     import java.nio.file.StandardOpenOption
     import java.util.stream.BaseStream
+    import java.util.UUID
     import java.util.stream.Stream
 
     use IoError.IoError
@@ -489,6 +490,50 @@ mod Fs.FsLayer {
                     "Path '${path}' is within a denied directory"))
             else
                 Ok(resolved.toString())
+        }
+
+    // ─── Atomic write helper ────────────────────────────────────────────
+
+    ///
+    /// Performs an atomic write to `file` by writing to a temporary sibling path
+    /// first, then atomically moving it into place.
+    ///
+    /// - `doWrite(tmp)` writes data to the temporary path.
+    /// - `doMoveAtomic(tmp, file)` atomically moves the temp file to the target.
+    /// - `doDelete(tmp)` cleans up the temp file on failure.
+    ///
+    /// The caller supplies these as effect operations so that this helper works
+    /// with any effect (`FileWrite`, `FileSystem`, etc.).
+    ///
+    pub def atomicWrite(
+        file: String,
+        doWrite: String -> Result[IoError, Unit] \ ef,
+        doMoveAtomic: String -> String -> Result[IoError, Unit] \ ef,
+        doDelete: String -> Result[IoError, Unit] \ ef
+    ): Result[IoError, Unit] \ ef =
+        let tmp = tempPathFor(file);
+        match doWrite(tmp) {
+            case Ok(_) => match doMoveAtomic(tmp, file) {
+                case Ok(_)  => Ok(())
+                case Err(e) => { discard doDelete(tmp); Err(e) }
+            }
+            case Err(e) => { discard doDelete(tmp); Err(e) }
+        }
+
+    ///
+    /// Generates a unique temporary file path in the same directory as `target`.
+    ///
+    /// Uses UUID for uniqueness. The result is a sibling of `target` with the
+    /// pattern `.~atomic~<name>.<uuid>.tmp`.
+    ///
+    def tempPathFor(target: String): String =
+        unsafe IO {
+            let path = Paths.get(target);
+            let parent = path.getParent();
+            let parentDir = if (Object.isNull(parent)) Paths.get(".") else parent;
+            let name = path.getFileName().toString();
+            let uuid = UUID.randomUUID().toString();
+            parentDir.resolve(".~atomic~${name}.${uuid}.tmp").toString()
         }
 
     // ─── Private helper ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `withAtomicWrite` middleware to both `FileWrite` and `FileSystem` effects that makes `write`, `writeLines`, and `writeBytes` crash-safe by writing to a temp file first, then atomically renaming it into place
- Introduces `FsLayer.atomicWrite` higher-order helper that encapsulates the write-to-temp/atomic-move/cleanup-on-failure logic, keeping both handler implementations concise and DRY
- All other operations (read, stat, test, list, glob, append, truncate, copy, move, delete, mkdir) pass through unchanged

## Test plan
- [x] Verify `withAtomicWrite` compiles and runs via `Fs.FileSystem.write` + `Fs.FileSystem.read` roundtrip
- [x] Verify no `.~atomic~*.tmp` files are left behind after successful writes
- [x] Verify temp file cleanup on write failure (e.g. write to non-existent directory)
- [x] Verify pass-through ops (append, delete, etc.) still work normally under `withAtomicWrite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)