### PR TITLE
feat: add withBackup middleware for Fs effect hierarchy

### DIFF
--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -608,4 +608,62 @@ pub mod Fs.FileSystem {
             def mkTempDir(prefix, k)          = k(FileSystem.mkTempDir(prefix))
         }
 
+    ///
+    /// Middleware that intercepts the `FileSystem` effect, creating a backup
+    /// of existing files before destructive operations. Before `write`,
+    /// `writeLines`, `writeBytes`, `truncate`, and `delete`, the existing
+    /// file is copied to `file + suffix` (e.g., `"data.txt.bak"` when
+    /// suffix is `".bak"`).
+    ///
+    /// For `copyWith` and `moveWith`, the destination file is backed up.
+    ///
+    /// If the file does not exist, no backup is created and the operation
+    /// proceeds normally. If the backup fails for any other reason, the
+    /// original operation is aborted and the backup error is returned.
+    ///
+    /// If a backup file already exists, it is overwritten. Only the most
+    /// recent previous version of each file is preserved.
+    ///
+    /// Read, stat, test, list, glob, append, mkdir, and mkTempDir operations
+    /// are passed through unchanged.
+    ///
+    pub def withBackup(suffix: String, f: Unit -> a \ ef): a \ (ef - FileSystem) + FileSystem =
+        let doCopy = (src, dst) -> FileSystem.copyWith(src = src, dst, Set#{Fs.CopyOption.ReplaceExisting});
+        run { f() } with handler FileSystem {
+            // Read/stat/test ops — pass through
+            def exists(filename, k)           = k(FileSystem.exists(filename))
+            def isDirectory(filename, k)      = k(FileSystem.isDirectory(filename))
+            def isRegularFile(filename, k)    = k(FileSystem.isRegularFile(filename))
+            def isSymbolicLink(filename, k)   = k(FileSystem.isSymbolicLink(filename))
+            def isReadable(filename, k)       = k(FileSystem.isReadable(filename))
+            def isWritable(filename, k)       = k(FileSystem.isWritable(filename))
+            def isExecutable(filename, k)     = k(FileSystem.isExecutable(filename))
+            def accessTime(filename, k)       = k(FileSystem.accessTime(filename))
+            def creationTime(filename, k)     = k(FileSystem.creationTime(filename))
+            def modificationTime(filename, k) = k(FileSystem.modificationTime(filename))
+            def size(filename, k)             = k(FileSystem.size(filename))
+            def read(filename, k)             = k(FileSystem.read(filename))
+            def readLines(filename, k)        = k(FileSystem.readLines(filename))
+            def readBytes(filename, k)        = k(FileSystem.readBytes(filename))
+            def list(filename, k)             = k(FileSystem.list(filename))
+            def glob(base, pattern, k)        = k(FileSystem.glob(base, pattern))
+
+            // Destructive ops — backup then proceed
+            def write(data, file, k)          = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileSystem.write(data, file)))
+            def writeLines(data, file, k)     = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileSystem.writeLines(data, file)))
+            def writeBytes(data, file, k)     = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileSystem.writeBytes(data, file)))
+            def truncate(file, k)             = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileSystem.truncate(file)))
+            def delete(file, k)               = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileSystem.delete(file)))
+            def copyWith(src, dst, opts, k)   = k(Fs.FsLayer.backup(dst, suffix, doCopy, () -> FileSystem.copyWith(src, dst, opts)))
+            def moveWith(src, dst, opts, k)   = k(Fs.FsLayer.backup(dst, suffix, doCopy, () -> FileSystem.moveWith(src, dst, opts)))
+
+            // Non-destructive write ops — pass through
+            def append(data, file, k)         = k(FileSystem.append(data, file))
+            def appendLines(data, file, k)    = k(FileSystem.appendLines(data, file))
+            def appendBytes(data, file, k)    = k(FileSystem.appendBytes(data, file))
+            def mkDir(d, k)                   = k(FileSystem.mkDir(d))
+            def mkDirs(d, k)                  = k(FileSystem.mkDirs(d))
+            def mkTempDir(prefix, k)          = k(FileSystem.mkTempDir(prefix))
+        }
+
 }

--- a/main/src/library/Fs/FileWrite.flix
+++ b/main/src/library/Fs/FileWrite.flix
@@ -380,4 +380,40 @@ pub mod Fs.FileWrite {
             def mkTempDir(prefix, k)        = k(FileWrite.mkTempDir(prefix))
         }
 
+    ///
+    /// Middleware that intercepts the `FileWrite` effect, creating a backup
+    /// of existing files before destructive operations. Before `write`,
+    /// `writeLines`, `writeBytes`, `truncate`, and `delete`, the existing
+    /// file is copied to `file + suffix` (e.g., `"data.txt.bak"` when
+    /// suffix is `".bak"`).
+    ///
+    /// For `copyWith` and `moveWith`, the destination file is backed up.
+    ///
+    /// If the file does not exist, no backup is created and the operation
+    /// proceeds normally. If the backup fails for any other reason, the
+    /// original operation is aborted and the backup error is returned.
+    ///
+    /// If a backup file already exists, it is overwritten. Only the most
+    /// recent previous version of each file is preserved.
+    ///
+    /// Append, mkdir, and mkTempDir operations are passed through unchanged.
+    ///
+    pub def withBackup(suffix: String, f: Unit -> a \ ef): a \ (ef - FileWrite) + FileWrite =
+        let doCopy = (src, dst) -> FileWrite.copyWith(src = src, dst, Set#{Fs.CopyOption.ReplaceExisting});
+        run { f() } with handler FileWrite {
+            def write(data, file, k)        = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileWrite.write(data, file)))
+            def writeLines(data, file, k)   = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileWrite.writeLines(data, file)))
+            def writeBytes(data, file, k)   = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileWrite.writeBytes(data, file)))
+            def truncate(file, k)           = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileWrite.truncate(file)))
+            def delete(file, k)             = k(Fs.FsLayer.backup(file, suffix, doCopy, () -> FileWrite.delete(file)))
+            def copyWith(src, dst, opts, k) = k(Fs.FsLayer.backup(dst, suffix, doCopy, () -> FileWrite.copyWith(src, dst, opts)))
+            def moveWith(src, dst, opts, k) = k(Fs.FsLayer.backup(dst, suffix, doCopy, () -> FileWrite.moveWith(src, dst, opts)))
+            def append(data, file, k)       = k(FileWrite.append(data, file))
+            def appendLines(data, file, k)  = k(FileWrite.appendLines(data, file))
+            def appendBytes(data, file, k)  = k(FileWrite.appendBytes(data, file))
+            def mkDir(d, k)                 = k(FileWrite.mkDir(d))
+            def mkDirs(d, k)                = k(FileWrite.mkDirs(d))
+            def mkTempDir(prefix, k)        = k(FileWrite.mkTempDir(prefix))
+        }
+
 }

--- a/main/src/library/Fs/FsLayer.flix
+++ b/main/src/library/Fs/FsLayer.flix
@@ -348,6 +348,7 @@ mod Fs.FsLayer {
         } catch {
             case ex: InvalidPathException       => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
             case ex: FileAlreadyExistsException => Err(IoError(ErrorKind.AlreadyExists, ex.getMessage()))
+            case ex: NoSuchFileException        => Err(IoError(ErrorKind.NotFound, ex.getMessage()))
             case ex: IOException                => Err(IoError(ErrorKind.Other, ex.getMessage()))
         }
 
@@ -367,6 +368,7 @@ mod Fs.FsLayer {
         } catch {
             case ex: InvalidPathException       => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
             case ex: FileAlreadyExistsException => Err(IoError(ErrorKind.AlreadyExists, ex.getMessage()))
+            case ex: NoSuchFileException        => Err(IoError(ErrorKind.NotFound, ex.getMessage()))
             case ex: IOException                => Err(IoError(ErrorKind.Other, ex.getMessage()))
         }
 
@@ -534,6 +536,30 @@ mod Fs.FsLayer {
             let name = path.getFileName().toString();
             let uuid = UUID.randomUUID().toString();
             parentDir.resolve(".~atomic~${name}.${uuid}.tmp").toString()
+        }
+
+    // ─── Backup helper ───────────────────────────────────────────────
+
+    ///
+    /// Performs a backup of `file` to `file + suffix` before executing `doAction`.
+    ///
+    /// - `doCopy(file, bak)` copies the file to the backup path.
+    /// - If the copy succeeds, `doAction()` is executed.
+    /// - If the copy fails with `NotFound`, the file doesn't exist yet, so
+    ///   `doAction()` proceeds without backup.
+    /// - If the copy fails with any other error, the operation is aborted.
+    ///
+    pub def backup(
+        file: String,
+        suffix: String,
+        doCopy: String -> String -> Result[IoError, Unit] \ ef,
+        doAction: Unit -> Result[IoError, a] \ ef
+    ): Result[IoError, a] \ ef =
+        let bak = file + suffix;
+        match doCopy(file, bak) {
+            case Ok(_)                              => doAction()
+            case Err(IoError(ErrorKind.NotFound, _)) => doAction()
+            case Err(e)                             => Err(e)
         }
 
     // ─── Private helper ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `withBackup` middleware to `FileWrite` and `FileSystem` that creates a backup copy (e.g., `file.bak`) of existing files before destructive operations (`write`, `writeLines`, `writeBytes`, `truncate`, `delete`, `copyWith`, `moveWith`). Non-destructive operations (`append*`, `mkDir*`, `mkTempDir`) pass through unchanged.
- Add `FsLayer.backup` effect-polymorphic helper that powers both middleware, following the same callback pattern as `atomicWrite`.
- Fix `FsLayer.copyWith` and `FsLayer.moveWith` to map `NoSuchFileException` to `ErrorKind.NotFound` (consistent with `delete`) instead of the generic `ErrorKind.Other`.

## Test plan
- [x] Run `./mill flix.run foo.flix` smoke test: first write proceeds without backup (file doesn't exist), second write creates `.bak` with previous content
- [x] Verify backup is skipped gracefully when file doesn't exist yet (no error)
- [x] Verify backup failure (e.g., permission denied) aborts the original operation
- [x] Verify `copyWith`/`moveWith` now return `ErrorKind.NotFound` for missing source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)