### PR TITLE
feat: add path-security middleware for DirList, Glob, FilePermission, FileTime

### DIFF
--- a/main/src/library/Fs/DirList.flix
+++ b/main/src/library/Fs/DirList.flix
@@ -56,4 +56,37 @@ pub mod Fs.DirList {
             def list(filename, k) = k(DirList.list(r(filename)))
         }
 
+    ///
+    /// Middleware that intercepts the `DirList` effect, validating that all file paths
+    /// resolve within the given `chrootDir`. Rejects paths that escape the chroot with
+    /// a `PermissionDenied` error.
+    ///
+    pub def withChroot(chrootDir: String, f: Unit -> a \ ef): a \ (ef - DirList) + DirList =
+        let c = p -> Fs.FsLayer.chroot(chrootDir, p);
+        run { f() } with handler DirList {
+            def list(filename, k) = k(Result.flatMap(p -> DirList.list(p), c(filename)))
+        }
+
+    ///
+    /// Middleware that intercepts the `DirList` effect, validating that all file paths
+    /// resolve within one of the given `allowedDirs`. Rejects paths outside the
+    /// allow list with a `PermissionDenied` error.
+    ///
+    pub def withAllowList(allowedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - DirList) + DirList =
+        let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
+        run { f() } with handler DirList {
+            def list(filename, k) = k(Result.flatMap(p -> DirList.list(p), c(filename)))
+        }
+
+    ///
+    /// Middleware that intercepts the `DirList` effect, validating that all file paths
+    /// do not resolve within any of the given `deniedDirs`. Rejects paths inside a
+    /// denied directory with a `PermissionDenied` error.
+    ///
+    pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - DirList) + DirList =
+        let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
+        run { f() } with handler DirList {
+            def list(filename, k) = k(Result.flatMap(p -> DirList.list(p), c(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FilePermission.flix
+++ b/main/src/library/Fs/FilePermission.flix
@@ -96,4 +96,43 @@ pub mod Fs.FilePermission {
             def isExecutable(filename, k) = k(FilePermission.isExecutable(r(filename)))
         }
 
+    ///
+    /// Middleware that intercepts the `FilePermission` effect, validating that all file paths
+    /// resolve within the given `chrootDir`. Rejects paths that escape the chroot with
+    /// a `PermissionDenied` error.
+    ///
+    pub def withChroot(chrootDir: String, f: Unit -> a \ ef): a \ (ef - FilePermission) + FilePermission =
+        let c = p -> Fs.FsLayer.chroot(chrootDir, p);
+        run { f() } with handler FilePermission {
+            def isReadable(filename, k)   = k(Result.flatMap(p -> FilePermission.isReadable(p), c(filename)))
+            def isWritable(filename, k)   = k(Result.flatMap(p -> FilePermission.isWritable(p), c(filename)))
+            def isExecutable(filename, k) = k(Result.flatMap(p -> FilePermission.isExecutable(p), c(filename)))
+        }
+
+    ///
+    /// Middleware that intercepts the `FilePermission` effect, validating that all file paths
+    /// resolve within one of the given `allowedDirs`. Rejects paths outside the
+    /// allow list with a `PermissionDenied` error.
+    ///
+    pub def withAllowList(allowedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FilePermission) + FilePermission =
+        let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
+        run { f() } with handler FilePermission {
+            def isReadable(filename, k)   = k(Result.flatMap(p -> FilePermission.isReadable(p), c(filename)))
+            def isWritable(filename, k)   = k(Result.flatMap(p -> FilePermission.isWritable(p), c(filename)))
+            def isExecutable(filename, k) = k(Result.flatMap(p -> FilePermission.isExecutable(p), c(filename)))
+        }
+
+    ///
+    /// Middleware that intercepts the `FilePermission` effect, validating that all file paths
+    /// do not resolve within any of the given `deniedDirs`. Rejects paths inside a
+    /// denied directory with a `PermissionDenied` error.
+    ///
+    pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FilePermission) + FilePermission =
+        let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
+        run { f() } with handler FilePermission {
+            def isReadable(filename, k)   = k(Result.flatMap(p -> FilePermission.isReadable(p), c(filename)))
+            def isWritable(filename, k)   = k(Result.flatMap(p -> FilePermission.isWritable(p), c(filename)))
+            def isExecutable(filename, k) = k(Result.flatMap(p -> FilePermission.isExecutable(p), c(filename)))
+        }
+
 }

--- a/main/src/library/Fs/FileTime.flix
+++ b/main/src/library/Fs/FileTime.flix
@@ -96,4 +96,43 @@ pub mod Fs.FileTime {
             def modificationTime(filename, k) = k(FileTime.modificationTime(r(filename)))
         }
 
+    ///
+    /// Middleware that intercepts the `FileTime` effect, validating that all file paths
+    /// resolve within the given `chrootDir`. Rejects paths that escape the chroot with
+    /// a `PermissionDenied` error.
+    ///
+    pub def withChroot(chrootDir: String, f: Unit -> a \ ef): a \ (ef - FileTime) + FileTime =
+        let c = p -> Fs.FsLayer.chroot(chrootDir, p);
+        run { f() } with handler FileTime {
+            def accessTime(filename, k)       = k(Result.flatMap(p -> FileTime.accessTime(p), c(filename)))
+            def creationTime(filename, k)     = k(Result.flatMap(p -> FileTime.creationTime(p), c(filename)))
+            def modificationTime(filename, k) = k(Result.flatMap(p -> FileTime.modificationTime(p), c(filename)))
+        }
+
+    ///
+    /// Middleware that intercepts the `FileTime` effect, validating that all file paths
+    /// resolve within one of the given `allowedDirs`. Rejects paths outside the
+    /// allow list with a `PermissionDenied` error.
+    ///
+    pub def withAllowList(allowedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileTime) + FileTime =
+        let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
+        run { f() } with handler FileTime {
+            def accessTime(filename, k)       = k(Result.flatMap(p -> FileTime.accessTime(p), c(filename)))
+            def creationTime(filename, k)     = k(Result.flatMap(p -> FileTime.creationTime(p), c(filename)))
+            def modificationTime(filename, k) = k(Result.flatMap(p -> FileTime.modificationTime(p), c(filename)))
+        }
+
+    ///
+    /// Middleware that intercepts the `FileTime` effect, validating that all file paths
+    /// do not resolve within any of the given `deniedDirs`. Rejects paths inside a
+    /// denied directory with a `PermissionDenied` error.
+    ///
+    pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - FileTime) + FileTime =
+        let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
+        run { f() } with handler FileTime {
+            def accessTime(filename, k)       = k(Result.flatMap(p -> FileTime.accessTime(p), c(filename)))
+            def creationTime(filename, k)     = k(Result.flatMap(p -> FileTime.creationTime(p), c(filename)))
+            def modificationTime(filename, k) = k(Result.flatMap(p -> FileTime.modificationTime(p), c(filename)))
+        }
+
 }

--- a/main/src/library/Fs/Glob.flix
+++ b/main/src/library/Fs/Glob.flix
@@ -56,4 +56,37 @@ pub mod Fs.Glob {
             def glob(base, pattern, k) = k(Glob.glob(r(base), pattern))
         }
 
+    ///
+    /// Middleware that intercepts the `Glob` effect, validating that all base paths
+    /// resolve within the given `chrootDir`. Rejects paths that escape the chroot with
+    /// a `PermissionDenied` error.
+    ///
+    pub def withChroot(chrootDir: String, f: Unit -> a \ ef): a \ (ef - Glob) + Glob =
+        let c = p -> Fs.FsLayer.chroot(chrootDir, p);
+        run { f() } with handler Glob {
+            def glob(base, pattern, k) = k(Result.flatMap(p -> Glob.glob(p, pattern), c(base)))
+        }
+
+    ///
+    /// Middleware that intercepts the `Glob` effect, validating that all base paths
+    /// resolve within one of the given `allowedDirs`. Rejects paths outside the
+    /// allow list with a `PermissionDenied` error.
+    ///
+    pub def withAllowList(allowedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - Glob) + Glob =
+        let c = p -> Fs.FsLayer.allowList(allowedDirs, p);
+        run { f() } with handler Glob {
+            def glob(base, pattern, k) = k(Result.flatMap(p -> Glob.glob(p, pattern), c(base)))
+        }
+
+    ///
+    /// Middleware that intercepts the `Glob` effect, validating that all base paths
+    /// do not resolve within any of the given `deniedDirs`. Rejects paths inside a
+    /// denied directory with a `PermissionDenied` error.
+    ///
+    pub def withDenyList(deniedDirs: Nel[String], f: Unit -> a \ ef): a \ (ef - Glob) + Glob =
+        let c = p -> Fs.FsLayer.denyList(deniedDirs, p);
+        run { f() } with handler Glob {
+            def glob(base, pattern, k) = k(Result.flatMap(p -> Glob.glob(p, pattern), c(base)))
+        }
+
 }


### PR DESCRIPTION
## Summary
- Add `withChroot`, `withAllowList`, and `withDenyList` middleware to **DirList**, **Glob**, **FilePermission**, and **FileTime** (12 new functions total)
- Closes a security gap where path-restricted sandboxes (e.g. chroot) could be bypassed via these four effects that accept path arguments but lacked path validation
- Follows the exact same pattern already established in FileTest.flix, FileRead.flix, and FileWrite.flix

## Test plan
- [x] Verified `DirList.withChroot` rejects escape paths (`../../secret`) with `PermissionDenied`
- [x] Verified `DirList.withChroot` allows valid paths within the chroot
- [x] Verified `Glob.withAllowList` rejects glob on a disallowed base path
- [x] Verified `FileTime.withDenyList` rejects reading mtime on a denied path
- [x] Verified `FilePermission.withChroot` rejects escape paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)