### PR TITLE
feat: add withMkParentDirs middleware for Fs effect hierarchy

### DIFF
--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -753,6 +753,60 @@ pub mod Fs.FileSystem {
         }
 
     ///
+    /// Middleware that intercepts the `FileSystem` effect, automatically creating
+    /// parent directories before write, append, copy, and move operations.
+    ///
+    /// Before `write`, `writeLines`, `writeBytes`, `append`, `appendLines`,
+    /// `appendBytes`, `copyWith`, and `moveWith`, the parent directory of the
+    /// target file is created via `mkDirs`. If the parent directory already
+    /// exists, this is a no-op.
+    ///
+    /// If parent directory creation fails, the original operation is aborted
+    /// and the error is returned.
+    ///
+    /// Read, stat, test, list, glob, `truncate`, `delete`, `mkDir`, `mkDirs`,
+    /// and `mkTempDir` are passed through unchanged.
+    ///
+    pub def withMkParentDirs(f: Unit -> a \ ef): a \ (ef - FileSystem) + FileSystem =
+        let mk = d -> FileSystem.mkDirs(d);
+        run { f() } with handler FileSystem {
+            // Read/stat/test ops — pass through
+            def exists(filename, k)           = k(FileSystem.exists(filename))
+            def isDirectory(filename, k)      = k(FileSystem.isDirectory(filename))
+            def isRegularFile(filename, k)    = k(FileSystem.isRegularFile(filename))
+            def isSymbolicLink(filename, k)   = k(FileSystem.isSymbolicLink(filename))
+            def isReadable(filename, k)       = k(FileSystem.isReadable(filename))
+            def isWritable(filename, k)       = k(FileSystem.isWritable(filename))
+            def isExecutable(filename, k)     = k(FileSystem.isExecutable(filename))
+            def accessTime(filename, k)       = k(FileSystem.accessTime(filename))
+            def creationTime(filename, k)     = k(FileSystem.creationTime(filename))
+            def modificationTime(filename, k) = k(FileSystem.modificationTime(filename))
+            def size(filename, k)             = k(FileSystem.size(filename))
+            def read(filename, k)             = k(FileSystem.read(filename))
+            def readLines(filename, k)        = k(FileSystem.readLines(filename))
+            def readBytes(filename, k)        = k(FileSystem.readBytes(filename))
+            def list(filename, k)             = k(FileSystem.list(filename))
+            def glob(base, pattern, k)        = k(FileSystem.glob(base, pattern))
+
+            // Write/append/copy/move — ensure parent dirs exist
+            def write(data, file, k)          = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileSystem.write(data, file)))
+            def writeLines(data, file, k)     = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileSystem.writeLines(data, file)))
+            def writeBytes(data, file, k)     = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileSystem.writeBytes(data, file)))
+            def append(data, file, k)         = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileSystem.append(data, file)))
+            def appendLines(data, file, k)    = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileSystem.appendLines(data, file)))
+            def appendBytes(data, file, k)    = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileSystem.appendBytes(data, file)))
+            def copyWith(src, dst, opts, k)   = k(Fs.FsLayer.ensureParentDirs(dst, mk, () -> FileSystem.copyWith(src, dst, opts)))
+            def moveWith(src, dst, opts, k)   = k(Fs.FsLayer.ensureParentDirs(dst, mk, () -> FileSystem.moveWith(src, dst, opts)))
+
+            // Other write ops — pass through
+            def truncate(file, k)             = k(FileSystem.truncate(file))
+            def delete(file, k)               = k(FileSystem.delete(file))
+            def mkDir(d, k)                   = k(FileSystem.mkDir(d))
+            def mkDirs(d, k)                  = k(FileSystem.mkDirs(d))
+            def mkTempDir(prefix, k)          = k(FileSystem.mkTempDir(prefix))
+        }
+
+    ///
     /// Middleware that intercepts the `FileSystem` effect, rejecting read, write,
     /// and append operations where the data exceeds `maxBytes`. For reads and
     /// `copyWith`, the file size is checked via `FileSystem.size`.

--- a/main/src/library/Fs/FileWrite.flix
+++ b/main/src/library/Fs/FileWrite.flix
@@ -472,6 +472,39 @@ pub mod Fs.FileWrite {
         }
 
     ///
+    /// Middleware that intercepts the `FileWrite` effect, automatically creating
+    /// parent directories before write, append, copy, and move operations.
+    ///
+    /// Before `write`, `writeLines`, `writeBytes`, `append`, `appendLines`,
+    /// `appendBytes`, `copyWith`, and `moveWith`, the parent directory of the
+    /// target file is created via `mkDirs`. If the parent directory already
+    /// exists, this is a no-op.
+    ///
+    /// If parent directory creation fails, the original operation is aborted
+    /// and the error is returned.
+    ///
+    /// `truncate`, `delete`, `mkDir`, `mkDirs`, and `mkTempDir` are passed
+    /// through unchanged.
+    ///
+    pub def withMkParentDirs(f: Unit -> a \ ef): a \ (ef - FileWrite) + FileWrite =
+        let mk = d -> FileWrite.mkDirs(d);
+        run { f() } with handler FileWrite {
+            def write(data, file, k)        = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileWrite.write(data, file)))
+            def writeLines(data, file, k)   = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileWrite.writeLines(data, file)))
+            def writeBytes(data, file, k)   = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileWrite.writeBytes(data, file)))
+            def append(data, file, k)       = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileWrite.append(data, file)))
+            def appendLines(data, file, k)  = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileWrite.appendLines(data, file)))
+            def appendBytes(data, file, k)  = k(Fs.FsLayer.ensureParentDirs(file, mk, () -> FileWrite.appendBytes(data, file)))
+            def copyWith(src, dst, opts, k) = k(Fs.FsLayer.ensureParentDirs(dst, mk, () -> FileWrite.copyWith(src, dst, opts)))
+            def moveWith(src, dst, opts, k) = k(Fs.FsLayer.ensureParentDirs(dst, mk, () -> FileWrite.moveWith(src, dst, opts)))
+            def truncate(file, k)           = k(FileWrite.truncate(file))
+            def delete(file, k)             = k(FileWrite.delete(file))
+            def mkDir(d, k)                 = k(FileWrite.mkDir(d))
+            def mkDirs(d, k)                = k(FileWrite.mkDirs(d))
+            def mkTempDir(prefix, k)        = k(FileWrite.mkTempDir(prefix))
+        }
+
+    ///
     /// Middleware that intercepts the `FileWrite` effect, rejecting write and
     /// append operations where the payload exceeds `maxBytes`. For `copyWith`,
     /// the source file size is checked via `FileStat.size`.

--- a/main/src/library/Fs/FsLayer.flix
+++ b/main/src/library/Fs/FsLayer.flix
@@ -630,6 +630,39 @@ mod Fs.FsLayer {
             parentDir.resolve(".~atomic~${name}.${uuid}.tmp").toString()
         }
 
+    // ─── Parent directory helper ────────────────────────────────────────
+
+    ///
+    /// Returns the parent directory of `path`, or `None` if the path has no parent
+    /// (e.g., a bare filename like `"test.txt"`).
+    ///
+    pub def parentDir(path: String): Option[String] =
+        unsafe IO {
+            let parent = Paths.get(path).getParent();
+            if (Object.isNull(parent)) None else Some(parent.toString())
+        }
+
+    ///
+    /// Ensures the parent directory of `file` exists before executing `doAction`.
+    ///
+    /// - If `file` has no parent (bare filename), `doAction()` proceeds directly.
+    /// - If `doMkDirs(parent)` succeeds, `doAction()` proceeds.
+    /// - If `doMkDirs(parent)` fails, the error is returned and `doAction` is
+    ///   not performed.
+    ///
+    pub def ensureParentDirs(
+        file: String,
+        doMkDirs: String -> Result[IoError, Unit] \ ef,
+        doAction: Unit -> Result[IoError, a] \ ef
+    ): Result[IoError, a] \ ef =
+        match parentDir(file) {
+            case None    => doAction()
+            case Some(d) => match doMkDirs(d) {
+                case Ok(_)  => doAction()
+                case Err(e) => Err(e)
+            }
+        }
+
     // ─── Backup helper ───────────────────────────────────────────────
 
     ///


### PR DESCRIPTION
## Summary
- Adds `parentDir` and `ensureParentDirs` helpers to `FsLayer` for extracting and creating parent directories
- Adds `withMkParentDirs` middleware to `FileWrite` and `FileSystem` that automatically creates parent directories before write, append, copy, and move operations
- Pass-through for `truncate`, `delete`, `mkDir`, `mkDirs`, `mkTempDir`, and all read/stat/test operations (FileSystem)

## Test plan
- [x] Smoke-tested with `foo.flix`: write to deeply nested path, append to existing path, write to bare filename — all return `Ok(())`
- [x] Verify composability with other middleware (e.g. `withBackup`, `withChroot`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)