### PR TITLE
refactor: rename handleWith* to runWith* in Fs effect hierarchy

### DIFF
--- a/main/src/library/Fs.flix
+++ b/main/src/library/Fs.flix
@@ -138,7 +138,7 @@ pub mod Fs {
     ///
     /// An effect used to check if a file exists.
     ///
-    /// Use the `FileExists.handleWithFileTest` handler.
+    /// Use the `FileExists.runWithFileTest` handler.
     ///
     pub eff FileExists {
 
@@ -152,7 +152,7 @@ pub mod Fs {
     ///
     /// An effect used to check if a path is a directory.
     ///
-    /// Use the `IsDirectory.handleWithFileTest` handler.
+    /// Use the `IsDirectory.runWithFileTest` handler.
     ///
     pub eff IsDirectory {
 
@@ -166,7 +166,7 @@ pub mod Fs {
     ///
     /// An effect used to check if a path is a regular file.
     ///
-    /// Use the `IsRegularFile.handleWithFileTest` handler.
+    /// Use the `IsRegularFile.runWithFileTest` handler.
     ///
     pub eff IsRegularFile {
 
@@ -180,7 +180,7 @@ pub mod Fs {
     ///
     /// An effect used to check if a path is a symbolic link.
     ///
-    /// Use the `IsSymbolicLink.handleWithFileTest` handler.
+    /// Use the `IsSymbolicLink.runWithFileTest` handler.
     ///
     pub eff IsSymbolicLink {
 
@@ -194,7 +194,7 @@ pub mod Fs {
     ///
     /// An effect used to check if a file is readable.
     ///
-    /// Use the `IsReadable.handleWithFilePermission` handler.
+    /// Use the `IsReadable.runWithFilePermission` handler.
     ///
     pub eff IsReadable {
 
@@ -208,7 +208,7 @@ pub mod Fs {
     ///
     /// An effect used to check if a file is writable.
     ///
-    /// Use the `IsWritable.handleWithFilePermission` handler.
+    /// Use the `IsWritable.runWithFilePermission` handler.
     ///
     pub eff IsWritable {
 
@@ -222,7 +222,7 @@ pub mod Fs {
     ///
     /// An effect used to check if a file is executable.
     ///
-    /// Use the `IsExecutable.handleWithFilePermission` handler.
+    /// Use the `IsExecutable.runWithFilePermission` handler.
     ///
     pub eff IsExecutable {
 
@@ -236,7 +236,7 @@ pub mod Fs {
     ///
     /// An effect used to read the last access time of a file.
     ///
-    /// Use the `AccessTime.handleWithFileTime` handler.
+    /// Use the `AccessTime.runWithFileTime` handler.
     ///
     pub eff AccessTime {
 
@@ -250,7 +250,7 @@ pub mod Fs {
     ///
     /// An effect used to read the creation time of a file.
     ///
-    /// Use the `CreationTime.handleWithFileTime` handler.
+    /// Use the `CreationTime.runWithFileTime` handler.
     ///
     pub eff CreationTime {
 
@@ -264,7 +264,7 @@ pub mod Fs {
     ///
     /// An effect used to read the last modification time of a file.
     ///
-    /// Use the `ModificationTime.handleWithFileTime` handler.
+    /// Use the `ModificationTime.runWithFileTime` handler.
     ///
     pub eff ModificationTime {
 
@@ -278,7 +278,7 @@ pub mod Fs {
     ///
     /// An effect used to read the size of a file.
     ///
-    /// Use the `FileSize.handleWithFileStat` handler.
+    /// Use the `FileSize.runWithFileStat` handler.
     ///
     pub eff FileSize {
 
@@ -292,7 +292,7 @@ pub mod Fs {
     ///
     /// An effect used to read the contents of a file as a string.
     ///
-    /// Use the `ReadFile.handleWithFileRead` handler.
+    /// Use the `ReadFile.runWithFileRead` handler.
     ///
     pub eff ReadFile {
 
@@ -306,7 +306,7 @@ pub mod Fs {
     ///
     /// An effect used to read the lines of a file.
     ///
-    /// Use the `ReadLines.handleWithFileRead` handler.
+    /// Use the `ReadLines.runWithFileRead` handler.
     ///
     pub eff ReadLines {
 
@@ -320,7 +320,7 @@ pub mod Fs {
     ///
     /// An effect used to read the bytes of a file.
     ///
-    /// Use the `ReadBytes.handleWithFileRead` handler.
+    /// Use the `ReadBytes.runWithFileRead` handler.
     ///
     pub eff ReadBytes {
 
@@ -334,7 +334,7 @@ pub mod Fs {
     ///
     /// An effect used to list the contents of a directory.
     ///
-    /// Use the `DirList.handleWithFileSystem` handler.
+    /// Use the `DirList.runWithFileSystem` handler.
     ///
     pub eff DirList {
 
@@ -348,7 +348,7 @@ pub mod Fs {
     ///
     /// An effect used to find files matching a glob pattern.
     ///
-    /// Use the `Glob.handleWithFileSystem` handler.
+    /// Use the `Glob.runWithFileSystem` handler.
     ///
     pub eff Glob {
 
@@ -362,7 +362,7 @@ pub mod Fs {
     ///
     /// An effect used to write the contents of a file as a string.
     ///
-    /// Use the `WriteFile.handleWithFileWrite` handler.
+    /// Use the `WriteFile.runWithFileWrite` handler.
     ///
     pub eff WriteFile {
 
@@ -378,7 +378,7 @@ pub mod Fs {
     ///
     /// An effect used to write lines to a file.
     ///
-    /// Use the `WriteLines.handleWithFileWrite` handler.
+    /// Use the `WriteLines.runWithFileWrite` handler.
     ///
     pub eff WriteLines {
 
@@ -394,7 +394,7 @@ pub mod Fs {
     ///
     /// An effect used to write bytes to a file.
     ///
-    /// Use the `WriteBytes.handleWithFileWrite` handler.
+    /// Use the `WriteBytes.runWithFileWrite` handler.
     ///
     pub eff WriteBytes {
 
@@ -410,7 +410,7 @@ pub mod Fs {
     ///
     /// An effect used to append a string to a file.
     ///
-    /// Use the `AppendFile.handleWithFileWrite` handler.
+    /// Use the `AppendFile.runWithFileWrite` handler.
     ///
     pub eff AppendFile {
 
@@ -426,7 +426,7 @@ pub mod Fs {
     ///
     /// An effect used to append lines to a file.
     ///
-    /// Use the `AppendLines.handleWithFileWrite` handler.
+    /// Use the `AppendLines.runWithFileWrite` handler.
     ///
     pub eff AppendLines {
 
@@ -442,7 +442,7 @@ pub mod Fs {
     ///
     /// An effect used to append bytes to a file.
     ///
-    /// Use the `AppendBytes.handleWithFileWrite` handler.
+    /// Use the `AppendBytes.runWithFileWrite` handler.
     ///
     pub eff AppendBytes {
 
@@ -458,7 +458,7 @@ pub mod Fs {
     ///
     /// An effect used to truncate a file.
     ///
-    /// Use the `Truncate.handleWithFileWrite` handler.
+    /// Use the `Truncate.runWithFileWrite` handler.
     ///
     pub eff Truncate {
 
@@ -472,7 +472,7 @@ pub mod Fs {
     ///
     /// An effect used to copy a file.
     ///
-    /// Use the `CopyFile.handleWithFileWrite` handler.
+    /// Use the `CopyFile.runWithFileWrite` handler.
     ///
     pub eff CopyFile {
 
@@ -486,7 +486,7 @@ pub mod Fs {
     ///
     /// An effect used to move (rename) a file or directory.
     ///
-    /// Use the `MoveFile.handleWithFileWrite` handler.
+    /// Use the `MoveFile.runWithFileWrite` handler.
     ///
     pub eff MoveFile {
 
@@ -500,7 +500,7 @@ pub mod Fs {
     ///
     /// An effect used to delete a file.
     ///
-    /// Use the `DeleteFile.handleWithFileWrite` handler.
+    /// Use the `DeleteFile.runWithFileWrite` handler.
     ///
     pub eff DeleteFile {
 
@@ -516,7 +516,7 @@ pub mod Fs {
     ///
     /// An effect used to create a directory.
     ///
-    /// Use the `MkDir.handleWithFileWrite` handler.
+    /// Use the `MkDir.runWithFileWrite` handler.
     ///
     pub eff MkDir {
 
@@ -530,7 +530,7 @@ pub mod Fs {
     ///
     /// An effect used to create a directory and all its parent directories.
     ///
-    /// Use the `MkDirs.handleWithFileWrite` handler.
+    /// Use the `MkDirs.runWithFileWrite` handler.
     ///
     pub eff MkDirs {
 
@@ -544,7 +544,7 @@ pub mod Fs {
     ///
     /// An effect used to create a temporary directory.
     ///
-    /// Use the `MkTempDir.handleWithFileWrite` handler.
+    /// Use the `MkTempDir.runWithFileWrite` handler.
     ///
     pub eff MkTempDir {
 

--- a/main/src/library/Fs/AccessTime.flix
+++ b/main/src/library/Fs/AccessTime.flix
@@ -21,8 +21,8 @@ pub mod Fs.AccessTime {
     ///
     /// Handles the `AccessTime` effect of the given function `f` using the `FileTime` effect.
     ///
-    pub def handleWithFileTime(f: a -> b \ ef): a -> b \ (ef - AccessTime) + FileTime = x ->
-        run { f(x) } with handler AccessTime {
+    pub def runWithFileTime(f: Unit -> a \ ef): a \ (ef - AccessTime) + FileTime =
+        run { f() } with handler AccessTime {
             def accessTime(filename, k) = k(Fs.FileTime.accessTime(filename))
         }
 

--- a/main/src/library/Fs/AppendBytes.flix
+++ b/main/src/library/Fs/AppendBytes.flix
@@ -21,8 +21,8 @@ pub mod Fs.AppendBytes {
     ///
     /// Handles the `AppendBytes` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - AppendBytes) + FileWrite = x ->
-        run { f(x) } with handler AppendBytes {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - AppendBytes) + FileWrite =
+        run { f() } with handler AppendBytes {
             def appendBytes(data, file, k) = k(Fs.FileWrite.appendBytes(data, file))
         }
 

--- a/main/src/library/Fs/AppendFile.flix
+++ b/main/src/library/Fs/AppendFile.flix
@@ -21,8 +21,8 @@ pub mod Fs.AppendFile {
     ///
     /// Handles the `AppendFile` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - AppendFile) + FileWrite = x ->
-        run { f(x) } with handler AppendFile {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - AppendFile) + FileWrite =
+        run { f() } with handler AppendFile {
             def append(data, file, k) = k(Fs.FileWrite.append(data, file))
         }
 

--- a/main/src/library/Fs/AppendLines.flix
+++ b/main/src/library/Fs/AppendLines.flix
@@ -21,8 +21,8 @@ pub mod Fs.AppendLines {
     ///
     /// Handles the `AppendLines` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - AppendLines) + FileWrite = x ->
-        run { f(x) } with handler AppendLines {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - AppendLines) + FileWrite =
+        run { f() } with handler AppendLines {
             def appendLines(data, file, k) = k(Fs.FileWrite.appendLines(data, file))
         }
 

--- a/main/src/library/Fs/CopyFile.flix
+++ b/main/src/library/Fs/CopyFile.flix
@@ -28,8 +28,8 @@ pub mod Fs.CopyFile {
     ///
     /// Handles the `CopyFile` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - CopyFile) + FileWrite = x ->
-        run { f(x) } with handler CopyFile {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - CopyFile) + FileWrite =
+        run { f() } with handler CopyFile {
             def copyWith(src, dst, opts, k) = k(Fs.FileWrite.copyWith(src, dst, opts))
         }
 

--- a/main/src/library/Fs/CreationTime.flix
+++ b/main/src/library/Fs/CreationTime.flix
@@ -21,8 +21,8 @@ pub mod Fs.CreationTime {
     ///
     /// Handles the `CreationTime` effect of the given function `f` using the `FileTime` effect.
     ///
-    pub def handleWithFileTime(f: a -> b \ ef): a -> b \ (ef - CreationTime) + FileTime = x ->
-        run { f(x) } with handler CreationTime {
+    pub def runWithFileTime(f: Unit -> a \ ef): a \ (ef - CreationTime) + FileTime =
+        run { f() } with handler CreationTime {
             def creationTime(filename, k) = k(Fs.FileTime.creationTime(filename))
         }
 

--- a/main/src/library/Fs/DeleteFile.flix
+++ b/main/src/library/Fs/DeleteFile.flix
@@ -21,8 +21,8 @@ pub mod Fs.DeleteFile {
     ///
     /// Handles the `DeleteFile` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - DeleteFile) + FileWrite = x ->
-        run { f(x) } with handler DeleteFile {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - DeleteFile) + FileWrite =
+        run { f() } with handler DeleteFile {
             def delete(file, k) = k(Fs.FileWrite.delete(file))
         }
 

--- a/main/src/library/Fs/DirList.flix
+++ b/main/src/library/Fs/DirList.flix
@@ -41,8 +41,8 @@ pub mod Fs.DirList {
     ///
     /// Handles the `DirList` effect of the given function `f` using the `FileSystem` effect.
     ///
-    pub def handleWithFileSystem(f: a -> b \ ef): a -> b \ (ef - DirList) + FileSystem = x ->
-        run { f(x) } with handler DirList {
+    pub def runWithFileSystem(f: Unit -> a \ ef): a \ (ef - DirList) + FileSystem =
+        run { f() } with handler DirList {
             def list(filename, k) = k(Fs.FileSystem.list(filename))
         }
 

--- a/main/src/library/Fs/FileExists.flix
+++ b/main/src/library/Fs/FileExists.flix
@@ -21,8 +21,8 @@ pub mod Fs.FileExists {
     ///
     /// Handles the `FileExists` effect of the given function `f` using the `FileTest` effect.
     ///
-    pub def handleWithFileTest(f: a -> b \ ef): a -> b \ (ef - FileExists) + FileTest = x ->
-        run { f(x) } with handler FileExists {
+    pub def runWithFileTest(f: Unit -> a \ ef): a \ (ef - FileExists) + FileTest =
+        run { f() } with handler FileExists {
             def exists(filename, k) = k(Fs.FileTest.exists(filename))
         }
 

--- a/main/src/library/Fs/FilePermission.flix
+++ b/main/src/library/Fs/FilePermission.flix
@@ -31,9 +31,9 @@ pub mod Fs.FilePermission {
         checked_ecast(
             Fs.FileSystem.handle(
                 y -> checked_ecast(
-                    Fs.FileStat.handleWithFileSystem(
-                        handleWithFileStat(f)
-                    )(y)
+                    Fs.FileStat.runWithFileSystem(
+                        () -> runWithFileStat(() -> f(y))
+                    )
                 )
             )(x)
         )
@@ -49,8 +49,8 @@ pub mod Fs.FilePermission {
     ///
     /// Handles the `FilePermission` effect of the given function `f` using the `FileStat` effect.
     ///
-    pub def handleWithFileStat(f: a -> b \ ef): a -> b \ (ef - FilePermission) + FileStat = x ->
-        run { f(x) } with handler FilePermission {
+    pub def runWithFileStat(f: Unit -> a \ ef): a \ (ef - FilePermission) + FileStat =
+        run { f() } with handler FilePermission {
             def isReadable(filename, k)  = k(Fs.FileStat.isReadable(filename))
             def isWritable(filename, k)  = k(Fs.FileStat.isWritable(filename))
             def isExecutable(filename, k) = k(Fs.FileStat.isExecutable(filename))

--- a/main/src/library/Fs/FileRead.flix
+++ b/main/src/library/Fs/FileRead.flix
@@ -30,7 +30,7 @@ pub mod Fs.FileRead {
     pub def handle(f: a -> b \ ef): a -> b \ (ef - FileRead) + IO = x ->
         checked_ecast(
             Fs.FileSystem.handle(
-                handleWithFileSystem(f)
+                y -> runWithFileSystem(() -> f(y))
             )(x)
         )
 
@@ -45,8 +45,8 @@ pub mod Fs.FileRead {
     ///
     /// Handles the `FileRead` effect of the given function `f` using the `FileSystem` effect.
     ///
-    pub def handleWithFileSystem(f: a -> b \ ef): a -> b \ (ef - FileRead) + FileSystem = x ->
-        run { f(x) } with handler FileRead {
+    pub def runWithFileSystem(f: Unit -> a \ ef): a \ (ef - FileRead) + FileSystem =
+        run { f() } with handler FileRead {
             def read(filename, k)      = k(Fs.FileSystem.read(filename))
             def readLines(filename, k) = k(Fs.FileSystem.readLines(filename))
             def readBytes(filename, k) = k(Fs.FileSystem.readBytes(filename))

--- a/main/src/library/Fs/FileSize.flix
+++ b/main/src/library/Fs/FileSize.flix
@@ -21,8 +21,8 @@ pub mod Fs.FileSize {
     ///
     /// Handles the `FileSize` effect of the given function `f` using the `FileStat` effect.
     ///
-    pub def handleWithFileStat(f: a -> b \ ef): a -> b \ (ef - FileSize) + FileStat = x ->
-        run { f(x) } with handler FileSize {
+    pub def runWithFileStat(f: Unit -> a \ ef): a \ (ef - FileSize) + FileStat =
+        run { f() } with handler FileSize {
             def size(filename, k) = k(Fs.FileStat.size(filename))
         }
 

--- a/main/src/library/Fs/FileStat.flix
+++ b/main/src/library/Fs/FileStat.flix
@@ -30,7 +30,7 @@ pub mod Fs.FileStat {
     pub def handle(f: a -> b \ ef): a -> b \ (ef - FileStat) + IO = x ->
         checked_ecast(
             Fs.FileSystem.handle(
-                handleWithFileSystem(f)
+                y -> runWithFileSystem(() -> f(y))
             )(x)
         )
 
@@ -45,8 +45,8 @@ pub mod Fs.FileStat {
     ///
     /// Handles the `FileStat` effect of the given function `f` using the `FileSystem` effect.
     ///
-    pub def handleWithFileSystem(f: a -> b \ ef): a -> b \ (ef - FileStat) + FileSystem = x ->
-        run { f(x) } with handler FileStat {
+    pub def runWithFileSystem(f: Unit -> a \ ef): a \ (ef - FileStat) + FileSystem =
+        run { f() } with handler FileStat {
             def exists(filename, k)           = k(Fs.FileSystem.exists(filename))
             def isDirectory(filename, k)      = k(Fs.FileSystem.isDirectory(filename))
             def isRegularFile(filename, k)    = k(Fs.FileSystem.isRegularFile(filename))

--- a/main/src/library/Fs/FileTest.flix
+++ b/main/src/library/Fs/FileTest.flix
@@ -31,9 +31,9 @@ pub mod Fs.FileTest {
         checked_ecast(
             Fs.FileSystem.handle(
                 y -> checked_ecast(
-                    Fs.FileStat.handleWithFileSystem(
-                        handleWithFileStat(f)
-                    )(y)
+                    Fs.FileStat.runWithFileSystem(
+                        () -> runWithFileStat(() -> f(y))
+                    )
                 )
             )(x)
         )
@@ -49,8 +49,8 @@ pub mod Fs.FileTest {
     ///
     /// Handles the `FileTest` effect of the given function `f` using the `FileStat` effect.
     ///
-    pub def handleWithFileStat(f: a -> b \ ef): a -> b \ (ef - FileTest) + FileStat = x ->
-        run { f(x) } with handler FileTest {
+    pub def runWithFileStat(f: Unit -> a \ ef): a \ (ef - FileTest) + FileStat =
+        run { f() } with handler FileTest {
             def exists(filename, k)         = k(Fs.FileStat.exists(filename))
             def isDirectory(filename, k)    = k(Fs.FileStat.isDirectory(filename))
             def isRegularFile(filename, k)  = k(Fs.FileStat.isRegularFile(filename))

--- a/main/src/library/Fs/FileTime.flix
+++ b/main/src/library/Fs/FileTime.flix
@@ -29,9 +29,9 @@ pub mod Fs.FileTime {
         checked_ecast(
             Fs.FileSystem.handle(
                 y -> checked_ecast(
-                    Fs.FileStat.handleWithFileSystem(
-                        handleWithFileStat(f)
-                    )(y)
+                    Fs.FileStat.runWithFileSystem(
+                        () -> runWithFileStat(() -> f(y))
+                    )
                 )
             )(x)
         )
@@ -47,8 +47,8 @@ pub mod Fs.FileTime {
     ///
     /// Handles the `FileTime` effect of the given function `f` using the `FileStat` effect.
     ///
-    pub def handleWithFileStat(f: a -> b \ ef): a -> b \ (ef - FileTime) + FileStat = x ->
-        run { f(x) } with handler FileTime {
+    pub def runWithFileStat(f: Unit -> a \ ef): a \ (ef - FileTime) + FileStat =
+        run { f() } with handler FileTime {
             def accessTime(filename, k)       = k(Fs.FileStat.accessTime(filename))
             def creationTime(filename, k)     = k(Fs.FileStat.creationTime(filename))
             def modificationTime(filename, k) = k(Fs.FileStat.modificationTime(filename))

--- a/main/src/library/Fs/FileWrite.flix
+++ b/main/src/library/Fs/FileWrite.flix
@@ -44,7 +44,7 @@ pub mod Fs.FileWrite {
     pub def handle(f: a -> b \ ef): a -> b \ (ef - FileWrite) + IO = x ->
         checked_ecast(
             Fs.FileSystem.handle(
-                handleWithFileSystem(f)
+                y -> runWithFileSystem(() -> f(y))
             )(x)
         )
 
@@ -59,8 +59,8 @@ pub mod Fs.FileWrite {
     ///
     /// Handles the `FileWrite` effect of the given function `f` using the `FileSystem` effect.
     ///
-    pub def handleWithFileSystem(f: a -> b \ ef): a -> b \ (ef - FileWrite) + FileSystem = x ->
-        run { f(x) } with handler FileWrite {
+    pub def runWithFileSystem(f: Unit -> a \ ef): a \ (ef - FileWrite) + FileSystem =
+        run { f() } with handler FileWrite {
             def write(data, file, k)        = k(Fs.FileSystem.write(data, file))
             def writeLines(data, file, k)   = k(Fs.FileSystem.writeLines(data, file))
             def writeBytes(data, file, k)   = k(Fs.FileSystem.writeBytes(data, file))

--- a/main/src/library/Fs/Glob.flix
+++ b/main/src/library/Fs/Glob.flix
@@ -41,8 +41,8 @@ pub mod Fs.Glob {
     ///
     /// Handles the `Glob` effect of the given function `f` using the `FileSystem` effect.
     ///
-    pub def handleWithFileSystem(f: a -> b \ ef): a -> b \ (ef - Glob) + FileSystem = x ->
-        run { f(x) } with handler Glob {
+    pub def runWithFileSystem(f: Unit -> a \ ef): a \ (ef - Glob) + FileSystem =
+        run { f() } with handler Glob {
             def glob(base, pattern, k) = k(Fs.FileSystem.glob(base, pattern))
         }
 

--- a/main/src/library/Fs/IsDirectory.flix
+++ b/main/src/library/Fs/IsDirectory.flix
@@ -21,8 +21,8 @@ pub mod Fs.IsDirectory {
     ///
     /// Handles the `IsDirectory` effect of the given function `f` using the `FileTest` effect.
     ///
-    pub def handleWithFileTest(f: a -> b \ ef): a -> b \ (ef - IsDirectory) + FileTest = x ->
-        run { f(x) } with handler IsDirectory {
+    pub def runWithFileTest(f: Unit -> a \ ef): a \ (ef - IsDirectory) + FileTest =
+        run { f() } with handler IsDirectory {
             def isDirectory(filename, k) = k(Fs.FileTest.isDirectory(filename))
         }
 

--- a/main/src/library/Fs/IsExecutable.flix
+++ b/main/src/library/Fs/IsExecutable.flix
@@ -21,8 +21,8 @@ pub mod Fs.IsExecutable {
     ///
     /// Handles the `IsExecutable` effect of the given function `f` using the `FilePermission` effect.
     ///
-    pub def handleWithFilePermission(f: a -> b \ ef): a -> b \ (ef - IsExecutable) + FilePermission = x ->
-        run { f(x) } with handler IsExecutable {
+    pub def runWithFilePermission(f: Unit -> a \ ef): a \ (ef - IsExecutable) + FilePermission =
+        run { f() } with handler IsExecutable {
             def isExecutable(filename, k) = k(Fs.FilePermission.isExecutable(filename))
         }
 

--- a/main/src/library/Fs/IsReadable.flix
+++ b/main/src/library/Fs/IsReadable.flix
@@ -21,8 +21,8 @@ pub mod Fs.IsReadable {
     ///
     /// Handles the `IsReadable` effect of the given function `f` using the `FilePermission` effect.
     ///
-    pub def handleWithFilePermission(f: a -> b \ ef): a -> b \ (ef - IsReadable) + FilePermission = x ->
-        run { f(x) } with handler IsReadable {
+    pub def runWithFilePermission(f: Unit -> a \ ef): a \ (ef - IsReadable) + FilePermission =
+        run { f() } with handler IsReadable {
             def isReadable(filename, k) = k(Fs.FilePermission.isReadable(filename))
         }
 

--- a/main/src/library/Fs/IsRegularFile.flix
+++ b/main/src/library/Fs/IsRegularFile.flix
@@ -21,8 +21,8 @@ pub mod Fs.IsRegularFile {
     ///
     /// Handles the `IsRegularFile` effect of the given function `f` using the `FileTest` effect.
     ///
-    pub def handleWithFileTest(f: a -> b \ ef): a -> b \ (ef - IsRegularFile) + FileTest = x ->
-        run { f(x) } with handler IsRegularFile {
+    pub def runWithFileTest(f: Unit -> a \ ef): a \ (ef - IsRegularFile) + FileTest =
+        run { f() } with handler IsRegularFile {
             def isRegularFile(filename, k) = k(Fs.FileTest.isRegularFile(filename))
         }
 

--- a/main/src/library/Fs/IsSymbolicLink.flix
+++ b/main/src/library/Fs/IsSymbolicLink.flix
@@ -21,8 +21,8 @@ pub mod Fs.IsSymbolicLink {
     ///
     /// Handles the `IsSymbolicLink` effect of the given function `f` using the `FileTest` effect.
     ///
-    pub def handleWithFileTest(f: a -> b \ ef): a -> b \ (ef - IsSymbolicLink) + FileTest = x ->
-        run { f(x) } with handler IsSymbolicLink {
+    pub def runWithFileTest(f: Unit -> a \ ef): a \ (ef - IsSymbolicLink) + FileTest =
+        run { f() } with handler IsSymbolicLink {
             def isSymbolicLink(filename, k) = k(Fs.FileTest.isSymbolicLink(filename))
         }
 

--- a/main/src/library/Fs/IsWritable.flix
+++ b/main/src/library/Fs/IsWritable.flix
@@ -21,8 +21,8 @@ pub mod Fs.IsWritable {
     ///
     /// Handles the `IsWritable` effect of the given function `f` using the `FilePermission` effect.
     ///
-    pub def handleWithFilePermission(f: a -> b \ ef): a -> b \ (ef - IsWritable) + FilePermission = x ->
-        run { f(x) } with handler IsWritable {
+    pub def runWithFilePermission(f: Unit -> a \ ef): a \ (ef - IsWritable) + FilePermission =
+        run { f() } with handler IsWritable {
             def isWritable(filename, k) = k(Fs.FilePermission.isWritable(filename))
         }
 

--- a/main/src/library/Fs/MkDir.flix
+++ b/main/src/library/Fs/MkDir.flix
@@ -21,8 +21,8 @@ pub mod Fs.MkDir {
     ///
     /// Handles the `MkDir` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - MkDir) + FileWrite = x ->
-        run { f(x) } with handler MkDir {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - MkDir) + FileWrite =
+        run { f() } with handler MkDir {
             def mkDir(d, k) = k(Fs.FileWrite.mkDir(d))
         }
 

--- a/main/src/library/Fs/MkDirs.flix
+++ b/main/src/library/Fs/MkDirs.flix
@@ -21,8 +21,8 @@ pub mod Fs.MkDirs {
     ///
     /// Handles the `MkDirs` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - MkDirs) + FileWrite = x ->
-        run { f(x) } with handler MkDirs {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - MkDirs) + FileWrite =
+        run { f() } with handler MkDirs {
             def mkDirs(d, k) = k(Fs.FileWrite.mkDirs(d))
         }
 

--- a/main/src/library/Fs/MkTempDir.flix
+++ b/main/src/library/Fs/MkTempDir.flix
@@ -21,8 +21,8 @@ pub mod Fs.MkTempDir {
     ///
     /// Handles the `MkTempDir` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - MkTempDir) + FileWrite = x ->
-        run { f(x) } with handler MkTempDir {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - MkTempDir) + FileWrite =
+        run { f() } with handler MkTempDir {
             def mkTempDir(prefix, k) = k(Fs.FileWrite.mkTempDir(prefix))
         }
 

--- a/main/src/library/Fs/ModificationTime.flix
+++ b/main/src/library/Fs/ModificationTime.flix
@@ -21,8 +21,8 @@ pub mod Fs.ModificationTime {
     ///
     /// Handles the `ModificationTime` effect of the given function `f` using the `FileTime` effect.
     ///
-    pub def handleWithFileTime(f: a -> b \ ef): a -> b \ (ef - ModificationTime) + FileTime = x ->
-        run { f(x) } with handler ModificationTime {
+    pub def runWithFileTime(f: Unit -> a \ ef): a \ (ef - ModificationTime) + FileTime =
+        run { f() } with handler ModificationTime {
             def modificationTime(filename, k) = k(Fs.FileTime.modificationTime(filename))
         }
 

--- a/main/src/library/Fs/MoveFile.flix
+++ b/main/src/library/Fs/MoveFile.flix
@@ -28,8 +28,8 @@ pub mod Fs.MoveFile {
     ///
     /// Handles the `MoveFile` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - MoveFile) + FileWrite = x ->
-        run { f(x) } with handler MoveFile {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - MoveFile) + FileWrite =
+        run { f() } with handler MoveFile {
             def moveWith(src, dst, opts, k) = k(Fs.FileWrite.moveWith(src, dst, opts))
         }
 

--- a/main/src/library/Fs/ReadBytes.flix
+++ b/main/src/library/Fs/ReadBytes.flix
@@ -21,8 +21,8 @@ pub mod Fs.ReadBytes {
     ///
     /// Handles the `ReadBytes` effect of the given function `f` using the `FileRead` effect.
     ///
-    pub def handleWithFileRead(f: a -> b \ ef): a -> b \ (ef - ReadBytes) + FileRead = x ->
-        run { f(x) } with handler ReadBytes {
+    pub def runWithFileRead(f: Unit -> a \ ef): a \ (ef - ReadBytes) + FileRead =
+        run { f() } with handler ReadBytes {
             def readBytes(filename, k) = k(Fs.FileRead.readBytes(filename))
         }
 

--- a/main/src/library/Fs/ReadFile.flix
+++ b/main/src/library/Fs/ReadFile.flix
@@ -21,8 +21,8 @@ pub mod Fs.ReadFile {
     ///
     /// Handles the `ReadFile` effect of the given function `f` using the `FileRead` effect.
     ///
-    pub def handleWithFileRead(f: a -> b \ ef): a -> b \ (ef - ReadFile) + FileRead = x ->
-        run { f(x) } with handler ReadFile {
+    pub def runWithFileRead(f: Unit -> a \ ef): a \ (ef - ReadFile) + FileRead =
+        run { f() } with handler ReadFile {
             def read(filename, k) = k(Fs.FileRead.read(filename))
         }
 

--- a/main/src/library/Fs/ReadLines.flix
+++ b/main/src/library/Fs/ReadLines.flix
@@ -21,8 +21,8 @@ pub mod Fs.ReadLines {
     ///
     /// Handles the `ReadLines` effect of the given function `f` using the `FileRead` effect.
     ///
-    pub def handleWithFileRead(f: a -> b \ ef): a -> b \ (ef - ReadLines) + FileRead = x ->
-        run { f(x) } with handler ReadLines {
+    pub def runWithFileRead(f: Unit -> a \ ef): a \ (ef - ReadLines) + FileRead =
+        run { f() } with handler ReadLines {
             def readLines(filename, k) = k(Fs.FileRead.readLines(filename))
         }
 

--- a/main/src/library/Fs/Truncate.flix
+++ b/main/src/library/Fs/Truncate.flix
@@ -21,8 +21,8 @@ pub mod Fs.Truncate {
     ///
     /// Handles the `Truncate` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - Truncate) + FileWrite = x ->
-        run { f(x) } with handler Truncate {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - Truncate) + FileWrite =
+        run { f() } with handler Truncate {
             def truncate(file, k) = k(Fs.FileWrite.truncate(file))
         }
 

--- a/main/src/library/Fs/WriteBytes.flix
+++ b/main/src/library/Fs/WriteBytes.flix
@@ -21,8 +21,8 @@ pub mod Fs.WriteBytes {
     ///
     /// Handles the `WriteBytes` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - WriteBytes) + FileWrite = x ->
-        run { f(x) } with handler WriteBytes {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - WriteBytes) + FileWrite =
+        run { f() } with handler WriteBytes {
             def writeBytes(data, file, k) = k(Fs.FileWrite.writeBytes(data, file))
         }
 

--- a/main/src/library/Fs/WriteFile.flix
+++ b/main/src/library/Fs/WriteFile.flix
@@ -21,8 +21,8 @@ pub mod Fs.WriteFile {
     ///
     /// Handles the `WriteFile` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - WriteFile) + FileWrite = x ->
-        run { f(x) } with handler WriteFile {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - WriteFile) + FileWrite =
+        run { f() } with handler WriteFile {
             def write(data, file, k) = k(Fs.FileWrite.write(data, file))
         }
 

--- a/main/src/library/Fs/WriteLines.flix
+++ b/main/src/library/Fs/WriteLines.flix
@@ -21,8 +21,8 @@ pub mod Fs.WriteLines {
     ///
     /// Handles the `WriteLines` effect of the given function `f` using the `FileWrite` effect.
     ///
-    pub def handleWithFileWrite(f: a -> b \ ef): a -> b \ (ef - WriteLines) + FileWrite = x ->
-        run { f(x) } with handler WriteLines {
+    pub def runWithFileWrite(f: Unit -> a \ ef): a \ (ef - WriteLines) + FileWrite =
+        run { f() } with handler WriteLines {
             def writeLines(data, file, k) = k(Fs.FileWrite.writeLines(data, file))
         }
 


### PR DESCRIPTION
## Summary
- Renamed all `handleWith*` functions to `runWith*` across 36 Fs library files
- Changed signatures from function-based `(f: a -> b \ ef): a -> b` to thunk-based `(f: Unit -> a \ ef): a`, aligning leaf/compound effect handlers with the middleware pattern (`withLogging`, `withBaseDir`, etc.)
- Updated doc comments in `Fs.flix` to reference new names

## Test plan
- [x] `mill flix.test` — all 16,061 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)