### PR TITLE
feat: set up for syntax highlighting of documentation comments

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -54,8 +54,11 @@ object SemanticTokensProvider {
           case token: Token if token.kind.isModifier =>
             SemanticToken(SemanticTokenType.Modifier, Nil, token.mkSourceLocation())
 
-          case token: Token if token.kind.isComment =>
+          case token: Token if token.kind.isCommentNonDoc =>
             SemanticToken(SemanticTokenType.Comment, Nil, token.mkSourceLocation())
+
+          case token: Token if token.kind.isCommentDoc =>
+            SemanticToken(SemanticTokenType.Comment, List(SemanticTokenModifier.Documentation), token.mkSourceLocation())
         }
       case None => Iterator.empty
     }

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -197,12 +197,14 @@ sealed trait TokenKind {
     case _ => false
   }
 
-  /** Returns `true` if this token is a doc, line or block comment. */
-  def isComment: Boolean = this match {
+  /** Returns `true` if this token is a doc comment. */
+  def isCommentDoc: Boolean = this match {
     case TokenKind.CommentDoc => true
-    case _ if this.isCommentNonDoc => true
     case _ => false
   }
+
+  /** Returns `true` if this token is a doc, line or block comment. */
+  def isComment: Boolean = this.isCommentDoc || this.isCommentNonDoc
 
   /** Returns `true` if this token is a keyword. */
   def isKeyword: Boolean = this match {


### PR DESCRIPTION
This hopefully will make it so we can support different colors for doc comments and regular comments.

Then we have to update the theme to handle this.

related to #12516 