### PR TITLE
fix: RichString equality checks for same amount of chars

### DIFF
--- a/main/src/library/RichString.flix
+++ b/main/src/library/RichString.flix
@@ -125,7 +125,11 @@ pub mod RichString {
         });
         let l1 = Chain.flatMap(splitSpans, chain1);
         let l2 = Chain.flatMap(splitSpans, chain2);
-        Chain.zip(l1, l2) |> Chain.forAll((match (e1, e2) -> spanEquals(e1, e2)))
+        if (Chain.length(l1) != Chain.length(l2)) {
+            false
+        } else {
+            Chain.zip(l1, l2) |> Chain.forAll((match (e1, e2) -> spanEquals(e1, e2)))
+        }
 
     def spanEquals(s1: Span, s2: Span): Bool =
         let Span.Span({text = t1, fgColor = fg1, bgColor = bg1, styles = style1}) = s1;


### PR DESCRIPTION
The zip function does not check for same length (in characters). This was a previous oversight and wasn't checked.

Now it fails "fast" and checks it properly.