### PR TITLE
refactor: lift MoveOption and SizeUnit into companion modules

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Library.scala
+++ b/main/src/ca/uwaterloo/flix/api/Library.scala
@@ -135,6 +135,7 @@ object Library {
     "Fs/MkDirs.flix" -> LocalResource.get("/src/library/Fs/MkDirs.flix"),
     "Fs/MkTempDir.flix" -> LocalResource.get("/src/library/Fs/MkTempDir.flix"),
     "Fs/MoveFile.flix" -> LocalResource.get("/src/library/Fs/MoveFile.flix"),
+    "Fs/MoveOption.flix" -> LocalResource.get("/src/library/Fs/MoveOption.flix"),
     "Fixpoint3.flix" -> LocalResource.get("/src/library/Fixpoint3.flix"),
     "Fixpoint3/Ast.flix" -> LocalResource.get("/src/library/Fixpoint3/Ast.flix"),
     "Fixpoint3/Ast/Datalog.flix" -> LocalResource.get("/src/library/Fixpoint3/Ast/Datalog.flix"),

--- a/main/src/library/Fs.flix
+++ b/main/src/library/Fs.flix
@@ -105,25 +105,6 @@ pub mod Fs {
     }
 
     ///
-    /// Options for the `moveWith` operation.
-    ///
-    pub enum MoveOption with Eq, Order, ToString {
-        case AtomicMove
-        case ReplaceExisting
-    }
-
-    ///
-    /// Represents a size unit.
-    ///
-    pub enum SizeUnit with Eq, ToString {
-        case Bytes,
-        case KiloBytes,
-        case MegaBytes,
-        case GigaBytes,
-        case TeraBytes
-    }
-
-    ///
     /// An effect used to check if a file exists.
     ///
     /// Use the `FileExists.runWithFileTest` handler.

--- a/main/src/library/Fs/MoveOption.flix
+++ b/main/src/library/Fs/MoveOption.flix
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod Fs.MoveOption {
+
+    ///
+    /// Options for the `moveWith` operation.
+    ///
+    pub enum MoveOption with Eq, Order, ToString {
+        case AtomicMove
+        case ReplaceExisting
+    }
+
+}

--- a/main/src/library/Fs/SizeUnit.flix
+++ b/main/src/library/Fs/SizeUnit.flix
@@ -16,7 +16,16 @@
 
 pub mod Fs.SizeUnit {
 
-    use Fs.SizeUnit
+    ///
+    /// Represents a size unit.
+    ///
+    pub enum SizeUnit with Eq, ToString {
+        case Bytes,
+        case KiloBytes,
+        case MegaBytes,
+        case GigaBytes,
+        case TeraBytes
+    }
 
     ///
     /// Returns the number of bytes for the given size unit `u`.


### PR DESCRIPTION
## Summary
- Moves `MoveOption` from `Fs.flix` into a new `Fs/MoveOption.flix` companion module.
- Moves `SizeUnit` from `Fs.flix` into the existing `Fs/SizeUnit.flix` (which previously held only the `toBytes` helper).
- Each enum is now the **companion** of its enclosing module: `pub enum MoveOption` inside `pub mod Fs.MoveOption` lifts the symbol to canonical name `Fs.MoveOption` rather than `Fs.MoveOption.MoveOption`. Same for `SizeUnit`.
- Registers `Fs/MoveOption.flix` in `Library.scala`; drops the now-redundant `use Fs.SizeUnit` from `Fs/SizeUnit.flix`.

## Test plan
- [x] Compiler builds (`mill flix.compile`)
- [x] Standard library compiles cleanly (`mill flix.run` on empty file)
- [x] Full test suite (`mill flix.test`) — 16248 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)