### PR TITLE
refactor: move all Time declarations into separate files

### DIFF
--- a/main/src/library/Time.flix
+++ b/main/src/library/Time.flix
@@ -17,24 +17,6 @@
 pub mod Time {
 
     ///
-    /// Represents a duration of time stored as nanoseconds (Int64).
-    ///
-    pub enum Duration(Int64) with Eq, Order, Hash
-
-    ///
-    /// Represents a time unit.
-    ///
-    pub enum TimeUnit with Eq, ToString {
-        case Days,
-        case Hours,
-        case Microseconds,
-        case Milliseconds,
-        case Minutes,
-        case Nanoseconds,
-        case Seconds
-    }
-
-    ///
     /// An effect used to access the current (real-world) time.
     ///
     pub eff Clock {
@@ -58,57 +40,4 @@ pub mod Time {
 
     }
 
-}
-
-instance Add[Time.Duration] {
-    pub def add(x: Time.Duration, y: Time.Duration): Time.Duration =
-        let Time.Duration.Duration(x1) = x;
-        let Time.Duration.Duration(y1) = y;
-        Time.Duration.Duration(x1 + y1)
-}
-
-instance Sub[Time.Duration] {
-    pub def sub(x: Time.Duration, y: Time.Duration): Time.Duration =
-        let Time.Duration.Duration(x1) = x;
-        let Time.Duration.Duration(y1) = y;
-        Time.Duration.Duration(x1 - y1)
-}
-
-instance ToString[Time.Duration] {
-    pub def toString(d: Time.Duration): String =
-        let Time.Duration.Duration(nanos) = d;
-        if (nanos == 0i64)
-            "0ns"
-        else
-            let abs = Int64.abs(nanos);
-            let sign = if (nanos < 0i64) "-" else "";
-            if (abs >= 3_600_000_000_000i64)
-                let h = abs / 3_600_000_000_000i64;
-                let rem1 = abs - (h * 3_600_000_000_000i64);
-                let m = rem1 / 60_000_000_000i64;
-                let rem2 = rem1 - (m * 60_000_000_000i64);
-                let s = rem2 / 1_000_000_000i64;
-                "${sign}${h}h ${m}m ${s}s"
-            else if (abs >= 60_000_000_000i64)
-                let m = abs / 60_000_000_000i64;
-                let rem1 = abs - (m * 60_000_000_000i64);
-                let s = rem1 / 1_000_000_000i64;
-                "${sign}${m}m ${s}s"
-            else if (abs >= 1_000_000_000i64)
-                let s = abs / 1_000_000_000i64;
-                let rem1 = abs - (s * 1_000_000_000i64);
-                let ms = rem1 / 1_000_000i64;
-                "${sign}${s}s ${ms}ms"
-            else if (abs >= 1_000_000i64)
-                let ms = abs / 1_000_000i64;
-                "${sign}${ms}ms"
-            else if (abs >= 1_000i64)
-                let us = abs / 1_000i64;
-                "${sign}${us}us"
-            else
-                "${sign}${abs}ns"
-}
-
-instance Formattable[Time.Duration] {
-    pub def format(d: Time.Duration): RichString = RichString.fromString(ToString.toString(d))
 }

--- a/main/src/library/Time.flix
+++ b/main/src/library/Time.flix
@@ -15,29 +15,5 @@
  */
 
 pub mod Time {
-
-    ///
-    /// An effect used to access the current (real-world) time.
-    ///
-    pub eff Clock {
-
-        ///
-        /// Returns a measure of time since the epoch in the given time unit `u`.
-        ///
-        def currentTime(u: TimeUnit): Int64
-
-    }
-
-    ///
-    /// An effect used to sleep the current thread.
-    ///
-    pub eff Sleep {
-
-        ///
-        /// Sleeps the current thread for the given duration `d`.
-        ///
-        def sleep(d: Duration): Unit
-
-    }
-
+    /* empty */
 }

--- a/main/src/library/Time/Clock.flix
+++ b/main/src/library/Time/Clock.flix
@@ -23,6 +23,18 @@ pub mod Time.Clock {
     import java.util.concurrent.{TimeUnit => JTimeUnit}
 
     ///
+    /// An effect used to access the current (real-world) time.
+    ///
+    pub eff Clock {
+
+        ///
+        /// Returns a measure of time since the epoch in the given time unit `u`.
+        ///
+        def currentTime(u: TimeUnit): Int64
+
+    }
+
+    ///
     /// Returns the number of milliseconds since the epoch.
     ///
     /// Equivalent to `currentTime(TimeUnit.Milliseconds)`.

--- a/main/src/library/Time/Duration.flix
+++ b/main/src/library/Time/Duration.flix
@@ -18,6 +18,64 @@ pub mod Time.Duration {
 
     use Time.TimeUnit
 
+    ///
+    /// Represents a duration of time stored as nanoseconds (Int64).
+    ///
+    pub enum Duration(Int64) with Eq, Order, Hash
+
+    instance Add[Duration] {
+        pub def add(x: Duration, y: Duration): Duration =
+            let Duration.Duration(x1) = x;
+            let Duration.Duration(y1) = y;
+            Duration.Duration(x1 + y1)
+    }
+
+    instance Sub[Duration] {
+        pub def sub(x: Duration, y: Duration): Duration =
+            let Duration.Duration(x1) = x;
+            let Duration.Duration(y1) = y;
+            Duration.Duration(x1 - y1)
+    }
+
+    instance ToString[Duration] {
+        pub def toString(d: Duration): String =
+            let Duration.Duration(nanos) = d;
+            if (nanos == 0i64)
+                "0ns"
+            else
+                let abs = Int64.abs(nanos);
+                let sign = if (nanos < 0i64) "-" else "";
+                if (abs >= 3_600_000_000_000i64)
+                    let h = abs / 3_600_000_000_000i64;
+                    let rem1 = abs - (h * 3_600_000_000_000i64);
+                    let m = rem1 / 60_000_000_000i64;
+                    let rem2 = rem1 - (m * 60_000_000_000i64);
+                    let s = rem2 / 1_000_000_000i64;
+                    "${sign}${h}h ${m}m ${s}s"
+                else if (abs >= 60_000_000_000i64)
+                    let m = abs / 60_000_000_000i64;
+                    let rem1 = abs - (m * 60_000_000_000i64);
+                    let s = rem1 / 1_000_000_000i64;
+                    "${sign}${m}m ${s}s"
+                else if (abs >= 1_000_000_000i64)
+                    let s = abs / 1_000_000_000i64;
+                    let rem1 = abs - (s * 1_000_000_000i64);
+                    let ms = rem1 / 1_000_000i64;
+                    "${sign}${s}s ${ms}ms"
+                else if (abs >= 1_000_000i64)
+                    let ms = abs / 1_000_000i64;
+                    "${sign}${ms}ms"
+                else if (abs >= 1_000i64)
+                    let us = abs / 1_000i64;
+                    "${sign}${us}us"
+                else
+                    "${sign}${abs}ns"
+    }
+
+    instance Formattable[Duration] {
+        pub def format(d: Duration): RichString = RichString.fromString(ToString.toString(d))
+    }
+
     /// Returns the zero duration.
     pub def zero(): Time.Duration = Time.Duration.Duration(0i64)
 

--- a/main/src/library/Time/Sleep.flix
+++ b/main/src/library/Time/Sleep.flix
@@ -24,6 +24,18 @@ pub mod Time.Sleep {
     import java.lang.{Thread => JThread}
 
     ///
+    /// An effect used to sleep the current thread.
+    ///
+    pub eff Sleep {
+
+        ///
+        /// Sleeps the current thread for the given duration `d`.
+        ///
+        def sleep(d: Duration): Unit
+
+    }
+
+    ///
     /// Handles the `Sleep` effect of the given function `f`.
     ///
     /// In other words, re-interprets the `Sleep` effect using the `IO` effect.

--- a/main/src/library/Time/TimeUnit.flix
+++ b/main/src/library/Time/TimeUnit.flix
@@ -19,6 +19,19 @@ pub mod Time.TimeUnit {
     use Time.TimeUnit
 
     ///
+    /// Represents a time unit.
+    ///
+    pub enum TimeUnit with Eq, ToString {
+        case Days,
+        case Hours,
+        case Microseconds,
+        case Milliseconds,
+        case Minutes,
+        case Nanoseconds,
+        case Seconds
+    }
+
+    ///
     /// Returns the number of milliseconds for timeunit `u`
     ///
     pub def toMilliseconds(u: Time.TimeUnit): Int32 = match u {


### PR DESCRIPTION
## Summary
Moves all 4 declarations (2 enums + 2 effects) and 4 trait instances out of `Time.flix` and into their respective `Time/<Name>.flix` companion files. Each declaration is now the **companion** of its enclosing module — its canonical symbol is e.g. `Time.Duration` or `Time.Clock`.

`Time.flix` is reduced to the license header and `pub mod Time { /* empty */ }`.

This mirrors the recently-merged `refactor/lift-fs-effects` (PR #12643) and `refactor/lift-net-decls` (PR #12644) work, applied to `Time`.

## What moved (per group / commit)

- **Group T1 — Time enums (2 decls + 4 instances):** `Duration` (with its `Add`, `Sub`, `ToString`, and `Formattable` instances, previously declared at file top level) and `TimeUnit`. Instance bodies simplified from `Time.Duration` to bare `Duration`.
- **Group T2 — Time effects (2 decls):** `Clock` and `Sleep`.

## Imports
Every destination already had the necessary `use Time.<Sibling>` lines from its existing helper functions, so **no new imports were required** in any companion file. No edits to `Library.scala` either.

## Test plan
- [x] Compiler builds (`mill flix.compile`)
- [x] Standard library compiles cleanly (`mill flix.run` on empty file) — verified after each group
- [x] Full test suite (`mill flix.test`) — 16248 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)