### PR TITLE
refactor: move Abort, Assert, and Logger effects into companion modules

### DIFF
--- a/main/src/library/Abort.flix
+++ b/main/src/library/Abort.flix
@@ -14,25 +14,25 @@
  *  limitations under the License.
  */
 
-///
-/// An effect used to abort computation with an error message.
-///
-pub eff Abort {
-
-    ///
-    /// Immediately aborts the current computation with the given error message `m`.
-    ///
-    /// The computation cannot be resumed.
-    ///
-    def abort(m: RichString): Void
-
-}
-
 pub mod Abort {
 
     import java.lang.Thread
     import java.lang.StackTraceElement
     import java.lang.System
+
+    ///
+    /// An effect used to abort computation with an error message.
+    ///
+    pub eff Abort {
+
+        ///
+        /// Immediately aborts the current computation with the given error message `m`.
+        ///
+        /// The computation cannot be resumed.
+        ///
+        def abort(m: RichString): Void
+
+    }
 
     ///
     /// Aborts the current computation with the given error message `m` enriched with a JVM stack trace.

--- a/main/src/library/Assert.flix
+++ b/main/src/library/Assert.flix
@@ -15,23 +15,23 @@
  * limitations under the License.
  */
 
-///
-/// An effect used to perform assertions during program execution.
-///
-pub eff Assert {
-
-    ///
-    /// Asserts that the given condition `cond` is `true` with a message `msg`.
-    ///
-    def assert(cond: Bool, msg: RichString): Unit
-
-}
-
 pub mod Assert {
 
     use Sys.Console
     use RichString.{blue, red, text, yellow};
     import java.lang.AssertionError;
+
+    ///
+    /// An effect used to perform assertions during program execution.
+    ///
+    pub eff Assert {
+
+        ///
+        /// Asserts that the given condition `cond` is `true` with a message `msg`.
+        ///
+        def assert(cond: Bool, msg: RichString): Unit
+
+    }
 
     ///
     /// Asserts that the given condition `cond` is `true`.

--- a/main/src/library/Logger.flix
+++ b/main/src/library/Logger.flix
@@ -14,23 +14,23 @@
  *  limitations under the License.
  */
 
-///
-/// An effect used to log messages.
-///
-pub eff Logger {
-
-    ///
-    /// Logs the given message `m` at the given severity `s`.
-    ///
-    def log(s: Severity, m: RichString): Unit
-
-}
-
 pub mod Logger {
 
     use Sys.Console
     use RichString.{gray, cyan, green, yellow, red, bold, text};
     use Severity.{Warn, Fatal, Trace, Debug, Info}
+
+    ///
+    /// An effect used to log messages.
+    ///
+    pub eff Logger {
+
+        ///
+        /// Logs the given message `m` at the given severity `s`.
+        ///
+        def log(s: Severity, m: RichString): Unit
+
+    }
 
     ///
     /// Logs the message `m` at the `Trace` level.


### PR DESCRIPTION
Continues the colocation sweep: each of `Abort.flix`, `Assert.flix`, `Logger.flix` declared its effect at file root with a same-named `pub mod` sibling. This nests each effect declaration inside its companion module body so the type and its companion live together, matching the convention established by Time/Net/Fs/Sys/Math.

## Summary
- `Abort.flix`: move `pub eff Abort` into `pub mod Abort`
- `Assert.flix`: move `pub eff Assert` into `pub mod Assert`
- `Logger.flix`: move `pub eff Logger` into `pub mod Logger`

External callers (`\ Abort`, `Abort.abort(...)`, `Abort.runWithResult`, `Assert.assertTrue`, `Logger.trace`, etc.) keep working unchanged via companion lifting (#12518).

## Test plan
- [x] Standard library compiles (`mill flix.run` on empty file)
- [x] Full test suite green (16248 tests, 0 failures)