### PR TITLE
refactor: nest mutable collection structs into companion modules

### DIFF
--- a/main/src/library/BufReader.flix
+++ b/main/src/library/BufReader.flix
@@ -14,56 +14,56 @@
  *  limitations under the License.
  */
 
-///
-/// A `Readable` implementation that wraps an underlying `Readable` instance
-/// and stores the items read from the underlying instance in an internal buffer.
-///
-/// A call to `read` will read directly from the buffer if items are available, and
-/// will trigger a `read` from the underlying `reader` when the buffer is empty.
-///
-/// This has the effect of reducing the overall number of `read`s to the underlying
-/// `Readable`.
-///
-/// A call to `read` might read more than the requested number of items from the
-/// underlying reader, in order to fill the entire buffer.
-///
-/// A call to `read` might not read from the underlying `reader` at all, if there are
-/// enough items in the buffer.
-///
-/// `buffer`: the underlying buffer.
-/// `cursor`: the index in `buffer` of the first element logically considered to be in the buffer.
-/// `size`: the number of elements (starting at `cursor`) logically considered to be in the buffer.
-/// `reader`: the underlying `Readable` being read from.
-///
-pub struct BufReader[a: Type, t: Type, r: Region] {
-    buffer: Array[a, r],
-    mut cursor: Int32,
-    mut size: Int32,
-    reader: t
-}
-
-instance Readable[BufReader[a, t, rr]] with Readable[t] where Readable.Elm[t] ~ a {
-
-    type Elm = a
-
-    type Aef = rr + Readable.Aef[t]
-
-    pub def read(buffer: Array[a, rb], bufReader: BufReader[a, t, rr]): Result[IoError, Int32] \ rb + rr + Readable.Aef[t] =
-        BufReader.read(buffer, bufReader)
-
-}
-
-instance Peekable[BufReader[a, t, r]] with Readable[t] where Readable.Elm[t] ~ a {
-
-    pub def peek(bufReader: BufReader[a, t, r]): Result[IoError, Option[Readable.Elm[t]]] \ Readable.Aef[t] + r = BufReader.peek(bufReader)
-
-    pub def skip(n: Int32, bufReader: BufReader[a, t, r]): Result[IoError, Int32] \ Readable.Aef[t] + r = BufReader.skip(n, bufReader)
-
-    pub def readWhile(p: Readable.Elm[t] -> Bool, bufReader: BufReader[a, t, r]): Result[IoError, Vector[Readable.Elm[t]]] \ Readable.Aef[t] + r = BufReader.readWhile(p, bufReader)
-
-}
-
 pub mod BufReader {
+
+    ///
+    /// A `Readable` implementation that wraps an underlying `Readable` instance
+    /// and stores the items read from the underlying instance in an internal buffer.
+    ///
+    /// A call to `read` will read directly from the buffer if items are available, and
+    /// will trigger a `read` from the underlying `reader` when the buffer is empty.
+    ///
+    /// This has the effect of reducing the overall number of `read`s to the underlying
+    /// `Readable`.
+    ///
+    /// A call to `read` might read more than the requested number of items from the
+    /// underlying reader, in order to fill the entire buffer.
+    ///
+    /// A call to `read` might not read from the underlying `reader` at all, if there are
+    /// enough items in the buffer.
+    ///
+    /// `buffer`: the underlying buffer.
+    /// `cursor`: the index in `buffer` of the first element logically considered to be in the buffer.
+    /// `size`: the number of elements (starting at `cursor`) logically considered to be in the buffer.
+    /// `reader`: the underlying `Readable` being read from.
+    ///
+    pub struct BufReader[a: Type, t: Type, r: Region] {
+        buffer: Array[a, r],
+        mut cursor: Int32,
+        mut size: Int32,
+        reader: t
+    }
+
+    instance Readable[BufReader[a, t, rr]] with Readable[t] where Readable.Elm[t] ~ a {
+
+        type Elm = a
+
+        type Aef = rr + Readable.Aef[t]
+
+        pub def read(buffer: Array[a, rb], bufReader: BufReader[a, t, rr]): Result[IoError, Int32] \ rb + rr + Readable.Aef[t] =
+            BufReader.read(buffer, bufReader)
+
+    }
+
+    instance Peekable[BufReader[a, t, r]] with Readable[t] where Readable.Elm[t] ~ a {
+
+        pub def peek(bufReader: BufReader[a, t, r]): Result[IoError, Option[Readable.Elm[t]]] \ Readable.Aef[t] + r = BufReader.peek(bufReader)
+
+        pub def skip(n: Int32, bufReader: BufReader[a, t, r]): Result[IoError, Int32] \ Readable.Aef[t] + r = BufReader.skip(n, bufReader)
+
+        pub def readWhile(p: Readable.Elm[t] -> Bool, bufReader: BufReader[a, t, r]): Result[IoError, Vector[Readable.Elm[t]]] \ Readable.Aef[t] + r = BufReader.readWhile(p, bufReader)
+
+    }
 
     ///
     /// Constructs a `BufReader` wrapping `reader` with a default capacity of 4096 items.

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -15,47 +15,47 @@
  */
 
 
-///
-/// Represents a mutable deque.
-///
-/// Explanation of component types (from left to right):
-/// The 1st component is a reference the backing array.
-/// The 2nd component is a reference to the front index.
-/// The 3rd component is a reference to the back index.
-///
-/// If front == back then the deque is empty.
-/// Otherwise, the front index always points to an element (going counter-clockwise)
-/// and the back index always points to the first empty index (going clockwise).
-///
-pub struct MutDeque[a: Type, r: Region] {
-    r: Region[r],
-    mut values: Array[a, r],
-    mut front: Int32,
-    mut back: Int32
-}
-
-instance Iterable[MutDeque[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def iterator(rc: Region[r1], md: MutDeque[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutDeque.iterator(rc, md)
-}
-
-instance ForEach[MutDeque[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def forEach(f: a -> Unit \ ef, md: MutDeque[a, r]): Unit \ ef + r = MutDeque.forEach(f, md)
-}
-
-instance Formattable[MutDeque[a, r]] with Formattable[a] {
-    type Aef = Formattable.Aef[a] + r
-
-    pub def format(x: MutDeque[a, r]): RichString \ (Formattable.Aef[a] + r) =
-        use RichString.{fromString, joinWith};
-        fromString("MutDeque#{") + joinWith(Formattable.format, fromString(", "), MutDeque.toList(x)) + fromString("}")
-}
-
 pub mod MutDeque {
     use Math.Shuffle
+
+    ///
+    /// Represents a mutable deque.
+    ///
+    /// Explanation of component types (from left to right):
+    /// The 1st component is a reference the backing array.
+    /// The 2nd component is a reference to the front index.
+    /// The 3rd component is a reference to the back index.
+    ///
+    /// If front == back then the deque is empty.
+    /// Otherwise, the front index always points to an element (going counter-clockwise)
+    /// and the back index always points to the first empty index (going clockwise).
+    ///
+    pub struct MutDeque[a: Type, r: Region] {
+        r: Region[r],
+        mut values: Array[a, r],
+        mut front: Int32,
+        mut back: Int32
+    }
+
+    instance Iterable[MutDeque[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def iterator(rc: Region[r1], md: MutDeque[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutDeque.iterator(rc, md)
+    }
+
+    instance ForEach[MutDeque[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def forEach(f: a -> Unit \ ef, md: MutDeque[a, r]): Unit \ ef + r = MutDeque.forEach(f, md)
+    }
+
+    instance Formattable[MutDeque[a, r]] with Formattable[a] {
+        type Aef = Formattable.Aef[a] + r
+
+        pub def format(x: MutDeque[a, r]): RichString \ (Formattable.Aef[a] + r) =
+            use RichString.{fromString, joinWith};
+            fromString("MutDeque#{") + joinWith(Formattable.format, fromString(", "), MutDeque.toList(x)) + fromString("}")
+    }
 
     ///
     /// Constant denoting the minimum allowed capacity of the backing array.

--- a/main/src/library/MutHashMap.flix
+++ b/main/src/library/MutHashMap.flix
@@ -14,63 +14,63 @@
  * limitations under the License.
  */
 
-///
-/// Represents a mutable hash map that preserves insertion order.
-///
-/// Uses a hash table with separate chaining for collisions and a doubly-linked list
-/// to maintain insertion order.
-///
-pub struct MutHashMap[k: Type, v: Type, r: Region] {
-    rc: Region[r],
-    mut buckets: Array[Option[MutHashMap.Entry[k, v, r]], r],   // Hash table buckets
-    mut head: Option[MutHashMap.Entry[k, v, r]],                // First entry in insertion order
-    mut tail: Option[MutHashMap.Entry[k, v, r]],                // Last entry in insertion order
-    mut size: Int32                                             // Number of entries
-}
+pub mod MutHashMap {
 
-instance Iterable[MutHashMap[k, v, r]] {
-    type Elm = (k, v)
-    type Aef = r
-    pub def iterator(rc: Region[r1], m: MutHashMap[k, v, r]): Iterator[(k, v), r + r1, r1] \ (r + r1) =
-        MutHashMap.iterator(rc, m)
-}
+    ///
+    /// Represents a mutable hash map that preserves insertion order.
+    ///
+    /// Uses a hash table with separate chaining for collisions and a doubly-linked list
+    /// to maintain insertion order.
+    ///
+    pub struct MutHashMap[k: Type, v: Type, r: Region] {
+        rc: Region[r],
+        mut buckets: Array[Option[MutHashMap.Entry[k, v, r]], r],   // Hash table buckets
+        mut head: Option[MutHashMap.Entry[k, v, r]],                // First entry in insertion order
+        mut tail: Option[MutHashMap.Entry[k, v, r]],                // Last entry in insertion order
+        mut size: Int32                                             // Number of entries
+    }
 
-instance ForEach[MutHashMap[k, v, r]] {
-    type Elm = (k, v)
-    type Aef = r
-    pub def forEach(f: ((k, v)) -> Unit \ ef, m: MutHashMap[k, v, r]): Unit \ ef + r =
-        MutHashMap.forEach((k, v) -> f((k, v)), m)
-}
+    instance Iterable[MutHashMap[k, v, r]] {
+        type Elm = (k, v)
+        type Aef = r
+        pub def iterator(rc: Region[r1], m: MutHashMap[k, v, r]): Iterator[(k, v), r + r1, r1] \ (r + r1) =
+            MutHashMap.iterator(rc, m)
+    }
 
-instance Indexable[MutHashMap[k, v, r]] with Eq[k], Hash[k] {
-    type Elm = v
-    type Idx = k
-    type Aef = r + KeyNotFound
+    instance ForEach[MutHashMap[k, v, r]] {
+        type Elm = (k, v)
+        type Aef = r
+        pub def forEach(f: ((k, v)) -> Unit \ ef, m: MutHashMap[k, v, r]): Unit \ ef + r =
+            MutHashMap.forEach((k, v) -> f((k, v)), m)
+    }
 
-    pub def get(t: MutHashMap[k, v, r], i: k): v \ r + KeyNotFound = {
-        match MutHashMap.get(i, t) {
-            case Some(v) => v
-            case None => KeyNotFound.keyNotFound("key not found")
+    instance Indexable[MutHashMap[k, v, r]] with Eq[k], Hash[k] {
+        type Elm = v
+        type Idx = k
+        type Aef = r + KeyNotFound
+
+        pub def get(t: MutHashMap[k, v, r], i: k): v \ r + KeyNotFound = {
+            match MutHashMap.get(i, t) {
+                case Some(v) => v
+                case None => KeyNotFound.keyNotFound("key not found")
+            }
         }
     }
-}
 
-instance IndexableMut[MutHashMap[k, v, r]] with Eq[k], Hash[k] {
-    type Aef = r
+    instance IndexableMut[MutHashMap[k, v, r]] with Eq[k], Hash[k] {
+        type Aef = r
 
-    pub def put(t: MutHashMap[k, v, r], i: k, v: v): Unit \ r = MutHashMap.put(i, v, t)
-}
+        pub def put(t: MutHashMap[k, v, r], i: k, v: v): Unit \ r = MutHashMap.put(i, v, t)
+    }
 
-instance Formattable[MutHashMap[k, v, r]] with Formattable[k], Formattable[v] {
-    type Aef = Formattable.Aef[k] + Formattable.Aef[v] + r
+    instance Formattable[MutHashMap[k, v, r]] with Formattable[k], Formattable[v] {
+        type Aef = Formattable.Aef[k] + Formattable.Aef[v] + r
 
-    pub def format(x: MutHashMap[k, v, r]): RichString \ (Formattable.Aef[k] + Formattable.Aef[v] + r) =
-        use RichString.{fromString, joinWith};
-        let kvs = MutHashMap.toList(x) |> List.map(match (k, v) -> Formattable.format(k) + fromString(" => ") + Formattable.format(v));
-        fromString("MutHashMap#{") + joinWith(identity, fromString(", "), kvs) + fromString("}")
-}
-
-pub mod MutHashMap {
+        pub def format(x: MutHashMap[k, v, r]): RichString \ (Formattable.Aef[k] + Formattable.Aef[v] + r) =
+            use RichString.{fromString, joinWith};
+            let kvs = MutHashMap.toList(x) |> List.map(match (k, v) -> Formattable.format(k) + fromString(" => ") + Formattable.format(v));
+            fromString("MutHashMap#{") + joinWith(identity, fromString(", "), kvs) + fromString("}")
+    }
 
     ///
     /// Constant denoting the minimum allowed capacity of the bucket array.

--- a/main/src/library/MutHashSet.flix
+++ b/main/src/library/MutHashSet.flix
@@ -14,36 +14,36 @@
  * limitations under the License.
  */
 
-///
-/// Represents a mutable hash set that preserves insertion order.
-///
-pub struct MutHashSet[t: Type, r: Region] {
-    inner: MutHashMap[t, Unit, r]
-}
-
-instance ForEach[MutHashSet[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def forEach(f: a -> Unit \ ef, s: MutHashSet[a, r]): Unit \ ef + r =
-        MutHashSet.forEach(f, s)
-}
-
-instance Iterable[MutHashSet[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def iterator(rc: Region[r1], s: MutHashSet[a, r]): Iterator[a, r + r1, r1] \ (r + r1) =
-        MutHashSet.iterator(rc, s)
-}
-
-instance Formattable[MutHashSet[t, r]] with Formattable[t] {
-    type Aef = Formattable.Aef[t] + r
-
-    pub def format(x: MutHashSet[t, r]): RichString \ (Formattable.Aef[t] + r) =
-        use RichString.{fromString, joinWith};
-        fromString("MutHashSet#{") + joinWith(Formattable.format, fromString(", "), MutHashSet.toList(x)) + fromString("}")
-}
-
 pub mod MutHashSet {
+
+    ///
+    /// Represents a mutable hash set that preserves insertion order.
+    ///
+    pub struct MutHashSet[t: Type, r: Region] {
+        inner: MutHashMap[t, Unit, r]
+    }
+
+    instance ForEach[MutHashSet[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def forEach(f: a -> Unit \ ef, s: MutHashSet[a, r]): Unit \ ef + r =
+            MutHashSet.forEach(f, s)
+    }
+
+    instance Iterable[MutHashSet[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def iterator(rc: Region[r1], s: MutHashSet[a, r]): Iterator[a, r + r1, r1] \ (r + r1) =
+            MutHashSet.iterator(rc, s)
+    }
+
+    instance Formattable[MutHashSet[t, r]] with Formattable[t] {
+        type Aef = Formattable.Aef[t] + r
+
+        pub def format(x: MutHashSet[t, r]): RichString \ (Formattable.Aef[t] + r) =
+            use RichString.{fromString, joinWith};
+            fromString("MutHashSet#{") + joinWith(Formattable.format, fromString(", "), MutHashSet.toList(x)) + fromString("}")
+    }
 
     ///
     /// Returns a new empty set.

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -14,57 +14,57 @@
  * limitations under the License.
  */
 
-///
-/// Represents a mutable list.
-///
-/// Invariant
-///   - The length is always higher than the total capacity of the array.
-///   - The capacity of the array is always 8 or more.
-///
-pub struct MutList[a: Type, r: Region] {
-    r: Region[r],
-    mut values: Array[a, r],
-    mut length: Int32
-}
-
-instance Iterable[MutList[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def iterator(rc: Region[r1], l: MutList[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutList.iterator(rc, l)
-}
-
-instance ForEach[MutList[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def forEach(f: a -> Unit \ ef, l: MutList[a, r]): Unit \ ef + r = MutList.forEach(f, l)
-}
-
-instance Indexable[MutList[a, r]] {
-    type Idx = Int32
-    type Elm = a
-    type Aef = r + OutOfBounds
-    pub def get(t: MutList[a, r], i: Int32): a \ r + OutOfBounds =
-        if (0 <= i and i < MutList.length(t)) MutList.get(i, t)
-        else OutOfBounds.outOfBounds("index ${i} is out of bounds for MutList of length ${MutList.length(t)}")
-}
-
-instance IndexableMut[MutList[a, r]] {
-    type Aef = r + OutOfBounds
-    pub def put(t: MutList[a, r], i: Int32, v: a): Unit \ r + OutOfBounds =
-        if (0 <= i and i < MutList.length(t)) MutList.put(v, i, t)
-        else OutOfBounds.outOfBounds("index ${i} is out of bounds for MutList of length ${MutList.length(t)}")
-}
-
-instance Formattable[MutList[a, r]] with Formattable[a] {
-    type Aef = Formattable.Aef[a] + r
-
-    pub def format(x: MutList[a, r]): RichString \ (Formattable.Aef[a] + r) =
-        use RichString.{fromString, joinWith};
-        fromString("MutList#{") + joinWith(Formattable.format, fromString(", "), MutList.toList(x)) + fromString("}")
-}
-
 pub mod MutList {
     use Math.Shuffle
+
+    ///
+    /// Represents a mutable list.
+    ///
+    /// Invariant
+    ///   - The length is always higher than the total capacity of the array.
+    ///   - The capacity of the array is always 8 or more.
+    ///
+    pub struct MutList[a: Type, r: Region] {
+        r: Region[r],
+        mut values: Array[a, r],
+        mut length: Int32
+    }
+
+    instance Iterable[MutList[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def iterator(rc: Region[r1], l: MutList[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutList.iterator(rc, l)
+    }
+
+    instance ForEach[MutList[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def forEach(f: a -> Unit \ ef, l: MutList[a, r]): Unit \ ef + r = MutList.forEach(f, l)
+    }
+
+    instance Indexable[MutList[a, r]] {
+        type Idx = Int32
+        type Elm = a
+        type Aef = r + OutOfBounds
+        pub def get(t: MutList[a, r], i: Int32): a \ r + OutOfBounds =
+            if (0 <= i and i < MutList.length(t)) MutList.get(i, t)
+            else OutOfBounds.outOfBounds("index ${i} is out of bounds for MutList of length ${MutList.length(t)}")
+    }
+
+    instance IndexableMut[MutList[a, r]] {
+        type Aef = r + OutOfBounds
+        pub def put(t: MutList[a, r], i: Int32, v: a): Unit \ r + OutOfBounds =
+            if (0 <= i and i < MutList.length(t)) MutList.put(v, i, t)
+            else OutOfBounds.outOfBounds("index ${i} is out of bounds for MutList of length ${MutList.length(t)}")
+    }
+
+    instance Formattable[MutList[a, r]] with Formattable[a] {
+        type Aef = Formattable.Aef[a] + r
+
+        pub def format(x: MutList[a, r]): RichString \ (Formattable.Aef[a] + r) =
+            use RichString.{fromString, joinWith};
+            fromString("MutList#{") + joinWith(Formattable.format, fromString(", "), MutList.toList(x)) + fromString("}")
+    }
 
     ///
     /// Constant which stores the minimum capacity of a MutList.

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -14,56 +14,56 @@
  * limitations under the License.
  */
 
-///
-/// The Mutable Map type.
-///
-pub struct MutMap[k: Type, v: Type, r: Region] {
-    rc: Region[r],
-    mut inner: Map[k, v]
-}
+pub mod MutMap {
 
-instance Indexable[MutMap[k, v, r]] with Order[k] {
-    type Idx = k
-    type Elm = v
-    type Aef = r + KeyNotFound
+    ///
+    /// The Mutable Map type.
+    ///
+    pub struct MutMap[k: Type, v: Type, r: Region] {
+        rc: Region[r],
+        mut inner: Map[k, v]
+    }
 
-    pub def get(t: MutMap[k, v, r], i: k): v \ r + KeyNotFound = {
-        match MutMap.get(i, t) {
-            case Some(v) => v
-            case None => KeyNotFound.keyNotFound("key not found")
+    instance Indexable[MutMap[k, v, r]] with Order[k] {
+        type Idx = k
+        type Elm = v
+        type Aef = r + KeyNotFound
+
+        pub def get(t: MutMap[k, v, r], i: k): v \ r + KeyNotFound = {
+            match MutMap.get(i, t) {
+                case Some(v) => v
+                case None => KeyNotFound.keyNotFound("key not found")
+            }
         }
     }
-}
 
-instance IndexableMut[MutMap[k, v, r]] with Order[k] {
-    type Aef = r
+    instance IndexableMut[MutMap[k, v, r]] with Order[k] {
+        type Aef = r
 
-    pub def put(t: MutMap[k, v, r], i: k, v: v): Unit \ r = MutMap.put(i, v, t)
-}
+        pub def put(t: MutMap[k, v, r], i: k, v: v): Unit \ r = MutMap.put(i, v, t)
+    }
 
-instance Iterable[MutMap[k, v, r]] {
-    type Elm = (k, v)
-    type Aef = r
-    pub def iterator(rc: Region[r1], m: MutMap[k, v, r]): Iterator[(k, v), r + r1, r1] \ (r + r1) =
-        MutMap.iterator(rc, m)
-}
+    instance Iterable[MutMap[k, v, r]] {
+        type Elm = (k, v)
+        type Aef = r
+        pub def iterator(rc: Region[r1], m: MutMap[k, v, r]): Iterator[(k, v), r + r1, r1] \ (r + r1) =
+            MutMap.iterator(rc, m)
+    }
 
-instance ForEach[MutMap[k, v, r]] {
-    type Elm = (k, v)
-    type Aef = r
-    pub def forEach(f: ((k, v)) -> Unit \ ef, m: MutMap[k, v, r]): Unit \ ef + r = MutMap.forEach(k -> v -> f((k, v)), m)
-}
+    instance ForEach[MutMap[k, v, r]] {
+        type Elm = (k, v)
+        type Aef = r
+        pub def forEach(f: ((k, v)) -> Unit \ ef, m: MutMap[k, v, r]): Unit \ ef + r = MutMap.forEach(k -> v -> f((k, v)), m)
+    }
 
-instance Formattable[MutMap[k, v, r]] with Formattable[k], Formattable[v] {
-    type Aef = Formattable.Aef[k] + Formattable.Aef[v] + r
+    instance Formattable[MutMap[k, v, r]] with Formattable[k], Formattable[v] {
+        type Aef = Formattable.Aef[k] + Formattable.Aef[v] + r
 
-    pub def format(x: MutMap[k, v, r]): RichString \ (Formattable.Aef[k] + Formattable.Aef[v] + r) =
-        use RichString.{fromString, joinWith};
-        let kvs = MutMap.toList(x) |> List.map(match (k, v) -> Formattable.format(k) + fromString(" => ") + Formattable.format(v));
-        fromString("MutMap#{") + joinWith(identity, fromString(", "), kvs) + fromString("}")
-}
-
-pub mod MutMap {
+        pub def format(x: MutMap[k, v, r]): RichString \ (Formattable.Aef[k] + Formattable.Aef[v] + r) =
+            use RichString.{fromString, joinWith};
+            let kvs = MutMap.toList(x) |> List.map(match (k, v) -> Formattable.format(k) + fromString(" => ") + Formattable.format(v));
+            fromString("MutMap#{") + joinWith(identity, fromString(", "), kvs) + fromString("}")
+    }
 
     ///
     /// Returns a string representation of the given MutMap `m`.

--- a/main/src/library/MutPriorityQueue.flix
+++ b/main/src/library/MutPriorityQueue.flix
@@ -14,42 +14,42 @@
  * limitations under the License.
  */
 
-///
-/// Represents a mutable priority queue.
-/// Explanation of component types (left to right):
-/// Component 1: The region capability the queue is associated with.
-/// Component 2: A reference to the backing array.
-/// Component 3: A reference to the number of elements in the mutable priority queue.
-///
-/// The maximum element (if it exists) can always be accessed in constant time.
-///
-pub struct MutPriorityQueue[a: Type, r: Region] {
-    r: Region[r],
-    mut values: Array[a, r],
-    mut size: Int32
-}
-
-instance Iterable[MutPriorityQueue[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def iterator(rc: Region[r1], q: MutPriorityQueue[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutPriorityQueue.iterator(rc, q)
-}
-
-instance ForEach[MutPriorityQueue[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def forEach(f: a -> Unit \ ef, q: MutPriorityQueue[a, r]): Unit \ ef + r = MutPriorityQueue.forEach(f, q)
-}
-
-instance Formattable[MutPriorityQueue[a, r]] with Formattable[a], Order[a] {
-    type Aef = Formattable.Aef[a] + r
-
-    pub def format(x: MutPriorityQueue[a, r]): RichString \ (Formattable.Aef[a] + r) =
-        use RichString.{fromString, joinWith};
-        fromString("MutPriorityQueue#{") + joinWith(Formattable.format, fromString(", "), MutPriorityQueue.toList(x)) + fromString("}")
-}
-
 pub mod MutPriorityQueue {
+
+    ///
+    /// Represents a mutable priority queue.
+    /// Explanation of component types (left to right):
+    /// Component 1: The region capability the queue is associated with.
+    /// Component 2: A reference to the backing array.
+    /// Component 3: A reference to the number of elements in the mutable priority queue.
+    ///
+    /// The maximum element (if it exists) can always be accessed in constant time.
+    ///
+    pub struct MutPriorityQueue[a: Type, r: Region] {
+        r: Region[r],
+        mut values: Array[a, r],
+        mut size: Int32
+    }
+
+    instance Iterable[MutPriorityQueue[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def iterator(rc: Region[r1], q: MutPriorityQueue[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutPriorityQueue.iterator(rc, q)
+    }
+
+    instance ForEach[MutPriorityQueue[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def forEach(f: a -> Unit \ ef, q: MutPriorityQueue[a, r]): Unit \ ef + r = MutPriorityQueue.forEach(f, q)
+    }
+
+    instance Formattable[MutPriorityQueue[a, r]] with Formattable[a], Order[a] {
+        type Aef = Formattable.Aef[a] + r
+
+        pub def format(x: MutPriorityQueue[a, r]): RichString \ (Formattable.Aef[a] + r) =
+            use RichString.{fromString, joinWith};
+            fromString("MutPriorityQueue#{") + joinWith(Formattable.format, fromString(", "), MutPriorityQueue.toList(x)) + fromString("}")
+    }
 
     ///
     /// Constant which stores the minimum capacity of a MutPriorityQueue.

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -14,35 +14,35 @@
  * limitations under the License.
  */
 
-///
-/// The Mutable Set type.
-///
-pub struct MutSet[t: Type, r: Region] {
-    rc: Region[r],
-    mut inner: Set[t]
-}
-
-instance Iterable[MutSet[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def iterator(rc: Region[r1], s: MutSet[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutSet.iterator(rc, s)
-}
-
-instance ForEach[MutSet[a, r]] {
-    type Elm = a
-    type Aef = r
-    pub def forEach(f: a -> Unit \ ef, s: MutSet[a, r]): Unit \ ef + r = MutSet.forEach(f, s)
-}
-
-instance Formattable[MutSet[t, r]] with Formattable[t] {
-    type Aef = Formattable.Aef[t] + r
-
-    pub def format(x: MutSet[t, r]): RichString \ (Formattable.Aef[t] + r) =
-        use RichString.{fromString, joinWith};
-        fromString("MutSet#{") + joinWith(Formattable.format, fromString(", "), MutSet.toList(x)) + fromString("}")
-}
-
 pub mod MutSet {
+
+    ///
+    /// The Mutable Set type.
+    ///
+    pub struct MutSet[t: Type, r: Region] {
+        rc: Region[r],
+        mut inner: Set[t]
+    }
+
+    instance Iterable[MutSet[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def iterator(rc: Region[r1], s: MutSet[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutSet.iterator(rc, s)
+    }
+
+    instance ForEach[MutSet[a, r]] {
+        type Elm = a
+        type Aef = r
+        pub def forEach(f: a -> Unit \ ef, s: MutSet[a, r]): Unit \ ef + r = MutSet.forEach(f, s)
+    }
+
+    instance Formattable[MutSet[t, r]] with Formattable[t] {
+        type Aef = Formattable.Aef[t] + r
+
+        pub def format(x: MutSet[t, r]): RichString \ (Formattable.Aef[t] + r) =
+            use RichString.{fromString, joinWith};
+            fromString("MutSet#{") + joinWith(Formattable.format, fromString(", "), MutSet.toList(x)) + fromString("}")
+    }
 
     ///
     /// Returns a string representation of the given mutable set `s`.


### PR DESCRIPTION
Continues the colocation sweep: each of these files declared its struct (and several typeclass instances) at file root with a same-named \`pub mod\` sibling. This nests the struct and its instance blocks inside the same-named module body, matching the convention established in Time/Net/Fs/Sys/Math.

## Summary
Files affected (struct + instance blocks moved into \`pub mod\` body):
- \`BufReader.flix\` — struct + 2 instances
- \`MutDeque.flix\` — struct + 3 instances
- \`MutHashMap.flix\` — struct + 5 instances
- \`MutHashSet.flix\` — struct + 3 instances
- \`MutList.flix\` — struct + 5 instances
- \`MutMap.flix\` — struct + 5 instances
- \`MutPriorityQueue.flix\` — struct + 3 instances
- \`MutSet.flix\` — struct + 3 instances

\`BPlusTree\` and \`MutDisjointSets\` are intentionally excluded; both have additional cross-file Pattern B work that will land separately.

## Test plan
- [x] Standard library compiles (\`mill flix.run\` on empty file)
- [x] Full test suite green (16248 tests, 0 failures)