### PR TITLE
refactor: deduplicate and reorder sidebar in HtmlDocumentor

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -548,9 +548,9 @@ object HtmlDocumentor {
     docSideBar(mod.parent) { () =>
       docSubModules(mod)
       docSideBarSection(
-        "Traits",
-        sortedTraits,
-        (t: Trait) => sb.append(s"<a href='${escUrl(t.fileName)}'>${esc(t.name)}</a>"),
+        "Enums",
+        sortedEnums,
+        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Effects",
@@ -558,9 +558,9 @@ object HtmlDocumentor {
         (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
-        "Enums",
-        sortedEnums,
-        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
+        "Traits",
+        sortedTraits,
+        (t: Trait) => sb.append(s"<a href='${escUrl(t.fileName)}'>${esc(t.name)}</a>"),
       )
       docSideBarSection(
         "Type Aliases",
@@ -621,9 +621,9 @@ object HtmlDocumentor {
         (d: TypedAst.Sig) => sb.append(s"<a href='#sig-${escUrl(d.sym.name)}'>${esc(d.sym.name)}</a>"),
       )
       docSideBarSection(
-        "Traits",
-        sortedTraits,
-        (t: Trait) => sb.append(s"<a href='${escUrl(t.fileName)}'>${esc(t.name)}</a>"),
+        "Enums",
+        sortedEnums,
+        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Effects",
@@ -631,9 +631,9 @@ object HtmlDocumentor {
         (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
-        "Enums",
-        sortedEnums,
-        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
+        "Traits",
+        sortedTraits,
+        (t: Trait) => sb.append(s"<a href='${escUrl(t.fileName)}'>${esc(t.name)}</a>"),
       )
       docSideBarSection(
         "Type Aliases",
@@ -706,9 +706,9 @@ object HtmlDocumentor {
         sortedOps, (o: TypedAst.Op) => sb.append(s"<a href='#op-${escUrl(esc(o.sym.name))}'>${esc(o.sym.name)}</a>")
       )
       docSideBarSection(
-        "Traits",
-        sortedTraits,
-        (t: Trait) => sb.append(s"<a href='${escUrl(t.fileName)}'>${esc(t.name)}</a>"),
+        "Enums",
+        sortedEnums,
+        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Effects",
@@ -716,9 +716,9 @@ object HtmlDocumentor {
         (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
-        "Enums",
-        sortedEnums,
-        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
+        "Traits",
+        sortedTraits,
+        (t: Trait) => sb.append(s"<a href='${escUrl(t.fileName)}'>${esc(t.name)}</a>"),
       )
       docSideBarSection(
         "Type Aliases",
@@ -782,9 +782,9 @@ object HtmlDocumentor {
     docSideBar(Some(enm.parent)) { () =>
       mod.foreach(docSubModules)
       docSideBarSection(
-        "Traits",
-        sortedTraits,
-        (t: Trait) => sb.append(s"<a href='${escUrl(t.fileName)}'>${esc(t.name)}</a>"),
+        "Enums",
+        sortedEnums,
+        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Effects",
@@ -792,9 +792,9 @@ object HtmlDocumentor {
         (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
-        "Enums",
-        sortedEnums,
-        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
+        "Traits",
+        sortedTraits,
+        (t: Trait) => sb.append(s"<a href='${escUrl(t.fileName)}'>${esc(t.name)}</a>"),
       )
       docSideBarSection(
         "Type Aliases",
@@ -942,13 +942,7 @@ object HtmlDocumentor {
   }
 
   private def docSubModules(parentMod: Module)(implicit sb: StringBuilder): Unit = {
-    val subItems: List[Item] =
-      parentMod.submodules ++
-        parentMod.traits ++
-        parentMod.effects ++
-        parentMod.enums
-
-    val sortedItems = subItems.sortBy(_.name)
+    val sortedItems = parentMod.submodules.sortBy(_.name)
 
     if (sortedItems.isEmpty) {
       return


### PR DESCRIPTION
## Summary
- Restrict the sidebar "Modules" section to free-standing submodules; traits, effects, and enums that previously appeared there are removed since they already have their own sections.
- Reorder the sidebar to: Modules, Enums, Effects, Traits, Type Aliases, Definitions.

## Test plan
- [ ] Generate library docs and visually verify the sidebar on module, trait, effect, and enum pages.