### PR TITLE
refactor: nest Fixpoint3 types into companion modules

### DIFF
--- a/main/src/library/Fixpoint3.flix
+++ b/main/src/library/Fixpoint3.flix
@@ -92,17 +92,6 @@ pub mod Fixpoint3 {
     }
 
     ///
-    /// `Counter` is a wrapper around `Ref` for a simple counter.
-    ///
-    /// Its primary use is for generating identifiers.
-    ///
-    /// Not thread-safe.
-    ///
-    pub struct Counter[r: Region] {
-        mut state: Int32
-    }
-
-    ///
     /// A trait for types that contain predicate symbols.
     ///
     pub trait PredSymsOf[t] {
@@ -119,23 +108,6 @@ pub mod Fixpoint3 {
     ///
     pub trait SubstitutePredSym[t] {
         pub def substitute(x: t, s: Map[PredSym, PredSym]): t
-    }
-
-    ///
-    /// The purpose of `UniqueInts` is to assign unique numbers/identifiers to elements.
-    ///
-    /// Example of use: When generating joins automatically we have data of type
-    /// `(RelSym, Search)`. These needs to be placed somewhere in memory. For
-    /// a pair `(rel, search)` calling `createIndex((rel, search))` will return its
-    /// index if it has been seen before and otherwise return the new index
-    /// which henceforth will be returned for subsequent queries of `(rel, search)`.
-    ///
-    /// `ReverseUniqueInts` allows using an index, `i`, assigned by `UniqueInts`, and get
-    /// the value, which `UniqueInts` assigned index `i`.
-    ///
-    pub struct UniqueInts[k: Type, r: Region] {
-        map: MutMap[k, Int32, r],
-        counter: Counter[r]
     }
 
 }

--- a/main/src/library/Fixpoint3/Counter.flix
+++ b/main/src/library/Fixpoint3/Counter.flix
@@ -18,6 +18,17 @@
 pub mod Fixpoint3.Counter {
 
     ///
+    /// `Counter` is a wrapper around `Ref` for a simple counter.
+    ///
+    /// Its primary use is for generating identifiers.
+    ///
+    /// Not thread-safe.
+    ///
+    pub struct Counter[r: Region] {
+        mut state: Int32
+    }
+
+    ///
     /// Returns a fresh `Counter` initialized to `0`.
     ///
     pub def fresh(rc: Region[r]): Counter[r] \ r = new Counter @ rc {state = 0}

--- a/main/src/library/Fixpoint3/PrecedenceGraph.flix
+++ b/main/src/library/Fixpoint3/PrecedenceGraph.flix
@@ -74,12 +74,4 @@ pub mod Fixpoint3.PrecedenceGraph {
         MutList.toList(pseudoStratums)
     }
 
-    ///
-    /// A mutable graph.
-    ///
-    pub struct MutGraph[r] {
-        vertices: MutSet[Vertex, r],
-        adjList: MutMap[Vertex, Set[Vertex], r]
-    }
-
 }

--- a/main/src/library/Fixpoint3/PrecedenceGraph/MutGraph.flix
+++ b/main/src/library/Fixpoint3/PrecedenceGraph/MutGraph.flix
@@ -22,6 +22,14 @@ pub mod Fixpoint3.PrecedenceGraph.MutGraph {
     use Fixpoint3.Util.getOrCrash
 
     ///
+    /// A mutable graph.
+    ///
+    pub struct MutGraph[r] {
+        vertices: MutSet[Vertex, r],
+        adjList: MutMap[Vertex, Set[Vertex], r]
+    }
+
+    ///
     /// `Color` is used to label vertices during DFS traversal and topological sort.
     ///
     /// A vertex is colored `White` if unvisited, `Gray` if currently being visisted,

--- a/main/src/library/Fixpoint3/UniqueInts.flix
+++ b/main/src/library/Fixpoint3/UniqueInts.flix
@@ -19,6 +19,23 @@ pub mod Fixpoint3.UniqueInts {
     use Fixpoint3.Counter
 
     ///
+    /// The purpose of `UniqueInts` is to assign unique numbers/identifiers to elements.
+    ///
+    /// Example of use: When generating joins automatically we have data of type
+    /// `(RelSym, Search)`. These needs to be placed somewhere in memory. For
+    /// a pair `(rel, search)` calling `createIndex((rel, search))` will return its
+    /// index if it has been seen before and otherwise return the new index
+    /// which henceforth will be returned for subsequent queries of `(rel, search)`.
+    ///
+    /// `ReverseUniqueInts` allows using an index, `i`, assigned by `UniqueInts`, and get
+    /// the value, which `UniqueInts` assigned index `i`.
+    ///
+    pub struct UniqueInts[k: Type, r: Region] {
+        map: MutMap[k, Int32, r],
+        counter: Counter[r]
+    }
+
+    ///
     /// Returns an empty mapping from `k` to identifiers.
     ///
     pub def empty(rc: Region[r]): UniqueInts[k, r] \ r =


### PR DESCRIPTION
Continues the standard library refactor (#12649, #12651, #12652, #12654, #12657, #12658) to colocate types with their same-named companion modules.

## Changes

- `struct Counter` moved from `Fixpoint3.flix` into `Fixpoint3/Counter.flix` (`pub mod Fixpoint3.Counter`).
- `struct UniqueInts` moved from `Fixpoint3.flix` into `Fixpoint3/UniqueInts.flix` (`pub mod Fixpoint3.UniqueInts`).
- `struct MutGraph` moved from `Fixpoint3/PrecedenceGraph.flix` into `Fixpoint3/PrecedenceGraph/MutGraph.flix` (`pub mod Fixpoint3.PrecedenceGraph.MutGraph`).

No behavior change. No external API change — qualified callers continue to work via companion lifting.

## Verification

- `./mill flix.run out/empty.flix` — std lib compiles.
- `./mill flix.test.testForked "-oC"` — 16,248 tests pass, 0 failures.