### PR TITLE
refactor: nest SemiGroup and Monoid traits into companion modules

### DIFF
--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -14,31 +14,31 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for Monoids, objects that support an associative binary
-/// operation `combine` and neutral element `empty`.
-///
-pub lawful trait Monoid[a] with SemiGroup[a] {
-    ///
-    /// Returns a neutral element.
-    ///
-    pub def empty(): a
-
-    ///
-    /// Returns the result of combining `x` and `y` using SemiGroup's combine.
-    ///
-    pub def combine(x: a, y: a): a =
-        SemiGroup.combine(x, y)
-
-    law leftIdentity: forall(x: a) with Eq[a] Monoid.combine(Monoid.empty(), x) == x
-
-    law rightIdentity: forall(x: a) with Eq[a] Monoid.combine(x, Monoid.empty()) == x
-
-    law associative: forall(x: a, y: a, z: a) with Eq[a] Monoid.combine(Monoid.combine(x, y), z) == Monoid.combine(x, Monoid.combine(y, z))
-
-}
-
 pub mod Monoid {
+
+    ///
+    /// A trait for Monoids, objects that support an associative binary
+    /// operation `combine` and neutral element `empty`.
+    ///
+    pub lawful trait Monoid[a] with SemiGroup[a] {
+        ///
+        /// Returns a neutral element.
+        ///
+        pub def empty(): a
+
+        ///
+        /// Returns the result of combining `x` and `y` using SemiGroup's combine.
+        ///
+        pub def combine(x: a, y: a): a =
+            SemiGroup.combine(x, y)
+
+        law leftIdentity: forall(x: a) with Eq[a] Monoid.combine(Monoid.empty(), x) == x
+
+        law rightIdentity: forall(x: a) with Eq[a] Monoid.combine(x, Monoid.empty()) == x
+
+        law associative: forall(x: a, y: a, z: a) with Eq[a] Monoid.combine(Monoid.combine(x, y), z) == Monoid.combine(x, Monoid.combine(y, z))
+
+    }
 
     ///
     /// Returns the result of applying `combine` to all the elements in `t`, using `empty` as the initial value.

--- a/main/src/library/SemiGroup.flix
+++ b/main/src/library/SemiGroup.flix
@@ -15,26 +15,6 @@
  */
 
 ///
-/// A trait for types that form a semigroup.
-///
-pub trait SemiGroup[a] {
-    ///
-    /// An associative binary operation on `a`.
-    ///
-    pub def combine(x: a, y: a): a
-
-    ///
-    /// Returns `x` combined with itself `n` times.
-    ///
-    pub def combineN(x: a, n: Int32): a =
-        if (n <= 1) x
-        else SemiGroup.combine(x, SemiGroup.combineN(x, n - 1))
-
-    law associative: forall(x: a, y: a, z: a) with Eq[a] SemiGroup.combine(SemiGroup.combine(x, y), z) == SemiGroup.combine(x, SemiGroup.combine(y, z))
-
-}
-
-///
 /// Alias for `SemiGroup.combine`.
 ///
 pub def ++(x: a, y: a): a with SemiGroup[a] = SemiGroup.combine(x, y)
@@ -134,6 +114,26 @@ instance SemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with SemiGroup[a1]
 }
 
 pub mod SemiGroup {
+
+    ///
+    /// A trait for types that form a semigroup.
+    ///
+    pub trait SemiGroup[a] {
+        ///
+        /// An associative binary operation on `a`.
+        ///
+        pub def combine(x: a, y: a): a
+
+        ///
+        /// Returns `x` combined with itself `n` times.
+        ///
+        pub def combineN(x: a, n: Int32): a =
+            if (n <= 1) x
+            else SemiGroup.combine(x, SemiGroup.combineN(x, n - 1))
+
+        law associative: forall(x: a, y: a, z: a) with Eq[a] SemiGroup.combine(SemiGroup.combine(x, y), z) == SemiGroup.combine(x, SemiGroup.combine(y, z))
+
+    }
 
     pub enum Any(Bool)
 


### PR DESCRIPTION
## Summary
- Move `pub trait SemiGroup[a]` inside the existing `pub mod SemiGroup { ... }` block.
- Move `pub lawful trait Monoid[a]` inside the existing `pub mod Monoid { ... }` block.
- Pure relocation — no behavior change. Continues the companion-lifting refactor pattern from #12650, #12652, #12654, #12657, #12658, #12659.

## Test plan
- [x] `touch out/empty.flix && ./mill flix.run out/empty.flix` — standard library compiles
- [x] `./mill flix.test.testForked "-oC"` — 16248 tests passed, 0 failed (53 suites, ~3m20s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)