### PR TITLE
refactor: nest Hash and Order traits and instances into companion modules

### DIFF
--- a/main/src/library/Hash.flix
+++ b/main/src/library/Hash.flix
@@ -14,152 +14,152 @@
  *  limitations under the License.
  */
 
-import java.lang.Byte
-import java.lang.Character
-import java.lang.Double
-import java.lang.Float
-import java.lang.Integer
-import java.lang.Long
-import java.lang.Short
-
-use Bool.{==>}
-
-///
-/// A trait for types that can be hashed.
-///
-pub lawful trait Hash[a] {
-    ///
-    /// Returns a hash value for the given x.
-    ///
-    pub def hash(x: a): Int32
-
-    ///
-    /// Hash values are consistent with equality: equal values have equal hashes.
-    ///
-    law consistency: forall(x: a, y: a) with Eq[a] (x == y) ==> (Hash.hash(x) == Hash.hash(y))
-}
-
-instance Hash[Unit] {
-    pub def hash(_x: Unit): Int32 = 0
-}
-
-instance Hash[Bool] {
-    pub def hash(x: Bool): Int32 = match x {
-        case true => 1231
-        case false => 1237
-    }
-}
-
-instance Hash[Char] {
-    pub def hash(x: Char): Int32 = Character.hashCode(x)
-}
-
-instance Hash[Float32] {
-    pub def hash(x: Float32): Int32 = Float.hashCode(x)
-}
-
-instance Hash[Float64] {
-    pub def hash(x: Float64): Int32 = Double.hashCode(x)
-}
-
-instance Hash[BigDecimal] {
-    pub def hash(x: BigDecimal): Int32 = x.hashCode()
-}
-
-instance Hash[Int8] {
-    pub def hash(x: Int8): Int32 = Byte.hashCode(x)
-}
-
-instance Hash[Int16] {
-    pub def hash(x: Int16): Int32 = Short.hashCode(x)
-}
-
-instance Hash[Int32] {
-    pub def hash(x: Int32): Int32 = Integer.hashCode(x)
-}
-
-instance Hash[Int64] {
-    pub def hash(x: Int64): Int32 = Long.hashCode(x)
-}
-
-instance Hash[String] {
-    pub def hash(x: String): Int32 = x.hashCode()
-}
-
-instance Hash[BigInt] {
-    pub def hash(x: BigInt): Int32 = x.hashCode()
-}
-
-instance Hash[(a1, a2)] with Hash[a1], Hash[a2] {
-    pub def hash(t: (a1, a2)): Int32 = match t {
-        case (x1, x2) => Hash.hash(x1) `Hash.combine` Hash.hash(x2)
-    }
-}
-
-instance Hash[(a1, a2, a3)] with Hash[a1], Hash[a2], Hash[a3] {
-    pub def hash(t: (a1, a2, a3)): Int32 = match t {
-        case (x1, x2, x3) => Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3)
-    }
-}
-
-instance Hash[(a1, a2, a3, a4)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4] {
-    pub def hash(t: (a1, a2, a3, a4)): Int32 = match t {
-        case (x1, x2, x3, x4) =>
-            Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
-    }
-}
-
-instance Hash[(a1, a2, a3, a4, a5)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5] {
-    pub def hash(t: (a1, a2, a3, a4, a5)): Int32 = match t {
-        case (x1, x2, x3, x4, x5) =>
-            Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
-                `Hash.combine` Hash.hash(x5)
-    }
-}
-
-instance Hash[(a1, a2, a3, a4, a5, a6)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6] {
-    pub def hash(t: (a1, a2, a3, a4, a5, a6)): Int32 = match t {
-        case (x1, x2, x3, x4, x5, x6) =>
-            Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
-                `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6)
-    }
-}
-
-instance Hash[(a1, a2, a3, a4, a5, a6, a7)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6], Hash[a7] {
-    pub def hash(t: (a1, a2, a3, a4, a5, a6, a7)): Int32 = match t {
-        case (x1, x2, x3, x4, x5, x6, x7) =>
-            Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
-                `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6) `Hash.combine` Hash.hash(x7)
-    }
-}
-
-instance Hash[(a1, a2, a3, a4, a5, a6, a7, a8)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6], Hash[a7], Hash[a8] {
-    pub def hash(t: (a1, a2, a3, a4, a5, a6, a7, a8)): Int32 = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8) =>
-            Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
-                `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6) `Hash.combine` Hash.hash(x7) `Hash.combine` Hash.hash(x8)
-    }
-}
-
-instance Hash[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6], Hash[a7], Hash[a8], Hash[a9] {
-    pub def hash(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): Int32 = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8, x9) =>
-            Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
-                `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6) `Hash.combine` Hash.hash(x7) `Hash.combine` Hash.hash(x8)
-                `Hash.combine` Hash.hash(x9)
-    }
-}
-
-instance Hash[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6], Hash[a7], Hash[a8], Hash[a9], Hash[a10] {
-    pub def hash(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): Int32 = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) =>
-            Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
-                `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6) `Hash.combine` Hash.hash(x7) `Hash.combine` Hash.hash(x8)
-                `Hash.combine` Hash.hash(x9) `Hash.combine` Hash.hash(x10)
-    }
-}
-
 pub mod Hash {
+
+    use Bool.{==>}
+
+    import java.lang.Byte
+    import java.lang.Character
+    import java.lang.Double
+    import java.lang.Float
+    import java.lang.Integer
+    import java.lang.Long
+    import java.lang.Short
+
+    ///
+    /// A trait for types that can be hashed.
+    ///
+    pub lawful trait Hash[a] {
+        ///
+        /// Returns a hash value for the given x.
+        ///
+        pub def hash(x: a): Int32
+
+        ///
+        /// Hash values are consistent with equality: equal values have equal hashes.
+        ///
+        law consistency: forall(x: a, y: a) with Eq[a] (x == y) ==> (Hash.hash(x) == Hash.hash(y))
+    }
+
+    instance Hash[Unit] {
+        pub def hash(_x: Unit): Int32 = 0
+    }
+
+    instance Hash[Bool] {
+        pub def hash(x: Bool): Int32 = match x {
+            case true => 1231
+            case false => 1237
+        }
+    }
+
+    instance Hash[Char] {
+        pub def hash(x: Char): Int32 = Character.hashCode(x)
+    }
+
+    instance Hash[Float32] {
+        pub def hash(x: Float32): Int32 = Float.hashCode(x)
+    }
+
+    instance Hash[Float64] {
+        pub def hash(x: Float64): Int32 = Double.hashCode(x)
+    }
+
+    instance Hash[BigDecimal] {
+        pub def hash(x: BigDecimal): Int32 = x.hashCode()
+    }
+
+    instance Hash[Int8] {
+        pub def hash(x: Int8): Int32 = Byte.hashCode(x)
+    }
+
+    instance Hash[Int16] {
+        pub def hash(x: Int16): Int32 = Short.hashCode(x)
+    }
+
+    instance Hash[Int32] {
+        pub def hash(x: Int32): Int32 = Integer.hashCode(x)
+    }
+
+    instance Hash[Int64] {
+        pub def hash(x: Int64): Int32 = Long.hashCode(x)
+    }
+
+    instance Hash[String] {
+        pub def hash(x: String): Int32 = x.hashCode()
+    }
+
+    instance Hash[BigInt] {
+        pub def hash(x: BigInt): Int32 = x.hashCode()
+    }
+
+    instance Hash[(a1, a2)] with Hash[a1], Hash[a2] {
+        pub def hash(t: (a1, a2)): Int32 = match t {
+            case (x1, x2) => Hash.hash(x1) `Hash.combine` Hash.hash(x2)
+        }
+    }
+
+    instance Hash[(a1, a2, a3)] with Hash[a1], Hash[a2], Hash[a3] {
+        pub def hash(t: (a1, a2, a3)): Int32 = match t {
+            case (x1, x2, x3) => Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3)
+        }
+    }
+
+    instance Hash[(a1, a2, a3, a4)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4] {
+        pub def hash(t: (a1, a2, a3, a4)): Int32 = match t {
+            case (x1, x2, x3, x4) =>
+                Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
+        }
+    }
+
+    instance Hash[(a1, a2, a3, a4, a5)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5] {
+        pub def hash(t: (a1, a2, a3, a4, a5)): Int32 = match t {
+            case (x1, x2, x3, x4, x5) =>
+                Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
+                    `Hash.combine` Hash.hash(x5)
+        }
+    }
+
+    instance Hash[(a1, a2, a3, a4, a5, a6)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6] {
+        pub def hash(t: (a1, a2, a3, a4, a5, a6)): Int32 = match t {
+            case (x1, x2, x3, x4, x5, x6) =>
+                Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
+                    `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6)
+        }
+    }
+
+    instance Hash[(a1, a2, a3, a4, a5, a6, a7)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6], Hash[a7] {
+        pub def hash(t: (a1, a2, a3, a4, a5, a6, a7)): Int32 = match t {
+            case (x1, x2, x3, x4, x5, x6, x7) =>
+                Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
+                    `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6) `Hash.combine` Hash.hash(x7)
+        }
+    }
+
+    instance Hash[(a1, a2, a3, a4, a5, a6, a7, a8)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6], Hash[a7], Hash[a8] {
+        pub def hash(t: (a1, a2, a3, a4, a5, a6, a7, a8)): Int32 = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8) =>
+                Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
+                    `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6) `Hash.combine` Hash.hash(x7) `Hash.combine` Hash.hash(x8)
+        }
+    }
+
+    instance Hash[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6], Hash[a7], Hash[a8], Hash[a9] {
+        pub def hash(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): Int32 = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8, x9) =>
+                Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
+                    `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6) `Hash.combine` Hash.hash(x7) `Hash.combine` Hash.hash(x8)
+                    `Hash.combine` Hash.hash(x9)
+        }
+    }
+
+    instance Hash[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Hash[a1], Hash[a2], Hash[a3], Hash[a4], Hash[a5], Hash[a6], Hash[a7], Hash[a8], Hash[a9], Hash[a10] {
+        pub def hash(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): Int32 = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) =>
+                Hash.hash(x1) `Hash.combine` Hash.hash(x2) `Hash.combine` Hash.hash(x3) `Hash.combine` Hash.hash(x4)
+                    `Hash.combine` Hash.hash(x5) `Hash.combine` Hash.hash(x6) `Hash.combine` Hash.hash(x7) `Hash.combine` Hash.hash(x8)
+                    `Hash.combine` Hash.hash(x9) `Hash.combine` Hash.hash(x10)
+        }
+    }
 
     ///
     /// Combines the two given hash values.

--- a/main/src/library/Order.flix
+++ b/main/src/library/Order.flix
@@ -14,121 +14,121 @@
  * limitations under the License.
  */
 
-use Bool.{==>, <==>}
-
-///
-/// A trait for types with a total order.
-///
-pub lawful trait Order[a] with Eq[a] {
-
-    ///
-    /// Returns `Comparison.LessThan` if `x` < `y`, `Equal` if `x` == `y` or `Comparison.GreaterThan` `if `x` > `y`.
-    ///
-    pub def compare(x: a, y: a): Comparison
-
-    ///
-    /// Returns `true` if and only if `x < y`.
-    ///
-    pub def less(x: a, y: a): Bool = match Order.compare(x, y) {
-        case Comparison.LessThan   => true
-        case _          => false
-    }
-
-    ///
-    /// Returns `true` if and only if `x <= y`.
-    ///
-    pub def lessEqual(x: a, y: a): Bool = match Order.compare(x, y) {
-        case Comparison.LessThan   => true
-        case Comparison.EqualTo    => true
-        case _          => false
-    }
-
-    ///
-    /// Returns `true` if and only if `x > y`.
-    ///
-    pub def greater(x: a, y: a): Bool = match Order.compare(x, y) {
-        case Comparison.GreaterThan    => true
-        case _              => false
-    }
-
-    ///
-    /// Returns `true` if and only if `x >= y`.
-    ///
-    pub def greaterEqual(x: a, y: a): Bool = match Order.compare(x, y) {
-        case Comparison.GreaterThan    => true
-        case Comparison.EqualTo        => true
-        case _              => false
-    }
-
-    ///
-    /// Returns the minimum of `x` and `y`.
-    ///
-    pub def min(x: a, y: a): a = match (x <=> y) {
-        case Comparison.GreaterThan => y
-        case _ => x
-    }
-
-    ///
-    /// Returns the maximum of `x` and `y`.
-    ///
-    pub def max(x: a, y: a): a = match (x <=> y) {
-        case Comparison.LessThan => y
-        case _ => x
-    }
-
-    ///
-    /// Reflexivity: An element `x` is lower or equal to itself.
-    ///
-    law reflexivity: forall(x: a) x <= x
-
-    ///
-    /// Antisymmetry: If `x` is lower or equal to `y` and `y` is lower or equal to `x` then `x` must be equal to `y`.
-    ///
-    law symmetry: forall(x: a, y: a) ((x <= y) and (y <= x)) ==> (x == y)
-
-    ///
-    /// Transitivity: If `x` is lower or equal to `y` and `y` is lower equal to `z` then `x` must be lower or equal to `z`.
-    ///
-    law transitivity: forall(x: a, y: a, z: a) ((x <= y) and (y <= z)) ==> (x <= z)
-
-    ///
-    /// Totality: For each two elements `x` and `y` either `x` is lower or equal to `y` or the other way round.
-    ///
-    law totality: forall(x: a, y: a) ((x <= y) or (y <= x))
-
-    ///
-    /// Definition of the minimum function.
-    ///
-    law min: forall(x: a, y: a) ((x <= y) ==> (Order.min(x, y) == x)) and ((y <= x) ==> (Order.min(x, y) == y))
-
-    ///
-    /// Definition of the maximum function.
-    ///
-    law max: forall(x: a, y: a) ((y <= x) ==> (Order.max(x, y) == x)) and ((x <= y) ==> (Order.max(x, y) == y))
-
-    ///
-    /// x < y is logically equivalent to not (y <= x).
-    /// This law defines the associated strict total order "<" associated with "<=".
-    ///
-    law strictTotalOrder: forall(x: a, y: a) (x < y) <==> (not (y <= x))
-
-    ///
-    /// This law defines ">" based on "<".
-    ///
-    law inverseOrder1: forall(x: a, y: a) (x > y) <==> (y < x)
-
-    ///
-    /// This law defines ">=" based on "<=".
-    ///
-    law inverseOrder2: forall(x: a, y: a) (x >= y) <==> (y <= x)
-
-    ///
-    /// Definition of `compare` based on the defined total order.
-    ///
-    law compare: forall(x: a, y: a) ((x < y) ==> (Order.compare(x, y) == Comparison.LessThan)) and ((x == y) ==> (Order.compare(x, y) == Comparison.EqualTo)) and ((x > y) ==> (Order.compare(x, y) == Comparison.GreaterThan))
-}
-
 pub mod Order {
+
+    use Bool.{==>, <==>}
+
+    ///
+    /// A trait for types with a total order.
+    ///
+    pub lawful trait Order[a] with Eq[a] {
+
+        ///
+        /// Returns `Comparison.LessThan` if `x` < `y`, `Equal` if `x` == `y` or `Comparison.GreaterThan` `if `x` > `y`.
+        ///
+        pub def compare(x: a, y: a): Comparison
+
+        ///
+        /// Returns `true` if and only if `x < y`.
+        ///
+        pub def less(x: a, y: a): Bool = match Order.compare(x, y) {
+            case Comparison.LessThan   => true
+            case _          => false
+        }
+
+        ///
+        /// Returns `true` if and only if `x <= y`.
+        ///
+        pub def lessEqual(x: a, y: a): Bool = match Order.compare(x, y) {
+            case Comparison.LessThan   => true
+            case Comparison.EqualTo    => true
+            case _          => false
+        }
+
+        ///
+        /// Returns `true` if and only if `x > y`.
+        ///
+        pub def greater(x: a, y: a): Bool = match Order.compare(x, y) {
+            case Comparison.GreaterThan    => true
+            case _              => false
+        }
+
+        ///
+        /// Returns `true` if and only if `x >= y`.
+        ///
+        pub def greaterEqual(x: a, y: a): Bool = match Order.compare(x, y) {
+            case Comparison.GreaterThan    => true
+            case Comparison.EqualTo        => true
+            case _              => false
+        }
+
+        ///
+        /// Returns the minimum of `x` and `y`.
+        ///
+        pub def min(x: a, y: a): a = match (x <=> y) {
+            case Comparison.GreaterThan => y
+            case _ => x
+        }
+
+        ///
+        /// Returns the maximum of `x` and `y`.
+        ///
+        pub def max(x: a, y: a): a = match (x <=> y) {
+            case Comparison.LessThan => y
+            case _ => x
+        }
+
+        ///
+        /// Reflexivity: An element `x` is lower or equal to itself.
+        ///
+        law reflexivity: forall(x: a) x <= x
+
+        ///
+        /// Antisymmetry: If `x` is lower or equal to `y` and `y` is lower or equal to `x` then `x` must be equal to `y`.
+        ///
+        law symmetry: forall(x: a, y: a) ((x <= y) and (y <= x)) ==> (x == y)
+
+        ///
+        /// Transitivity: If `x` is lower or equal to `y` and `y` is lower equal to `z` then `x` must be lower or equal to `z`.
+        ///
+        law transitivity: forall(x: a, y: a, z: a) ((x <= y) and (y <= z)) ==> (x <= z)
+
+        ///
+        /// Totality: For each two elements `x` and `y` either `x` is lower or equal to `y` or the other way round.
+        ///
+        law totality: forall(x: a, y: a) ((x <= y) or (y <= x))
+
+        ///
+        /// Definition of the minimum function.
+        ///
+        law min: forall(x: a, y: a) ((x <= y) ==> (Order.min(x, y) == x)) and ((y <= x) ==> (Order.min(x, y) == y))
+
+        ///
+        /// Definition of the maximum function.
+        ///
+        law max: forall(x: a, y: a) ((y <= x) ==> (Order.max(x, y) == x)) and ((x <= y) ==> (Order.max(x, y) == y))
+
+        ///
+        /// x < y is logically equivalent to not (y <= x).
+        /// This law defines the associated strict total order "<" associated with "<=".
+        ///
+        law strictTotalOrder: forall(x: a, y: a) (x < y) <==> (not (y <= x))
+
+        ///
+        /// This law defines ">" based on "<".
+        ///
+        law inverseOrder1: forall(x: a, y: a) (x > y) <==> (y < x)
+
+        ///
+        /// This law defines ">=" based on "<=".
+        ///
+        law inverseOrder2: forall(x: a, y: a) (x >= y) <==> (y <= x)
+
+        ///
+        /// Definition of `compare` based on the defined total order.
+        ///
+        law compare: forall(x: a, y: a) ((x < y) ==> (Order.compare(x, y) == Comparison.LessThan)) and ((x == y) ==> (Order.compare(x, y) == Comparison.EqualTo)) and ((x > y) ==> (Order.compare(x, y) == Comparison.GreaterThan))
+    }
 
     ///
     /// Returns the minimum of `x` and `y` according to the given comparator `cmp`.
@@ -150,316 +150,289 @@ pub mod Order {
     pub def thenCompare(c1: Comparison, c2: Lazy[Comparison]): Comparison =
         if (c1 != Comparison.EqualTo) c1 else force c2
 
-}
+    instance Order[Unit] {
 
-instance Order[Unit] {
+        pub def compare(_: Unit, _: Unit): Comparison = Comparison.EqualTo
 
-    pub def compare(_: Unit, _: Unit): Comparison = Comparison.EqualTo
+    }
 
-}
+    instance Order[Bool] {
 
-instance Order[Bool] {
+        pub def compare(x: Bool, y: Bool): Comparison =
+            if (x) {
+                if (y)
+                    Comparison.EqualTo
+                else
+                    Comparison.GreaterThan
+            } else {
+                if (y)
+                    Comparison.LessThan
+                else
+                    Comparison.EqualTo
+            }
 
-    pub def compare(x: Bool, y: Bool): Comparison =
-        if (x) {
-            if (y)
-                Comparison.EqualTo
-            else
-                Comparison.GreaterThan
-        } else {
-            if (y)
+    }
+
+    instance Order[Char] {
+
+        redef less(x: Char, y: Char): Bool = %%CHAR_LT%%(x, y)
+
+        redef lessEqual(x: Char, y: Char): Bool = %%CHAR_LE%%(x, y)
+
+        redef greater(x: Char, y: Char): Bool = %%CHAR_GT%%(x, y)
+
+        redef greaterEqual(x: Char, y: Char): Bool = %%CHAR_GE%%(x, y)
+
+        pub def compare(x: Char, y: Char): Comparison =
+            if (%%CHAR_LT%%(x, y))
                 Comparison.LessThan
+            else if (%%CHAR_GT%%(x, y))
+                Comparison.GreaterThan
             else
                 Comparison.EqualTo
-        }
 
-}
+    }
 
-instance Order[Char] {
+    instance Order[Float32] {
 
-    redef less(x: Char, y: Char): Bool = %%CHAR_LT%%(x, y)
+        redef less(x: Float32, y: Float32): Bool = %%FLOAT32_LT%%(x, y)
 
-    redef lessEqual(x: Char, y: Char): Bool = %%CHAR_LE%%(x, y)
+        redef lessEqual(x: Float32, y: Float32): Bool = %%FLOAT32_LE%%(x, y)
 
-    redef greater(x: Char, y: Char): Bool = %%CHAR_GT%%(x, y)
+        redef greater(x: Float32, y: Float32): Bool = %%FLOAT32_GT%%(x, y)
 
-    redef greaterEqual(x: Char, y: Char): Bool = %%CHAR_GE%%(x, y)
+        redef greaterEqual(x: Float32, y: Float32): Bool = %%FLOAT32_GE%%(x, y)
 
-    pub def compare(x: Char, y: Char): Comparison =
-        if (%%CHAR_LT%%(x, y))
-            Comparison.LessThan
-        else if (%%CHAR_GT%%(x, y))
-            Comparison.GreaterThan
-        else
-            Comparison.EqualTo
+        pub def compare(x: Float32, y: Float32): Comparison =
+            if (%%FLOAT32_LT%%(x, y))
+                Comparison.LessThan
+            else if (%%FLOAT32_GT%%(x, y))
+                Comparison.GreaterThan
+            else
+                Comparison.EqualTo
 
-}
+    }
 
-instance Order[Float32] {
+    instance Order[Float64] {
 
-    redef less(x: Float32, y: Float32): Bool = %%FLOAT32_LT%%(x, y)
+        redef less(x: Float64, y: Float64): Bool = %%FLOAT64_LT%%(x, y)
 
-    redef lessEqual(x: Float32, y: Float32): Bool = %%FLOAT32_LE%%(x, y)
+        redef lessEqual(x: Float64, y: Float64): Bool = %%FLOAT64_LE%%(x, y)
 
-    redef greater(x: Float32, y: Float32): Bool = %%FLOAT32_GT%%(x, y)
+        redef greater(x: Float64, y: Float64): Bool = %%FLOAT64_GT%%(x, y)
 
-    redef greaterEqual(x: Float32, y: Float32): Bool = %%FLOAT32_GE%%(x, y)
+        redef greaterEqual(x: Float64, y: Float64): Bool = %%FLOAT64_GE%%(x, y)
 
-    pub def compare(x: Float32, y: Float32): Comparison =
-        if (%%FLOAT32_LT%%(x, y))
-            Comparison.LessThan
-        else if (%%FLOAT32_GT%%(x, y))
-            Comparison.GreaterThan
-        else
-            Comparison.EqualTo
+        pub def compare(x: Float64, y: Float64): Comparison =
+            if (%%FLOAT64_LT%%(x, y))
+                Comparison.LessThan
+            else if (%%FLOAT64_GT%%(x, y))
+                Comparison.GreaterThan
+            else
+                Comparison.EqualTo
 
-}
+    }
 
-instance Order[Float64] {
+    instance Order[BigDecimal] {
 
-    redef less(x: Float64, y: Float64): Bool = %%FLOAT64_LT%%(x, y)
+        redef less(x: BigDecimal, y: BigDecimal): Bool =
+            x.compareTo(y) < 0
 
-    redef lessEqual(x: Float64, y: Float64): Bool = %%FLOAT64_LE%%(x, y)
+        redef lessEqual(x: BigDecimal, y: BigDecimal): Bool =
+            x.compareTo(y) <= 0
 
-    redef greater(x: Float64, y: Float64): Bool = %%FLOAT64_GT%%(x, y)
+        redef greater(x: BigDecimal, y: BigDecimal): Bool =
+            x.compareTo(y) > 0
 
-    redef greaterEqual(x: Float64, y: Float64): Bool = %%FLOAT64_GE%%(x, y)
+        redef greaterEqual(x: BigDecimal, y: BigDecimal): Bool =
+            x.compareTo(y) >= 0
 
-    pub def compare(x: Float64, y: Float64): Comparison =
-        if (%%FLOAT64_LT%%(x, y))
-            Comparison.LessThan
-        else if (%%FLOAT64_GT%%(x, y))
-            Comparison.GreaterThan
-        else
-            Comparison.EqualTo
+        pub def compare(x: BigDecimal, y: BigDecimal): Comparison =
+            match x.compareTo(y) {
+                case 0          => Comparison.EqualTo
+                case z if z < 0 => Comparison.LessThan
+                case _          => Comparison.GreaterThan
+            }
 
-}
+    }
 
-instance Order[BigDecimal] {
+    instance Order[Int8] {
 
-    redef less(x: BigDecimal, y: BigDecimal): Bool =
-        x.compareTo(y) < 0
+        redef less(x: Int8, y: Int8): Bool = %%INT8_LT%%(x, y)
 
-    redef lessEqual(x: BigDecimal, y: BigDecimal): Bool =
-        x.compareTo(y) <= 0
+        redef lessEqual(x: Int8, y: Int8): Bool = %%INT8_LE%%(x, y)
 
-    redef greater(x: BigDecimal, y: BigDecimal): Bool =
-        x.compareTo(y) > 0
+        redef greater(x: Int8, y: Int8): Bool = %%INT8_GT%%(x, y)
 
-    redef greaterEqual(x: BigDecimal, y: BigDecimal): Bool =
-        x.compareTo(y) >= 0
+        redef greaterEqual(x: Int8, y: Int8): Bool = %%INT8_GE%%(x, y)
 
-    pub def compare(x: BigDecimal, y: BigDecimal): Comparison =
-        match x.compareTo(y) {
-            case 0          => Comparison.EqualTo
-            case z if z < 0 => Comparison.LessThan
-            case _          => Comparison.GreaterThan
-        }
+        pub def compare(x: Int8, y: Int8): Comparison =
+            if (%%INT8_LT%%(x, y))
+                Comparison.LessThan
+            else if (%%INT8_GT%%(x, y))
+                Comparison.GreaterThan
+            else
+                Comparison.EqualTo
 
-}
+    }
 
-instance Order[Int8] {
+    instance Order[Int16] {
 
-    redef less(x: Int8, y: Int8): Bool = %%INT8_LT%%(x, y)
+        redef less(x: Int16, y: Int16): Bool = %%INT16_LT%%(x, y)
 
-    redef lessEqual(x: Int8, y: Int8): Bool = %%INT8_LE%%(x, y)
+        redef lessEqual(x: Int16, y: Int16): Bool = %%INT16_LE%%(x, y)
 
-    redef greater(x: Int8, y: Int8): Bool = %%INT8_GT%%(x, y)
+        redef greater(x: Int16, y: Int16): Bool = %%INT16_GT%%(x, y)
 
-    redef greaterEqual(x: Int8, y: Int8): Bool = %%INT8_GE%%(x, y)
+        redef greaterEqual(x: Int16, y: Int16): Bool = %%INT16_GE%%(x, y)
 
-    pub def compare(x: Int8, y: Int8): Comparison =
-        if (%%INT8_LT%%(x, y))
-            Comparison.LessThan
-        else if (%%INT8_GT%%(x, y))
-            Comparison.GreaterThan
-        else
-            Comparison.EqualTo
+        pub def compare(x: Int16, y: Int16): Comparison =
+            if (%%INT16_LT%%(x, y))
+                Comparison.LessThan
+            else if (%%INT16_GT%%(x, y))
+                Comparison.GreaterThan
+            else
+                Comparison.EqualTo
 
-}
+    }
 
-instance Order[Int16] {
+    instance Order[Int32] {
 
-    redef less(x: Int16, y: Int16): Bool = %%INT16_LT%%(x, y)
+        redef less(x: Int32, y: Int32): Bool = %%INT32_LT%%(x, y)
 
-    redef lessEqual(x: Int16, y: Int16): Bool = %%INT16_LE%%(x, y)
+        redef lessEqual(x: Int32, y: Int32): Bool = %%INT32_LE%%(x, y)
 
-    redef greater(x: Int16, y: Int16): Bool = %%INT16_GT%%(x, y)
+        redef greater(x: Int32, y: Int32): Bool = %%INT32_GT%%(x, y)
 
-    redef greaterEqual(x: Int16, y: Int16): Bool = %%INT16_GE%%(x, y)
+        redef greaterEqual(x: Int32, y: Int32): Bool = %%INT32_GE%%(x, y)
 
-    pub def compare(x: Int16, y: Int16): Comparison =
-        if (%%INT16_LT%%(x, y))
-            Comparison.LessThan
-        else if (%%INT16_GT%%(x, y))
-            Comparison.GreaterThan
-        else
-            Comparison.EqualTo
+        pub def compare(x: Int32, y: Int32): Comparison =
+            if (%%INT32_LT%%(x, y))
+                Comparison.LessThan
+            else if (%%INT32_GT%%(x, y))
+                Comparison.GreaterThan
+            else
+                Comparison.EqualTo
 
-}
+    }
 
-instance Order[Int32] {
+    instance Order[Int64] {
 
-    redef less(x: Int32, y: Int32): Bool = %%INT32_LT%%(x, y)
+        redef less(x: Int64, y: Int64): Bool = %%INT64_LT%%(x, y)
 
-    redef lessEqual(x: Int32, y: Int32): Bool = %%INT32_LE%%(x, y)
+        redef lessEqual(x: Int64, y: Int64): Bool = %%INT64_LE%%(x, y)
 
-    redef greater(x: Int32, y: Int32): Bool = %%INT32_GT%%(x, y)
+        redef greater(x: Int64, y: Int64): Bool = %%INT64_GT%%(x, y)
 
-    redef greaterEqual(x: Int32, y: Int32): Bool = %%INT32_GE%%(x, y)
+        redef greaterEqual(x: Int64, y: Int64): Bool = %%INT64_GE%%(x, y)
 
-    pub def compare(x: Int32, y: Int32): Comparison =
-        if (%%INT32_LT%%(x, y))
-            Comparison.LessThan
-        else if (%%INT32_GT%%(x, y))
-            Comparison.GreaterThan
-        else
-            Comparison.EqualTo
+        pub def compare(x: Int64, y: Int64): Comparison =
+            if (%%INT64_LT%%(x, y))
+                Comparison.LessThan
+            else if (%%INT64_GT%%(x, y))
+                Comparison.GreaterThan
+            else
+                Comparison.EqualTo
 
-}
+    }
 
-instance Order[Int64] {
+    instance Order[BigInt] {
 
-    redef less(x: Int64, y: Int64): Bool = %%INT64_LT%%(x, y)
+        redef less(x: BigInt, y: BigInt): Bool =
+            x.compareTo(y) < 0
 
-    redef lessEqual(x: Int64, y: Int64): Bool = %%INT64_LE%%(x, y)
+        redef lessEqual(x: BigInt, y: BigInt): Bool =
+            x.compareTo(y) <= 0
 
-    redef greater(x: Int64, y: Int64): Bool = %%INT64_GT%%(x, y)
+        redef greater(x: BigInt, y: BigInt): Bool =
+            x.compareTo(y) > 0
 
-    redef greaterEqual(x: Int64, y: Int64): Bool = %%INT64_GE%%(x, y)
+        redef greaterEqual(x: BigInt, y: BigInt): Bool =
+            x.compareTo(y) >= 0
 
-    pub def compare(x: Int64, y: Int64): Comparison =
-        if (%%INT64_LT%%(x, y))
-            Comparison.LessThan
-        else if (%%INT64_GT%%(x, y))
-            Comparison.GreaterThan
-        else
-            Comparison.EqualTo
+        pub def compare(x: BigInt, y: BigInt): Comparison =
+            match x.compareTo(y) {
+                case 0          => Comparison.EqualTo
+                case z if z < 0 => Comparison.LessThan
+                case _          => Comparison.GreaterThan
+            }
 
-}
+    }
 
-instance Order[BigInt] {
+    instance Order[String] {
 
-    redef less(x: BigInt, y: BigInt): Bool =
-        x.compareTo(y) < 0
+        pub def compare(x: String, y: String): Comparison =
+            Comparison.fromInt32(x.compareTo(y))
 
-    redef lessEqual(x: BigInt, y: BigInt): Bool =
-        x.compareTo(y) <= 0
+    }
 
-    redef greater(x: BigInt, y: BigInt): Bool =
-        x.compareTo(y) > 0
+    instance Order[(a1, a2)] with Order[a1], Order[a2] {
 
-    redef greaterEqual(x: BigInt, y: BigInt): Bool =
-        x.compareTo(y) >= 0
-
-    pub def compare(x: BigInt, y: BigInt): Comparison =
-        match x.compareTo(y) {
-            case 0          => Comparison.EqualTo
-            case z if z < 0 => Comparison.LessThan
-            case _          => Comparison.GreaterThan
-        }
-
-}
-
-instance Order[String] {
-
-    pub def compare(x: String, y: String): Comparison =
-        Comparison.fromInt32(x.compareTo(y))
-
-}
-
-instance Order[(a1, a2)] with Order[a1], Order[a2] {
-
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2), t2: (a1, a2)): Comparison =
-        let (x1, x2) = t1;
-        let (y1, y2) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => x2 <=> y2
-            case res => res
-        }
-
-}
-
-instance Order[(a1, a2, a3)] with Order[a1], Order[a2], Order[a3] {
-
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3), t2: (a1, a2, a3)): Comparison =
-        let (x1, x2, x3) = t1;
-        let (y1, y2, y3) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => x3 <=> y3
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2), t2: (a1, a2)): Comparison =
+            let (x1, x2) = t1;
+            let (y1, y2) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => x2 <=> y2
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4)] with Order[a1], Order[a2], Order[a3], Order[a4] {
+    instance Order[(a1, a2, a3)] with Order[a1], Order[a2], Order[a3] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4), t2: (a1, a2, a3, a4)): Comparison =
-        let (x1, x2, x3, x4) = t1;
-        let (y1, y2, y3, y4) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => x4 <=> y4
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3), t2: (a1, a2, a3)): Comparison =
+            let (x1, x2, x3) = t1;
+            let (y1, y2, y3) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => x3 <=> y3
                     case res => res
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5] {
+    instance Order[(a1, a2, a3, a4)] with Order[a1], Order[a2], Order[a3], Order[a4] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5), t2: (a1, a2, a3, a4, a5)): Comparison =
-        let (x1, x2, x3, x4, x5) = t1;
-        let (y1, y2, y3, y4, y5) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => x5 <=> y5
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4), t2: (a1, a2, a3, a4)): Comparison =
+            let (x1, x2, x3, x4) = t1;
+            let (y1, y2, y3, y4) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => x4 <=> y4
                         case res => res
                     }
                     case res => res
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6] {
+    instance Order[(a1, a2, a3, a4, a5)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6), t2: (a1, a2, a3, a4, a5, a6)): Comparison =
-        let (x1, x2, x3, x4, x5, x6) = t1;
-        let (y1, y2, y3, y4, y5, y6) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => x6 <=> y6
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5), t2: (a1, a2, a3, a4, a5)): Comparison =
+            let (x1, x2, x3, x4, x5) = t1;
+            let (y1, y2, y3, y4, y5) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => x5 <=> y5
                             case res => res
                         }
                         case res => res
@@ -468,26 +441,23 @@ instance Order[(a1, a2, a3, a4, a5, a6)] with Order[a1], Order[a2], Order[a3], O
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6, a7)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7] {
+    instance Order[(a1, a2, a3, a4, a5, a6)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7), t2: (a1, a2, a3, a4, a5, a6, a7)): Comparison =
-        let (x1, x2, x3, x4, x5, x6, x7) = t1;
-        let (y1, y2, y3, y4, y5, y6, y7) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => match x6 <=> y6 {
-                                case Comparison.EqualTo => x7 <=> y7
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6), t2: (a1, a2, a3, a4, a5, a6)): Comparison =
+            let (x1, x2, x3, x4, x5, x6) = t1;
+            let (y1, y2, y3, y4, y5, y6) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => x6 <=> y6
                                 case res => res
                             }
                             case res => res
@@ -498,27 +468,24 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7)] with Order[a1], Order[a2], Order[a3
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6, a7, a8)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8] {
+    instance Order[(a1, a2, a3, a4, a5, a6, a7)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8), t2: (a1, a2, a3, a4, a5, a6, a7, a8)): Comparison =
-        let (x1, x2, x3, x4, x5, x6, x7, x8) = t1;
-        let (y1, y2, y3, y4, y5, y6, y7, y8) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => match x6 <=> y6 {
-                                case Comparison.EqualTo => match x7 <=> y7 {
-                                    case Comparison.EqualTo => x8 <=> y8
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7), t2: (a1, a2, a3, a4, a5, a6, a7)): Comparison =
+            let (x1, x2, x3, x4, x5, x6, x7) = t1;
+            let (y1, y2, y3, y4, y5, y6, y7) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => match x6 <=> y6 {
+                                    case Comparison.EqualTo => x7 <=> y7
                                     case res => res
                                 }
                                 case res => res
@@ -531,28 +498,25 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8)] with Order[a1], Order[a2], Orde
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9] {
+    instance Order[(a1, a2, a3, a4, a5, a6, a7, a8)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): Comparison =
-        let (x1, x2, x3, x4, x5, x6, x7, x8, x9) = t1;
-        let (y1, y2, y3, y4, y5, y6, y7, y8, y9) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => match x6 <=> y6 {
-                                case Comparison.EqualTo => match x7 <=> y7 {
-                                    case Comparison.EqualTo => match x8 <=> y8 {
-                                        case Comparison.EqualTo => x9 <=> y9
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8), t2: (a1, a2, a3, a4, a5, a6, a7, a8)): Comparison =
+            let (x1, x2, x3, x4, x5, x6, x7, x8) = t1;
+            let (y1, y2, y3, y4, y5, y6, y7, y8) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => match x6 <=> y6 {
+                                    case Comparison.EqualTo => match x7 <=> y7 {
+                                        case Comparison.EqualTo => x8 <=> y8
                                         case res => res
                                     }
                                     case res => res
@@ -567,29 +531,26 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with Order[a1], Order[a2], 
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10] {
+    instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): Comparison =
-        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) = t1;
-        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => match x6 <=> y6 {
-                                case Comparison.EqualTo => match x7 <=> y7 {
-                                    case Comparison.EqualTo => match x8 <=> y8 {
-                                        case Comparison.EqualTo => match x9 <=> y9 {
-                                            case Comparison.EqualTo => x10 <=> y10
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): Comparison =
+            let (x1, x2, x3, x4, x5, x6, x7, x8, x9) = t1;
+            let (y1, y2, y3, y4, y5, y6, y7, y8, y9) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => match x6 <=> y6 {
+                                    case Comparison.EqualTo => match x7 <=> y7 {
+                                        case Comparison.EqualTo => match x8 <=> y8 {
+                                            case Comparison.EqualTo => x9 <=> y9
                                             case res => res
                                         }
                                         case res => res
@@ -606,30 +567,27 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Order[a1], Order[
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11] {
+    instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)): Comparison =
-        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) = t1;
-        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => match x6 <=> y6 {
-                                case Comparison.EqualTo => match x7 <=> y7 {
-                                    case Comparison.EqualTo => match x8 <=> y8 {
-                                        case Comparison.EqualTo => match x9 <=> y9 {
-                                            case Comparison.EqualTo => match x10 <=> y10 {
-                                                case Comparison.EqualTo => x11 <=> y11
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): Comparison =
+            let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) = t1;
+            let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => match x6 <=> y6 {
+                                    case Comparison.EqualTo => match x7 <=> y7 {
+                                        case Comparison.EqualTo => match x8 <=> y8 {
+                                            case Comparison.EqualTo => match x9 <=> y9 {
+                                                case Comparison.EqualTo => x10 <=> y10
                                                 case res => res
                                             }
                                             case res => res
@@ -648,31 +606,28 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)] with Order[a1], O
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12] {
+    instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)): Comparison =
-        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) = t1;
-        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => match x6 <=> y6 {
-                                case Comparison.EqualTo => match x7 <=> y7 {
-                                    case Comparison.EqualTo => match x8 <=> y8 {
-                                        case Comparison.EqualTo => match x9 <=> y9 {
-                                            case Comparison.EqualTo => match x10 <=> y10 {
-                                                case Comparison.EqualTo => match x11 <=> y11 {
-                                                    case Comparison.EqualTo => x12 <=> y12
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)): Comparison =
+            let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) = t1;
+            let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => match x6 <=> y6 {
+                                    case Comparison.EqualTo => match x7 <=> y7 {
+                                        case Comparison.EqualTo => match x8 <=> y8 {
+                                            case Comparison.EqualTo => match x9 <=> y9 {
+                                                case Comparison.EqualTo => match x10 <=> y10 {
+                                                    case Comparison.EqualTo => x11 <=> y11
                                                     case res => res
                                                 }
                                                 case res => res
@@ -693,32 +648,29 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with Order[a
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13] {
+    instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)): Comparison =
-        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) = t1;
-        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => match x6 <=> y6 {
-                                case Comparison.EqualTo => match x7 <=> y7 {
-                                    case Comparison.EqualTo => match x8 <=> y8 {
-                                        case Comparison.EqualTo => match x9 <=> y9 {
-                                            case Comparison.EqualTo => match x10 <=> y10 {
-                                                case Comparison.EqualTo => match x11 <=> y11 {
-                                                    case Comparison.EqualTo => match x12 <=> y12 {
-                                                        case Comparison.EqualTo => x13 <=> y13
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)): Comparison =
+            let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) = t1;
+            let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => match x6 <=> y6 {
+                                    case Comparison.EqualTo => match x7 <=> y7 {
+                                        case Comparison.EqualTo => match x8 <=> y8 {
+                                            case Comparison.EqualTo => match x9 <=> y9 {
+                                                case Comparison.EqualTo => match x10 <=> y10 {
+                                                    case Comparison.EqualTo => match x11 <=> y11 {
+                                                        case Comparison.EqualTo => x12 <=> y12
                                                         case res => res
                                                     }
                                                     case res => res
@@ -741,33 +693,30 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with Or
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13], Order[a14] {
+    instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)): Comparison =
-        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) = t1;
-        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => match x6 <=> y6 {
-                                case Comparison.EqualTo => match x7 <=> y7 {
-                                    case Comparison.EqualTo => match x8 <=> y8 {
-                                        case Comparison.EqualTo => match x9 <=> y9 {
-                                            case Comparison.EqualTo => match x10 <=> y10 {
-                                                case Comparison.EqualTo => match x11 <=> y11 {
-                                                    case Comparison.EqualTo => match x12 <=> y12 {
-                                                        case Comparison.EqualTo => match x13 <=> y13 {
-                                                            case Comparison.EqualTo => x14 <=> y14
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)): Comparison =
+            let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) = t1;
+            let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => match x6 <=> y6 {
+                                    case Comparison.EqualTo => match x7 <=> y7 {
+                                        case Comparison.EqualTo => match x8 <=> y8 {
+                                            case Comparison.EqualTo => match x9 <=> y9 {
+                                                case Comparison.EqualTo => match x10 <=> y10 {
+                                                    case Comparison.EqualTo => match x11 <=> y11 {
+                                                        case Comparison.EqualTo => match x12 <=> y12 {
+                                                            case Comparison.EqualTo => x13 <=> y13
                                                             case res => res
                                                         }
                                                         case res => res
@@ -792,34 +741,31 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] wi
                 }
                 case res => res
             }
-            case res => res
-        }
 
-}
+    }
 
-instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13], Order[a14], Order[a15] {
+    instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13], Order[a14] {
 
-    ///
-    /// Compares `t1` and `t2` lexicographically.
-    ///
-    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)): Comparison =
-        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) = t1;
-        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15) = t2;
-        match x1 <=> y1 {
-            case Comparison.EqualTo => match x2 <=> y2 {
-                case Comparison.EqualTo => match x3 <=> y3 {
-                    case Comparison.EqualTo => match x4 <=> y4 {
-                        case Comparison.EqualTo => match x5 <=> y5 {
-                            case Comparison.EqualTo => match x6 <=> y6 {
-                                case Comparison.EqualTo => match x7 <=> y7 {
-                                    case Comparison.EqualTo => match x8 <=> y8 {
-                                        case Comparison.EqualTo => match x9 <=> y9 {
-                                            case Comparison.EqualTo => match x10 <=> y10 {
-                                                case Comparison.EqualTo => match x11 <=> y11 {
-                                                    case Comparison.EqualTo => match x12 <=> y12 {
-                                                        case Comparison.EqualTo => match x13 <=> y13 {
-                                                            case Comparison.EqualTo => match x14 <=> y14 {
-                                                                case Comparison.EqualTo => x15 <=> y15
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)): Comparison =
+            let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) = t1;
+            let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => match x6 <=> y6 {
+                                    case Comparison.EqualTo => match x7 <=> y7 {
+                                        case Comparison.EqualTo => match x8 <=> y8 {
+                                            case Comparison.EqualTo => match x9 <=> y9 {
+                                                case Comparison.EqualTo => match x10 <=> y10 {
+                                                    case Comparison.EqualTo => match x11 <=> y11 {
+                                                        case Comparison.EqualTo => match x12 <=> y12 {
+                                                            case Comparison.EqualTo => match x13 <=> y13 {
+                                                                case Comparison.EqualTo => x14 <=> y14
                                                                 case res => res
                                                             }
                                                             case res => res
@@ -846,7 +792,60 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15
                 }
                 case res => res
             }
-            case res => res
-        }
 
+    }
+
+    instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13], Order[a14], Order[a15] {
+
+        ///
+        /// Compares `t1` and `t2` lexicographically.
+        ///
+        pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)): Comparison =
+            let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) = t1;
+            let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15) = t2;
+            match x1 <=> y1 {
+                case Comparison.EqualTo => match x2 <=> y2 {
+                    case Comparison.EqualTo => match x3 <=> y3 {
+                        case Comparison.EqualTo => match x4 <=> y4 {
+                            case Comparison.EqualTo => match x5 <=> y5 {
+                                case Comparison.EqualTo => match x6 <=> y6 {
+                                    case Comparison.EqualTo => match x7 <=> y7 {
+                                        case Comparison.EqualTo => match x8 <=> y8 {
+                                            case Comparison.EqualTo => match x9 <=> y9 {
+                                                case Comparison.EqualTo => match x10 <=> y10 {
+                                                    case Comparison.EqualTo => match x11 <=> y11 {
+                                                        case Comparison.EqualTo => match x12 <=> y12 {
+                                                            case Comparison.EqualTo => match x13 <=> y13 {
+                                                                case Comparison.EqualTo => match x14 <=> y14 {
+                                                                    case Comparison.EqualTo => x15 <=> y15
+                                                                    case res => res
+                                                                }
+                                                                case res => res
+                                                            }
+                                                            case res => res
+                                                        }
+                                                        case res => res
+                                                    }
+                                                    case res => res
+                                                }
+                                                case res => res
+                                            }
+                                            case res => res
+                                        }
+                                        case res => res
+                                    }
+                                    case res => res
+                                }
+                                case res => res
+                            }
+                            case res => res
+                        }
+                        case res => res
+                    }
+                    case res => res
+                }
+                case res => res
+            }
+
+    }
 }


### PR DESCRIPTION
## Summary

- Moves the `pub lawful trait Hash[a]` and `pub lawful trait Order[a]` declarations, plus all their `instance` blocks, inside the existing same-named `pub mod Hash`/`pub mod Order` blocks.
- Continues the companion-module nesting series (cf. #12664 SemiGroup/Monoid, #12659 Fixpoint3, #12658 BPlusTree, #12657 core data enums, #12654 utility enums).
- Two minor adjustments vs. #12664: the `use Bool.{==>, <==>}` and the `import java.lang.*` lines in `Hash.flix` also move into their respective mods, since the trait laws / instance bodies are their only consumers and top-level `use`/`import` does not reach into a nested `pub mod`.

## Test plan

- [x] Stdlib smoke test: `./mill flix.run out/empty.flix`
- [x] `StandardLibrarySuite` (13,800 stdlib tests, including TestHash and TestOrder)
- [x] Full forked test suite: `./mill flix.test.testForked "-oC"` — 16,248 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)