### PR TITLE
refactor: nest Functor, Applicative, and Monad traits into companion modules

### DIFF
--- a/main/src/library/Applicative.flix
+++ b/main/src/library/Applicative.flix
@@ -14,115 +14,115 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for functors that support application, i.e. allow to:
-///
-/// - Make an applicative value out of a normal value (embed it into a default context), e.g. embed `5` into `Some(5)`.
-/// - Apply a function-type applicative to a matching argument-type applicative, resulting in an applicative of
-/// the function's result type.
-///
-/// The meaning of the application realized by the `ap` function is defined by the respective instance.
-/// Conceptually this can be understood as applying functions "contained" in the first applicative to arguments
-/// in the second applicative, where the possible quantity of functions/arguments depends on the type `m`.
-/// For example, an `Option[a -> b]` can be `None`, or contain a function of type `a -> b`, and only in the
-/// latter case a function is applied. A `List[a -> b]` is an applicative that contains a list of functions,
-/// which are all to be applied to all arguments contained in the arguments list.
-///
-/// A minimal implementation must define `point` and at least one of `ap` and `map2` (if `map2` is implemented,
-/// `ap` can be defined based on `map2` as shown below). If both `ap` and `map2` are defined,
-/// they must be equivalent to their default definitions:
-///     `ap(f: m[a -> b \ e], x: m[a]): m[b] \ ef = map2(identity, f, x)`
-///     `map2(f: a -> b -> c \ e, x: m[a], y: m[b]): m[c] \ ef = ap(Functor.map(f, x), y)`
-///
-pub lawful trait Applicative[m : Type -> Type] with Functor[m] {
-    ///
-    /// Puts `x` into a default context.
-    ///
-    pub def point(x: a): m[a]
-
-    ///
-    /// Apply the function-type applicative `f` to the argument-type applicative `x`.
-    ///
-    pub def ap(f: m[a -> b \ ef], x: m[a]): m[b] \ ef
-
-    ///
-    /// Lift a binary function to work on `Applicative`s.
-    /// Instances can define more efficient implementations than the default implementation
-    /// (which is `Applicative.ap(Functor.map(f, x1), x2)`).
-    ///
-    pub def map2(f: t1 -> t2 -> r \ ef, x1: m[t1], x2: m[t2]): m[r] \ ef = Applicative.ap(Functor.map(f, x1), x2)
-
-    ///
-    /// Lift a ternary function to work on `Applicative`s.
-    /// Instances can define more efficient implementations than the default implementation
-    /// (which is `Applicative.ap(Applicative.map2(f, x1, x2), x3)`).
-    ///
-    pub def map3(f: t1 -> t2 -> t3 -> r \ ef, x1: m[t1], x2: m[t2], x3: m[t3]): m[r] \ ef = Applicative.ap(Applicative.map2(f, x1, x2), x3)
-
-    ///
-    /// Lift a 4-ary function to work on `Applicative`s.
-    /// Instances can define more efficient implementations than the default implementation
-    /// (which is `Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)`).
-    ///
-    pub def map4(f: t1 -> t2 -> t3 -> t4 -> r \ ef, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]): m[r] \ ef = Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)
-
-    ///
-    /// Lift a 5-ary function to work on `Applicative`s.
-    /// Instances can define more efficient implementations than the default implementation
-    /// (which is `Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)`).
-    ///
-    pub def map5(f: t1 -> t2 -> t3 -> t4 -> t5 -> r \ ef, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]): m[r] \ ef = Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
-
-    ///
-    /// Applying the identity function wrapped into an applicative preserves every applicative value.
-    ///
-    law identity: forall(x: m[a]) with Eq[m[a]] Applicative.ap(Applicative.point(identity), x) == x
-
-    ///
-    /// Applicatively composing two functions and then applicatively applying the resulting function is the same
-    /// as applicatively applying the functions one by one.
-    ///
-    law composition: forall(f: m[b -> c], g: m[a -> b], v: m[a]) with Eq[m[c]] Applicative.ap(Applicative.ap(Applicative.ap(Applicative.point((f, g) -> g >> f), f), g), v) == Applicative.ap(f, Applicative.ap(g, v))
-
-    ///
-    /// `point` is a homomorphism from normal to applicative values regarding application (normal vs. applicative).
-    ///
-    // TODO error in type checker does not allow to compile this, see #2099
-    // law homomorphism: forall(f: a -> b, x: a) with Eq[m[b]] Applicative.ap(Applicative.point(f), Applicative.point(x)) == Applicative.point(f(x))
-
-    ///
-    /// Directly applicatively applying a function `f` to an argument `x` put into a default context is the same as putting the function that takes a function and applies it to `x` into a default context and applicatively applying it to `f`.
-    ///
-    law interchange: forall(f: m[a -> b], x: a) with Eq[m[b]] Applicative.ap(f, Applicative.point(x)) == Applicative.ap(Applicative.point(f -> f(x)), f)
-
-    ///
-    /// `map2` is equivalent to its default implementation.
-    ///
-    law map2Correspondence: forall(f: t1 -> t2 -> r, x1: m[t1], x2: m[t2]) with Eq[m[r]] Applicative.map2(f, x1, x2) == Applicative.ap(Functor.map(f, x1), x2)
-
-    ///
-    /// `map3` is equivalent to its default implementation.
-    ///
-    law map3Correspondence: forall(f: t1 -> t2 -> t3 -> r, x1: m[t1], x2: m[t2], x3: m[t3]) with Eq[m[r]] Applicative.map3(f, x1, x2, x3) == Applicative.ap(Applicative.map2(f, x1, x2), x3)
-
-    ///
-    /// `map4` is equivalent to its default implementation.
-    ///
-    law map4Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]) with Eq[m[r]] Applicative.map4(f, x1, x2, x3, x4) == Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)
-
-    ///
-    /// `map5` is equivalent to its default implementation.
-    ///
-    law map5Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> t5 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]) with Eq[m[r]] Applicative.map5(f, x1, x2, x3, x4, x5) == Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
-
-    ///
-    /// Mapping a function over an applicative (with `Functor.map`) is the same as putting the function
-    /// into a default context and applying it to the applicative.
-    ///
-    law mapCorrespondence: forall(f: a -> b, x: m[a]) with Eq[m[b]] Functor.map(f, x) == Applicative.ap(Applicative.point(f), x)
-}
-
 pub mod Applicative {
+
+    ///
+    /// A trait for functors that support application, i.e. allow to:
+    ///
+    /// - Make an applicative value out of a normal value (embed it into a default context), e.g. embed `5` into `Some(5)`.
+    /// - Apply a function-type applicative to a matching argument-type applicative, resulting in an applicative of
+    /// the function's result type.
+    ///
+    /// The meaning of the application realized by the `ap` function is defined by the respective instance.
+    /// Conceptually this can be understood as applying functions "contained" in the first applicative to arguments
+    /// in the second applicative, where the possible quantity of functions/arguments depends on the type `m`.
+    /// For example, an `Option[a -> b]` can be `None`, or contain a function of type `a -> b`, and only in the
+    /// latter case a function is applied. A `List[a -> b]` is an applicative that contains a list of functions,
+    /// which are all to be applied to all arguments contained in the arguments list.
+    ///
+    /// A minimal implementation must define `point` and at least one of `ap` and `map2` (if `map2` is implemented,
+    /// `ap` can be defined based on `map2` as shown below). If both `ap` and `map2` are defined,
+    /// they must be equivalent to their default definitions:
+    ///     `ap(f: m[a -> b \ e], x: m[a]): m[b] \ ef = map2(identity, f, x)`
+    ///     `map2(f: a -> b -> c \ e, x: m[a], y: m[b]): m[c] \ ef = ap(Functor.map(f, x), y)`
+    ///
+    pub lawful trait Applicative[m : Type -> Type] with Functor[m] {
+        ///
+        /// Puts `x` into a default context.
+        ///
+        pub def point(x: a): m[a]
+
+        ///
+        /// Apply the function-type applicative `f` to the argument-type applicative `x`.
+        ///
+        pub def ap(f: m[a -> b \ ef], x: m[a]): m[b] \ ef
+
+        ///
+        /// Lift a binary function to work on `Applicative`s.
+        /// Instances can define more efficient implementations than the default implementation
+        /// (which is `Applicative.ap(Functor.map(f, x1), x2)`).
+        ///
+        pub def map2(f: t1 -> t2 -> r \ ef, x1: m[t1], x2: m[t2]): m[r] \ ef = Applicative.ap(Functor.map(f, x1), x2)
+
+        ///
+        /// Lift a ternary function to work on `Applicative`s.
+        /// Instances can define more efficient implementations than the default implementation
+        /// (which is `Applicative.ap(Applicative.map2(f, x1, x2), x3)`).
+        ///
+        pub def map3(f: t1 -> t2 -> t3 -> r \ ef, x1: m[t1], x2: m[t2], x3: m[t3]): m[r] \ ef = Applicative.ap(Applicative.map2(f, x1, x2), x3)
+
+        ///
+        /// Lift a 4-ary function to work on `Applicative`s.
+        /// Instances can define more efficient implementations than the default implementation
+        /// (which is `Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)`).
+        ///
+        pub def map4(f: t1 -> t2 -> t3 -> t4 -> r \ ef, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]): m[r] \ ef = Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)
+
+        ///
+        /// Lift a 5-ary function to work on `Applicative`s.
+        /// Instances can define more efficient implementations than the default implementation
+        /// (which is `Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)`).
+        ///
+        pub def map5(f: t1 -> t2 -> t3 -> t4 -> t5 -> r \ ef, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]): m[r] \ ef = Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
+
+        ///
+        /// Applying the identity function wrapped into an applicative preserves every applicative value.
+        ///
+        law identity: forall(x: m[a]) with Eq[m[a]] Applicative.ap(Applicative.point(identity), x) == x
+
+        ///
+        /// Applicatively composing two functions and then applicatively applying the resulting function is the same
+        /// as applicatively applying the functions one by one.
+        ///
+        law composition: forall(f: m[b -> c], g: m[a -> b], v: m[a]) with Eq[m[c]] Applicative.ap(Applicative.ap(Applicative.ap(Applicative.point((f, g) -> g >> f), f), g), v) == Applicative.ap(f, Applicative.ap(g, v))
+
+        ///
+        /// `point` is a homomorphism from normal to applicative values regarding application (normal vs. applicative).
+        ///
+        // TODO error in type checker does not allow to compile this, see #2099
+        // law homomorphism: forall(f: a -> b, x: a) with Eq[m[b]] Applicative.ap(Applicative.point(f), Applicative.point(x)) == Applicative.point(f(x))
+
+        ///
+        /// Directly applicatively applying a function `f` to an argument `x` put into a default context is the same as putting the function that takes a function and applies it to `x` into a default context and applicatively applying it to `f`.
+        ///
+        law interchange: forall(f: m[a -> b], x: a) with Eq[m[b]] Applicative.ap(f, Applicative.point(x)) == Applicative.ap(Applicative.point(f -> f(x)), f)
+
+        ///
+        /// `map2` is equivalent to its default implementation.
+        ///
+        law map2Correspondence: forall(f: t1 -> t2 -> r, x1: m[t1], x2: m[t2]) with Eq[m[r]] Applicative.map2(f, x1, x2) == Applicative.ap(Functor.map(f, x1), x2)
+
+        ///
+        /// `map3` is equivalent to its default implementation.
+        ///
+        law map3Correspondence: forall(f: t1 -> t2 -> t3 -> r, x1: m[t1], x2: m[t2], x3: m[t3]) with Eq[m[r]] Applicative.map3(f, x1, x2, x3) == Applicative.ap(Applicative.map2(f, x1, x2), x3)
+
+        ///
+        /// `map4` is equivalent to its default implementation.
+        ///
+        law map4Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]) with Eq[m[r]] Applicative.map4(f, x1, x2, x3, x4) == Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)
+
+        ///
+        /// `map5` is equivalent to its default implementation.
+        ///
+        law map5Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> t5 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]) with Eq[m[r]] Applicative.map5(f, x1, x2, x3, x4, x5) == Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
+
+        ///
+        /// Mapping a function over an applicative (with `Functor.map`) is the same as putting the function
+        /// into a default context and applying it to the applicative.
+        ///
+        law mapCorrespondence: forall(f: a -> b, x: m[a]) with Eq[m[b]] Functor.map(f, x) == Applicative.ap(Applicative.point(f), x)
+    }
 
     ///
     /// Chain two applicative actions, returns the product of their results.

--- a/main/src/library/Functor.flix
+++ b/main/src/library/Functor.flix
@@ -14,28 +14,28 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for types that can be mapped over.
-///
-pub lawful trait Functor[m : Type -> Type] {
-    ///
-    /// Applies the function `f` to `x` preserving its structure.
-    ///
-    pub def map(f: a -> b \ ef, x: m[a]): m[b] \ ef
-
-    ///
-    /// Mapping the identity function over a functor preserves the functor.
-    ///
-    law identity: forall(x: m[a]) with Eq[m[a]] Functor.map(identity, x) == x
-
-    ///
-    /// Composing two functions and mapping the resulting function over a functor is the same as
-    /// mapping the functions one after the other over the functor.
-    ///
-    law composition: forall(f: b -> c, g: a -> b, v: m[a]) with Eq[m[c]] Functor.map(g >> f, v) == Functor.map(f, Functor.map(g, v))
-}
-
 pub mod Functor {
+
+    ///
+    /// A trait for types that can be mapped over.
+    ///
+    pub lawful trait Functor[m : Type -> Type] {
+        ///
+        /// Applies the function `f` to `x` preserving its structure.
+        ///
+        pub def map(f: a -> b \ ef, x: m[a]): m[b] \ ef
+
+        ///
+        /// Mapping the identity function over a functor preserves the functor.
+        ///
+        law identity: forall(x: m[a]) with Eq[m[a]] Functor.map(identity, x) == x
+
+        ///
+        /// Composing two functions and mapping the resulting function over a functor is the same as
+        /// mapping the functions one after the other over the functor.
+        ///
+        law composition: forall(f: b -> c, g: a -> b, v: m[a]) with Eq[m[c]] Functor.map(g >> f, v) == Functor.map(f, Functor.map(g, v))
+    }
 
     ///
     /// Replaces the value `a` in `s` by the given value `x` preserving the structure of `s`.

--- a/main/src/library/Monad.flix
+++ b/main/src/library/Monad.flix
@@ -14,45 +14,44 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for applicatives that support monadic bind (`flatMap`), i.e., allow to apply a function
-/// that takes a normal value and produces a monadic value to a monadic value. That is, the bind mechanism
-/// supports extraction of monadic values, or, viewed differently, allows to combine (flatten) nested
-/// monadic values (`flapMap` can be understood as a `Functor.map` followed by a `flatten`).
-///
-pub lawful trait Monad[m : Type -> Type] with Applicative[m] {
-
-    ///
-    /// Apply function `f` to the monadic value `x`, resulting in a combined monadic value.
-    ///
-    pub def flatMap(f: a -> m[b] \ ef, x: m[a]) : m[b] \ ef
-
-    ///
-    /// Applying `flatMap` to the `point` function is the identity function.
-    ///
-    law leftIdentity: forall(f: a -> m[b], x: m[a]) with Eq[m[a]] Monad.flatMap(Applicative.point, x) == x
-
-    ///
-    /// Applying `flatMap` to a function and to a non-monadic argument after applying `point` to it is the same
-    /// as applying the function directly to that argument.
-    ///
-    law rightIdentity: forall(f: a -> m[b], x: a) with Eq[m[b]] Monad.flatMap(f, Applicative.point(x)) == f(x)
-
-    ///
-    /// Subsequent `flatMap` calls (nested in the monadic argument) can be moved to the outside by
-    /// providing a lambda as first argument which then calls `flatMap`.
-    ///
-    law associativity: forall(x: m[a], f: a -> m[b], g: b -> m[c]) with Eq[m[c]] Monad.flatMap(g, Monad.flatMap(f, x)) == Monad.flatMap(y -> Monad.flatMap(g, f(y)), x)
-
-    ///
-    /// Applicatively applying a monadic function to a monadic argument is the same as using `flatMap`
-    /// to extract function and argument, applying them normally and then applying `point` to the result.
-    ///
-    law apCorrespondence: forall(f: m[a -> b], x: m[a]) with Eq[m[b]] Applicative.ap(f, x) == Monad.flatMap(g -> Monad.flatMap(y -> Applicative.point(g(y)), x), f)
-}
-
-
 pub mod Monad {
+
+    ///
+    /// A trait for applicatives that support monadic bind (`flatMap`), i.e., allow to apply a function
+    /// that takes a normal value and produces a monadic value to a monadic value. That is, the bind mechanism
+    /// supports extraction of monadic values, or, viewed differently, allows to combine (flatten) nested
+    /// monadic values (`flapMap` can be understood as a `Functor.map` followed by a `flatten`).
+    ///
+    pub lawful trait Monad[m : Type -> Type] with Applicative[m] {
+
+        ///
+        /// Apply function `f` to the monadic value `x`, resulting in a combined monadic value.
+        ///
+        pub def flatMap(f: a -> m[b] \ ef, x: m[a]) : m[b] \ ef
+
+        ///
+        /// Applying `flatMap` to the `point` function is the identity function.
+        ///
+        law leftIdentity: forall(f: a -> m[b], x: m[a]) with Eq[m[a]] Monad.flatMap(Applicative.point, x) == x
+
+        ///
+        /// Applying `flatMap` to a function and to a non-monadic argument after applying `point` to it is the same
+        /// as applying the function directly to that argument.
+        ///
+        law rightIdentity: forall(f: a -> m[b], x: a) with Eq[m[b]] Monad.flatMap(f, Applicative.point(x)) == f(x)
+
+        ///
+        /// Subsequent `flatMap` calls (nested in the monadic argument) can be moved to the outside by
+        /// providing a lambda as first argument which then calls `flatMap`.
+        ///
+        law associativity: forall(x: m[a], f: a -> m[b], g: b -> m[c]) with Eq[m[c]] Monad.flatMap(g, Monad.flatMap(f, x)) == Monad.flatMap(y -> Monad.flatMap(g, f(y)), x)
+
+        ///
+        /// Applicatively applying a monadic function to a monadic argument is the same as using `flatMap`
+        /// to extract function and argument, applying them normally and then applying `point` to the result.
+        ///
+        law apCorrespondence: forall(f: m[a -> b], x: m[a]) with Eq[m[b]] Applicative.ap(f, x) == Monad.flatMap(g -> Monad.flatMap(y -> Applicative.point(g(y)), x), f)
+    }
 
     ///
     /// The monadic `join` operator.


### PR DESCRIPTION
## Summary

- Moves the `pub lawful trait Functor`, `pub lawful trait Applicative`, and `pub lawful trait Monad` declarations inside their existing same-named `pub mod Functor`/`pub mod Applicative`/`pub mod Monad` blocks.
- Continues the companion-module nesting series (cf. #12665 Hash/Order, #12664 SemiGroup/Monoid).
- These three files have no top-level `instance` blocks (instances live in consumer files like `List.flix`, `Option.flix`, `Vector.flix`, etc.) and no top-level `use`/`import` statements, so the change is just the trait move + 4-space re-indent.

## Test plan

- [x] Stdlib smoke test: `./mill flix.run out/empty.flix`
- [x] `StandardLibrarySuite` (13,800 stdlib tests)
- [x] Full forked test suite: `./mill flix.test.testForked "-oC"` — 16,248 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)