### PR TITLE
refactor: nest stdlib traits and instances into companion modules

### DIFF
--- a/main/src/library/Coerce.flix
+++ b/main/src/library/Coerce.flix
@@ -14,19 +14,23 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for type that can be coerced.
-///
-/// Currently only supports newtype-style wrappers.
-///
-pub trait Coerce[t] {
-    ///
-    /// The return type of the coerce function.
-    ///
-    type Out
+pub mod Coerce {
 
     ///
-    /// Returns the unwrapped value of `x`.
+    /// A trait for type that can be coerced.
     ///
-    pub def coerce(x: t): Coerce.Out[t]
+    /// Currently only supports newtype-style wrappers.
+    ///
+    pub trait Coerce[t] {
+        ///
+        /// The return type of the coerce function.
+        ///
+        type Out
+
+        ///
+        /// Returns the unwrapped value of `x`.
+        ///
+        pub def coerce(x: t): Coerce.Out[t]
+    }
+
 }

--- a/main/src/library/CommutativeGroup.flix
+++ b/main/src/library/CommutativeGroup.flix
@@ -14,46 +14,50 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for types that form a commutative group (abelian group)
-/// i.e. groups where the `combine` function is commutative.
-///
-/// The default instances for number define the additive inverse in the real numbers.
-///
-pub lawful trait CommutativeGroup[a] with Group[a], CommutativeMonoid[a] {}
+pub mod CommutativeGroup {
 
-instance CommutativeGroup[Unit]
+    ///
+    /// A trait for types that form a commutative group (abelian group)
+    /// i.e. groups where the `combine` function is commutative.
+    ///
+    /// The default instances for number define the additive inverse in the real numbers.
+    ///
+    pub lawful trait CommutativeGroup[a] with Group[a], CommutativeMonoid[a] {}
 
-instance CommutativeGroup[Int8]
+    instance CommutativeGroup[Unit]
 
-instance CommutativeGroup[Int16]
+    instance CommutativeGroup[Int8]
 
-instance CommutativeGroup[Int32]
+    instance CommutativeGroup[Int16]
 
-instance CommutativeGroup[Int64]
+    instance CommutativeGroup[Int32]
 
-instance CommutativeGroup[BigInt]
+    instance CommutativeGroup[Int64]
 
-instance CommutativeGroup[Float32]
+    instance CommutativeGroup[BigInt]
 
-instance CommutativeGroup[Float64]
+    instance CommutativeGroup[Float32]
 
-instance CommutativeGroup[BigDecimal]
+    instance CommutativeGroup[Float64]
 
-instance CommutativeGroup[(a1, a2)] with CommutativeGroup[a1], CommutativeGroup[a2]
+    instance CommutativeGroup[BigDecimal]
 
-instance CommutativeGroup[(a1, a2, a3)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3]
+    instance CommutativeGroup[(a1, a2)] with CommutativeGroup[a1], CommutativeGroup[a2]
 
-instance CommutativeGroup[(a1, a2, a3, a4)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4]
+    instance CommutativeGroup[(a1, a2, a3)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3]
 
-instance CommutativeGroup[(a1, a2, a3, a4, a5)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5]
+    instance CommutativeGroup[(a1, a2, a3, a4)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4]
 
-instance CommutativeGroup[(a1, a2, a3, a4, a5, a6)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6]
+    instance CommutativeGroup[(a1, a2, a3, a4, a5)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5]
 
-instance CommutativeGroup[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6], CommutativeGroup[a7]
+    instance CommutativeGroup[(a1, a2, a3, a4, a5, a6)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6]
 
-instance CommutativeGroup[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6], CommutativeGroup[a7], CommutativeGroup[a8]
+    instance CommutativeGroup[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6], CommutativeGroup[a7]
 
-instance CommutativeGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6], CommutativeGroup[a7], CommutativeGroup[a8], CommutativeGroup[a9]
+    instance CommutativeGroup[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6], CommutativeGroup[a7], CommutativeGroup[a8]
 
-instance CommutativeGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6], CommutativeGroup[a7], CommutativeGroup[a8], CommutativeGroup[a9], CommutativeGroup[a10]
+    instance CommutativeGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6], CommutativeGroup[a7], CommutativeGroup[a8], CommutativeGroup[a9]
+
+    instance CommutativeGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeGroup[a1], CommutativeGroup[a2], CommutativeGroup[a3], CommutativeGroup[a4], CommutativeGroup[a5], CommutativeGroup[a6], CommutativeGroup[a7], CommutativeGroup[a8], CommutativeGroup[a9], CommutativeGroup[a10]
+
+}

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -14,63 +14,68 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for types that form a commutative monoid.
-///
-pub lawful trait CommutativeMonoid[a] with Monoid[a] {
+pub mod CommutativeMonoid {
 
     ///
-    /// Returns a neutral element.
+    /// A trait for types that form a commutative monoid.
     ///
-    pub def empty(): a = Monoid.empty()
+    pub lawful trait CommutativeMonoid[a] with Monoid[a] {
 
-    ///
-    /// An associative & commutative binary operation on `a`.
-    ///
-    pub def combine(x: a, y: a): a =
-        Monoid.combine(x, y)
+        ///
+        /// Returns a neutral element.
+        ///
+        pub def empty(): a = Monoid.empty()
 
-    law leftIdentity: forall(x: a) with Eq[a] CommutativeMonoid.combine(CommutativeMonoid.empty(), x) == x
+        ///
+        /// An associative & commutative binary operation on `a`.
+        ///
+        pub def combine(x: a, y: a): a =
+            Monoid.combine(x, y)
 
-    law rightIdentity: forall(x: a) with Eq[a] CommutativeMonoid.combine(x, CommutativeMonoid.empty()) == x
+        law leftIdentity: forall(x: a) with Eq[a] CommutativeMonoid.combine(CommutativeMonoid.empty(), x) == x
 
-    law associative: forall(x: a, y: a, z: a) with Eq[a] CommutativeMonoid.combine(CommutativeMonoid.combine(x, y), z) == CommutativeMonoid.combine(x, CommutativeMonoid.combine(y, z))
+        law rightIdentity: forall(x: a) with Eq[a] CommutativeMonoid.combine(x, CommutativeMonoid.empty()) == x
 
-    law commutative: forall(x: a, y: a) with Eq[a] CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
+        law associative: forall(x: a, y: a, z: a) with Eq[a] CommutativeMonoid.combine(CommutativeMonoid.combine(x, y), z) == CommutativeMonoid.combine(x, CommutativeMonoid.combine(y, z))
+
+        law commutative: forall(x: a, y: a) with Eq[a] CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
+
+    }
+
+    instance CommutativeMonoid[Unit]
+
+    instance CommutativeMonoid[Int8]
+
+    instance CommutativeMonoid[Int16]
+
+    instance CommutativeMonoid[Int32]
+
+    instance CommutativeMonoid[Int64]
+
+    instance CommutativeMonoid[BigInt]
+
+    instance CommutativeMonoid[Float32]
+
+    instance CommutativeMonoid[Float64]
+
+    instance CommutativeMonoid[BigDecimal]
+
+    instance CommutativeMonoid[(a1, a2)] with CommutativeMonoid[a1], CommutativeMonoid[a2]
+
+    instance CommutativeMonoid[(a1, a2, a3)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3]
+
+    instance CommutativeMonoid[(a1, a2, a3, a4)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4]
+
+    instance CommutativeMonoid[(a1, a2, a3, a4, a5)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5]
+
+    instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6]
+
+    instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7]
+
+    instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7], CommutativeMonoid[a8]
+
+    instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7], CommutativeMonoid[a8], CommutativeMonoid[a9]
+
+    instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7], CommutativeMonoid[a8], CommutativeMonoid[a9], CommutativeMonoid[a10]
 
 }
-instance CommutativeMonoid[Unit]
-
-instance CommutativeMonoid[Int8]
-
-instance CommutativeMonoid[Int16]
-
-instance CommutativeMonoid[Int32]
-
-instance CommutativeMonoid[Int64]
-
-instance CommutativeMonoid[BigInt]
-
-instance CommutativeMonoid[Float32]
-
-instance CommutativeMonoid[Float64]
-
-instance CommutativeMonoid[BigDecimal]
-
-instance CommutativeMonoid[(a1, a2)] with CommutativeMonoid[a1], CommutativeMonoid[a2]
-
-instance CommutativeMonoid[(a1, a2, a3)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3]
-
-instance CommutativeMonoid[(a1, a2, a3, a4)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4]
-
-instance CommutativeMonoid[(a1, a2, a3, a4, a5)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5]
-
-instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6]
-
-instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7]
-
-instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7], CommutativeMonoid[a8]
-
-instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7], CommutativeMonoid[a8], CommutativeMonoid[a9]
-
-instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7], CommutativeMonoid[a8], CommutativeMonoid[a9], CommutativeMonoid[a10]

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -15,59 +15,62 @@
  */
 
 ///
-/// A trait for types that form a commutative semigroup.
-///
-pub lawful trait CommutativeSemiGroup[a] with SemiGroup[a] {
-
-    ///
-    /// An associative & commutative binary operation on `a`.
-    ///
-    pub def combine(x: a, y: a): a = SemiGroup.combine(x, y)
-
-    law associative: forall(x: a, y: a, z: a) with Eq[a] CommutativeSemiGroup.combine(CommutativeSemiGroup.combine(x, y), z) == CommutativeSemiGroup.combine(x, CommutativeSemiGroup.combine(y, z))
-
-    law commutative: forall(x: a, y: a) with Eq[a] CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
-
-}
-
-///
 /// Alias for `CommutativeSemiGroup.combine`.
 ///
 pub def |+|(x: a, y: a): a with CommutativeSemiGroup[a] = CommutativeSemiGroup.combine(x, y)
 
-instance CommutativeSemiGroup[Unit]
+pub mod CommutativeSemiGroup {
 
-instance CommutativeSemiGroup[Int8]
+    ///
+    /// A trait for types that form a commutative semigroup.
+    ///
+    pub lawful trait CommutativeSemiGroup[a] with SemiGroup[a] {
 
-instance CommutativeSemiGroup[Int16]
+        ///
+        /// An associative & commutative binary operation on `a`.
+        ///
+        pub def combine(x: a, y: a): a = SemiGroup.combine(x, y)
 
-instance CommutativeSemiGroup[Int32]
+        law associative: forall(x: a, y: a, z: a) with Eq[a] CommutativeSemiGroup.combine(CommutativeSemiGroup.combine(x, y), z) == CommutativeSemiGroup.combine(x, CommutativeSemiGroup.combine(y, z))
 
-instance CommutativeSemiGroup[Int64]
+        law commutative: forall(x: a, y: a) with Eq[a] CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
 
-instance CommutativeSemiGroup[BigInt]
+    }
 
-instance CommutativeSemiGroup[Float32]
+    instance CommutativeSemiGroup[Unit]
 
-instance CommutativeSemiGroup[Float64]
+    instance CommutativeSemiGroup[Int8]
 
-instance CommutativeSemiGroup[BigDecimal]
+    instance CommutativeSemiGroup[Int16]
 
-instance CommutativeSemiGroup[(a1, a2)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2]
+    instance CommutativeSemiGroup[Int32]
 
-instance CommutativeSemiGroup[(a1, a2, a3)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3]
+    instance CommutativeSemiGroup[Int64]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4]
+    instance CommutativeSemiGroup[BigInt]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5]
+    instance CommutativeSemiGroup[Float32]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6]
+    instance CommutativeSemiGroup[Float64]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7]
+    instance CommutativeSemiGroup[BigDecimal]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8]
+    instance CommutativeSemiGroup[(a1, a2)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9]
+    instance CommutativeSemiGroup[(a1, a2, a3)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9], CommutativeSemiGroup[a10]
+    instance CommutativeSemiGroup[(a1, a2, a3, a4)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4]
 
+    instance CommutativeSemiGroup[(a1, a2, a3, a4, a5)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5]
+
+    instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6]
+
+    instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7]
+
+    instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8]
+
+    instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9]
+
+    instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9], CommutativeSemiGroup[a10]
+
+}

--- a/main/src/library/Formattable.flix
+++ b/main/src/library/Formattable.flix
@@ -14,70 +14,74 @@
  * limitations under the License.
  */
 
-///
-/// A trait for types that can be formatted as a `RichString`.
-///
-pub trait Formattable[a] {
+pub mod Formattable {
+
     ///
-    /// The associated effect of the Formattable which represents the effect of formatting.
+    /// A trait for types that can be formatted as a `RichString`.
     ///
-    type Aef[a]: Eff = {}
+    pub trait Formattable[a] {
+        ///
+        /// The associated effect of the Formattable which represents the effect of formatting.
+        ///
+        type Aef[a]: Eff = {}
 
-    pub def format(x: a): RichString \ Formattable.Aef[a]
-}
+        pub def format(x: a): RichString \ Formattable.Aef[a]
+    }
 
-instance Formattable[Unit] {
-    pub def format(x: Unit): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[Unit] {
+        pub def format(x: Unit): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[Bool] {
-    pub def format(x: Bool): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[Bool] {
+        pub def format(x: Bool): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[Char] {
-    pub def format(x: Char): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[Char] {
+        pub def format(x: Char): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[Int8] {
-    pub def format(x: Int8): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[Int8] {
+        pub def format(x: Int8): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[Int16] {
-    pub def format(x: Int16): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[Int16] {
+        pub def format(x: Int16): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[Int32] {
-    pub def format(x: Int32): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[Int32] {
+        pub def format(x: Int32): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[Int64] {
-    pub def format(x: Int64): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[Int64] {
+        pub def format(x: Int64): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[Float32] {
-    pub def format(x: Float32): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[Float32] {
+        pub def format(x: Float32): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[Float64] {
-    pub def format(x: Float64): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[Float64] {
+        pub def format(x: Float64): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[String] {
-    pub def format(x: String): RichString = RichString.fromString(x)
-}
+    instance Formattable[String] {
+        pub def format(x: String): RichString = RichString.fromString(x)
+    }
 
-instance Formattable[BigInt] {
-    pub def format(x: BigInt): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[BigInt] {
+        pub def format(x: BigInt): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[BigDecimal] {
-    pub def format(x: BigDecimal): RichString = RichString.fromString(ToString.toString(x))
-}
+    instance Formattable[BigDecimal] {
+        pub def format(x: BigDecimal): RichString = RichString.fromString(ToString.toString(x))
+    }
 
-instance Formattable[(a1, a2)] with Formattable[a1], Formattable[a2] {
-    type Aef[(a1, a2)] = Formattable.Aef[a1] + Formattable.Aef[a2]
+    instance Formattable[(a1, a2)] with Formattable[a1], Formattable[a2] {
+        type Aef[(a1, a2)] = Formattable.Aef[a1] + Formattable.Aef[a2]
 
-    pub def format(x: (a1, a2)): RichString \ Formattable.Aef[a1] + Formattable.Aef[a2] =
-        let (v1, v2) = x;
-        RichString.fromString("(") + Formattable.format(v1) + RichString.fromString(", ") + Formattable.format(v2) + RichString.fromString(")")
+        pub def format(x: (a1, a2)): RichString \ Formattable.Aef[a1] + Formattable.Aef[a2] =
+            let (v1, v2) = x;
+            RichString.fromString("(") + Formattable.format(v1) + RichString.fromString(", ") + Formattable.format(v2) + RichString.fromString(")")
+    }
+
 }

--- a/main/src/library/FromString.flix
+++ b/main/src/library/FromString.flix
@@ -14,71 +14,75 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for types that can be constructed from strings.
-///
-pub trait FromString[a] {
+pub mod FromString {
+
     ///
-    /// Optionally returns the value associated with the given string `s`.
+    /// A trait for types that can be constructed from strings.
     ///
-    pub def fromString(x: String): Option[a]
-}
-
-instance FromString[Unit] {
-    pub def fromString(x: String): Option[Unit] = match x {
-        case "()" => Some(())
-        case _    => None
+    pub trait FromString[a] {
+        ///
+        /// Optionally returns the value associated with the given string `s`.
+        ///
+        pub def fromString(x: String): Option[a]
     }
-}
 
-instance FromString[Bool] {
-    pub def fromString(x: String): Option[Bool] = match x {
-        case "true"  => Some(true)
-        case "false" => Some(false)
-        case _       => None
+    instance FromString[Unit] {
+        pub def fromString(x: String): Option[Unit] = match x {
+            case "()" => Some(())
+            case _    => None
+        }
     }
-}
 
-instance FromString[Char] {
-    pub def fromString(x: String): Option[Char] =
-        if (String.length(x) == 1)
-            Some(String.charAt(0, x))
-        else
-            None
-}
+    instance FromString[Bool] {
+        pub def fromString(x: String): Option[Bool] = match x {
+            case "true"  => Some(true)
+            case "false" => Some(false)
+            case _       => None
+        }
+    }
 
-instance FromString[Float32] {
-    pub def fromString(x: String): Option[Float32] = Float32.fromString(x)
-}
+    instance FromString[Char] {
+        pub def fromString(x: String): Option[Char] =
+            if (String.length(x) == 1)
+                Some(String.charAt(0, x))
+            else
+                None
+    }
 
-instance FromString[Float64] {
-    pub def fromString(x: String): Option[Float64] = Float64.fromString(x)
-}
+    instance FromString[Float32] {
+        pub def fromString(x: String): Option[Float32] = Float32.fromString(x)
+    }
 
-instance FromString[BigDecimal] {
-    pub def fromString(x: String): Option[BigDecimal] = BigDecimal.fromString(x)
-}
+    instance FromString[Float64] {
+        pub def fromString(x: String): Option[Float64] = Float64.fromString(x)
+    }
 
-instance FromString[Int8] {
-    pub def fromString(x: String): Option[Int8] = Int8.fromString(x)
-}
+    instance FromString[BigDecimal] {
+        pub def fromString(x: String): Option[BigDecimal] = BigDecimal.fromString(x)
+    }
 
-instance FromString[Int16] {
-    pub def fromString(x: String): Option[Int16] = Int16.fromString(x)
-}
+    instance FromString[Int8] {
+        pub def fromString(x: String): Option[Int8] = Int8.fromString(x)
+    }
 
-instance FromString[Int32] {
-    pub def fromString(x: String): Option[Int32] = Int32.fromString(x)
-}
+    instance FromString[Int16] {
+        pub def fromString(x: String): Option[Int16] = Int16.fromString(x)
+    }
 
-instance FromString[Int64] {
-    pub def fromString(x: String): Option[Int64] = Int64.fromString(x)
-}
+    instance FromString[Int32] {
+        pub def fromString(x: String): Option[Int32] = Int32.fromString(x)
+    }
 
-instance FromString[BigInt] {
-    pub def fromString(x: String): Option[BigInt] = BigInt.fromString(x)
-}
+    instance FromString[Int64] {
+        pub def fromString(x: String): Option[Int64] = Int64.fromString(x)
+    }
 
-instance FromString[String] {
-    pub def fromString(x: String): Option[String] = Some(x)
+    instance FromString[BigInt] {
+        pub def fromString(x: String): Option[BigInt] = BigInt.fromString(x)
+    }
+
+    instance FromString[String] {
+        pub def fromString(x: String): Option[String] = Some(x)
+    }
+
 }

--- a/main/src/library/Group.flix
+++ b/main/src/library/Group.flix
@@ -14,152 +14,156 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for types that form a group.
-///
-/// The default instances for numbers define the additive inverse in the real numbers.
-///
-pub trait Group[a] with Monoid[a] {
+pub mod Group {
 
     ///
-    /// Returns the neutral element.
+    /// A trait for types that form a group.
     ///
-    pub def empty(): a =
-        Monoid.empty()
-
+    /// The default instances for numbers define the additive inverse in the real numbers.
     ///
-    /// Returns the inverse element of `x`.
-    ///
-    pub def inverse(x: a): a
+    pub trait Group[a] with Monoid[a] {
 
-    ///
-    /// Returns the result of combining `x` and `y` using `Monoid`'s combine.
-    ///
-    pub def combine(x: a, y: a): a =
-        Monoid.combine(x, y)
+        ///
+        /// Returns the neutral element.
+        ///
+        pub def empty(): a =
+            Monoid.empty()
 
-    ///
-    /// Returns `y` removed from `x`.
-    ///
-    /// Equivalent to `Group.combine(x, Group.inverse(y))`
-    ///
-    pub def remove(x: a, y: a): a =
-        Group.combine(x, Group.inverse(y))
+        ///
+        /// Returns the inverse element of `x`.
+        ///
+        pub def inverse(x: a): a
 
-    ///
-    /// Combining the inverse of `x` with `x` yields the neutral element in the group.
-    ///
-    /// The operation is commutative i.e. if `y` is the inverse of `x` and `e` is the
-    /// identity (neutral element) then
-    /// `combine(x, y) == combine(y, x) == e`
-    ///
-    law leftInvertible: forall(x: a) with Eq[a] Group.combine(Group.inverse(x), x) == Group.empty()
+        ///
+        /// Returns the result of combining `x` and `y` using `Monoid`'s combine.
+        ///
+        pub def combine(x: a, y: a): a =
+            Monoid.combine(x, y)
 
-    ///
-    /// Combining the inverse of `x` with `x` yields the neutral element in the group.
-    ///
-    /// The operation is commutative i.e. if `y` is the inverse of `x` and `e` is the
-    /// identity (neutral element) then
-    /// `combine(x, y) == combine(y, x) == e`
-    ///
-    law rightInvertible: forall(x: a) with Eq[a] Group.combine(x, Group.inverse(x)) == Group.empty()
+        ///
+        /// Returns `y` removed from `x`.
+        ///
+        /// Equivalent to `Group.combine(x, Group.inverse(y))`
+        ///
+        pub def remove(x: a, y: a): a =
+            Group.combine(x, Group.inverse(y))
 
-}
+        ///
+        /// Combining the inverse of `x` with `x` yields the neutral element in the group.
+        ///
+        /// The operation is commutative i.e. if `y` is the inverse of `x` and `e` is the
+        /// identity (neutral element) then
+        /// `combine(x, y) == combine(y, x) == e`
+        ///
+        law leftInvertible: forall(x: a) with Eq[a] Group.combine(Group.inverse(x), x) == Group.empty()
 
-instance Group[Unit] {
-    pub def inverse(_: Unit): Unit = ()
-}
+        ///
+        /// Combining the inverse of `x` with `x` yields the neutral element in the group.
+        ///
+        /// The operation is commutative i.e. if `y` is the inverse of `x` and `e` is the
+        /// identity (neutral element) then
+        /// `combine(x, y) == combine(y, x) == e`
+        ///
+        law rightInvertible: forall(x: a) with Eq[a] Group.combine(x, Group.inverse(x)) == Group.empty()
 
-instance Group[Int8] {
-    pub def inverse(x: Int8): Int8 = -x
-    redef remove(x: Int8, y: Int8): Int8 = x - y
-}
-
-instance Group[Int16] {
-    pub def inverse(x: Int16): Int16 = -x
-    redef remove(x: Int16, y: Int16): Int16 = x - y
-}
-
-instance Group[Int32] {
-    pub def inverse(x: Int32): Int32 = -x
-    redef remove(x: Int32, y: Int32): Int32 = x - y
-}
-
-instance Group[Int64] {
-    pub def inverse(x: Int64): Int64 = -x
-    redef remove(x: Int64, y: Int64): Int64 = x - y
-}
-
-instance Group[BigInt] {
-    pub def inverse(x: BigInt): BigInt = -x
-    redef remove(x: BigInt, y: BigInt): BigInt = x - y
-}
-
-instance Group[Float32] {
-    pub def inverse(x: Float32): Float32 = -x
-    redef remove(x: Float32, y: Float32): Float32 = x - y
-}
-
-instance Group[Float64] {
-    pub def inverse(x: Float64): Float64 = -x
-    redef remove(x: Float64, y: Float64): Float64 = x - y
-}
-
-instance Group[BigDecimal] {
-    pub def inverse(x: BigDecimal): BigDecimal = -x
-    redef remove(x: BigDecimal, y: BigDecimal): BigDecimal = x - y
-}
-
-instance Group[(a1, a2)] with Group[a1], Group[a2] {
-    pub def inverse(x: (a1, a2)): (a1, a2) = match x {
-        case (a1, a2) => (Group.inverse(a1), Group.inverse(a2))
     }
-}
 
-instance Group[(a1, a2, a3)] with Group[a1], Group[a2], Group[a3] {
-    pub def inverse(x: (a1, a2, a3)): (a1, a2, a3) = match x {
-        case (a1, a2, a3) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3))
+    instance Group[Unit] {
+        pub def inverse(_: Unit): Unit = ()
     }
-}
 
-instance Group[(a1, a2, a3, a4)] with Group[a1], Group[a2], Group[a3], Group[a4] {
-    pub def inverse(x: (a1, a2, a3, a4)): (a1, a2, a3, a4) = match x {
-        case (a1, a2, a3, a4) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4))
+    instance Group[Int8] {
+        pub def inverse(x: Int8): Int8 = -x
+        redef remove(x: Int8, y: Int8): Int8 = x - y
     }
-}
 
-instance Group[(a1, a2, a3, a4, a5)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5] {
-    pub def inverse(x: (a1, a2, a3, a4, a5)): (a1, a2, a3, a4, a5) = match x {
-        case (a1, a2, a3, a4, a5) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5))
+    instance Group[Int16] {
+        pub def inverse(x: Int16): Int16 = -x
+        redef remove(x: Int16, y: Int16): Int16 = x - y
     }
-}
 
-instance Group[(a1, a2, a3, a4, a5, a6)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6] {
-    pub def inverse(x: (a1, a2, a3, a4, a5, a6)): (a1, a2, a3, a4, a5, a6) = match x {
-        case (a1, a2, a3, a4, a5, a6) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6))
+    instance Group[Int32] {
+        pub def inverse(x: Int32): Int32 = -x
+        redef remove(x: Int32, y: Int32): Int32 = x - y
     }
-}
 
-instance Group[(a1, a2, a3, a4, a5, a6, a7)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6], Group[a7] {
-    pub def inverse(x: (a1, a2, a3, a4, a5, a6, a7)): (a1, a2, a3, a4, a5, a6, a7) = match x {
-        case (a1, a2, a3, a4, a5, a6, a7) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6), Group.inverse(a7))
+    instance Group[Int64] {
+        pub def inverse(x: Int64): Int64 = -x
+        redef remove(x: Int64, y: Int64): Int64 = x - y
     }
-}
 
-instance Group[(a1, a2, a3, a4, a5, a6, a7, a8)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6], Group[a7], Group[a8] {
-    pub def inverse(x: (a1, a2, a3, a4, a5, a6, a7, a8)): (a1, a2, a3, a4, a5, a6, a7, a8) = match x {
-        case (a1, a2, a3, a4, a5, a6, a7, a8) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6), Group.inverse(a7), Group.inverse(a8))
+    instance Group[BigInt] {
+        pub def inverse(x: BigInt): BigInt = -x
+        redef remove(x: BigInt, y: BigInt): BigInt = x - y
     }
-}
 
-instance Group[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6], Group[a7], Group[a8], Group[a9] {
-    pub def inverse(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = match x {
-        case (a1, a2, a3, a4, a5, a6, a7, a8, a9) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6), Group.inverse(a7), Group.inverse(a8), Group.inverse(a9))
+    instance Group[Float32] {
+        pub def inverse(x: Float32): Float32 = -x
+        redef remove(x: Float32, y: Float32): Float32 = x - y
     }
-}
 
-instance Group[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6], Group[a7], Group[a8], Group[a9], Group[a10] {
-    pub def inverse(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = match x {
-        case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6), Group.inverse(a7), Group.inverse(a8), Group.inverse(a9), Group.inverse(a10))
+    instance Group[Float64] {
+        pub def inverse(x: Float64): Float64 = -x
+        redef remove(x: Float64, y: Float64): Float64 = x - y
     }
+
+    instance Group[BigDecimal] {
+        pub def inverse(x: BigDecimal): BigDecimal = -x
+        redef remove(x: BigDecimal, y: BigDecimal): BigDecimal = x - y
+    }
+
+    instance Group[(a1, a2)] with Group[a1], Group[a2] {
+        pub def inverse(x: (a1, a2)): (a1, a2) = match x {
+            case (a1, a2) => (Group.inverse(a1), Group.inverse(a2))
+        }
+    }
+
+    instance Group[(a1, a2, a3)] with Group[a1], Group[a2], Group[a3] {
+        pub def inverse(x: (a1, a2, a3)): (a1, a2, a3) = match x {
+            case (a1, a2, a3) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3))
+        }
+    }
+
+    instance Group[(a1, a2, a3, a4)] with Group[a1], Group[a2], Group[a3], Group[a4] {
+        pub def inverse(x: (a1, a2, a3, a4)): (a1, a2, a3, a4) = match x {
+            case (a1, a2, a3, a4) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4))
+        }
+    }
+
+    instance Group[(a1, a2, a3, a4, a5)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5] {
+        pub def inverse(x: (a1, a2, a3, a4, a5)): (a1, a2, a3, a4, a5) = match x {
+            case (a1, a2, a3, a4, a5) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5))
+        }
+    }
+
+    instance Group[(a1, a2, a3, a4, a5, a6)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6] {
+        pub def inverse(x: (a1, a2, a3, a4, a5, a6)): (a1, a2, a3, a4, a5, a6) = match x {
+            case (a1, a2, a3, a4, a5, a6) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6))
+        }
+    }
+
+    instance Group[(a1, a2, a3, a4, a5, a6, a7)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6], Group[a7] {
+        pub def inverse(x: (a1, a2, a3, a4, a5, a6, a7)): (a1, a2, a3, a4, a5, a6, a7) = match x {
+            case (a1, a2, a3, a4, a5, a6, a7) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6), Group.inverse(a7))
+        }
+    }
+
+    instance Group[(a1, a2, a3, a4, a5, a6, a7, a8)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6], Group[a7], Group[a8] {
+        pub def inverse(x: (a1, a2, a3, a4, a5, a6, a7, a8)): (a1, a2, a3, a4, a5, a6, a7, a8) = match x {
+            case (a1, a2, a3, a4, a5, a6, a7, a8) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6), Group.inverse(a7), Group.inverse(a8))
+        }
+    }
+
+    instance Group[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6], Group[a7], Group[a8], Group[a9] {
+        pub def inverse(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = match x {
+            case (a1, a2, a3, a4, a5, a6, a7, a8, a9) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6), Group.inverse(a7), Group.inverse(a8), Group.inverse(a9))
+        }
+    }
+
+    instance Group[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Group[a1], Group[a2], Group[a3], Group[a4], Group[a5], Group[a6], Group[a7], Group[a8], Group[a9], Group[a10] {
+        pub def inverse(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = match x {
+            case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) => (Group.inverse(a1), Group.inverse(a2), Group.inverse(a3), Group.inverse(a4), Group.inverse(a5), Group.inverse(a6), Group.inverse(a7), Group.inverse(a8), Group.inverse(a9), Group.inverse(a10))
+        }
+    }
+
 }

--- a/main/src/library/JoinLattice.flix
+++ b/main/src/library/JoinLattice.flix
@@ -15,198 +15,202 @@
  *  limitations under the License.
  */
 
-use Bool.{==>}
+pub mod JoinLattice {
 
-///
-/// A trait for join semi lattices.
-///
-pub lawful trait JoinLattice[a] with PartialOrder[a] {
+    use Bool.{==>}
 
     ///
-    /// Returns the least upper bound of `x` and `y`.
+    /// A trait for join semi lattices.
     ///
-    pub def leastUpperBound(x: a, y: a): a
+    pub lawful trait JoinLattice[a] with PartialOrder[a] {
 
-    ///
-    /// The law asserts that the least upper bound operator returns
-    /// an element that is greater than or equal to each of its arguments.
-    ///
-    law leastUpperBound1: forall(x: a, y: a)
-        PartialOrder.lessEqual(x, JoinLattice.leastUpperBound(x, y)) and
-        PartialOrder.lessEqual(y, JoinLattice.leastUpperBound(x, y))
+        ///
+        /// Returns the least upper bound of `x` and `y`.
+        ///
+        pub def leastUpperBound(x: a, y: a): a
 
-    ///
-    /// The law asserts that the least upper bound operator returns
-    /// the smallest element that is larger than its two arguments.
-    ///
-    law leastUpperBound2: forall(x: a, y: a, z: a)
-        (PartialOrder.lessEqual(x, z) and PartialOrder.lessEqual(y, z)) ==>
-        PartialOrder.lessEqual(JoinLattice.leastUpperBound(x, y), z)
+        ///
+        /// The law asserts that the least upper bound operator returns
+        /// an element that is greater than or equal to each of its arguments.
+        ///
+        law leastUpperBound1: forall(x: a, y: a)
+            PartialOrder.lessEqual(x, JoinLattice.leastUpperBound(x, y)) and
+            PartialOrder.lessEqual(y, JoinLattice.leastUpperBound(x, y))
 
-}
+        ///
+        /// The law asserts that the least upper bound operator returns
+        /// the smallest element that is larger than its two arguments.
+        ///
+        law leastUpperBound2: forall(x: a, y: a, z: a)
+            (PartialOrder.lessEqual(x, z) and PartialOrder.lessEqual(y, z)) ==>
+            PartialOrder.lessEqual(JoinLattice.leastUpperBound(x, y), z)
 
-instance JoinLattice[Int8] {
-    pub def leastUpperBound(x: Int8, y: Int8): Int8 = Order.max(x, y)
-}
-
-instance JoinLattice[Int16] {
-    pub def leastUpperBound(x: Int16, y: Int16): Int16 = Order.max(x, y)
-}
-
-instance JoinLattice[Int32] {
-    pub def leastUpperBound(x: Int32, y: Int32): Int32 = Order.max(x, y)
-}
-
-instance JoinLattice[Int64] {
-    pub def leastUpperBound(x: Int64, y: Int64): Int64 = Order.max(x, y)
-}
-
-instance JoinLattice[BigInt] {
-    pub def leastUpperBound(x: BigInt, y: BigInt): BigInt = Order.max(x, y)
-}
-
-instance JoinLattice[(a1, a2)] with JoinLattice[a1], JoinLattice[a2] {
-    pub def leastUpperBound(x: (a1, a2),
-                            y: (a1, a2)): (a1, a2) = match (x, y) {
-        case ((x1, x2), (y1, y2)) => (
-            JoinLattice.leastUpperBound(x1, y1),
-            JoinLattice.leastUpperBound(x2, y2)
-        )
     }
-}
 
-instance JoinLattice[(a1, a2, a3)] with JoinLattice[a1], JoinLattice[a2],
-                                        JoinLattice[a3] {
-    pub def leastUpperBound(x: (a1, a2, a3),
-                            y: (a1, a2, a3)): (a1, a2, a3) = match (x, y) {
-        case ((x1, x2, x3), (y1, y2, y3)) => (
-            JoinLattice.leastUpperBound(x1, y1),
-            JoinLattice.leastUpperBound(x2, y2),
-            JoinLattice.leastUpperBound(x3, y3)
-        )
+    instance JoinLattice[Int8] {
+        pub def leastUpperBound(x: Int8, y: Int8): Int8 = Order.max(x, y)
     }
-}
 
-instance JoinLattice[(a1, a2, a3, a4)] with JoinLattice[a1], JoinLattice[a2],
-                                            JoinLattice[a3], JoinLattice[a4] {
-    pub def leastUpperBound(x: (a1, a2, a3, a4),
-                            y: (a1, a2, a3, a4)): (a1, a2, a3, a4) = match (x, y) {
-        case ((x1, x2, x3, x4), (y1, y2, y3, y4)) => (
-            JoinLattice.leastUpperBound(x1, y1),
-            JoinLattice.leastUpperBound(x2, y2),
-            JoinLattice.leastUpperBound(x3, y3),
-            JoinLattice.leastUpperBound(x4, y4)
-        )
+    instance JoinLattice[Int16] {
+        pub def leastUpperBound(x: Int16, y: Int16): Int16 = Order.max(x, y)
     }
-}
 
-instance JoinLattice[(a1, a2, a3, a4, a5)] with JoinLattice[a1], JoinLattice[a2],
-                                                JoinLattice[a3], JoinLattice[a4],
-                                                JoinLattice[a5] {
-    pub def leastUpperBound(x: (a1, a2, a3, a4, a5),
-                            y: (a1, a2, a3, a4, a5)): (a1, a2, a3, a4, a5) = match (x, y) {
-        case ((x1, x2, x3, x4, x5), (y1, y2, y3, y4, y5)) => (
-            JoinLattice.leastUpperBound(x1, y1),
-            JoinLattice.leastUpperBound(x2, y2),
-            JoinLattice.leastUpperBound(x3, y3),
-            JoinLattice.leastUpperBound(x4, y4),
-            JoinLattice.leastUpperBound(x5, y5)
-        )
+    instance JoinLattice[Int32] {
+        pub def leastUpperBound(x: Int32, y: Int32): Int32 = Order.max(x, y)
     }
-}
 
-instance JoinLattice[(a1, a2, a3, a4, a5, a6)] with JoinLattice[a1], JoinLattice[a2],
+    instance JoinLattice[Int64] {
+        pub def leastUpperBound(x: Int64, y: Int64): Int64 = Order.max(x, y)
+    }
+
+    instance JoinLattice[BigInt] {
+        pub def leastUpperBound(x: BigInt, y: BigInt): BigInt = Order.max(x, y)
+    }
+
+    instance JoinLattice[(a1, a2)] with JoinLattice[a1], JoinLattice[a2] {
+        pub def leastUpperBound(x: (a1, a2),
+                                y: (a1, a2)): (a1, a2) = match (x, y) {
+            case ((x1, x2), (y1, y2)) => (
+                JoinLattice.leastUpperBound(x1, y1),
+                JoinLattice.leastUpperBound(x2, y2)
+            )
+        }
+    }
+
+    instance JoinLattice[(a1, a2, a3)] with JoinLattice[a1], JoinLattice[a2],
+                                            JoinLattice[a3] {
+        pub def leastUpperBound(x: (a1, a2, a3),
+                                y: (a1, a2, a3)): (a1, a2, a3) = match (x, y) {
+            case ((x1, x2, x3), (y1, y2, y3)) => (
+                JoinLattice.leastUpperBound(x1, y1),
+                JoinLattice.leastUpperBound(x2, y2),
+                JoinLattice.leastUpperBound(x3, y3)
+            )
+        }
+    }
+
+    instance JoinLattice[(a1, a2, a3, a4)] with JoinLattice[a1], JoinLattice[a2],
+                                                JoinLattice[a3], JoinLattice[a4] {
+        pub def leastUpperBound(x: (a1, a2, a3, a4),
+                                y: (a1, a2, a3, a4)): (a1, a2, a3, a4) = match (x, y) {
+            case ((x1, x2, x3, x4), (y1, y2, y3, y4)) => (
+                JoinLattice.leastUpperBound(x1, y1),
+                JoinLattice.leastUpperBound(x2, y2),
+                JoinLattice.leastUpperBound(x3, y3),
+                JoinLattice.leastUpperBound(x4, y4)
+            )
+        }
+    }
+
+    instance JoinLattice[(a1, a2, a3, a4, a5)] with JoinLattice[a1], JoinLattice[a2],
                                                     JoinLattice[a3], JoinLattice[a4],
-                                                    JoinLattice[a5], JoinLattice[a6] {
-    pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6),
-                            y: (a1, a2, a3, a4, a5, a6)): (a1, a2, a3, a4, a5, a6) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6), (y1, y2, y3, y4, y5, y6)) => (
-            JoinLattice.leastUpperBound(x1, y1),
-            JoinLattice.leastUpperBound(x2, y2),
-            JoinLattice.leastUpperBound(x3, y3),
-            JoinLattice.leastUpperBound(x4, y4),
-            JoinLattice.leastUpperBound(x5, y5),
-            JoinLattice.leastUpperBound(x6, y6)
-        )
+                                                    JoinLattice[a5] {
+        pub def leastUpperBound(x: (a1, a2, a3, a4, a5),
+                                y: (a1, a2, a3, a4, a5)): (a1, a2, a3, a4, a5) = match (x, y) {
+            case ((x1, x2, x3, x4, x5), (y1, y2, y3, y4, y5)) => (
+                JoinLattice.leastUpperBound(x1, y1),
+                JoinLattice.leastUpperBound(x2, y2),
+                JoinLattice.leastUpperBound(x3, y3),
+                JoinLattice.leastUpperBound(x4, y4),
+                JoinLattice.leastUpperBound(x5, y5)
+            )
+        }
     }
-}
 
-instance JoinLattice[(a1, a2, a3, a4, a5, a6, a7)] with JoinLattice[a1], JoinLattice[a2],
+    instance JoinLattice[(a1, a2, a3, a4, a5, a6)] with JoinLattice[a1], JoinLattice[a2],
                                                         JoinLattice[a3], JoinLattice[a4],
-                                                        JoinLattice[a5], JoinLattice[a6],
-                                                        JoinLattice[a7] {
-    pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6, a7),
-                            y: (a1, a2, a3, a4, a5, a6, a7)): (a1, a2, a3, a4, a5, a6, a7) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7), (y1, y2, y3, y4, y5, y6, y7)) => (
-            JoinLattice.leastUpperBound(x1, y1),
-            JoinLattice.leastUpperBound(x2, y2),
-            JoinLattice.leastUpperBound(x3, y3),
-            JoinLattice.leastUpperBound(x4, y4),
-            JoinLattice.leastUpperBound(x5, y5),
-            JoinLattice.leastUpperBound(x6, y6),
-            JoinLattice.leastUpperBound(x7, y7)
-        )
+                                                        JoinLattice[a5], JoinLattice[a6] {
+        pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6),
+                                y: (a1, a2, a3, a4, a5, a6)): (a1, a2, a3, a4, a5, a6) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6), (y1, y2, y3, y4, y5, y6)) => (
+                JoinLattice.leastUpperBound(x1, y1),
+                JoinLattice.leastUpperBound(x2, y2),
+                JoinLattice.leastUpperBound(x3, y3),
+                JoinLattice.leastUpperBound(x4, y4),
+                JoinLattice.leastUpperBound(x5, y5),
+                JoinLattice.leastUpperBound(x6, y6)
+            )
+        }
     }
-}
 
-instance JoinLattice[(a1, a2, a3, a4, a5, a6, a7, a8)] with JoinLattice[a1], JoinLattice[a2],
+    instance JoinLattice[(a1, a2, a3, a4, a5, a6, a7)] with JoinLattice[a1], JoinLattice[a2],
                                                             JoinLattice[a3], JoinLattice[a4],
                                                             JoinLattice[a5], JoinLattice[a6],
-                                                            JoinLattice[a7], JoinLattice[a8] {
-    pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6, a7, a8),
-                            y: (a1, a2, a3, a4, a5, a6, a7, a8)): (a1, a2, a3, a4, a5, a6, a7, a8) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7, x8), (y1, y2, y3, y4, y5, y6, y7, y8)) => (
-            JoinLattice.leastUpperBound(x1, y1),
-            JoinLattice.leastUpperBound(x2, y2),
-            JoinLattice.leastUpperBound(x3, y3),
-            JoinLattice.leastUpperBound(x4, y4),
-            JoinLattice.leastUpperBound(x5, y5),
-            JoinLattice.leastUpperBound(x6, y6),
-            JoinLattice.leastUpperBound(x7, y7),
-            JoinLattice.leastUpperBound(x8, y8)
-        )
+                                                            JoinLattice[a7] {
+        pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6, a7),
+                                y: (a1, a2, a3, a4, a5, a6, a7)): (a1, a2, a3, a4, a5, a6, a7) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7), (y1, y2, y3, y4, y5, y6, y7)) => (
+                JoinLattice.leastUpperBound(x1, y1),
+                JoinLattice.leastUpperBound(x2, y2),
+                JoinLattice.leastUpperBound(x3, y3),
+                JoinLattice.leastUpperBound(x4, y4),
+                JoinLattice.leastUpperBound(x5, y5),
+                JoinLattice.leastUpperBound(x6, y6),
+                JoinLattice.leastUpperBound(x7, y7)
+            )
+        }
     }
-}
 
-instance JoinLattice[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with JoinLattice[a1], JoinLattice[a2],
+    instance JoinLattice[(a1, a2, a3, a4, a5, a6, a7, a8)] with JoinLattice[a1], JoinLattice[a2],
                                                                 JoinLattice[a3], JoinLattice[a4],
                                                                 JoinLattice[a5], JoinLattice[a6],
-                                                                JoinLattice[a7], JoinLattice[a8],
-                                                                JoinLattice[a9] {
-    pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9),
-                            y: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7, x8, x9), (y1, y2, y3, y4, y5, y6, y7, y8, y9)) => (
-            JoinLattice.leastUpperBound(x1, y1),
-            JoinLattice.leastUpperBound(x2, y2),
-            JoinLattice.leastUpperBound(x3, y3),
-            JoinLattice.leastUpperBound(x4, y4),
-            JoinLattice.leastUpperBound(x5, y5),
-            JoinLattice.leastUpperBound(x6, y6),
-            JoinLattice.leastUpperBound(x7, y7),
-            JoinLattice.leastUpperBound(x8, y8),
-            JoinLattice.leastUpperBound(x9, y9)
-        )
+                                                                JoinLattice[a7], JoinLattice[a8] {
+        pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6, a7, a8),
+                                y: (a1, a2, a3, a4, a5, a6, a7, a8)): (a1, a2, a3, a4, a5, a6, a7, a8) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7, x8), (y1, y2, y3, y4, y5, y6, y7, y8)) => (
+                JoinLattice.leastUpperBound(x1, y1),
+                JoinLattice.leastUpperBound(x2, y2),
+                JoinLattice.leastUpperBound(x3, y3),
+                JoinLattice.leastUpperBound(x4, y4),
+                JoinLattice.leastUpperBound(x5, y5),
+                JoinLattice.leastUpperBound(x6, y6),
+                JoinLattice.leastUpperBound(x7, y7),
+                JoinLattice.leastUpperBound(x8, y8)
+            )
+        }
     }
-}
 
-instance JoinLattice[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with JoinLattice[a1], JoinLattice[a2],
-                                                                     JoinLattice[a3], JoinLattice[a4],
-                                                                     JoinLattice[a5], JoinLattice[a6],
-                                                                     JoinLattice[a7], JoinLattice[a8],
-                                                                     JoinLattice[a9], JoinLattice[a10] {
-    pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10),
-                            y: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10), (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10)) => (
-            JoinLattice.leastUpperBound(x1, y1),
-            JoinLattice.leastUpperBound(x2, y2),
-            JoinLattice.leastUpperBound(x3, y3),
-            JoinLattice.leastUpperBound(x4, y4),
-            JoinLattice.leastUpperBound(x5, y5),
-            JoinLattice.leastUpperBound(x6, y6),
-            JoinLattice.leastUpperBound(x7, y7),
-            JoinLattice.leastUpperBound(x8, y8),
-            JoinLattice.leastUpperBound(x9, y9),
-            JoinLattice.leastUpperBound(x10, y10)
-        )
+    instance JoinLattice[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with JoinLattice[a1], JoinLattice[a2],
+                                                                    JoinLattice[a3], JoinLattice[a4],
+                                                                    JoinLattice[a5], JoinLattice[a6],
+                                                                    JoinLattice[a7], JoinLattice[a8],
+                                                                    JoinLattice[a9] {
+        pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9),
+                                y: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7, x8, x9), (y1, y2, y3, y4, y5, y6, y7, y8, y9)) => (
+                JoinLattice.leastUpperBound(x1, y1),
+                JoinLattice.leastUpperBound(x2, y2),
+                JoinLattice.leastUpperBound(x3, y3),
+                JoinLattice.leastUpperBound(x4, y4),
+                JoinLattice.leastUpperBound(x5, y5),
+                JoinLattice.leastUpperBound(x6, y6),
+                JoinLattice.leastUpperBound(x7, y7),
+                JoinLattice.leastUpperBound(x8, y8),
+                JoinLattice.leastUpperBound(x9, y9)
+            )
+        }
     }
+
+    instance JoinLattice[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with JoinLattice[a1], JoinLattice[a2],
+                                                                         JoinLattice[a3], JoinLattice[a4],
+                                                                         JoinLattice[a5], JoinLattice[a6],
+                                                                         JoinLattice[a7], JoinLattice[a8],
+                                                                         JoinLattice[a9], JoinLattice[a10] {
+        pub def leastUpperBound(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10),
+                                y: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10), (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10)) => (
+                JoinLattice.leastUpperBound(x1, y1),
+                JoinLattice.leastUpperBound(x2, y2),
+                JoinLattice.leastUpperBound(x3, y3),
+                JoinLattice.leastUpperBound(x4, y4),
+                JoinLattice.leastUpperBound(x5, y5),
+                JoinLattice.leastUpperBound(x6, y6),
+                JoinLattice.leastUpperBound(x7, y7),
+                JoinLattice.leastUpperBound(x8, y8),
+                JoinLattice.leastUpperBound(x9, y9),
+                JoinLattice.leastUpperBound(x10, y10)
+            )
+        }
+    }
+
 }

--- a/main/src/library/LowerBound.flix
+++ b/main/src/library/LowerBound.flix
@@ -14,58 +14,56 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for partially ordered types that have a lower bound.
-///
-pub trait LowerBound[a] {
+pub mod LowerBound {
+
     ///
-    /// Returns the smallest value of `a`.
+    /// A trait for partially ordered types that have a lower bound.
     ///
-    pub def minValue(): a
+    pub trait LowerBound[a] {
+        ///
+        /// Returns the smallest value of `a`.
+        ///
+        pub def minValue(): a
+    }
+
+    instance LowerBound[(a1, a2)] with LowerBound[a1], LowerBound[a2] {
+        pub def minValue(): (a1, a2) = (LowerBound.minValue(), LowerBound.minValue())
+    }
+
+    instance LowerBound[(a1, a2, a3)] with LowerBound[a1], LowerBound[a2], LowerBound[a3] {
+        pub def minValue(): (a1, a2, a3) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
+    }
+
+    instance LowerBound[(a1, a2, a3, a4)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4] {
+        pub def minValue(): (a1, a2, a3, a4) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
+    }
+
+    instance LowerBound[(a1, a2, a3, a4, a5)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5] {
+        pub def minValue(): (a1, a2, a3, a4, a5) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
+    }
+
+    instance LowerBound[(a1, a2, a3, a4, a5, a6)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6] {
+        pub def minValue(): (a1, a2, a3, a4, a5, a6) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
+    }
+
+    instance LowerBound[(a1, a2, a3, a4, a5, a6, a7)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6], LowerBound[a7] {
+        pub def minValue(): (a1, a2, a3, a4, a5, a6, a7) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
+    }
+
+    instance LowerBound[(a1, a2, a3, a4, a5, a6, a7, a8)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6], LowerBound[a7], LowerBound[a8] {
+        pub def minValue(): (a1, a2, a3, a4, a5, a6, a7, a8) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
+    }
+
+    instance LowerBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6], LowerBound[a7], LowerBound[a8], LowerBound[a9] {
+        pub def minValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
+    }
+
+    instance LowerBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6], LowerBound[a7], LowerBound[a8], LowerBound[a9], LowerBound[a10] {
+        pub def minValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
+    }
+
+    instance LowerBound[Unit] {
+        pub def minValue(): Unit = ()
+    }
+
 }
-
-instance LowerBound[(a1, a2)] with LowerBound[a1], LowerBound[a2] {
-    pub def minValue(): (a1, a2) = (LowerBound.minValue(), LowerBound.minValue())
-}
-
-instance LowerBound[(a1, a2, a3)] with LowerBound[a1], LowerBound[a2], LowerBound[a3] {
-    pub def minValue(): (a1, a2, a3) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
-}
-
-instance LowerBound[(a1, a2, a3, a4)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4] {
-    pub def minValue(): (a1, a2, a3, a4) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
-}
-
-instance LowerBound[(a1, a2, a3, a4, a5)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5] {
-    pub def minValue(): (a1, a2, a3, a4, a5) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
-}
-
-instance LowerBound[(a1, a2, a3, a4, a5, a6)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6] {
-    pub def minValue(): (a1, a2, a3, a4, a5, a6) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
-}
-
-instance LowerBound[(a1, a2, a3, a4, a5, a6, a7)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6], LowerBound[a7] {
-    pub def minValue(): (a1, a2, a3, a4, a5, a6, a7) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
-}
-
-instance LowerBound[(a1, a2, a3, a4, a5, a6, a7, a8)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6], LowerBound[a7], LowerBound[a8] {
-    pub def minValue(): (a1, a2, a3, a4, a5, a6, a7, a8) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
-}
-
-instance LowerBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6], LowerBound[a7], LowerBound[a8], LowerBound[a9] {
-    pub def minValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
-}
-
-instance LowerBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with LowerBound[a1], LowerBound[a2], LowerBound[a3], LowerBound[a4], LowerBound[a5], LowerBound[a6], LowerBound[a7], LowerBound[a8], LowerBound[a9], LowerBound[a10] {
-    pub def minValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
-}
-
-instance LowerBound[Unit] {
-    pub def minValue(): Unit = ()
-}
-
-
-
-
-
-

--- a/main/src/library/MeetLattice.flix
+++ b/main/src/library/MeetLattice.flix
@@ -14,200 +14,204 @@
  *  limitations under the License.
  */
 
-use Bool.{==>}
+pub mod MeetLattice {
 
-///
-/// A trait for meet semi lattices.
-/// A Meet Lattice is pair of functions (⊑, ⊓) where ⊑ is a partial order and ⊓ satisfy two properties:
-/// lower-bound and greatest-lower-bound.
-///
-pub lawful trait MeetLattice[a] with PartialOrder[a] {
+    use Bool.{==>}
 
     ///
-    /// Returns the greatest lower bound of `x` and `y`.
+    /// A trait for meet semi lattices.
+    /// A Meet Lattice is pair of functions (⊑, ⊓) where ⊑ is a partial order and ⊓ satisfy two properties:
+    /// lower-bound and greatest-lower-bound.
     ///
-    pub def greatestLowerBound(x: a, y: a): a
+    pub lawful trait MeetLattice[a] with PartialOrder[a] {
 
-    ///
-    /// The lower bound law asserts that the greatest lower bound operator returns an element that
-    /// is less than or equal to each of its arguments.
-    ///
-    law greatestLowerBound1: forall(x: a, y: a)
-        PartialOrder.lessEqual(MeetLattice.greatestLowerBound(x, y), x) and
-        PartialOrder.lessEqual(MeetLattice.greatestLowerBound(x, y), y)
+        ///
+        /// Returns the greatest lower bound of `x` and `y`.
+        ///
+        pub def greatestLowerBound(x: a, y: a): a
 
-    ///
-    /// The greatest lower bound law asserts that the greatest lower bound operator returns the
-    /// largest element that is smaller than its two arguments.
-    ///
-    law greatestLowerBound2: forall(x: a, y: a, z: a)
-        (PartialOrder.lessEqual(z, x) and PartialOrder.lessEqual(z, y)) ==>
-        PartialOrder.lessEqual(z, MeetLattice.greatestLowerBound(x, y))
+        ///
+        /// The lower bound law asserts that the greatest lower bound operator returns an element that
+        /// is less than or equal to each of its arguments.
+        ///
+        law greatestLowerBound1: forall(x: a, y: a)
+            PartialOrder.lessEqual(MeetLattice.greatestLowerBound(x, y), x) and
+            PartialOrder.lessEqual(MeetLattice.greatestLowerBound(x, y), y)
 
-}
+        ///
+        /// The greatest lower bound law asserts that the greatest lower bound operator returns the
+        /// largest element that is smaller than its two arguments.
+        ///
+        law greatestLowerBound2: forall(x: a, y: a, z: a)
+            (PartialOrder.lessEqual(z, x) and PartialOrder.lessEqual(z, y)) ==>
+            PartialOrder.lessEqual(z, MeetLattice.greatestLowerBound(x, y))
 
-instance MeetLattice[Int8] {
-    pub def greatestLowerBound(x: Int8, y: Int8): Int8 = Order.min(x, y)
-}
-
-instance MeetLattice[Int16] {
-    pub def greatestLowerBound(x: Int16, y: Int16): Int16 = Order.min(x, y)
-}
-
-instance MeetLattice[Int32] {
-    pub def greatestLowerBound(x: Int32, y: Int32): Int32 = Order.min(x, y)
-}
-
-instance MeetLattice[Int64] {
-    pub def greatestLowerBound(x: Int64, y: Int64): Int64 = Order.min(x, y)
-}
-
-instance MeetLattice[BigInt] {
-    pub def greatestLowerBound(x: BigInt, y: BigInt): BigInt = Order.min(x, y)
-}
-
-instance MeetLattice[(a1, a2)] with MeetLattice[a1], MeetLattice[a2] {
-    pub def greatestLowerBound(x: (a1, a2),
-                            y: (a1, a2)): (a1, a2) = match (x, y) {
-        case ((x1, x2), (y1, y2)) => (
-            MeetLattice.greatestLowerBound(x1, y1),
-            MeetLattice.greatestLowerBound(x2, y2)
-        )
     }
-}
 
-instance MeetLattice[(a1, a2, a3)] with MeetLattice[a1], MeetLattice[a2],
-                                        MeetLattice[a3] {
-    pub def greatestLowerBound(x: (a1, a2, a3),
-                            y: (a1, a2, a3)): (a1, a2, a3) = match (x, y) {
-        case ((x1, x2, x3), (y1, y2, y3)) => (
-            MeetLattice.greatestLowerBound(x1, y1),
-            MeetLattice.greatestLowerBound(x2, y2),
-            MeetLattice.greatestLowerBound(x3, y3)
-        )
+    instance MeetLattice[Int8] {
+        pub def greatestLowerBound(x: Int8, y: Int8): Int8 = Order.min(x, y)
     }
-}
 
-instance MeetLattice[(a1, a2, a3, a4)] with MeetLattice[a1], MeetLattice[a2],
-                                            MeetLattice[a3], MeetLattice[a4] {
-    pub def greatestLowerBound(x: (a1, a2, a3, a4),
-                            y: (a1, a2, a3, a4)): (a1, a2, a3, a4) = match (x, y) {
-        case ((x1, x2, x3, x4), (y1, y2, y3, y4)) => (
-            MeetLattice.greatestLowerBound(x1, y1),
-            MeetLattice.greatestLowerBound(x2, y2),
-            MeetLattice.greatestLowerBound(x3, y3),
-            MeetLattice.greatestLowerBound(x4, y4)
-        )
+    instance MeetLattice[Int16] {
+        pub def greatestLowerBound(x: Int16, y: Int16): Int16 = Order.min(x, y)
     }
-}
 
-instance MeetLattice[(a1, a2, a3, a4, a5)] with MeetLattice[a1], MeetLattice[a2],
-                                                MeetLattice[a3], MeetLattice[a4],
-                                                MeetLattice[a5] {
-    pub def greatestLowerBound(x: (a1, a2, a3, a4, a5),
-                            y: (a1, a2, a3, a4, a5)): (a1, a2, a3, a4, a5) = match (x, y) {
-        case ((x1, x2, x3, x4, x5), (y1, y2, y3, y4, y5)) => (
-            MeetLattice.greatestLowerBound(x1, y1),
-            MeetLattice.greatestLowerBound(x2, y2),
-            MeetLattice.greatestLowerBound(x3, y3),
-            MeetLattice.greatestLowerBound(x4, y4),
-            MeetLattice.greatestLowerBound(x5, y5)
-        )
+    instance MeetLattice[Int32] {
+        pub def greatestLowerBound(x: Int32, y: Int32): Int32 = Order.min(x, y)
     }
-}
 
-instance MeetLattice[(a1, a2, a3, a4, a5, a6)] with MeetLattice[a1], MeetLattice[a2],
+    instance MeetLattice[Int64] {
+        pub def greatestLowerBound(x: Int64, y: Int64): Int64 = Order.min(x, y)
+    }
+
+    instance MeetLattice[BigInt] {
+        pub def greatestLowerBound(x: BigInt, y: BigInt): BigInt = Order.min(x, y)
+    }
+
+    instance MeetLattice[(a1, a2)] with MeetLattice[a1], MeetLattice[a2] {
+        pub def greatestLowerBound(x: (a1, a2),
+                                y: (a1, a2)): (a1, a2) = match (x, y) {
+            case ((x1, x2), (y1, y2)) => (
+                MeetLattice.greatestLowerBound(x1, y1),
+                MeetLattice.greatestLowerBound(x2, y2)
+            )
+        }
+    }
+
+    instance MeetLattice[(a1, a2, a3)] with MeetLattice[a1], MeetLattice[a2],
+                                            MeetLattice[a3] {
+        pub def greatestLowerBound(x: (a1, a2, a3),
+                                y: (a1, a2, a3)): (a1, a2, a3) = match (x, y) {
+            case ((x1, x2, x3), (y1, y2, y3)) => (
+                MeetLattice.greatestLowerBound(x1, y1),
+                MeetLattice.greatestLowerBound(x2, y2),
+                MeetLattice.greatestLowerBound(x3, y3)
+            )
+        }
+    }
+
+    instance MeetLattice[(a1, a2, a3, a4)] with MeetLattice[a1], MeetLattice[a2],
+                                                MeetLattice[a3], MeetLattice[a4] {
+        pub def greatestLowerBound(x: (a1, a2, a3, a4),
+                                y: (a1, a2, a3, a4)): (a1, a2, a3, a4) = match (x, y) {
+            case ((x1, x2, x3, x4), (y1, y2, y3, y4)) => (
+                MeetLattice.greatestLowerBound(x1, y1),
+                MeetLattice.greatestLowerBound(x2, y2),
+                MeetLattice.greatestLowerBound(x3, y3),
+                MeetLattice.greatestLowerBound(x4, y4)
+            )
+        }
+    }
+
+    instance MeetLattice[(a1, a2, a3, a4, a5)] with MeetLattice[a1], MeetLattice[a2],
                                                     MeetLattice[a3], MeetLattice[a4],
-                                                    MeetLattice[a5], MeetLattice[a6] {
-    pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6),
-                            y: (a1, a2, a3, a4, a5, a6)): (a1, a2, a3, a4, a5, a6) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6), (y1, y2, y3, y4, y5, y6)) => (
-            MeetLattice.greatestLowerBound(x1, y1),
-            MeetLattice.greatestLowerBound(x2, y2),
-            MeetLattice.greatestLowerBound(x3, y3),
-            MeetLattice.greatestLowerBound(x4, y4),
-            MeetLattice.greatestLowerBound(x5, y5),
-            MeetLattice.greatestLowerBound(x6, y6)
-        )
+                                                    MeetLattice[a5] {
+        pub def greatestLowerBound(x: (a1, a2, a3, a4, a5),
+                                y: (a1, a2, a3, a4, a5)): (a1, a2, a3, a4, a5) = match (x, y) {
+            case ((x1, x2, x3, x4, x5), (y1, y2, y3, y4, y5)) => (
+                MeetLattice.greatestLowerBound(x1, y1),
+                MeetLattice.greatestLowerBound(x2, y2),
+                MeetLattice.greatestLowerBound(x3, y3),
+                MeetLattice.greatestLowerBound(x4, y4),
+                MeetLattice.greatestLowerBound(x5, y5)
+            )
+        }
     }
-}
 
-instance MeetLattice[(a1, a2, a3, a4, a5, a6, a7)] with MeetLattice[a1], MeetLattice[a2],
+    instance MeetLattice[(a1, a2, a3, a4, a5, a6)] with MeetLattice[a1], MeetLattice[a2],
                                                         MeetLattice[a3], MeetLattice[a4],
-                                                        MeetLattice[a5], MeetLattice[a6],
-                                                        MeetLattice[a7] {
-    pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6, a7),
-                            y: (a1, a2, a3, a4, a5, a6, a7)): (a1, a2, a3, a4, a5, a6, a7) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7), (y1, y2, y3, y4, y5, y6, y7)) => (
-            MeetLattice.greatestLowerBound(x1, y1),
-            MeetLattice.greatestLowerBound(x2, y2),
-            MeetLattice.greatestLowerBound(x3, y3),
-            MeetLattice.greatestLowerBound(x4, y4),
-            MeetLattice.greatestLowerBound(x5, y5),
-            MeetLattice.greatestLowerBound(x6, y6),
-            MeetLattice.greatestLowerBound(x7, y7)
-        )
+                                                        MeetLattice[a5], MeetLattice[a6] {
+        pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6),
+                                y: (a1, a2, a3, a4, a5, a6)): (a1, a2, a3, a4, a5, a6) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6), (y1, y2, y3, y4, y5, y6)) => (
+                MeetLattice.greatestLowerBound(x1, y1),
+                MeetLattice.greatestLowerBound(x2, y2),
+                MeetLattice.greatestLowerBound(x3, y3),
+                MeetLattice.greatestLowerBound(x4, y4),
+                MeetLattice.greatestLowerBound(x5, y5),
+                MeetLattice.greatestLowerBound(x6, y6)
+            )
+        }
     }
-}
 
-instance MeetLattice[(a1, a2, a3, a4, a5, a6, a7, a8)] with MeetLattice[a1], MeetLattice[a2],
+    instance MeetLattice[(a1, a2, a3, a4, a5, a6, a7)] with MeetLattice[a1], MeetLattice[a2],
                                                             MeetLattice[a3], MeetLattice[a4],
                                                             MeetLattice[a5], MeetLattice[a6],
-                                                            MeetLattice[a7], MeetLattice[a8] {
-    pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6, a7, a8),
-                            y: (a1, a2, a3, a4, a5, a6, a7, a8)): (a1, a2, a3, a4, a5, a6, a7, a8) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7, x8), (y1, y2, y3, y4, y5, y6, y7, y8)) => (
-            MeetLattice.greatestLowerBound(x1, y1),
-            MeetLattice.greatestLowerBound(x2, y2),
-            MeetLattice.greatestLowerBound(x3, y3),
-            MeetLattice.greatestLowerBound(x4, y4),
-            MeetLattice.greatestLowerBound(x5, y5),
-            MeetLattice.greatestLowerBound(x6, y6),
-            MeetLattice.greatestLowerBound(x7, y7),
-            MeetLattice.greatestLowerBound(x8, y8)
-        )
+                                                            MeetLattice[a7] {
+        pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6, a7),
+                                y: (a1, a2, a3, a4, a5, a6, a7)): (a1, a2, a3, a4, a5, a6, a7) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7), (y1, y2, y3, y4, y5, y6, y7)) => (
+                MeetLattice.greatestLowerBound(x1, y1),
+                MeetLattice.greatestLowerBound(x2, y2),
+                MeetLattice.greatestLowerBound(x3, y3),
+                MeetLattice.greatestLowerBound(x4, y4),
+                MeetLattice.greatestLowerBound(x5, y5),
+                MeetLattice.greatestLowerBound(x6, y6),
+                MeetLattice.greatestLowerBound(x7, y7)
+            )
+        }
     }
-}
 
-instance MeetLattice[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with MeetLattice[a1], MeetLattice[a2],
+    instance MeetLattice[(a1, a2, a3, a4, a5, a6, a7, a8)] with MeetLattice[a1], MeetLattice[a2],
                                                                 MeetLattice[a3], MeetLattice[a4],
                                                                 MeetLattice[a5], MeetLattice[a6],
-                                                                MeetLattice[a7], MeetLattice[a8],
-                                                                MeetLattice[a9] {
-    pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9),
-                            y: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7, x8, x9), (y1, y2, y3, y4, y5, y6, y7, y8, y9)) => (
-            MeetLattice.greatestLowerBound(x1, y1),
-            MeetLattice.greatestLowerBound(x2, y2),
-            MeetLattice.greatestLowerBound(x3, y3),
-            MeetLattice.greatestLowerBound(x4, y4),
-            MeetLattice.greatestLowerBound(x5, y5),
-            MeetLattice.greatestLowerBound(x6, y6),
-            MeetLattice.greatestLowerBound(x7, y7),
-            MeetLattice.greatestLowerBound(x8, y8),
-            MeetLattice.greatestLowerBound(x9, y9)
-        )
+                                                                MeetLattice[a7], MeetLattice[a8] {
+        pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6, a7, a8),
+                                y: (a1, a2, a3, a4, a5, a6, a7, a8)): (a1, a2, a3, a4, a5, a6, a7, a8) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7, x8), (y1, y2, y3, y4, y5, y6, y7, y8)) => (
+                MeetLattice.greatestLowerBound(x1, y1),
+                MeetLattice.greatestLowerBound(x2, y2),
+                MeetLattice.greatestLowerBound(x3, y3),
+                MeetLattice.greatestLowerBound(x4, y4),
+                MeetLattice.greatestLowerBound(x5, y5),
+                MeetLattice.greatestLowerBound(x6, y6),
+                MeetLattice.greatestLowerBound(x7, y7),
+                MeetLattice.greatestLowerBound(x8, y8)
+            )
+        }
     }
-}
 
-instance MeetLattice[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with MeetLattice[a1], MeetLattice[a2],
-                                                                     MeetLattice[a3], MeetLattice[a4],
-                                                                     MeetLattice[a5], MeetLattice[a6],
-                                                                     MeetLattice[a7], MeetLattice[a8],
-                                                                     MeetLattice[a9], MeetLattice[a10] {
-    pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10),
-                            y: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10), (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10)) => (
-            MeetLattice.greatestLowerBound(x1, y1),
-            MeetLattice.greatestLowerBound(x2, y2),
-            MeetLattice.greatestLowerBound(x3, y3),
-            MeetLattice.greatestLowerBound(x4, y4),
-            MeetLattice.greatestLowerBound(x5, y5),
-            MeetLattice.greatestLowerBound(x6, y6),
-            MeetLattice.greatestLowerBound(x7, y7),
-            MeetLattice.greatestLowerBound(x8, y8),
-            MeetLattice.greatestLowerBound(x9, y9),
-            MeetLattice.greatestLowerBound(x10, y10)
-        )
+    instance MeetLattice[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with MeetLattice[a1], MeetLattice[a2],
+                                                                    MeetLattice[a3], MeetLattice[a4],
+                                                                    MeetLattice[a5], MeetLattice[a6],
+                                                                    MeetLattice[a7], MeetLattice[a8],
+                                                                    MeetLattice[a9] {
+        pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9),
+                                y: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7, x8, x9), (y1, y2, y3, y4, y5, y6, y7, y8, y9)) => (
+                MeetLattice.greatestLowerBound(x1, y1),
+                MeetLattice.greatestLowerBound(x2, y2),
+                MeetLattice.greatestLowerBound(x3, y3),
+                MeetLattice.greatestLowerBound(x4, y4),
+                MeetLattice.greatestLowerBound(x5, y5),
+                MeetLattice.greatestLowerBound(x6, y6),
+                MeetLattice.greatestLowerBound(x7, y7),
+                MeetLattice.greatestLowerBound(x8, y8),
+                MeetLattice.greatestLowerBound(x9, y9)
+            )
+        }
     }
+
+    instance MeetLattice[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with MeetLattice[a1], MeetLattice[a2],
+                                                                         MeetLattice[a3], MeetLattice[a4],
+                                                                         MeetLattice[a5], MeetLattice[a6],
+                                                                         MeetLattice[a7], MeetLattice[a8],
+                                                                         MeetLattice[a9], MeetLattice[a10] {
+        pub def greatestLowerBound(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10),
+                                y: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10), (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10)) => (
+                MeetLattice.greatestLowerBound(x1, y1),
+                MeetLattice.greatestLowerBound(x2, y2),
+                MeetLattice.greatestLowerBound(x3, y3),
+                MeetLattice.greatestLowerBound(x4, y4),
+                MeetLattice.greatestLowerBound(x5, y5),
+                MeetLattice.greatestLowerBound(x6, y6),
+                MeetLattice.greatestLowerBound(x7, y7),
+                MeetLattice.greatestLowerBound(x8, y8),
+                MeetLattice.greatestLowerBound(x9, y9),
+                MeetLattice.greatestLowerBound(x10, y10)
+            )
+        }
+    }
+
 }

--- a/main/src/library/PartialOrder.flix
+++ b/main/src/library/PartialOrder.flix
@@ -14,184 +14,188 @@
  *  limitations under the License.
  */
 
-use Bool.{==>}
+pub mod PartialOrder {
 
-///
-/// A Partial Order is a function ⊑ which satisfies three properties: reflexivity, anti-symmetry, and transitivity.
-///
-pub lawful trait PartialOrder[a] {
+    use Bool.{==>}
 
     ///
-    /// Returns `true` if `x` is smaller or equal to `y`.
+    /// A Partial Order is a function ⊑ which satisfies three properties: reflexivity, anti-symmetry, and transitivity.
     ///
-    pub def lessEqual(x: a, y: a): Bool
-    // TODO This should not return a Boolean, but instead perform a three-way comparison.
+    pub lawful trait PartialOrder[a] {
 
-    ///
-    /// Reflexivity: An element `x` is lower or equal to itself.
-    ///
-    law reflexivity: forall(x: a) PartialOrder.lessEqual(x, x)
+        ///
+        /// Returns `true` if `x` is smaller or equal to `y`.
+        ///
+        pub def lessEqual(x: a, y: a): Bool
+        // TODO This should not return a Boolean, but instead perform a three-way comparison.
 
-    ///
-    /// Transitivity: If `x` is lower or equal to `y` and `y` is lower equal to `z` then `x` must be lower or equal to `z`.
-    ///
-    law transitivity: forall(x: a, y: a, z: a) (PartialOrder.lessEqual(x, y) and PartialOrder.lessEqual(y, z)) ==> PartialOrder.lessEqual(x, z)
-}
+        ///
+        /// Reflexivity: An element `x` is lower or equal to itself.
+        ///
+        law reflexivity: forall(x: a) PartialOrder.lessEqual(x, x)
 
-instance PartialOrder[Int8] {
-    pub def lessEqual(x: Int8, y: Int8): Bool = %%INT8_LE%%(x, y)
-}
-
-instance PartialOrder[Int16] {
-    pub def lessEqual(x: Int16, y: Int16): Bool = %%INT16_LE%%(x, y)
-}
-
-instance PartialOrder[Int32] {
-    pub def lessEqual(x: Int32, y: Int32): Bool = %%INT32_LE%%(x, y)
-}
-
-instance PartialOrder[Int64] {
-    pub def lessEqual(x: Int64, y: Int64): Bool = %%INT64_LE%%(x, y)
-}
-
-instance PartialOrder[BigInt] {
-    pub def lessEqual(x: BigInt, y: BigInt): Bool =
-        x.compareTo(y) <= 0
-}
-
-instance PartialOrder[(a1, a2)] with PartialOrder[a1], PartialOrder[a2] {
-    pub def lessEqual(x: (a1, a2),
-                           y: (a1, a2)): Bool = match (x, y) {
-        case ((x1, x2), (y1, y2)) =>
-            PartialOrder.lessEqual(x1, y1) and
-            PartialOrder.lessEqual(x2, y2)
+        ///
+        /// Transitivity: If `x` is lower or equal to `y` and `y` is lower equal to `z` then `x` must be lower or equal to `z`.
+        ///
+        law transitivity: forall(x: a, y: a, z: a) (PartialOrder.lessEqual(x, y) and PartialOrder.lessEqual(y, z)) ==> PartialOrder.lessEqual(x, z)
     }
-}
 
-instance PartialOrder[(a1, a2, a3)] with PartialOrder[a1], PartialOrder[a2],
-                                         PartialOrder[a3] {
-    pub def lessEqual(x: (a1, a2, a3),
-                           y: (a1, a2, a3)): Bool = match (x, y) {
-        case ((x1, x2, x3), (y1, y2, y3)) =>
-            PartialOrder.lessEqual(x1, y1) and
-            PartialOrder.lessEqual(x2, y2) and
-            PartialOrder.lessEqual(x3, y3)
+    instance PartialOrder[Int8] {
+        pub def lessEqual(x: Int8, y: Int8): Bool = %%INT8_LE%%(x, y)
     }
-}
 
-instance PartialOrder[(a1, a2, a3, a4)] with PartialOrder[a1], PartialOrder[a2],
-                                             PartialOrder[a3], PartialOrder[a4] {
-    pub def lessEqual(x: (a1, a2, a3, a4),
-                           y: (a1, a2, a3, a4)): Bool = match (x, y) {
-        case ((x1, x2, x3, x4), (y1, y2, y3, y4)) =>
-            PartialOrder.lessEqual(x1, y1) and
-            PartialOrder.lessEqual(x2, y2) and
-            PartialOrder.lessEqual(x3, y3) and
-            PartialOrder.lessEqual(x4, y4)
+    instance PartialOrder[Int16] {
+        pub def lessEqual(x: Int16, y: Int16): Bool = %%INT16_LE%%(x, y)
     }
-}
 
-instance PartialOrder[(a1, a2, a3, a4, a5)] with PartialOrder[a1], PartialOrder[a2],
-                                                 PartialOrder[a3], PartialOrder[a4],
-                                                 PartialOrder[a5] {
-    pub def lessEqual(x: (a1, a2, a3, a4, a5),
-                           y: (a1, a2, a3, a4, a5)): Bool = match (x, y) {
-        case ((x1, x2, x3, x4, x5), (y1, y2, y3, y4, y5)) =>
-            PartialOrder.lessEqual(x1, y1) and
-            PartialOrder.lessEqual(x2, y2) and
-            PartialOrder.lessEqual(x3, y3) and
-            PartialOrder.lessEqual(x4, y4) and
-            PartialOrder.lessEqual(x5, y5)
+    instance PartialOrder[Int32] {
+        pub def lessEqual(x: Int32, y: Int32): Bool = %%INT32_LE%%(x, y)
     }
-}
 
-instance PartialOrder[(a1, a2, a3, a4, a5, a6)] with PartialOrder[a1], PartialOrder[a2],
+    instance PartialOrder[Int64] {
+        pub def lessEqual(x: Int64, y: Int64): Bool = %%INT64_LE%%(x, y)
+    }
+
+    instance PartialOrder[BigInt] {
+        pub def lessEqual(x: BigInt, y: BigInt): Bool =
+            x.compareTo(y) <= 0
+    }
+
+    instance PartialOrder[(a1, a2)] with PartialOrder[a1], PartialOrder[a2] {
+        pub def lessEqual(x: (a1, a2),
+                               y: (a1, a2)): Bool = match (x, y) {
+            case ((x1, x2), (y1, y2)) =>
+                PartialOrder.lessEqual(x1, y1) and
+                PartialOrder.lessEqual(x2, y2)
+        }
+    }
+
+    instance PartialOrder[(a1, a2, a3)] with PartialOrder[a1], PartialOrder[a2],
+                                             PartialOrder[a3] {
+        pub def lessEqual(x: (a1, a2, a3),
+                               y: (a1, a2, a3)): Bool = match (x, y) {
+            case ((x1, x2, x3), (y1, y2, y3)) =>
+                PartialOrder.lessEqual(x1, y1) and
+                PartialOrder.lessEqual(x2, y2) and
+                PartialOrder.lessEqual(x3, y3)
+        }
+    }
+
+    instance PartialOrder[(a1, a2, a3, a4)] with PartialOrder[a1], PartialOrder[a2],
+                                                 PartialOrder[a3], PartialOrder[a4] {
+        pub def lessEqual(x: (a1, a2, a3, a4),
+                               y: (a1, a2, a3, a4)): Bool = match (x, y) {
+            case ((x1, x2, x3, x4), (y1, y2, y3, y4)) =>
+                PartialOrder.lessEqual(x1, y1) and
+                PartialOrder.lessEqual(x2, y2) and
+                PartialOrder.lessEqual(x3, y3) and
+                PartialOrder.lessEqual(x4, y4)
+        }
+    }
+
+    instance PartialOrder[(a1, a2, a3, a4, a5)] with PartialOrder[a1], PartialOrder[a2],
                                                      PartialOrder[a3], PartialOrder[a4],
-                                                     PartialOrder[a5], PartialOrder[a6] {
-    pub def lessEqual(x: (a1, a2, a3, a4, a5, a6),
-                           y: (a1, a2, a3, a4, a5, a6)): Bool = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6), (y1, y2, y3, y4, y5, y6)) =>
-            PartialOrder.lessEqual(x1, y1) and
-            PartialOrder.lessEqual(x2, y2) and
-            PartialOrder.lessEqual(x3, y3) and
-            PartialOrder.lessEqual(x4, y4) and
-            PartialOrder.lessEqual(x5, y5) and
-            PartialOrder.lessEqual(x6, y6)
+                                                     PartialOrder[a5] {
+        pub def lessEqual(x: (a1, a2, a3, a4, a5),
+                               y: (a1, a2, a3, a4, a5)): Bool = match (x, y) {
+            case ((x1, x2, x3, x4, x5), (y1, y2, y3, y4, y5)) =>
+                PartialOrder.lessEqual(x1, y1) and
+                PartialOrder.lessEqual(x2, y2) and
+                PartialOrder.lessEqual(x3, y3) and
+                PartialOrder.lessEqual(x4, y4) and
+                PartialOrder.lessEqual(x5, y5)
+        }
     }
-}
 
-instance PartialOrder[(a1, a2, a3, a4, a5, a6, a7)] with PartialOrder[a1], PartialOrder[a2],
+    instance PartialOrder[(a1, a2, a3, a4, a5, a6)] with PartialOrder[a1], PartialOrder[a2],
                                                          PartialOrder[a3], PartialOrder[a4],
-                                                         PartialOrder[a5], PartialOrder[a6],
-                                                         PartialOrder[a7] {
-    pub def lessEqual(x: (a1, a2, a3, a4, a5, a6, a7),
-                           y: (a1, a2, a3, a4, a5, a6, a7)): Bool = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7), (y1, y2, y3, y4, y5, y6, y7)) =>
-            PartialOrder.lessEqual(x1, y1) and
-            PartialOrder.lessEqual(x2, y2) and
-            PartialOrder.lessEqual(x3, y3) and
-            PartialOrder.lessEqual(x4, y4) and
-            PartialOrder.lessEqual(x5, y5) and
-            PartialOrder.lessEqual(x6, y6) and
-            PartialOrder.lessEqual(x7, y7)
+                                                         PartialOrder[a5], PartialOrder[a6] {
+        pub def lessEqual(x: (a1, a2, a3, a4, a5, a6),
+                               y: (a1, a2, a3, a4, a5, a6)): Bool = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6), (y1, y2, y3, y4, y5, y6)) =>
+                PartialOrder.lessEqual(x1, y1) and
+                PartialOrder.lessEqual(x2, y2) and
+                PartialOrder.lessEqual(x3, y3) and
+                PartialOrder.lessEqual(x4, y4) and
+                PartialOrder.lessEqual(x5, y5) and
+                PartialOrder.lessEqual(x6, y6)
+        }
     }
-}
 
-instance PartialOrder[(a1, a2, a3, a4, a5, a6, a7, a8)] with PartialOrder[a1], PartialOrder[a2],
+    instance PartialOrder[(a1, a2, a3, a4, a5, a6, a7)] with PartialOrder[a1], PartialOrder[a2],
                                                              PartialOrder[a3], PartialOrder[a4],
                                                              PartialOrder[a5], PartialOrder[a6],
-                                                             PartialOrder[a7], PartialOrder[a8] {
-    pub def lessEqual(x: (a1, a2, a3, a4, a5, a6, a7, a8),
-                           y: (a1, a2, a3, a4, a5, a6, a7, a8)): Bool = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7, x8), (y1, y2, y3, y4, y5, y6, y7, y8)) =>
-            PartialOrder.lessEqual(x1, y1) and
-            PartialOrder.lessEqual(x2, y2) and
-            PartialOrder.lessEqual(x3, y3) and
-            PartialOrder.lessEqual(x4, y4) and
-            PartialOrder.lessEqual(x5, y5) and
-            PartialOrder.lessEqual(x6, y6) and
-            PartialOrder.lessEqual(x7, y7) and
-            PartialOrder.lessEqual(x8, y8)
+                                                             PartialOrder[a7] {
+        pub def lessEqual(x: (a1, a2, a3, a4, a5, a6, a7),
+                               y: (a1, a2, a3, a4, a5, a6, a7)): Bool = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7), (y1, y2, y3, y4, y5, y6, y7)) =>
+                PartialOrder.lessEqual(x1, y1) and
+                PartialOrder.lessEqual(x2, y2) and
+                PartialOrder.lessEqual(x3, y3) and
+                PartialOrder.lessEqual(x4, y4) and
+                PartialOrder.lessEqual(x5, y5) and
+                PartialOrder.lessEqual(x6, y6) and
+                PartialOrder.lessEqual(x7, y7)
+        }
     }
-}
 
-instance PartialOrder[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with PartialOrder[a1], PartialOrder[a2],
+    instance PartialOrder[(a1, a2, a3, a4, a5, a6, a7, a8)] with PartialOrder[a1], PartialOrder[a2],
                                                                  PartialOrder[a3], PartialOrder[a4],
                                                                  PartialOrder[a5], PartialOrder[a6],
-                                                                 PartialOrder[a7], PartialOrder[a8],
-                                                                 PartialOrder[a9] {
-    pub def lessEqual(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9),
-                           y: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): Bool = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7, x8, x9), (y1, y2, y3, y4, y5, y6, y7, y8, y9)) =>
-            PartialOrder.lessEqual(x1, y1) and
-            PartialOrder.lessEqual(x2, y2) and
-            PartialOrder.lessEqual(x3, y3) and
-            PartialOrder.lessEqual(x4, y4) and
-            PartialOrder.lessEqual(x5, y5) and
-            PartialOrder.lessEqual(x6, y6) and
-            PartialOrder.lessEqual(x7, y7) and
-            PartialOrder.lessEqual(x8, y8) and
-            PartialOrder.lessEqual(x9, y9)
+                                                                 PartialOrder[a7], PartialOrder[a8] {
+        pub def lessEqual(x: (a1, a2, a3, a4, a5, a6, a7, a8),
+                               y: (a1, a2, a3, a4, a5, a6, a7, a8)): Bool = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7, x8), (y1, y2, y3, y4, y5, y6, y7, y8)) =>
+                PartialOrder.lessEqual(x1, y1) and
+                PartialOrder.lessEqual(x2, y2) and
+                PartialOrder.lessEqual(x3, y3) and
+                PartialOrder.lessEqual(x4, y4) and
+                PartialOrder.lessEqual(x5, y5) and
+                PartialOrder.lessEqual(x6, y6) and
+                PartialOrder.lessEqual(x7, y7) and
+                PartialOrder.lessEqual(x8, y8)
+        }
     }
-}
 
-instance PartialOrder[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with PartialOrder[a1], PartialOrder[a2],
-                                                                      PartialOrder[a3], PartialOrder[a4],
-                                                                      PartialOrder[a5], PartialOrder[a6],
-                                                                      PartialOrder[a7], PartialOrder[a8],
-                                                                      PartialOrder[a9], PartialOrder[a10] {
-    pub def lessEqual(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10),
-                           y: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): Bool = match (x, y) {
-        case ((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10), (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10)) =>
-            PartialOrder.lessEqual(x1, y1) and
-            PartialOrder.lessEqual(x2, y2) and
-            PartialOrder.lessEqual(x3, y3) and
-            PartialOrder.lessEqual(x4, y4) and
-            PartialOrder.lessEqual(x5, y5) and
-            PartialOrder.lessEqual(x6, y6) and
-            PartialOrder.lessEqual(x7, y7) and
-            PartialOrder.lessEqual(x8, y8) and
-            PartialOrder.lessEqual(x9, y9) and
-            PartialOrder.lessEqual(x10, y10)
+    instance PartialOrder[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with PartialOrder[a1], PartialOrder[a2],
+                                                                     PartialOrder[a3], PartialOrder[a4],
+                                                                     PartialOrder[a5], PartialOrder[a6],
+                                                                     PartialOrder[a7], PartialOrder[a8],
+                                                                     PartialOrder[a9] {
+        pub def lessEqual(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9),
+                               y: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): Bool = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7, x8, x9), (y1, y2, y3, y4, y5, y6, y7, y8, y9)) =>
+                PartialOrder.lessEqual(x1, y1) and
+                PartialOrder.lessEqual(x2, y2) and
+                PartialOrder.lessEqual(x3, y3) and
+                PartialOrder.lessEqual(x4, y4) and
+                PartialOrder.lessEqual(x5, y5) and
+                PartialOrder.lessEqual(x6, y6) and
+                PartialOrder.lessEqual(x7, y7) and
+                PartialOrder.lessEqual(x8, y8) and
+                PartialOrder.lessEqual(x9, y9)
+        }
     }
+
+    instance PartialOrder[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with PartialOrder[a1], PartialOrder[a2],
+                                                                          PartialOrder[a3], PartialOrder[a4],
+                                                                          PartialOrder[a5], PartialOrder[a6],
+                                                                          PartialOrder[a7], PartialOrder[a8],
+                                                                          PartialOrder[a9], PartialOrder[a10] {
+        pub def lessEqual(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10),
+                               y: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): Bool = match (x, y) {
+            case ((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10), (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10)) =>
+                PartialOrder.lessEqual(x1, y1) and
+                PartialOrder.lessEqual(x2, y2) and
+                PartialOrder.lessEqual(x3, y3) and
+                PartialOrder.lessEqual(x4, y4) and
+                PartialOrder.lessEqual(x5, y5) and
+                PartialOrder.lessEqual(x6, y6) and
+                PartialOrder.lessEqual(x7, y7) and
+                PartialOrder.lessEqual(x8, y8) and
+                PartialOrder.lessEqual(x9, y9) and
+                PartialOrder.lessEqual(x10, y10)
+        }
+    }
+
 }

--- a/main/src/library/ToFlix.flix
+++ b/main/src/library/ToFlix.flix
@@ -14,104 +14,108 @@
  *  limitations under the License.
  */
 
-import java.lang.Byte
-import java.lang.Character
-import java.lang.Double
-import java.lang.Float
-import java.lang.Integer
-import java.lang.Long
-import java.lang.Short
-import java.math.BigInteger
-import java.util.{List => JList}
-import java.util.{Map => JMap}
-import java.util.{Set => JSet}
+pub mod ToFlix {
 
-///
-/// A trait for marshaling values to Flix objects.
-///
-pub trait ToFlix[t: Type] {
-    type In[t]: Type
-    type Aef[t]: Eff = {}
-    pub def toFlix(t: ToFlix.In[t]): t \ ToFlix.Aef[t]
-}
+    import java.lang.Byte
+    import java.lang.Character
+    import java.lang.Double
+    import java.lang.Float
+    import java.lang.Integer
+    import java.lang.Long
+    import java.lang.Short
+    import java.math.BigInteger
+    import java.util.{List => JList}
+    import java.util.{Map => JMap}
+    import java.util.{Set => JSet}
 
-instance ToFlix[Int8] {
-    type In = Byte
-    pub def toFlix(i: Byte): Int8 = Int8.byteValue(i)
-}
-
-instance ToFlix[Int16] {
-    type In = Short
-    pub def toFlix(i: Short): Int16 = Int16.shortValue(i)
-}
-
-instance ToFlix[Int32] {
-    type In = Integer
-    pub def toFlix(i: Integer): Int32 = Int32.intValue(i)
-}
-
-instance ToFlix[Int64] {
-    type In = Long
-    pub def toFlix(i: Long): Int64 = Int64.longValue(i)
-}
-
-instance ToFlix[Float32] {
-    type In = Float
-    pub def toFlix(d: Float): Float32 = Float32.floatValue(d)
-}
-
-instance ToFlix[Float64] {
-    type In = Double
-    pub def toFlix(d: Double): Float64 = Float64.doubleValue(d)
-}
-
-instance ToFlix[BigInt] {
-    type In = BigInteger
-    pub def toFlix(i: BigInteger): BigInt = i
-}
-
-instance ToFlix[BigDecimal] {
-    type In = BigDecimal
-    pub def toFlix(d: BigDecimal): BigDecimal = d
-}
-
-instance ToFlix[Char] {
-    type In = Character
-    pub def toFlix(c: Character): Char = Char.charValue(c)
-}
-
-instance ToFlix[String] {
-    type In = String
-    pub def toFlix(s: String): String = s
-}
-
-instance ToFlix[List[a]] {
-    type In = JList[a]
-    pub def toFlix(l: JList[a]): List[a] = Adaptor.fromList(l)
-}
-
-instance ToFlix[Chain[a]] {
-    type In = JList[a]
-    pub def toFlix(l: JList[a]): Chain[a] = region rc {
-        let it = unsafe IO { l.iterator() };
-        it |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toChain
+    ///
+    /// A trait for marshaling values to Flix objects.
+    ///
+    pub trait ToFlix[t: Type] {
+        type In[t]: Type
+        type Aef[t]: Eff = {}
+        pub def toFlix(t: ToFlix.In[t]): t \ ToFlix.Aef[t]
     }
-}
 
-instance ToFlix[Vector[a]] {
-    type In = JList[a]
-    pub def toFlix(l: JList[a]): Vector[a] = region rc {
-        let iter = unsafe IO { l.iterator() };
-        iter |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toVector
+    instance ToFlix[Int8] {
+        type In = Byte
+        pub def toFlix(i: Byte): Int8 = Int8.byteValue(i)
     }
-}
 
-instance ToFlix[Set[a]] with Order[a] {
-    type In = JSet[a]
-    pub def toFlix(s: JSet[a]): Set[a] = Adaptor.fromSet(s)
-}
+    instance ToFlix[Int16] {
+        type In = Short
+        pub def toFlix(i: Short): Int16 = Int16.shortValue(i)
+    }
 
-instance ToFlix[Map[k, v]] with Order[k] {
-    type In = JMap[k, v]
-    pub def toFlix(m: JMap[k, v]): Map[k, v] = Adaptor.fromMap(m)
+    instance ToFlix[Int32] {
+        type In = Integer
+        pub def toFlix(i: Integer): Int32 = Int32.intValue(i)
+    }
+
+    instance ToFlix[Int64] {
+        type In = Long
+        pub def toFlix(i: Long): Int64 = Int64.longValue(i)
+    }
+
+    instance ToFlix[Float32] {
+        type In = Float
+        pub def toFlix(d: Float): Float32 = Float32.floatValue(d)
+    }
+
+    instance ToFlix[Float64] {
+        type In = Double
+        pub def toFlix(d: Double): Float64 = Float64.doubleValue(d)
+    }
+
+    instance ToFlix[BigInt] {
+        type In = BigInteger
+        pub def toFlix(i: BigInteger): BigInt = i
+    }
+
+    instance ToFlix[BigDecimal] {
+        type In = BigDecimal
+        pub def toFlix(d: BigDecimal): BigDecimal = d
+    }
+
+    instance ToFlix[Char] {
+        type In = Character
+        pub def toFlix(c: Character): Char = Char.charValue(c)
+    }
+
+    instance ToFlix[String] {
+        type In = String
+        pub def toFlix(s: String): String = s
+    }
+
+    instance ToFlix[List[a]] {
+        type In = JList[a]
+        pub def toFlix(l: JList[a]): List[a] = Adaptor.fromList(l)
+    }
+
+    instance ToFlix[Chain[a]] {
+        type In = JList[a]
+        pub def toFlix(l: JList[a]): Chain[a] = region rc {
+            let it = unsafe IO { l.iterator() };
+            it |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toChain
+        }
+    }
+
+    instance ToFlix[Vector[a]] {
+        type In = JList[a]
+        pub def toFlix(l: JList[a]): Vector[a] = region rc {
+            let iter = unsafe IO { l.iterator() };
+            iter |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toVector
+        }
+    }
+
+    instance ToFlix[Set[a]] with Order[a] {
+        type In = JSet[a]
+        pub def toFlix(s: JSet[a]): Set[a] = Adaptor.fromSet(s)
+    }
+
+    instance ToFlix[Map[k, v]] with Order[k] {
+        type In = JMap[k, v]
+        pub def toFlix(m: JMap[k, v]): Map[k, v] = Adaptor.fromMap(m)
+    }
+
 }

--- a/main/src/library/ToJava.flix
+++ b/main/src/library/ToJava.flix
@@ -14,115 +14,119 @@
  *  limitations under the License.
  */
 
-import java.lang.Byte
-import java.lang.Character
-import java.lang.Double
-import java.lang.Float
-import java.lang.Integer
-import java.lang.Long
-import java.lang.Short
-import java.math.BigInteger
-import java.util.{List => JList}
-import java.util.{Map => JMap}
-import java.util.{Set => JSet}
+pub mod ToJava {
 
-///
-/// A trait for marshaling values to Java objects.
-///
-pub trait ToJava[t: Type] {
-    type Out[t]: Type
-    type Aef[t]: Eff = {}
-    pub def toJava(t: t): ToJava.Out[t] \ ToJava.Aef[t]
-}
+    import java.lang.Byte
+    import java.lang.Character
+    import java.lang.Double
+    import java.lang.Float
+    import java.lang.Integer
+    import java.lang.Long
+    import java.lang.Short
+    import java.math.BigInteger
+    import java.util.{List => JList}
+    import java.util.{Map => JMap}
+    import java.util.{Set => JSet}
 
-instance ToJava[Int8] {
-    type Out = Byte
-    pub def toJava(i: Int8): Byte = Int8.valueOf(i)
-}
+    ///
+    /// A trait for marshaling values to Java objects.
+    ///
+    pub trait ToJava[t: Type] {
+        type Out[t]: Type
+        type Aef[t]: Eff = {}
+        pub def toJava(t: t): ToJava.Out[t] \ ToJava.Aef[t]
+    }
 
-instance ToJava[Int16] {
-    type Out = Short
-    pub def toJava(i: Int16): Short = Int16.valueOf(i)
-}
+    instance ToJava[Int8] {
+        type Out = Byte
+        pub def toJava(i: Int8): Byte = Int8.valueOf(i)
+    }
 
-instance ToJava[Int32] {
-    type Out = Integer
-    pub def toJava(i: Int32): Integer = Int32.valueOf(i)
-}
+    instance ToJava[Int16] {
+        type Out = Short
+        pub def toJava(i: Int16): Short = Int16.valueOf(i)
+    }
 
-instance ToJava[Int64] {
-    type Out = Long
-    pub def toJava(i: Int64): Long = Int64.valueOf(i)
-}
+    instance ToJava[Int32] {
+        type Out = Integer
+        pub def toJava(i: Int32): Integer = Int32.valueOf(i)
+    }
 
-instance ToJava[Float32] {
-    type Out = Float
-    pub def toJava(d: Float32): Float = Float32.valueOf(d)
-}
+    instance ToJava[Int64] {
+        type Out = Long
+        pub def toJava(i: Int64): Long = Int64.valueOf(i)
+    }
 
-instance ToJava[Float64] {
-    type Out = Double
-    pub def toJava(d: Float64): Double = Float64.valueOf(d)
-}
+    instance ToJava[Float32] {
+        type Out = Float
+        pub def toJava(d: Float32): Float = Float32.valueOf(d)
+    }
 
-instance ToJava[BigInt] {
-    type Out = BigInteger
-    pub def toJava(i: BigInt): BigInteger = i
-}
+    instance ToJava[Float64] {
+        type Out = Double
+        pub def toJava(d: Float64): Double = Float64.valueOf(d)
+    }
 
-instance ToJava[BigDecimal] {
-    type Out = BigDecimal
-    pub def toJava(d: BigDecimal): BigDecimal = d
-}
+    instance ToJava[BigInt] {
+        type Out = BigInteger
+        pub def toJava(i: BigInt): BigInteger = i
+    }
 
-instance ToJava[Char] {
-    type Out = Character
-    pub def toJava(c: Char): Character = Char.valueOf(c)
-}
+    instance ToJava[BigDecimal] {
+        type Out = BigDecimal
+        pub def toJava(d: BigDecimal): BigDecimal = d
+    }
 
-instance ToJava[String] {
-    type Out = String
-    pub def toJava(s: String): String = s
-}
+    instance ToJava[Char] {
+        type Out = Character
+        pub def toJava(c: Char): Character = Char.valueOf(c)
+    }
 
-instance ToJava[List[a]] {
-    type Out = JList[a]
-    type Aef = IO
-    pub def toJava(l: List[a]): JList[a] \ IO = Adaptor.toList(l)
-}
+    instance ToJava[String] {
+        type Out = String
+        pub def toJava(s: String): String = s
+    }
 
-instance ToJava[Chain[a]] {
-    type Out = JList[a]
-    type Aef = IO
-    pub def toJava(c: Chain[a]): JList[a] \ IO = Adaptor.toList(c)
-}
+    instance ToJava[List[a]] {
+        type Out = JList[a]
+        type Aef = IO
+        pub def toJava(l: List[a]): JList[a] \ IO = Adaptor.toList(l)
+    }
 
-instance ToJava[Vector[a]] {
-    type Out = JList[a]
-    type Aef = IO
-    pub def toJava(v: Vector[a]): JList[a] \ IO = Adaptor.toList(v)
-}
+    instance ToJava[Chain[a]] {
+        type Out = JList[a]
+        type Aef = IO
+        pub def toJava(c: Chain[a]): JList[a] \ IO = Adaptor.toList(c)
+    }
 
-instance ToJava[Nel[a]] {
-    type Out = JList[a]
-    type Aef = IO
-    pub def toJava(l: Nel[a]): JList[a] \ IO = Adaptor.toList(l)
-}
+    instance ToJava[Vector[a]] {
+        type Out = JList[a]
+        type Aef = IO
+        pub def toJava(v: Vector[a]): JList[a] \ IO = Adaptor.toList(v)
+    }
 
-instance ToJava[Nec[a]] {
-    type Out = JList[a]
-    type Aef = IO
-    pub def toJava(l: Nec[a]): JList[a] \ IO = Adaptor.toList(l)
-}
+    instance ToJava[Nel[a]] {
+        type Out = JList[a]
+        type Aef = IO
+        pub def toJava(l: Nel[a]): JList[a] \ IO = Adaptor.toList(l)
+    }
 
-instance ToJava[Set[a]] with Order[a] {
-    type Out = JSet[a]
-    type Aef = IO
-    pub def toJava(s: Set[a]): JSet[a] \ IO = Adaptor.toSet(s)
-}
+    instance ToJava[Nec[a]] {
+        type Out = JList[a]
+        type Aef = IO
+        pub def toJava(l: Nec[a]): JList[a] \ IO = Adaptor.toList(l)
+    }
 
-instance ToJava[Map[k, v]] with Order[k] {
-    type Out = JMap[k, v]
-    type Aef = IO
-    pub def toJava(m: Map[k, v]): JMap[k, v] \ IO = Adaptor.toMap(m)
+    instance ToJava[Set[a]] with Order[a] {
+        type Out = JSet[a]
+        type Aef = IO
+        pub def toJava(s: Set[a]): JSet[a] \ IO = Adaptor.toSet(s)
+    }
+
+    instance ToJava[Map[k, v]] with Order[k] {
+        type Out = JMap[k, v]
+        type Aef = IO
+        pub def toJava(m: Map[k, v]): JMap[k, v] \ IO = Adaptor.toMap(m)
+    }
+
 }

--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -14,173 +14,177 @@
  *  limitations under the License.
  */
 
-import java.lang.Byte
-import java.lang.Character
-import java.lang.Double
-import java.lang.Float
-import java.lang.Integer
-import java.lang.Long
-import java.lang.Short
+pub mod ToString {
 
-///
-/// A trait for types that can be converted to strings.
-///
-pub trait ToString[a] {
+    import java.lang.Byte
+    import java.lang.Character
+    import java.lang.Double
+    import java.lang.Float
+    import java.lang.Integer
+    import java.lang.Long
+    import java.lang.Short
+
     ///
-    /// Returns a string representation of the given x.
+    /// A trait for types that can be converted to strings.
     ///
-    pub def toString(x: a): String
-}
-
-instance ToString[Unit] {
-    pub def toString(_x: Unit): String = "()"
-}
-
-instance ToString[Bool] {
-    pub def toString(x: Bool): String = match x {
-        case true  => "true"
-        case false => "false"
+    pub trait ToString[a] {
+        ///
+        /// Returns a string representation of the given x.
+        ///
+        pub def toString(x: a): String
     }
-}
 
-instance ToString[Char] {
-    pub def toString(x: Char): String = Character.toString(x)
-}
-
-instance ToString[Float32] {
-    pub def toString(x: Float32): String = Float.toString(x)
-}
-
-instance ToString[Float64] {
-    pub def toString(x: Float64): String = Double.toString(x)
-}
-
-instance ToString[Int8] {
-    pub def toString(x: Int8): String = Byte.toString(x)
-}
-
-instance ToString[Int16] {
-    pub def toString(x: Int16): String = Short.toString(x)
-}
-
-instance ToString[Int32] {
-    pub def toString(x: Int32): String = Integer.toString(x)
-}
-
-instance ToString[Int64] {
-    pub def toString(x: Int64): String = Long.toString(x)
-}
-
-instance ToString[String] {
-    pub def toString(x: String): String = x
-}
-
-instance ToString[BigInt] {
-    pub def toString(x: BigInt): String = x.toString()
-}
-
-instance ToString[BigDecimal] {
-    pub def toString(x: BigDecimal): String = x.toString()
-}
-
-instance ToString[Regex] {
-    pub def toString(x: Regex): String = x.toString()
-}
-
-instance ToString[(a1, a2)] with ToString[a1], ToString[a2] {
-    pub def toString(t: (a1, a2)): String = match t {
-        case (x1, x2) =>
-            "(${x1}, ${x2})"
+    instance ToString[Unit] {
+        pub def toString(_x: Unit): String = "()"
     }
-}
 
-instance ToString[(a1, a2, a3)] with ToString[a1], ToString[a2], ToString[a3] {
-    pub def toString(t: (a1, a2, a3)): String = match t {
-        case (x1, x2, x3) =>
-            "(${x1}, ${x2}, ${x3})"
+    instance ToString[Bool] {
+        pub def toString(x: Bool): String = match x {
+            case true  => "true"
+            case false => "false"
+        }
     }
-}
 
-instance ToString[(a1, a2, a3, a4)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4] {
-    pub def toString(t: (a1, a2, a3, a4)): String = match t {
-        case (x1, x2, x3, x4) =>
-            "(${x1}, ${x2}, ${x3}, ${x4})"
+    instance ToString[Char] {
+        pub def toString(x: Char): String = Character.toString(x)
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5] {
-    pub def toString(t: (a1, a2, a3, a4, a5)): String = match t {
-        case (x1, x2, x3, x4, x5) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5})"
+    instance ToString[Float32] {
+        pub def toString(x: Float32): String = Float.toString(x)
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6)): String = match t {
-        case (x1, x2, x3, x4, x5, x6) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6})"
+    instance ToString[Float64] {
+        pub def toString(x: Float64): String = Double.toString(x)
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6, a7)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7)): String = match t {
-        case (x1, x2, x3, x4, x5, x6, x7) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7})"
+    instance ToString[Int8] {
+        pub def toString(x: Int8): String = Byte.toString(x)
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8)): String = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8})"
+    instance ToString[Int16] {
+        pub def toString(x: Int16): String = Short.toString(x)
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): String = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8, x9) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9})"
+    instance ToString[Int32] {
+        pub def toString(x: Int32): String = Integer.toString(x)
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): String = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10})"
+    instance ToString[Int64] {
+        pub def toString(x: Int64): String = Long.toString(x)
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)): String = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11})"
+    instance ToString[String] {
+        pub def toString(x: String): String = x
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)): String = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12})"
+    instance ToString[BigInt] {
+        pub def toString(x: BigInt): String = x.toString()
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12], ToString[a13] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)): String = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12}, ${x13})"
+    instance ToString[BigDecimal] {
+        pub def toString(x: BigDecimal): String = x.toString()
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12], ToString[a13], ToString[a14] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)): String = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12}, ${x13}, ${x14})"
+    instance ToString[Regex] {
+        pub def toString(x: Regex): String = x.toString()
     }
-}
 
-instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12], ToString[a13], ToString[a14], ToString[a15] {
-    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)): String = match t {
-        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) =>
-            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12}, ${x13}, ${x14}, ${x15})"
+    instance ToString[(a1, a2)] with ToString[a1], ToString[a2] {
+        pub def toString(t: (a1, a2)): String = match t {
+            case (x1, x2) =>
+                "(${x1}, ${x2})"
+        }
     }
+
+    instance ToString[(a1, a2, a3)] with ToString[a1], ToString[a2], ToString[a3] {
+        pub def toString(t: (a1, a2, a3)): String = match t {
+            case (x1, x2, x3) =>
+                "(${x1}, ${x2}, ${x3})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4] {
+        pub def toString(t: (a1, a2, a3, a4)): String = match t {
+            case (x1, x2, x3, x4) =>
+                "(${x1}, ${x2}, ${x3}, ${x4})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5] {
+        pub def toString(t: (a1, a2, a3, a4, a5)): String = match t {
+            case (x1, x2, x3, x4, x5) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6)): String = match t {
+            case (x1, x2, x3, x4, x5, x6) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6, a7)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6, a7)): String = match t {
+            case (x1, x2, x3, x4, x5, x6, x7) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8)): String = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): String = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8, x9) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): String = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)): String = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)): String = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12], ToString[a13] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)): String = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12}, ${x13})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12], ToString[a13], ToString[a14] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)): String = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12}, ${x13}, ${x14})"
+        }
+    }
+
+    instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12], ToString[a13], ToString[a14], ToString[a15] {
+        pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)): String = match t {
+            case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) =>
+                "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12}, ${x13}, ${x14}, ${x15})"
+        }
+    }
+
 }

--- a/main/src/library/UpperBound.flix
+++ b/main/src/library/UpperBound.flix
@@ -14,52 +14,56 @@
  *  limitations under the License.
  */
 
-///
-/// A trait for partially ordered types that have an upper bound.
-///
-pub trait UpperBound[a] {
+pub mod UpperBound {
+
     ///
-    /// Returns the largest value of `a`.
+    /// A trait for partially ordered types that have an upper bound.
     ///
-    pub def maxValue(): a
-}
+    pub trait UpperBound[a] {
+        ///
+        /// Returns the largest value of `a`.
+        ///
+        pub def maxValue(): a
+    }
 
-instance UpperBound[(a1, a2)] with UpperBound[a1], UpperBound[a2] {
-    pub def maxValue(): (a1, a2) = (UpperBound.maxValue(), UpperBound.maxValue())
-}
+    instance UpperBound[(a1, a2)] with UpperBound[a1], UpperBound[a2] {
+        pub def maxValue(): (a1, a2) = (UpperBound.maxValue(), UpperBound.maxValue())
+    }
 
-instance UpperBound[(a1, a2, a3)] with UpperBound[a1], UpperBound[a2], UpperBound[a3] {
-    pub def maxValue(): (a1, a2, a3) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
-}
+    instance UpperBound[(a1, a2, a3)] with UpperBound[a1], UpperBound[a2], UpperBound[a3] {
+        pub def maxValue(): (a1, a2, a3) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
+    }
 
-instance UpperBound[(a1, a2, a3, a4)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4] {
-    pub def maxValue(): (a1, a2, a3, a4) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
-}
+    instance UpperBound[(a1, a2, a3, a4)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4] {
+        pub def maxValue(): (a1, a2, a3, a4) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
+    }
 
-instance UpperBound[(a1, a2, a3, a4, a5)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5] {
-    pub def maxValue(): (a1, a2, a3, a4, a5) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
-}
+    instance UpperBound[(a1, a2, a3, a4, a5)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5] {
+        pub def maxValue(): (a1, a2, a3, a4, a5) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
+    }
 
-instance UpperBound[(a1, a2, a3, a4, a5, a6)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6] {
-    pub def maxValue(): (a1, a2, a3, a4, a5, a6) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
-}
+    instance UpperBound[(a1, a2, a3, a4, a5, a6)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6] {
+        pub def maxValue(): (a1, a2, a3, a4, a5, a6) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
+    }
 
-instance UpperBound[(a1, a2, a3, a4, a5, a6, a7)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6], UpperBound[a7] {
-    pub def maxValue(): (a1, a2, a3, a4, a5, a6, a7) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
-}
+    instance UpperBound[(a1, a2, a3, a4, a5, a6, a7)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6], UpperBound[a7] {
+        pub def maxValue(): (a1, a2, a3, a4, a5, a6, a7) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
+    }
 
-instance UpperBound[(a1, a2, a3, a4, a5, a6, a7, a8)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6], UpperBound[a7], UpperBound[a8] {
-    pub def maxValue(): (a1, a2, a3, a4, a5, a6, a7, a8) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
-}
+    instance UpperBound[(a1, a2, a3, a4, a5, a6, a7, a8)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6], UpperBound[a7], UpperBound[a8] {
+        pub def maxValue(): (a1, a2, a3, a4, a5, a6, a7, a8) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
+    }
 
-instance UpperBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6], UpperBound[a7], UpperBound[a8], UpperBound[a9] {
-    pub def maxValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
-}
+    instance UpperBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6], UpperBound[a7], UpperBound[a8], UpperBound[a9] {
+        pub def maxValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
+    }
 
-instance UpperBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6], UpperBound[a7], UpperBound[a8], UpperBound[a9], UpperBound[a10] {
-    pub def maxValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
-}
+    instance UpperBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with UpperBound[a1], UpperBound[a2], UpperBound[a3], UpperBound[a4], UpperBound[a5], UpperBound[a6], UpperBound[a7], UpperBound[a8], UpperBound[a9], UpperBound[a10] {
+        pub def maxValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
+    }
 
-instance UpperBound[Unit] {
-    pub def maxValue(): Unit = ()
+    instance UpperBound[Unit] {
+        pub def maxValue(): Unit = ()
+    }
+
 }


### PR DESCRIPTION
## Summary

Continues the pattern established in #12665 (Hash, Order) and #12666 (Functor, Applicative, Monad), nesting the trait declaration and all its instances inside a same-named `pub mod` block.

Refactored 15 stdlib files:

- **Ordering / lattices:** `PartialOrder`, `LowerBound`, `UpperBound`, `JoinLattice`, `MeetLattice`
- **Algebraic structures:** `Group`, `CommutativeGroup`, `CommutativeMonoid`, `CommutativeSemiGroup`
- **Conversion / formatting:** `ToString`, `FromString`, `ToJava`, `ToFlix`, `Coerce`, `Formattable`

No behavioral change — purely structural. Java imports and `use` clauses (e.g. `use Bool.{==>}`) are moved inside their respective module blocks. The `|+|` operator alias in `CommutativeSemiGroup` is kept at file top-level to mirror `SemiGroup.flix`'s treatment of `++` and preserve unqualified call-site ergonomics (existing `TestCommutativeSemiGroup` uses `1 |+| 1` without a `use` clause).

## Test plan

- [x] `./mill flix.run out/empty.flix` compiles the standard library
- [x] Smoke-tested all refactored traits via `./mill flix.run` on a small example exercising `PartialOrder.lessEqual`, `JoinLattice.leastUpperBound`, `MeetLattice.greatestLowerBound`, `LowerBound.minValue`, `UpperBound.maxValue`, `Group.inverse`/`remove`, `CommutativeMonoid.combine`/`empty`, `CommutativeSemiGroup.combine`, `|+|`, `ToString.toString` (incl. tuples), `FromString.fromString`, and `Formattable.format`.
- [ ] Full test suite (`./mill flix.test.testForked "-oC"`) — recommend running in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)