### PR TITLE
refactor: replace txtmark with commonmark-java

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -21,7 +21,7 @@ object flix extends ScalaModule {
     mvn"org.jline:jline:3.30.9",
     mvn"org.json4s::json4s-native:4.0.7",
     mvn"org.ow2.asm:asm:9.9.1",
-    mvn"com.github.rjeschke:txtmark:0.13",
+    mvn"org.commonmark:commonmark:0.24.0",
     mvn"com.github.scopt::scopt:4.1.0",
     mvn"org.apache.commons:commons-lang3:3.20.0",
     mvn"io.get-coursier::coursier:2.1.24",

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -22,7 +22,8 @@ import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeC
 import ca.uwaterloo.flix.language.fmt.{FormatType, DisplayType}
 import ca.uwaterloo.flix.tools.pkg.PackageModules
 import ca.uwaterloo.flix.util.LocalResource
-import com.github.rjeschke.txtmark
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
 
 import java.io.IOException
 import java.net.URLEncoder
@@ -1375,18 +1376,13 @@ object HtmlDocumentor {
       return
     }
 
-    val escaped = esc(text)
-
-    val config =
-      txtmark.Configuration.builder()
-        .build()
-    val parsed = txtmark.Processor.process(escaped, config)
-
-    // Since both esc and process escapes the & character, it needs to be unescaped once
-    val unescaped = parsed.replace("&amp;", "&")
+    val parser = Parser.builder().build()
+    val node = parser.parse(text)
+    val renderer = HtmlRenderer.builder().escapeHtml(true).build()
+    val html = renderer.render(node)
 
     sb.append("<div class='doc'>")
-    sb.append(unescaped)
+    sb.append(html)
     sb.append("</div>")
   }
 


### PR DESCRIPTION
## Summary

- Replace the abandoned **txtmark 0.13** (last release 2015, repo archived) with the actively-maintained **commonmark-java 0.24.0** in `HtmlDocumentor`. commonmark-java has no runtime transitive dependencies and follows the CommonMark spec exactly.
- Drop the manual `esc(text)` pre-pass and `&amp;`-unescape: commonmark's `HtmlRenderer` escapes text content correctly during rendering, and `escapeHtml(true)` matches the prior behavior of treating raw HTML in doc comments as literal text.
- Fat-JAR size impact: **+150 KB** (33.27 MB → 33.43 MB, +0.45%).

## Test plan

- [x] `./mill flix.run out/empty.flix` — stdlib compiles cleanly
- [x] `./mill flix.run doc` — generates 298 HTML pages in `build/doc/`; spot-check of `List.html` shows correct paragraph wrapping (`<p>...</p>`), inline code (`<code>...</code>`), and HTML escaping (`>` → `&gt;`)
- [x] Visual diff of generated stdlib docs against the pre-swap output for any markdown edge-case differences (e.g. raw HTML, list/paragraph tightness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)