### PR TITLE
feat: preserve doc indentation and style module docs

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -22,6 +22,7 @@ object flix extends ScalaModule {
     mvn"org.json4s::json4s-native:4.0.7",
     mvn"org.ow2.asm:asm:9.9.1",
     mvn"org.commonmark:commonmark:0.24.0",
+    mvn"org.commonmark:commonmark-ext-gfm-tables:0.24.0",
     mvn"com.github.scopt::scopt:4.1.0",
     mvn"org.apache.commons:commons-lang3:3.20.0",
     mvn"io.get-coursier::coursier:2.1.24",

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/Doc.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/Doc.scala
@@ -25,8 +25,7 @@ import ca.uwaterloo.flix.language.ast.SourceLocation
   */
 case class Doc(lines: List[String], loc: SourceLocation) {
   def text: String = lines.
-    dropWhile(_.trim.isEmpty).
-    map(_.trim).
+    dropWhile(_.isBlank).
     mkString("\n")
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -22,6 +22,7 @@ import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeC
 import ca.uwaterloo.flix.language.fmt.{FormatType, DisplayType}
 import ca.uwaterloo.flix.tools.pkg.PackageModules
 import ca.uwaterloo.flix.util.LocalResource
+import org.commonmark.ext.gfm.tables.TablesExtension
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
 
@@ -583,7 +584,7 @@ object HtmlDocumentor {
 
     sb.append("<main>")
     sb.append(s"<h1>${esc(mod.qualifiedName)}</h1>")
-    docDoc(mod.doc)
+    modDoc(mod.doc)
     docSection("Type Aliases", sortedTypeAliases, docTypeAlias)
     docSection("Definitions", sortedDefs, docDef)
     sb.append("</main>")
@@ -860,6 +861,7 @@ object HtmlDocumentor {
        |<link href='https://fonts.googleapis.com/css?family=Oswald&display=swap' rel='stylesheet'>
        |<link href='https://fonts.googleapis.com/css?family=Noto+Sans&display=swap' rel='stylesheet'>
        |<link href='https://fonts.googleapis.com/css?family=Inter&display=swap' rel='stylesheet'>
+       |<link href='https://fonts.googleapis.com/css?family=Open+Sans&display=swap' rel='stylesheet'>
        |<link href='styles.css' rel='stylesheet'>
        |<link href='favicon.png' rel='icon'>
        |<script type='module' src='./index.js'></script>
@@ -1378,17 +1380,32 @@ object HtmlDocumentor {
     * The result will be appended to the given `StringBuilder`, `sb`.
     */
   private def docDoc(doc: Doc)(implicit sb: StringBuilder): Unit = {
+    renderDoc(doc, "doc")
+  }
+
+  /**
+    * Renders a module-level [[Doc]] using the `mod-doc` CSS class.
+    *
+    * Module-level documentation uses its own class so it can carry distinct
+    * typography from item-level docs (e.g. larger font, different family).
+    */
+  private def modDoc(doc: Doc)(implicit sb: StringBuilder): Unit = {
+    renderDoc(doc, "mod-doc")
+  }
+
+  private def renderDoc(doc: Doc, cls: String)(implicit sb: StringBuilder): Unit = {
     val text = doc.text
     if (text.isBlank) {
       return
     }
 
-    val parser = Parser.builder().build()
+    val extensions = java.util.List.of(TablesExtension.create())
+    val parser = Parser.builder().extensions(extensions).build()
     val node = parser.parse(text)
-    val renderer = HtmlRenderer.builder().escapeHtml(true).build()
+    val renderer = HtmlRenderer.builder().extensions(extensions).escapeHtml(true).build()
     val html = renderer.render(node)
 
-    sb.append("<div class='doc'>")
+    sb.append(s"<div class='$cls'>")
     sb.append(html)
     sb.append("</div>")
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -648,8 +648,13 @@ object Weeder2 {
       docTree match {
         case None => Validation.Success(Doc(List.empty, tree0.loc))
         case Some(tree) =>
-          // strip prefixing `///` and trim
-          var lines = text(tree).map(_.stripPrefix("///").trim)
+          // Strip the `///` prefix, one optional separator space, and trailing whitespace.
+          // Internal indentation is preserved so that code blocks and ASCII layout survive.
+          var lines = text(tree).map { s =>
+            val s1 = s.stripPrefix("///")
+            val s2 = if (s1.startsWith(" ")) s1.drop(1) else s1
+            s2.stripTrailing()
+          }
           // Drop first/last line if it is empty
           if (lines.headOption.exists(_.isEmpty)) {
             lines = lines.tail

--- a/main/src/library/Fs.flix
+++ b/main/src/library/Fs.flix
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-/// Effect Hierarchy ([D] = has @DefaultHandler):
+/// ## Effect Hierarchy
 ///
+/// `[D]` = has `@DefaultHandler`.
+///
+/// ```
 /// FileSystem [D]                      (29 ops — unified root)
 /// ├── FileStat [D]                    (11 ops)
 /// │   ├── FileTest [D]                (4 ops)
@@ -52,29 +55,31 @@
 ///     ├── MkDir                             — mkDir
 ///     ├── MkDirs                            — mkDirs
 ///     └── MkTempDir                         — mkTempDir
+/// ```
 ///
-/// Middleware Availability:
+/// ## Middleware Availability
 ///
-///                    FileTest  FilePermission  FileTime  FileStat  FileRead  DirList  Glob  FileWrite  FileSystem
-/// withLogging        x         x               x         x         x         x        x     x          x
-/// withBaseDir        x         x               x         x         x         x        x     x          x
-/// withChroot         x         x               x         x         x         x        x     x          x
-/// withAllowList      x         x               x         x         x         x        x     x          x
-/// withDenyList       x         x               x         x         x         x        x     x          x
-/// withAllowGlob      x         x               x         x         x         x        x     x          x
-/// withDenyGlob       x         x               x         x         x         x        x     x          x
-/// withFollowLinks    x         x               x         x         x         x        x     x          x
-/// withTransferLimit                                                x                        x          x
-/// withChecksum                                                     x                        x          x
-/// withDryRun                                                                                x          x
-/// withReadOnly                                                                              x          x
-/// withAtomicWrite                                                                           x          x
-/// withBackup                                                                                x          x
-/// withConflictCheck                                                                         x          x
-/// withMkParentDirs                                                                          x          x
-/// withSizeRotation                                                                          x          x
-/// withMemoryOverlay                                                                                    x
-/// withInMemoryFS                                                                                       x
+/// |                   | FileTest | FilePermission | FileTime | FileStat | FileRead | DirList | Glob | FileWrite | FileSystem |
+/// |-------------------|:--------:|:--------------:|:--------:|:--------:|:--------:|:-------:|:----:|:---------:|:----------:|
+/// | withLogging       | x        | x              | x        | x        | x        | x       | x    | x         | x          |
+/// | withBaseDir       | x        | x              | x        | x        | x        | x       | x    | x         | x          |
+/// | withChroot        | x        | x              | x        | x        | x        | x       | x    | x         | x          |
+/// | withAllowList     | x        | x              | x        | x        | x        | x       | x    | x         | x          |
+/// | withDenyList      | x        | x              | x        | x        | x        | x       | x    | x         | x          |
+/// | withAllowGlob     | x        | x              | x        | x        | x        | x       | x    | x         | x          |
+/// | withDenyGlob      | x        | x              | x        | x        | x        | x       | x    | x         | x          |
+/// | withFollowLinks   | x        | x              | x        | x        | x        | x       | x    | x         | x          |
+/// | withTransferLimit |          |                |          |          | x        |         |      | x         | x          |
+/// | withChecksum      |          |                |          |          | x        |         |      | x         | x          |
+/// | withDryRun        |          |                |          |          |          |         |      | x         | x          |
+/// | withReadOnly      |          |                |          |          |          |         |      | x         | x          |
+/// | withAtomicWrite   |          |                |          |          |          |         |      | x         | x          |
+/// | withBackup        |          |                |          |          |          |         |      | x         | x          |
+/// | withConflictCheck |          |                |          |          |          |         |      | x         | x          |
+/// | withMkParentDirs  |          |                |          |          |          |         |      | x         | x          |
+/// | withSizeRotation  |          |                |          |          |          |         |      | x         | x          |
+/// | withMemoryOverlay |          |                |          |          |          |         |      |           | x          |
+/// | withInMemoryFS    |          |                |          |          |          |         |      |           | x          |
 pub mod Fs {
     /* empty */
 }

--- a/main/src/resources/doc/styles.css
+++ b/main/src/resources/doc/styles.css
@@ -618,6 +618,23 @@ main h2 {
     color: var(--doc-code-color);
 }
 
+.mod-doc {
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
+
+    max-width: 60rem;
+
+    font-family: "Open Sans", sans-serif;
+    font-size: 1rem;
+}
+.mod-doc p {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+.mod-doc p:last-child {
+    margin-bottom: 0;
+}
+
 code {
     font-family: "Fira Code", monospace;
 }


### PR DESCRIPTION
## Summary

- **Preserve doc-comment indentation**: `Weeder2.pickDocumentation` and `Doc.text` no longer trim each line. The weeder now strips just the `///` prefix and one optional separator space, then rstrips trailing whitespace. Internal indentation survives so that Markdown fenced code blocks and ASCII layouts (like the Effect Hierarchy in `Fs.flix`) round-trip cleanly.
- **`modDoc` helper + `mod-doc` CSS class**: module-level documentation now renders via a separate `modDoc` helper that wraps in `<div class='mod-doc'>` instead of `<div class='doc'>`. The new class uses Open Sans at 1rem with a 60rem max-width and no left margin, giving module pages a more readable, prose-oriented look distinct from item-level docs.
- **GFM tables**: registers `commonmark-ext-gfm-tables` so Markdown tables in doc comments render as real `<table>` elements with `<thead>`/`<tbody>`.
- **`Fs.flix`**: converted the existing prose labels into `## Effect Hierarchy` and `## Middleware Availability` headings, fenced the effect-hierarchy tree, and rewrote the middleware availability matrix as a Markdown table. All three improvements (indentation, fenced code, table) are visible on the rendered Fs page.

## Test plan

- [x] `./mill flix.compile`
- [x] `./mill flix.assembly` and `flix doc` — `build/doc/Fs.html` renders the tree with intact indentation, the table as a real `<table>`, and `<h2>` section headings under the module page
- [x] `./mill flix.test.testForked -oC` (run before merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)