### PR TITLE
chore: reformat library (batch 1)

### DIFF
--- a/main/src/library/Float32.flix
+++ b/main/src/library/Float32.flix
@@ -110,9 +110,9 @@ pub mod Float32 {
     ///
     pub def fromString(s: String): Option[Float32] = try {
         Some(Float.parseFloat(s.strip()))
-     } catch {
-         case _: NumberFormatException => None
-     }
+    } catch {
+        case _: NumberFormatException => None
+    }
 
     ///
     /// Convert `x` to an `Option[Int8]`.
@@ -212,12 +212,11 @@ pub mod Float32 {
     ///
     def clamp(min: {min = Float32}, max: {max = Float32}, x: Float32): Float32 =
         if (x < min#min)
-             min#min
+            min#min
+        else if (x > max#max)
+            max#max
         else
-            if (x > max#max)
-                max#max
-            else
-                x
+            x
 
     ///
     /// Convert `x` to an `Int8`.

--- a/main/src/library/Float64.flix
+++ b/main/src/library/Float64.flix
@@ -230,12 +230,11 @@ pub mod Float64 {
     ///
     def clamp(min: {min = Float64}, max: {max = Float64}, x: Float64): Float64 =
         if (x < min#min)
-             min#min
+            min#min
+        else if (x > max#max)
+            max#max
         else
-            if (x > max#max)
-                max#max
-            else
-                x
+            x
 
     ///
     /// Convert `x` to an `Int8`.

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -59,9 +59,12 @@ pub mod Int16 {
     /// If the absolute value exceeds maxValue(), -1 is returned.
     ///
     pub def abs(x: Int16): Int16 = {
-        if      (x >= 0i16)         x
-        else if (x == minValue())   -1i16
-        else                        -x
+        if (x >= 0i16)
+            x
+        else if (x == minValue())
+            -1i16
+        else
+            -x
     }
 
     ///
@@ -91,11 +94,16 @@ pub mod Int16 {
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
     pub def dist(x: Int16, y: Int16): Int16 = {
-        if      (x >= 0i16 and y >= 0i16)               abs(x - y)
-        else if (x < 0i16 and y < 0i16)                 abs(x - y)
-        else if (x == minValue() or y == minValue())    -1i16
-        else if (minValue() + abs(x) + abs(y) >= 0i16)  -1i16
-        else                                            abs(x - y)
+        if (x >= 0i16 and y >= 0i16)
+            abs(x - y)
+        else if (x < 0i16 and y < 0i16)
+            abs(x - y)
+        else if (x == minValue() or y == minValue())
+            -1i16
+        else if (minValue() + abs(x) + abs(y) >= 0i16)
+            -1i16
+        else
+            abs(x - y)
     }
 
     ///
@@ -103,9 +111,12 @@ pub mod Int16 {
     /// The sign of x - y.
     ///
     pub def compare(x: Int16, y: Int16): Int32 = {
-        if      (x == y)    0
-        else if (x < y)     -1
-        else                1
+        if (x == y)
+            0
+        else if (x < y)
+            -1
+        else
+            1
     }
 
     ///
@@ -135,9 +146,12 @@ pub mod Int16 {
     /// representation of `x`.
     ///
     pub def bitCount(x: Int16): Int32 = {
-        if      (x == 0i16)            0
-        else if (x `remainder` 2i16 != 0i16) bitCount(logicalRightShift(dist = 1, x)) + 1
-        else                           bitCount(logicalRightShift(dist = 1, x))
+        if (x == 0i16)
+            0
+        else if (x `remainder` 2i16 != 0i16)
+            bitCount(logicalRightShift(dist = 1, x)) + 1
+        else
+            bitCount(logicalRightShift(dist = 1, x))
     }
 
     ///
@@ -162,13 +176,13 @@ pub mod Int16 {
     /// Returns the value obtained by reversing the bits in the
     /// two's complement binary representation of `x`.
     ///
-    pub def reverse(x: Int16): Int16 = reverseHelper(x, 0, size()-1)
+    pub def reverse(x: Int16): Int16 = reverseHelper(x, 0, size() - 1)
 
     ///
     /// Helper function for `reverse`.
     ///
     def reverseHelper(x: Int16, l: Int32, r: Int32): Int16 =
-        if (l >= r) x else reverseHelper(swap(x, l, r), l+1, r-1)
+        if (l >= r) x else reverseHelper(swap(x, l, r), l + 1, r - 1)
 
     ///
     /// Helper function for `reverse`.
@@ -176,7 +190,7 @@ pub mod Int16 {
     def swap(x: Int16, l: Int32, r: Int32): Int16 = match (getBit(pos = l, x), getBit(pos = r, x)) {
         case (1, 0) => clearBit(pos = l, setBit(pos = r, x))
         case (0, 1) => clearBit(pos = r, setBit(pos = l, x))
-        case _ => x
+        case _      => x
     }
 
     ///
@@ -203,11 +217,16 @@ pub mod Int16 {
     /// Otherwise recursively check the next bit in the same way.
     ///
     def oneBitPositionHelper(x: Int16, position: Int32, delta: Int32): Int32 = {
-        if      (position < 0)                   -1
-        else if (position > (size() - 1))        -1
-        else if (getBit(pos = position, x) == 1) position
-        else if (delta == 0)                     -1
-        else                                     oneBitPositionHelper(x, position + delta, delta)
+        if (position < 0)
+            -1
+        else if (position > (size() - 1))
+            -1
+        else if (getBit(pos = position, x) == 1)
+            position
+        else if (delta == 0)
+            -1
+        else
+            oneBitPositionHelper(x, position + delta, delta)
     }
 
     ///
@@ -408,12 +427,11 @@ pub mod Int16 {
     ///
     def clamp(min: {min = Int16}, max: {max = Int16}, x: Int16): Int16 =
         if (x < min#min)
-             min#min
+            min#min
+        else if (x > max#max)
+            max#max
         else
-            if (x > max#max)
-                max#max
-            else
-                x
+            x
 
     ///
     /// Convert `x` to an `Int8`.

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -59,9 +59,12 @@ pub mod Int32 {
     /// If the absolute value exceeds maxValue(), -1 is returned.
     ///
     pub def abs(x: Int32): Int32 = {
-        if      (x >= 0)            x
-        else if (x == minValue())   -1
-        else                        -x
+        if (x >= 0)
+            x
+        else if (x == minValue())
+            -1
+        else
+            -x
     }
 
     ///
@@ -91,11 +94,16 @@ pub mod Int32 {
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
     pub def dist(x: Int32, y: Int32): Int32 = {
-        if      (x >= 0 and y >= 0)                     abs(x - y)
-        else if (x < 0 and y < 0)                       abs(x - y)
-        else if (x == minValue() or y == minValue())    -1
-        else if (minValue() + abs(x) + abs(y) >= 0)     -1
-        else                                            abs(x - y)
+        if (x >= 0 and y >= 0)
+            abs(x - y)
+        else if (x < 0 and y < 0)
+            abs(x - y)
+        else if (x == minValue() or y == minValue())
+            -1
+        else if (minValue() + abs(x) + abs(y) >= 0)
+            -1
+        else
+            abs(x - y)
     }
 
     ///
@@ -103,9 +111,12 @@ pub mod Int32 {
     /// The sign of x - y.
     ///
     pub def compare(x: Int32, y: Int32): Int32 = {
-        if      (x == y)    0
-        else if (x < y)     -1
-        else                1
+        if (x == y)
+            0
+        else if (x < y)
+            -1
+        else
+            1
     }
 
     ///
@@ -135,9 +146,12 @@ pub mod Int32 {
     /// representation of `x`.
     ///
     pub def bitCount(x: Int32): Int32 = {
-        if      (x == 0)         0
-        else if (x `remainder` 2 != 0) bitCount(logicalRightShift(dist = 1, x)) + 1
-        else                           bitCount(logicalRightShift(dist = 1, x))
+        if (x == 0)
+            0
+        else if (x `remainder` 2 != 0)
+            bitCount(logicalRightShift(dist = 1, x)) + 1
+        else
+            bitCount(logicalRightShift(dist = 1, x))
     }
 
     ///
@@ -158,13 +172,13 @@ pub mod Int32 {
     /// Returns the value obtained by reversing the bits in the
     /// two's complement binary representation of `x`.
     ///
-    pub def reverse(x: Int32): Int32 = reverseHelper(x, 0, size()-1)
+    pub def reverse(x: Int32): Int32 = reverseHelper(x, 0, size() - 1)
 
     ///
     /// Helper function for `reverse`.
     ///
     def reverseHelper(x: Int32, l: Int32, r: Int32): Int32 =
-        if (l >= r) x else reverseHelper(swap(x, l, r), l+1, r-1)
+        if (l >= r) x else reverseHelper(swap(x, l, r), l + 1, r - 1)
 
     ///
     /// Helper function for `reverse`.
@@ -172,7 +186,7 @@ pub mod Int32 {
     def swap(x: Int32, l: Int32, r: Int32): Int32 = match (getBit(pos = l, x), getBit(pos = r, x)) {
         case (1, 0) => clearBit(pos = l, setBit(pos = r, x))
         case (0, 1) => clearBit(pos = r, setBit(pos = l, x))
-        case _ => x
+        case _      => x
     }
 
     ///
@@ -199,11 +213,16 @@ pub mod Int32 {
     /// Otherwise recursively check the next bit in the same way.
     ///
     def oneBitPositionHelper(x: Int32, position: Int32, delta: Int32): Int32 = {
-        if      (position < 0)                   -1
-        else if (position > size() - 1)          -1
-        else if (getBit(pos = position, x) == 1) position
-        else if (delta == 0)                     -1
-        else                                     oneBitPositionHelper(x, position + delta, delta)
+        if (position < 0)
+            -1
+        else if (position > size() - 1)
+            -1
+        else if (getBit(pos = position, x) == 1)
+            position
+        else if (delta == 0)
+            -1
+        else
+            oneBitPositionHelper(x, position + delta, delta)
     }
 
     ///
@@ -367,7 +386,7 @@ pub mod Int32 {
     /// (i.e. -128 to 127).
     ///
     pub def tryToInt8(x: Int32): Option[Int8] =
-       if (x < Int8.toInt32(Int8.minValue()) or x > Int8.toInt32(Int8.maxValue()))
+        if (x < Int8.toInt32(Int8.minValue()) or x > Int8.toInt32(Int8.maxValue()))
             None
         else
             Some(Integer.valueOf(x).byteValue())
@@ -408,7 +427,7 @@ pub mod Int32 {
     /// The numeric value of `x` may lose precision.
     ///
     pub def toFloat32(x: Int32): Float32 =
-         Integer.valueOf(x).floatValue()
+        Integer.valueOf(x).floatValue()
 
     ///
     /// Convert `x` to a Float64.
@@ -431,12 +450,11 @@ pub mod Int32 {
     ///
     def clamp(min: {min = Int32}, max: {max = Int32}, x: Int32): Int32 =
         if (x < min#min)
-             min#min
+            min#min
+        else if (x > max#max)
+            max#max
         else
-            if (x > max#max)
-                max#max
-            else
-                x
+            x
 
     ///
     /// Convert `x` to an `Int8`.
@@ -447,7 +465,6 @@ pub mod Int32 {
         let mini32 = Int8.toInt32(min#min);
         let maxi32 = Int8.toInt32(max#max);
         Integer.valueOf(clamp(min = mini32, max = maxi32, x)).byteValue()
-
 
     ///
     /// Convert `x` to an `Int16`.

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -59,9 +59,12 @@ pub mod Int64 {
     /// If the absolute value exceeds maxValue(), -1 is returned.
     ///
     pub def abs(x: Int64): Int64 = {
-        if      (x >= 0i64)         x
-        else if (x == minValue())   -1i64
-        else                        -x
+        if (x >= 0i64)
+            x
+        else if (x == minValue())
+            -1i64
+        else
+            -x
     }
 
     ///
@@ -91,11 +94,16 @@ pub mod Int64 {
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
     pub def dist(x: Int64, y: Int64): Int64 = {
-        if (x >= 0i64 and y >= 0i64)                    abs(x - y)
-        else if (x < 0i64 and y < 0i64)                 abs(x - y)
-        else if (x == minValue() or y == minValue())    -1i64
-        else if (minValue() + abs(x) + abs(y) >= 0i64)  -1i64
-        else                                            abs(x - y)
+        if (x >= 0i64 and y >= 0i64)
+            abs(x - y)
+        else if (x < 0i64 and y < 0i64)
+            abs(x - y)
+        else if (x == minValue() or y == minValue())
+            -1i64
+        else if (minValue() + abs(x) + abs(y) >= 0i64)
+            -1i64
+        else
+            abs(x - y)
     }
 
     ///
@@ -103,9 +111,12 @@ pub mod Int64 {
     /// The sign of x - y.
     ///
     pub def compare(x: Int64, y: Int64): Int32 = {
-        if (x == y)     0
-        else if (x < y) -1
-        else            1
+        if (x == y)
+            0
+        else if (x < y)
+            -1
+        else
+            1
     }
 
     ///
@@ -135,9 +146,12 @@ pub mod Int64 {
     /// representation of `x`.
     ///
     pub def bitCount(x: Int64): Int32 = {
-        if      (x == 0i64)            0
-        else if (x `remainder` 2i64 != 0i64) bitCount(logicalRightShift(dist = 1, x)) + 1
-        else                           bitCount(logicalRightShift(dist = 1, x))
+        if (x == 0i64)
+            0
+        else if (x `remainder` 2i64 != 0i64)
+            bitCount(logicalRightShift(dist = 1, x)) + 1
+        else
+            bitCount(logicalRightShift(dist = 1, x))
     }
 
     ///
@@ -158,13 +172,13 @@ pub mod Int64 {
     /// Returns the value obtained by reversing the bits in the
     /// two's complement binary representation of `x`.
     ///
-    pub def reverse(x: Int64): Int64 = reverseHelper(x, 0, size()-1)
+    pub def reverse(x: Int64): Int64 = reverseHelper(x, 0, size() - 1)
 
     ///
     /// Helper function for `reverse`.
     ///
     def reverseHelper(x: Int64, l: Int32, r: Int32): Int64 =
-        if (l >= r) x else reverseHelper(swap(x, l, r), l+1, r-1)
+        if (l >= r) x else reverseHelper(swap(x, l, r), l + 1, r - 1)
 
     ///
     /// Helper function for `reverse`.
@@ -172,7 +186,7 @@ pub mod Int64 {
     def swap(x: Int64, l: Int32, r: Int32): Int64 = match (getBit(pos = l, x), getBit(pos = r, x)) {
         case (1, 0) => clearBit(pos = l, setBit(pos = r, x))
         case (0, 1) => clearBit(pos = r, setBit(pos = l, x))
-        case _ => x
+        case _      => x
     }
 
     ///
@@ -199,11 +213,16 @@ pub mod Int64 {
     /// Otherwise recursively check the next bit in the same way.
     ///
     def oneBitPositionHelper(x: Int64, position: Int32, delta: Int32): Int32 = {
-        if (position < 0)                        -1
-        else if (position > (size() - 1))        -1
-        else if (getBit(pos = position, x) == 1) position
-        else if (delta == 0)                     -1
-        else                                     oneBitPositionHelper(x, position + delta, delta)
+        if (position < 0)
+            -1
+        else if (position > (size() - 1))
+            -1
+        else if (getBit(pos = position, x) == 1)
+            position
+        else if (delta == 0)
+            -1
+        else
+            oneBitPositionHelper(x, position + delta, delta)
     }
 
     ///
@@ -435,12 +454,11 @@ pub mod Int64 {
     ///
     def clamp(min: {min = Int64}, max: {max = Int64}, x: Int64): Int64 =
         if (x < min#min)
-             min#min
+            min#min
+        else if (x > max#max)
+            max#max
         else
-            if (x > max#max)
-                max#max
-            else
-                x
+            x
 
     ///
     /// Convert `x` to an `Int8`.
@@ -461,7 +479,6 @@ pub mod Int64 {
         let mini64 = Int16.toInt64(min#min);
         let maxi64 = Int16.toInt64(max#max);
         Long.valueOf(clamp(min = mini64, max = maxi64, x)).shortValue()
-
 
     ///
     /// Convert `x` to an `Int32`.

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -59,9 +59,12 @@ pub mod Int8 {
     /// If the absolute value exceeds maxValue(), -1 is returned.
     ///
     pub def abs(x: Int8): Int8 = {
-        if      (x >= 0i8)          x
-        else if (x == minValue())   -1i8
-        else                        -x
+        if (x >= 0i8)
+            x
+        else if (x == minValue())
+            -1i8
+        else
+            -x
     }
 
     ///
@@ -91,11 +94,16 @@ pub mod Int8 {
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
     pub def dist(x: Int8, y: Int8): Int8 = {
-        if      (x >= 0i8 and y >= 0i8)                 abs(x - y)
-        else if (x < 0i8 and y < 0i8)                   abs(x - y)
-        else if (x == minValue() or y == minValue())    -1i8
-        else if (minValue() + abs(x) + abs(y) >= 0i8)   -1i8
-        else                                            abs(x - y)
+        if (x >= 0i8 and y >= 0i8)
+            abs(x - y)
+        else if (x < 0i8 and y < 0i8)
+            abs(x - y)
+        else if (x == minValue() or y == minValue())
+            -1i8
+        else if (minValue() + abs(x) + abs(y) >= 0i8)
+            -1i8
+        else
+            abs(x - y)
     }
 
     ///
@@ -103,9 +111,12 @@ pub mod Int8 {
     /// The sign of x - y.
     ///
     pub def compare(x: Int8, y: Int8): Int32 = {
-        if      (x == y)    0
-        else if (x < y)     -1
-        else                1
+        if (x == y)
+            0
+        else if (x < y)
+            -1
+        else
+            1
     }
 
     ///
@@ -118,7 +129,6 @@ pub mod Int8 {
     /// Returns `base` raised to the power of `n`.
     ///
     pub def pow(base: {base = Int8}, n: Int8): Int8 = %%INT8_EXP%%(base#base, n)
-
 
     ///
     /// Returns the logical right shift of `x` by `distance`.
@@ -136,9 +146,12 @@ pub mod Int8 {
     /// representation of `x`.
     ///
     pub def bitCount(x: Int8): Int32 = {
-        if      (x == 0i8)           0
-        else if (x `remainder` 2i8 != 0i8) bitCount(logicalRightShift(dist = 1, x)) + 1
-        else                         bitCount(logicalRightShift(dist = 1, x))
+        if (x == 0i8)
+            0
+        else if (x `remainder` 2i8 != 0i8)
+            bitCount(logicalRightShift(dist = 1, x)) + 1
+        else
+            bitCount(logicalRightShift(dist = 1, x))
     }
 
     ///
@@ -163,13 +176,13 @@ pub mod Int8 {
     /// Returns the value obtained by reversing the bits in the
     /// two's complement binary representation of `x`.
     ///
-    pub def reverse(x: Int8): Int8 = reverseHelper(x, 0, size()-1)
+    pub def reverse(x: Int8): Int8 = reverseHelper(x, 0, size() - 1)
 
     ///
     /// Helper function for `reverse`.
     ///
     def reverseHelper(x: Int8, l: Int32, r: Int32): Int8 =
-        if (l >= r) x else reverseHelper(swap(x, l, r), l+1, r-1)
+        if (l >= r) x else reverseHelper(swap(x, l, r), l + 1, r - 1)
 
     ///
     /// Helper function for `reverse`.
@@ -177,7 +190,7 @@ pub mod Int8 {
     def swap(x: Int8, l: Int32, r: Int32): Int8 = match (getBit(pos = l, x), getBit(pos = r, x)) {
         case (1, 0) => clearBit(pos = l, setBit(pos = r, x))
         case (0, 1) => clearBit(pos = r, setBit(pos = l, x))
-        case _ => x
+        case _      => x
     }
 
     ///
@@ -204,11 +217,16 @@ pub mod Int8 {
     /// Otherwise recursively check the next bit in the same way.
     ///
     def oneBitPositionHelper(x: Int8, position: Int32, delta: Int32): Int32 = {
-        if      (position < 0)                   -1
-        else if (position > (size() - 1))        -1
-        else if (getBit(pos = position, x) == 1) position
-        else if (delta == 0)                     -1
-        else                                     oneBitPositionHelper(x, position + delta, delta)
+        if (position < 0)
+            -1
+        else if (position > (size() - 1))
+            -1
+        else if (getBit(pos = position, x) == 1)
+            position
+        else if (delta == 0)
+            -1
+        else
+            oneBitPositionHelper(x, position + delta, delta)
     }
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 pub mod List {
     use Math.Shuffle
 
@@ -25,7 +24,7 @@ pub mod List {
     /// an element `v` followed by a list `vs` represented by `v :: vs`.
     ///
     pub enum List[t] {
-        case Nil,
+        case Nil
         case Cons(t, List[t])
     }
 
@@ -48,9 +47,9 @@ pub mod List {
     instance Eq[List[a]] with Eq[a] {
         @Terminates @Tailrec
         pub def eq(l1: List[a], l2: List[a]): Bool = match (l1, l2) {
-            case (Nil, Nil) => true
+            case (Nil, Nil)         => true
             case (x :: rs, y :: qs) => if (x != y) false else rs == qs
-            case _ => false
+            case _                  => false
         }
     }
 
@@ -61,9 +60,9 @@ pub mod List {
         ///
         @Terminates @Tailrec
         pub def compare(l1: List[a], l2: List[a]): Comparison = match (l1, l2) {
-            case (_ :: _, Nil) => Comparison.GreaterThan
-            case (Nil, Nil) => Comparison.EqualTo
-            case (Nil, _ :: _) => Comparison.LessThan
+            case (_ :: _, Nil)      => Comparison.GreaterThan
+            case (Nil, Nil)         => Comparison.EqualTo
+            case (Nil, _ :: _)      => Comparison.LessThan
             case (z :: zs, w :: ws) =>
                 let cmp = z <=> w;
                 if (cmp == Comparison.EqualTo) zs <=> ws else cmp
@@ -76,12 +75,12 @@ pub mod List {
     }
 
     instance Applicative[List] {
-        pub def point(a: a) : List[a] = List.point(a)
-        pub def ap(f: List[a -> b \ ef], x: List[a]) : List[b] \ ef = List.ap(f, x)
+        pub def point(a: a): List[a] = List.point(a)
+        pub def ap(f: List[a -> b \ ef], x: List[a]): List[b] \ ef = List.ap(f, x)
     }
 
     instance Monad[List] {
-        pub def flatMap(f: a -> List[b] \ ef, x : List[a]) : List[b] \ ef = List.flatMap(f, x)
+        pub def flatMap(f: a -> List[b] \ ef, x: List[a]): List[b] \ ef = List.flatMap(f, x)
     }
 
     instance MonadZero[List] {
@@ -154,8 +153,9 @@ pub mod List {
     pub def toString(l: List[a]): String with ToString[a] = region rc {
         List.iterator(rc, l)
             |> Iterator.map(ToString.toString)
-            |> xs -> Iterator.append(xs, Iterator.singleton(rc, "Nil"))
-            |> Iterator.join(" :: ")
+            |> xs ->
+                Iterator.append(xs, Iterator.singleton(rc, "Nil"))
+                    |> Iterator.join(" :: ")
     }
 
     ///
@@ -445,14 +445,14 @@ pub mod List {
     /// Return the singleton list with element `x`.
     ///
     @Terminates
-    pub def point(a: a) : List[a] = a :: Nil
+    pub def point(a: a): List[a] = a :: Nil
 
     ///
     /// Apply every function from `f` to every argument from `x` and return a list with all results.
     /// For `f = f1, f2, ...` and `x = x1, x2, ...` the results appear in the order
     /// `f1(x1), f1(x2), ..., f2(x1), f2(x2), ...`.
     ///
-    pub def ap(f: List[a -> b \ ef], x: List[a]) : List[b] \ ef =
+    pub def ap(f: List[a -> b \ ef], x: List[a]): List[b] \ ef =
         map(g -> map(g, x), f) |> flatten
 
     ///
@@ -592,7 +592,7 @@ pub mod List {
                 else
                     loop(l1, ys, c + 1, y :: acc)
             }
-            case _ => reverseAppend(acc, ll2)
+            case _                  => reverseAppend(acc, ll2)
         };
         loop(drop(-i, l1), l2, 0, Nil)
 
@@ -622,7 +622,7 @@ pub mod List {
     def at(i: Int32, l: List[a]): a = match (i, l) {
         case (0, x :: _)  => x
         case (p, _ :: xs) => at(p - 1, xs)
-        case _ => unreachable!()
+        case _            => unreachable!()
     }
 
     ///
@@ -630,7 +630,7 @@ pub mod List {
     ///
     @Terminates
     def removeIndex(i: Int32, l: List[a]): List[a] = match (i, l) {
-        case (_, Nil) => l
+        case (_, Nil)     => l
         case (0, _ :: xs) => xs
         case (p, x :: xs) => x :: removeIndex(p - 1, xs)
     }
@@ -700,9 +700,9 @@ pub mod List {
     pub def intersperse(a: a, l: List[a]): List[a] =
         @Tailrec
         def loop(ll, acc) = match ll {
-            case x1 :: Nil      => x1 :: acc
-            case x1 :: xs       => loop(xs, a :: x1 :: acc)
-            case _              => unreachable!()
+            case x1 :: Nil => x1 :: acc
+            case x1 :: xs  => loop(xs, a :: x1 :: acc)
+            case _         => unreachable!()
         };
         match l {
             case Nil => Nil
@@ -717,13 +717,13 @@ pub mod List {
     pub def intercalate(l1: List[a], l2: List[List[a]]): List[a] =
         @Tailrec
         def loop(ll, acc) = match ll {
-            case x :: Nil       => reverseAppend(x, acc)
-            case x1 :: xs       => loop(xs, reverseAppend(l1, reverseAppend(x1, acc)))
-            case _              => unreachable!()
+            case x :: Nil => reverseAppend(x, acc)
+            case x1 :: xs => loop(xs, reverseAppend(l1, reverseAppend(x1, acc)))
+            case _        => unreachable!()
         };
         match l2 {
             case Nil => Nil
-            case _ => reverse(loop(l2, Nil))
+            case _   => reverse(loop(l2, Nil))
         }
 
     ///
@@ -848,7 +848,7 @@ pub mod List {
             case x :: xs => loop(xs, f(x, acc))
         };
         match reverse(l) {
-            case Nil => None
+            case Nil     => None
             case x :: xs => loop(xs, x)
         }
 
@@ -918,7 +918,7 @@ pub mod List {
         };
         match l {
             case Nil => None
-            case _ => Some(reverse(loop(l, Nil)))
+            case _   => Some(reverse(loop(l, Nil)))
         }
 
     ///
@@ -1059,9 +1059,13 @@ pub mod List {
     /// The function `f` must be pure and define an equivalence relation.
     ///
     pub def groupWith(f: (a, a) -> Bool, l: List[a]): List[Nel[a]] =
-        (Nil, l) ||> List.foldLeft(acc -> value -> {
-            groupWithHelper(value, f, acc)
-        }) |> List.map(Nel.reverse)
+        (Nil, l)
+            ||> List.foldLeft(
+                acc -> value -> {
+                    groupWithHelper(value, f, acc)
+                }
+            )
+            |> List.map(Nel.reverse)
 
     ///
     /// Partitions `l` into sublists such that for any two elements `x` and `y` in a sublist,
@@ -1087,7 +1091,7 @@ pub mod List {
         // Record seen elements in reverse order in `acc`.
         @Tailrec
         def loop(cur, acc) = match cur {
-            case Nil => (Nel.singleton(value) :: acc) |> List.reverse
+            case Nil     => (Nel.singleton(value) :: acc) |> List.reverse
             case x :: xs =>
                 if (f(value, Nel.head(x))) {
                     let newNel = Nel.cons(value, x);
@@ -1126,7 +1130,7 @@ pub mod List {
             case (x :: xs, y :: ys) =>
                 let z = f(x, y);
                 loop(xs, ys, z :: acc)
-            case _ => acc
+            case _                  => acc
         };
         reverse(loop(l1, l2, Nil))
 
@@ -1195,7 +1199,7 @@ pub mod List {
             case (x :: xs, y :: ys, z :: zs) =>
                 let r = f(x, y, z);
                 loop(xs, ys, zs, r :: acc)
-            case _ => acc
+            case _                           => acc
         };
         reverse(loop(l1, l2, l3, Nil))
 
@@ -1257,10 +1261,11 @@ pub mod List {
         @Tailrec
         def loop(ll, acc) = match ll {
             case Nil     => acc
-            case x :: xs => match f(x) {
-                case None    => loop(xs, acc)
-                case Some(v) => loop(xs, v :: acc)
-            }
+            case x :: xs =>
+                match f(x) {
+                    case None    => loop(xs, acc)
+                    case Some(v) => loop(xs, v :: acc)
+                }
         };
         reverse(loop(l, Nil))
 
@@ -1272,10 +1277,11 @@ pub mod List {
     @Terminates @Tailrec
     pub def findMap(f: a -> Option[b] \ ef, l: List[a]): Option[b] \ ef = match l {
         case Nil     => None
-        case x :: xs => match f(x) {
-            case None    => findMap(f, xs)
-            case Some(v) => Some(v)
-        }
+        case x :: xs =>
+            match f(x) {
+                case None    => findMap(f, xs)
+                case Some(v) => Some(v)
+            }
     }
 
     ///
@@ -1318,10 +1324,14 @@ pub mod List {
     /// If multiple mappings with the same key are produced only the last occurrence is kept.
     ///
     pub def toMapWith(f: a -> (k, v) \ ef, l: List[a]): Map[k, v] \ ef with Order[k] =
-        foldLeft((acc, x) -> {
-            let (key, val) = f(x);
-            Map.insert(key, val, acc)
-        }, Map.empty(), l)
+        foldLeft(
+            (acc, x) -> {
+                let (key, val) = f(x);
+                Map.insert(key, val, acc)
+            },
+            Map.empty(),
+            l
+        )
 
     ///
     /// Applies `f` to every element of `l`.
@@ -1340,7 +1350,7 @@ pub mod List {
         @Tailrec
         def loop(ll, i) = match ll {
             case Nil     => ()
-            case x :: xs => f(i, x); loop(xs, i+1)
+            case x :: xs => f(i, x); loop(xs, i + 1)
         };
         loop(l, 0)
 
@@ -1414,7 +1424,7 @@ pub mod List {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(cmp: (a,a) -> Comparison, l: List[a]): List[a] = region rc {
+    pub def sortWith(cmp: (a, a) -> Comparison, l: List[a]): List[a] = region rc {
         toArray(rc, l) !> Array.sortWith(cmp) |> Array.toList
     }
 
@@ -1467,7 +1477,7 @@ pub mod List {
             case Err(e)      => Err(e)
         };
         match loop(Nil) {
-            case Ok(l) => Ok(reverse(l))
+            case Ok(l)    => Ok(reverse(l))
             case Err(err) => Err(err)
         }
 
@@ -1581,7 +1591,7 @@ pub mod List {
         @Tailrec
         def loop(ll, k) = match ll {
             case Nil     => k(Applicative.point(Nil))
-            case x :: xs => {let ans = f(x); loop(xs, ks -> k(consA(ans, ks)))}
+            case x :: xs => { let ans = f(x); loop(xs, ks -> k(consA(ans, ks))) }
         };
         loop(l, identity)
 
@@ -1595,11 +1605,13 @@ pub mod List {
         def loop(ll1, ll2, acc) = match (ll1, ll2) {
             case (x :: xs, y :: ys) => {
                 let cmp = x <=> y;
-                if (cmp == Comparison.LessThan or cmp == Comparison.EqualTo) loop(xs, ll2, x :: acc)
-                else                                   loop(ll1, ys, y :: acc)
+                if (cmp == Comparison.LessThan or cmp == Comparison.EqualTo)
+                    loop(xs, ll2, x :: acc)
+                else
+                    loop(ll1, ys, y :: acc)
             }
-            case (Nil    , _) => reverse(reverseAppend(ll2, acc))
-            case (_, Nil    ) => reverse(reverseAppend(ll1, acc))
+            case (Nil, _)           => reverse(reverseAppend(ll2, acc))
+            case (_, Nil)           => reverse(reverseAppend(ll1, acc))
         };
         loop(l1, l2, Nil)
 
@@ -1616,8 +1628,8 @@ pub mod List {
     pub def frequency(l: List[t]): Map[t, Int32] with Order[t] =
         @Tailrec
         def freq(ll, m) = match ll {
-            case Nil      => m
-            case x :: xs  =>
+            case Nil     => m
+            case x :: xs =>
                 match Map.get(x, m) {
                     case None    => freq(xs, Map.insert(x, 1, m))
                     case Some(_) => freq(xs, Map.update(v -> Some(v + 1), x, m))

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -24,7 +24,7 @@ pub mod Option {
     /// whereas the constructor `Some(v)` represents the value `v`.
     ///
     pub enum Option[t] with Eq, Order, ToString {
-        case None,
+        case None
         case Some(t)
     }
 
@@ -33,27 +33,27 @@ pub mod Option {
     }
 
     instance PartialOrder[Option[t]] with PartialOrder[t] {
-        pub def lessEqual(x: Option[t], y: Option[t]): Bool = match (x,y) {
-           case (None, _)           => true
-           case (Some(a), Some(b))  => PartialOrder.lessEqual(a,b)
-           case _                   => false
-       }
+        pub def lessEqual(x: Option[t], y: Option[t]): Bool = match (x, y) {
+            case (None, _)          => true
+            case (Some(a), Some(b)) => PartialOrder.lessEqual(a, b)
+            case _                  => false
+        }
     }
 
     instance JoinLattice[Option[t]] with JoinLattice[t] {
-        pub def leastUpperBound(x: Option[t], y: Option[t]): Option[t] = match (x,y) {
-           case (None, _)           => y
-           case (_, None)           => x
-           case (Some(a), Some(b))  => Some(JoinLattice.leastUpperBound(a,b))
-       }
+        pub def leastUpperBound(x: Option[t], y: Option[t]): Option[t] = match (x, y) {
+            case (None, _)          => y
+            case (_, None)          => x
+            case (Some(a), Some(b)) => Some(JoinLattice.leastUpperBound(a, b))
+        }
     }
 
     instance MeetLattice[Option[t]] with MeetLattice[t] {
-        pub def greatestLowerBound(x: Option[t], y: Option[t]): Option[t] = match (x,y) {
-           case (None, _)           => None
-           case (_, None)           => None
-           case (Some(a), Some(b))  => Some(MeetLattice.greatestLowerBound(a, b))
-       }
+        pub def greatestLowerBound(x: Option[t], y: Option[t]): Option[t] = match (x, y) {
+            case (None, _)          => None
+            case (_, None)          => None
+            case (Some(a), Some(b)) => Some(MeetLattice.greatestLowerBound(a, b))
+        }
     }
 
     instance Hash[Option[a]] with Hash[a] {
@@ -68,9 +68,9 @@ pub mod Option {
     }
 
     instance Applicative[Option] {
-        pub def point(x: a) : Option[a] = Option.point(x)
+        pub def point(x: a): Option[a] = Option.point(x)
 
-        pub def ap(f: Option[a -> b \ ef], x: Option[a]) : Option[b] \ ef = Option.ap(f, x)
+        pub def ap(f: Option[a -> b \ ef], x: Option[a]): Option[b] \ ef = Option.ap(f, x)
 
         // Same as the default implementation using `map` and `ap` but with less indirection.
         redef map2(f: t1 -> t2 -> r \ ef, x1: Option[t1], x2: Option[t2]): Option[r] \ ef = Option.map2(f, x1, x2)
@@ -80,7 +80,7 @@ pub mod Option {
     }
 
     instance Monad[Option] {
-        pub def flatMap(f: a -> Option[b] \ ef, x : Option[a]) : Option[b] \ ef = Option.flatMap(f, x)
+        pub def flatMap(f: a -> Option[b] \ ef, x: Option[a]): Option[b] \ ef = Option.flatMap(f, x)
     }
 
     instance MonadZero[Option] {
@@ -116,7 +116,7 @@ pub mod Option {
             use Applicative.{point};
             use Functor.{map};
             match t {
-                case None => point(None)
+                case None    => point(None)
                 case Some(a) => f(a) |> map(Some)
             }
 
@@ -125,7 +125,7 @@ pub mod Option {
             use Functor.{map};
             match t {
                 case Some(ma) => map(Some, ma)
-                case None => point(None)
+                case None     => point(None)
             }
 
     }
@@ -139,9 +139,9 @@ pub mod Option {
 
     instance SemiGroup[Option[a]] with SemiGroup[a] {
         pub def combine(x: Option[a], y: Option[a]): Option[a] = match (x, y) {
-            case (a, None)              => a
-            case (None, b)              => b
-            case (Some(x1), Some(y1))   => Some(SemiGroup.combine(x1, y1))
+            case (a, None)            => a
+            case (None, b)            => b
+            case (Some(x1), Some(y1)) => Some(SemiGroup.combine(x1, y1))
         }
     }
 
@@ -267,19 +267,20 @@ pub mod Option {
     ///
     /// Returns `Some(x)`.
     ///
-    pub def point(x: a) : Option[a] = Some(x)
+    pub def point(x: a): Option[a] = Some(x)
 
     ///
     /// If both arguments are `Some`, return a `Some` containing the result of applying the function inside
     /// `f` to the value inside `x`. Otherwise return `None`.
     ///
-    pub def ap(f: Option[a -> b \ ef], x: Option[a]) : Option[b] \ ef =
+    pub def ap(f: Option[a -> b \ ef], x: Option[a]): Option[b] \ ef =
         match f {
             case None    => None
-            case Some(g) => match x {
-                case None    => None
-                case Some(y) => Some(g(y))
-            }
+            case Some(g) =>
+                match x {
+                    case None    => None
+                    case Some(y) => Some(g(y))
+                }
         }
 
     ///
@@ -360,9 +361,9 @@ pub mod Option {
     ///
     pub def sequence(l: List[Option[a]]): Option[List[a]] =
         def loop(ll, k) = match ll {
-            case Nil            => k(Nil)
-            case None :: _      => None
-            case Some(x) :: xs  => loop(xs, ks -> k(x :: ks))
+            case Nil           => k(Nil)
+            case None :: _     => None
+            case Some(x) :: xs => loop(xs, ks -> k(x :: ks))
         };
         loop(l, ks -> Some(ks))
 
@@ -372,10 +373,11 @@ pub mod Option {
     pub def traverse(f: a -> Option[b] \ ef, l: List[a]): Option[List[b]] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k(Nil)
-            case x :: xs => match f(x) {
-                case None    => None
-                case Some(y) => loop(xs, ys -> k(y :: ys))
-            }
+            case x :: xs =>
+                match f(x) {
+                    case None    => None
+                    case Some(y) => loop(xs, ys -> k(y :: ys))
+                }
         };
         loop(l, ks -> Some(ks))
 
@@ -387,10 +389,11 @@ pub mod Option {
     ///
     pub def traverseX(f: a -> Option[b] \ ef, l: List[a]): Option[Unit] \ ef = match l {
         case Nil     => Some()
-        case x :: xs => match f(x) {
-            case None    => None
-            case Some(_) => traverseX(f, xs)
-        }
+        case x :: xs =>
+            match f(x) {
+                case None    => None
+                case Some(_) => traverseX(f, xs)
+            }
     }
 
     ///
@@ -405,10 +408,11 @@ pub mod Option {
     ///
     pub def foldLeftM(f: (b, a) -> Option[b] \ ef, s: b, l: List[a]): Option[b] \ ef = match l {
         case Nil     => Some(s)
-        case x :: xs => match f(s, x) {
-            case Some(s1) => foldLeftM(f, s1, xs)
-            case None     => None
-        }
+        case x :: xs =>
+            match f(s, x) {
+                case Some(s1) => foldLeftM(f, s1, xs)
+                case None     => None
+            }
     }
 
     ///
@@ -424,10 +428,14 @@ pub mod Option {
     pub def foldRightM(f: (a, b) -> Option[b] \ ef, s: b, l: List[a]): Option[b] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k(s)
-            case x :: xs => loop(xs, s1 -> match f(x, s1) {
-                case Some(s2) => k(s2)
-                case None     => None
-            })
+            case x :: xs =>
+                loop(
+                    xs,
+                    s1 -> match f(x, s1) {
+                        case Some(s2) => k(s2)
+                        case None     => None
+                    }
+                )
         };
         loop(l, s1 -> checked_ecast(Some(s1)))
 
@@ -563,7 +571,7 @@ pub mod Option {
     ///
     /// Returns `None` if any of `o1`, `o2`, ... `o7` are `None`.
     ///
-    pub def map7(f: (t1, t2, t3, t4, t5, t6, t7) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3], o4: Option[t4], o5: Option[t5], o6: Option[t6], o7: Option[t7]): Option[u] \ ef=
+    pub def map7(f: (t1, t2, t3, t4, t5, t6, t7) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3], o4: Option[t4], o5: Option[t5], o6: Option[t6], o7: Option[t7]): Option[u] \ ef =
         ap(map6(f, o1, o2, o3, o4, o5, o6), o7)
 
     ///

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -91,14 +91,14 @@ pub def on(f: (b, b) -> c \ ef1, g: a -> b \ ef2, x: a, y: a): c \ { ef1, ef2 } 
 ///
 pub def fst(p: (a, b)): a =
     let (x, _) = p;
-        x
+    x
 
 ///
 /// Returns the second component of `t`.
 ///
 pub def snd(p: (a, b)): b =
     let (_, y) = p;
-        y
+    y
 
 ///
 /// Returns the pair `p` with the components swapped.
@@ -106,7 +106,7 @@ pub def snd(p: (a, b)): b =
 ///
 pub def swap(p: (a, b)): (b, a) =
     let (x, y) = p;
-        (y, x)
+    (y, x)
 
 ///
 /// Forwards function composition. Applies the function on the left first.
@@ -134,7 +134,7 @@ pub def ||>(x: (a, b), f: a -> (b -> c \ ef)): c \ ef = f(fst(x), snd(x))
 ///
 /// Given a value `x` and a function `f` returns `x`.
 ///
-pub def !>( x: a, f: a -> Unit \ ef): a \ ef = f(x); x
+pub def !>(x: a, f: a -> Unit \ ef): a \ ef = f(x); x
 
 ///
 /// Coerces the given value `x`.
@@ -157,9 +157,9 @@ pub def touch(_: Region[r]): Unit \ r = checked_ecast(())
 ///
 pub def bug!(m: String): a = unsafe IO {
     System.err.println("*".repeat(80));
-    System.err.println("**") ;
-    System.err.println("**  BUG: ${m}") ;
-    System.err.println("**") ;
+    System.err.println("**");
+    System.err.println("**  BUG: ${m}");
+    System.err.println("**");
     System.err.println("*".repeat(80));
     System.err.println("");
     ?panic
@@ -200,7 +200,7 @@ pub enum Purity3[a: Type, b: Type, c: Type, d: Type, ef: Eff] {
 ///
 pub def purityOf(f: a -> b \ ef): Purity[a, b, ef] =
     match Reflect.reflectEff((ProxyEff.Proxy: ProxyEff[ef])) {
-        case Reflect.Purity.Pure => Purity.Pure(unchecked_cast (f as a -> b \ {}))
+        case Reflect.Purity.Pure   => Purity.Pure(unchecked_cast(f as a -> b \ {}))
         case Reflect.Purity.Impure => Purity.Impure(f)
     }
 
@@ -212,7 +212,7 @@ pub def purityOf(f: a -> b \ ef): Purity[a, b, ef] =
 ///
 pub def purityOf2(f: a -> b -> c \ ef): Purity2[a, b, c, ef] =
     match Reflect.reflectEff((ProxyEff.Proxy: ProxyEff[ef])) {
-        case Reflect.Purity.Pure   => Purity2.Pure(unchecked_cast (f as a -> b -> c \ {}))
+        case Reflect.Purity.Pure   => Purity2.Pure(unchecked_cast(f as a -> b -> c \ {}))
         case Reflect.Purity.Impure => Purity2.Impure(f)
     }
 
@@ -224,6 +224,6 @@ pub def purityOf2(f: a -> b -> c \ ef): Purity2[a, b, c, ef] =
 ///
 pub def purityOf3(f: a -> b -> c -> d \ ef): Purity3[a, b, c, d, ef] =
     match Reflect.reflectEff((ProxyEff.Proxy: ProxyEff[ef])) {
-        case Reflect.Purity.Pure   => Purity3.Pure(unchecked_cast (f as a -> b -> c -> d \ {}))
+        case Reflect.Purity.Pure   => Purity3.Pure(unchecked_cast(f as a -> b -> c -> d \ {}))
         case Reflect.Purity.Impure => Purity3.Impure(f)
     }


### PR DESCRIPTION
As mentioned in the PR https://github.com/flix/flix/pull/12669 .
This is the first batch formatting the standard library with the source code formatter. 

- Float32-Float64.flix
- Int8-Int64.flix
- List.flix
- Option.flix
- Prelude.flix

Looking forward to the feedback.