### PR TITLE
feat: add --top live compiler profiler TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -176,7 +176,7 @@ object Main {
           flix.setFormatter(formatter)
 
           // Run the compilation pipeline, optionally wrapped in the live `--top` TUI.
-          val (optRoot, errors, cgResult) = TopRenderer.runDuring(flix, options.top) {
+          val (optRoot, errors, cgResult) = CompilerTop.runDuring(flix, options.top) {
             val (root, errs) = flix.check()
             val cg = if (errs.isEmpty) root.map(flix.codeGen) else None
             (root, errs, cg)

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -175,39 +175,18 @@ object Main {
 
           flix.setFormatter(formatter)
 
-          // Start the live `--top` TUI, if requested.
-          val topRenderer = if (options.top) {
-            val r = new TopRenderer(flix)
-            r.start()
-            Some(r)
-          } else None
-          def stopTop(): Unit = topRenderer.foreach(_.stop())
-
-          // evaluate main.
-          try {
-            flix.check() match {
-              case (Some(root), Nil) =>
-                val main = flix.codeGen(root).getMain
-                // Stop the renderer before user main runs so it doesn't
-                // collide with the TUI repaint. The final frame drawn here
-                // is what completes the progress bar.
-                stopTop()
-                main match {
-                  case None => // nop
-                  case Some(m) =>
-                    // Invoke main with the supplied arguments.
-                    m(cmdOpts.args.toArray)
-                }
-                System.exit(0)
-              case (optRoot, errors) =>
-                stopTop()
-                println(CompilationMessage.formatAll(errors)(formatter, optRoot))
-                System.exit(1)
-            }
-          } catch {
-            case t: Throwable =>
-              stopTop()
-              throw t
+          // Run the compilation pipeline, optionally wrapped in the live `--top` TUI.
+          val (optRoot, errors, cgResult) = TopRenderer.runDuring(flix, options.top) {
+            val (root, errs) = flix.check()
+            val cg = if (errs.isEmpty) root.map(flix.codeGen) else None
+            (root, errs, cg)
+          }
+          if (errors.isEmpty) {
+            cgResult.flatMap(_.getMain).foreach(_(cmdOpts.args.toArray))
+            System.exit(0)
+          } else {
+            println(CompilationMessage.formatAll(errors)(formatter, optRoot))
+            System.exit(1)
           }
 
         case Command.Init =>

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -72,6 +72,7 @@ object Main {
       outputJvm = false,
       outputPath = Options.Default.outputPath,
       threads = cmdOpts.threads.getOrElse(Options.Default.threads),
+      top = cmdOpts.top,
       loadClassFiles = Options.Default.loadClassFiles,
       assumeYes = cmdOpts.assumeYes,
       xprintphases = cmdOpts.xprintphases,
@@ -91,6 +92,12 @@ object Main {
 
     // Don't use progress bar if not attached to a console.
     if (System.console() == null) {
+      options = options.copy(progress = false)
+    }
+
+    // Don't use progress bar if --top is set: the live TUI repaints the screen
+    // every 100ms and the spinner would just fight with it.
+    if (cmdOpts.top) {
       options = options.copy(progress = false)
     }
 
@@ -168,19 +175,39 @@ object Main {
 
           flix.setFormatter(formatter)
 
+          // Start the live `--top` TUI, if requested.
+          val topRenderer = if (options.top) {
+            val r = new TopRenderer(flix)
+            r.start()
+            Some(r)
+          } else None
+          def stopTop(): Unit = topRenderer.foreach(_.stop())
+
           // evaluate main.
-          flix.check() match {
-            case (Some(root), Nil) =>
-              flix.codeGen(root).getMain match {
-                case None => // nop
-                case Some(m) =>
-                  // Invoke main with the supplied arguments.
-                  m(cmdOpts.args.toArray)
-              }
-              System.exit(0)
-            case (optRoot, errors) =>
-              println(CompilationMessage.formatAll(errors)(formatter, optRoot))
-              System.exit(1)
+          try {
+            flix.check() match {
+              case (Some(root), Nil) =>
+                val main = flix.codeGen(root).getMain
+                // Stop the renderer before user main runs so it doesn't
+                // collide with the TUI repaint. The final frame drawn here
+                // is what completes the progress bar.
+                stopTop()
+                main match {
+                  case None => // nop
+                  case Some(m) =>
+                    // Invoke main with the supplied arguments.
+                    m(cmdOpts.args.toArray)
+                }
+                System.exit(0)
+              case (optRoot, errors) =>
+                stopTop()
+                println(CompilationMessage.formatAll(errors)(formatter, optRoot))
+                System.exit(1)
+            }
+          } catch {
+            case t: Throwable =>
+              stopTop()
+              throw t
           }
 
         case Command.Init =>
@@ -468,6 +495,7 @@ object Main {
     json: Boolean = false,
     listen: Option[Int] = None,
     threads: Option[Int] = None,
+    top: Boolean = false,
     assumeYes: Boolean = false,
     xbenchmarkCodeSize: Boolean = false,
     xbenchmarkIncremental: Boolean = false,
@@ -660,6 +688,9 @@ object Main {
 
       opt[Int]("threads").action((n, c) => c.copy(threads = Some(n))).
         text("number of threads to use for compilation.")
+
+      opt[Unit]("top").action((_, c) => c.copy(top = true)).
+        text("displays a live view of the DefnSyms the compiler spends most time on.")
 
       opt[Unit]("yes").action((_, c) => c.copy(assumeYes = true)).
         text("automatically answer yes to all prompts.")

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -90,9 +90,9 @@ object Main {
       options = options.copy(progress = false)
     }
 
-    // Don't use progress bar if not attached to a console.
+    // Don't use progress bar / --top TUI if not attached to a console.
     if (System.console() == null) {
-      options = options.copy(progress = false)
+      options = options.copy(progress = false, top = false)
     }
 
     // Don't use progress bar if --top is set: the live TUI repaints the screen
@@ -175,18 +175,19 @@ object Main {
 
           flix.setFormatter(formatter)
 
-          // Run the compilation pipeline, optionally wrapped in the live `--top` TUI.
-          val (optRoot, errors, cgResult) = CompilerTop.runDuring(flix, options.top) {
-            val (root, errs) = flix.check()
-            val cg = if (errs.isEmpty) root.map(flix.codeGen) else None
-            (root, errs, cg)
-          }
-          if (errors.isEmpty) {
-            cgResult.flatMap(_.getMain).foreach(_(cmdOpts.args.toArray))
-            System.exit(0)
-          } else {
-            println(CompilationMessage.formatAll(errors)(formatter, optRoot))
-            System.exit(1)
+          // evaluate main.
+          flix.check() match {
+            case (Some(root), Nil) =>
+              flix.codeGen(root).getMain match {
+                case None => // nop
+                case Some(m) =>
+                  // Invoke main with the supplied arguments.
+                  m(cmdOpts.args.toArray)
+              }
+              System.exit(0)
+            case (optRoot, errors) =>
+              println(CompilationMessage.formatAll(errors)(formatter, optRoot))
+              System.exit(1)
           }
 
         case Command.Init =>

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -72,7 +72,7 @@ object Main {
       outputJvm = false,
       outputPath = Options.Default.outputPath,
       threads = cmdOpts.threads.getOrElse(Options.Default.threads),
-      top = cmdOpts.top,
+      compilerTop = cmdOpts.top,
       loadClassFiles = Options.Default.loadClassFiles,
       assumeYes = cmdOpts.assumeYes,
       xprintphases = cmdOpts.xprintphases,
@@ -92,7 +92,7 @@ object Main {
 
     // Don't use progress bar / --top TUI if not attached to a console.
     if (System.console() == null) {
-      options = options.copy(progress = false, top = false)
+      options = options.copy(progress = false, compilerTop = false)
     }
 
     // Don't use progress bar if --top is set: the live TUI repaints the screen
@@ -670,7 +670,7 @@ object Main {
         text("number of threads to use for compilation.")
 
       opt[Unit]("top").action((_, c) => c.copy(top = true)).
-        text("displays a live view of the DefnSyms the compiler spends most time on.")
+        text("displays a live view of where the compiler spends its time.")
 
       opt[Unit]("yes").action((_, c) => c.copy(assumeYes = true)).
         text("automatically answer yes to all prompts.")

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -111,9 +111,23 @@ class Flix {
   var phaseTimers: ArrayBuffer[PhaseTime] = ArrayBuffer.empty
 
   /**
+    * Tracks the time spent compiling each [[Symbol.DefnSym]].
+    *
+    * Driven by the `--top` option.
+    */
+  val defnTimer: DefnTimer = new DefnTimer(() => currentPhaseName)
+
+  /**
     * The current phase we are in. Initially null.
     */
   private var currentPhase: PhaseTime = _
+
+  /**
+    * The name of the phase currently executing. Read by the `--top` renderer
+    * thread, written by whichever thread calls [[phase]] / [[phaseNew]];
+    * volatile so cross-thread reads are visible.
+    */
+  @volatile var currentPhaseName: String = "starting"
 
   /**
     * The progress bar.
@@ -440,6 +454,8 @@ class Flix {
 
     // Reset the phase information.
     phaseTimers = ArrayBuffer.empty
+    currentPhaseName = "starting"
+    defnTimer.reset()
 
     // Reset the phase list file if relevant
     if (this.options.xprintphases) {
@@ -687,6 +703,7 @@ class Flix {
   def phaseNew[A, B](phase: String)(f: => (A, B))(implicit d: Debug[A]): (A, B) = {
     // Initialize the phase time object.
     currentPhase = PhaseTime(phase, 0)
+    currentPhaseName = phase
 
     if (options.progress) {
       progressBar.observe(currentPhase.phase, "")
@@ -717,6 +734,7 @@ class Flix {
   def phase[A](phase: String)(f: => A)(implicit d: Debug[A]): A = {
     // Initialize the phase time object.
     currentPhase = PhaseTime(phase, 0)
+    currentPhaseName = phase
 
     if (options.progress) {
       progressBar.observe(currentPhase.phase, "")

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -111,7 +111,7 @@ class Flix {
   var phaseTimers: ArrayBuffer[PhaseTime] = ArrayBuffer.empty
 
   /**
-    * Optional profiler that records per-`DefnSym` timing data. Installed
+    * Optional profiler that records where compile time is spent. Installed
     * by [[setOptions]] when `--top` is enabled; absent on the default
     * path so [[track]] is a no-op with no measurement overhead.
     */
@@ -436,7 +436,7 @@ class Flix {
     if (opts == null)
       throw new IllegalArgumentException("'opts' must be non-null.")
     options = opts
-    if (opts.top && compilerTop.isEmpty) {
+    if (opts.compilerTop && compilerTop.isEmpty) {
       val p = new CompilerProfiler(() => currentPhaseName)
       setProfiler(Some(p))
       val t = new CompilerTop(this, p)

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -597,8 +597,12 @@ class Flix {
     // Reset the progress bar.
     progressBar.complete()
 
-    // Stop the live `--top` TUI, if it is running.
-    compilerTop.foreach(_.stop())
+    // Stop the live `--top` TUI only if there are errors and no `codeGen`
+    // will follow. On the success path, leave it running so `codeGen` can
+    // continue updating it through the mid-end and backend phases.
+    if (errors.nonEmpty) {
+      compilerTop.foreach(_.stop())
+    }
 
     // Print summary?
     if (options.xsummary) {

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -113,7 +113,7 @@ class Flix {
   /**
     * Optional profiler that records where compile time is spent. Installed
     * by [[setOptions]] when `--top` is enabled; absent on the default
-    * path so [[track]] is a no-op with no measurement overhead.
+    * path so [[profile]] is a no-op with no measurement overhead.
     */
   private var profiler: Option[CompilerProfiler] = None
 
@@ -123,7 +123,7 @@ class Flix {
   /** Returns the currently installed profiler, or `None`. */
   def getProfiler: Option[CompilerProfiler] = profiler
 
-  /** Installs (or removes, when `None`) the profiler that backs [[track]]. */
+  /** Installs (or removes, when `None`) the profiler that backs [[profile]]. */
   def setProfiler(p: Option[CompilerProfiler]): Unit = profiler = p
 
   /**
@@ -131,7 +131,7 @@ class Flix {
     * the currently running phase. When no profiler is installed, `thunk`
     * runs unchanged.
     */
-  def track[A](sym: Symbol.DefnSym, loc: SourceLocation)(thunk: => A): A =
+  def profile[A](sym: Symbol.DefnSym, loc: SourceLocation)(thunk: => A): A =
     profiler match {
       case Some(p) => p.track(sym, loc)(thunk)
       case None    => thunk

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -148,7 +148,7 @@ class Flix {
     * Name of the currently-executing phase, or `None` before the first
     * phase has started or after [[compile]] has reset state.
     */
-  def currentPhaseName: Option[String] =
+  def getCurrentPhaseName: Option[String] =
     currentPhase.map(_.phase)
 
   /**
@@ -437,7 +437,7 @@ class Flix {
       throw new IllegalArgumentException("'opts' must be non-null.")
     options = opts
     if (opts.compilerTop && compilerTop.isEmpty) {
-      val p = new CompilerProfiler(() => currentPhaseName)
+      val p = new CompilerProfiler(() => getCurrentPhaseName)
       setProfiler(Some(p))
       val t = new CompilerTop(this, p)
       t.start()

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -112,10 +112,13 @@ class Flix {
 
   /**
     * Optional profiler that records per-`DefnSym` timing data. Installed
-    * by [[CompilerTop.runDuring]] when `--top` is enabled; absent on the
-    * default path so [[track]] is a no-op with no measurement overhead.
+    * by [[setOptions]] when `--top` is enabled; absent on the default
+    * path so [[track]] is a no-op with no measurement overhead.
     */
   private var profiler: Option[CompilerProfiler] = None
+
+  /** The live `--top` TUI, if it has been started. */
+  private var compilerTop: Option[CompilerTop] = None
 
   /** Returns the currently installed profiler, or `None`. */
   def getProfiler: Option[CompilerProfiler] = profiler
@@ -433,6 +436,13 @@ class Flix {
     if (opts == null)
       throw new IllegalArgumentException("'opts' must be non-null.")
     options = opts
+    if (opts.top && compilerTop.isEmpty) {
+      val p = new CompilerProfiler(() => currentPhaseName)
+      setProfiler(Some(p))
+      val t = new CompilerTop(this, p)
+      t.start()
+      compilerTop = Some(t)
+    }
     this
   }
 
@@ -587,6 +597,9 @@ class Flix {
     // Reset the progress bar.
     progressBar.complete()
 
+    // Stop the live `--top` TUI, if it is running.
+    compilerTop.foreach(_.stop())
+
     // Print summary?
     if (options.xsummary) {
       result.foreach(root => {
@@ -676,6 +689,9 @@ class Flix {
 
     // Reset the progress bar.
     progressBar.complete()
+
+    // Stop the live `--top` TUI, if it is running.
+    compilerTop.foreach(_.stop())
 
     // Return the result.
     result

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -118,18 +118,18 @@ class Flix {
   val compilerProfiler: CompilerProfiler = new CompilerProfiler(() => currentPhaseName)
 
   /**
-    * The current phase we are in. Initially null. Volatile so the `--top`
+    * The current phase we are in. Initially `None`. Volatile so the `--top`
     * renderer thread sees each store made by the compile thread in
     * [[phase]] / [[phaseNew]].
     */
-  @volatile private var currentPhase: PhaseTime = _
+  @volatile private var currentPhase: Option[PhaseTime] = None
 
   /**
     * Name of the currently-executing phase, or `None` before the first
     * phase has started or after [[compile]] has reset state.
     */
   def currentPhaseName: Option[String] =
-    Option(currentPhase).map(_.phase)
+    currentPhase.map(_.phase)
 
   /**
     * The progress bar.
@@ -456,7 +456,7 @@ class Flix {
 
     // Reset the phase information.
     phaseTimers = ArrayBuffer.empty
-    currentPhase = null
+    currentPhase = None
     compilerProfiler.reset()
 
     // Reset the phase list file if relevant
@@ -704,10 +704,10 @@ class Flix {
     */
   def phaseNew[A, B](phase: String)(f: => (A, B))(implicit d: Debug[A]): (A, B) = {
     // Initialize the phase time object.
-    currentPhase = PhaseTime(phase, 0)
+    currentPhase = Some(PhaseTime(phase, 0))
 
     if (options.progress) {
-      progressBar.observe(currentPhase.phase, "")
+      progressBar.observe(phase, "")
     }
 
     // Measure the execution time.
@@ -715,11 +715,10 @@ class Flix {
     val (root, errs) = f
     val e = System.nanoTime() - t
 
-    // Update the phase time.
-    currentPhase = currentPhase.copy(time = e)
-
-    // And add it to the list of executed phases.
-    phaseTimers += currentPhase
+    // Update the phase time and add it to the list of executed phases.
+    val finished = PhaseTime(phase, e)
+    currentPhase = Some(finished)
+    phaseTimers += finished
 
     if (this.options.xprintphases) {
       d.output(phase, root)(this)
@@ -734,10 +733,10 @@ class Flix {
     */
   def phase[A](phase: String)(f: => A)(implicit d: Debug[A]): A = {
     // Initialize the phase time object.
-    currentPhase = PhaseTime(phase, 0)
+    currentPhase = Some(PhaseTime(phase, 0))
 
     if (options.progress) {
-      progressBar.observe(currentPhase.phase, "")
+      progressBar.observe(phase, "")
     }
 
     // Measure the execution time.
@@ -745,11 +744,10 @@ class Flix {
     val r = f
     val e = System.nanoTime() - t
 
-    // Update the phase time.
-    currentPhase = currentPhase.copy(time = e)
-
-    // And add it to the list of executed phases.
-    phaseTimers += currentPhase
+    // Update the phase time and add it to the list of executed phases.
+    val finished = PhaseTime(phase, e)
+    currentPhase = Some(finished)
+    phaseTimers += finished
 
     if (this.options.xprintphases) {
       d.output(phase, r)(this)

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -111,11 +111,28 @@ class Flix {
   var phaseTimers: ArrayBuffer[PhaseTime] = ArrayBuffer.empty
 
   /**
-    * Tracks the time spent compiling each [[Symbol.DefnSym]].
-    *
-    * Driven by the `--top` option.
+    * Optional profiler that records per-`DefnSym` timing data. Installed
+    * by [[CompilerTop.runDuring]] when `--top` is enabled; absent on the
+    * default path so [[track]] is a no-op with no measurement overhead.
     */
-  val compilerProfiler: CompilerProfiler = new CompilerProfiler(() => currentPhaseName)
+  private var profiler: Option[CompilerProfiler] = None
+
+  /** Returns the currently installed profiler, or `None`. */
+  def getProfiler: Option[CompilerProfiler] = profiler
+
+  /** Installs (or removes, when `None`) the profiler that backs [[track]]. */
+  def setProfiler(p: Option[CompilerProfiler]): Unit = profiler = p
+
+  /**
+    * Records the time spent running `thunk` against `sym`, attributed to
+    * the currently running phase. When no profiler is installed, `thunk`
+    * runs unchanged.
+    */
+  def track[A](sym: Symbol.DefnSym, loc: SourceLocation)(thunk: => A): A =
+    profiler match {
+      case Some(p) => p.track(sym, loc)(thunk)
+      case None    => thunk
+    }
 
   /**
     * The current phase we are in. Initially `None`. Volatile so the `--top`
@@ -457,7 +474,6 @@ class Flix {
     // Reset the phase information.
     phaseTimers = ArrayBuffer.empty
     currentPhase = None
-    compilerProfiler.reset()
 
     // Reset the phase list file if relevant
     if (this.options.xprintphases) {

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -115,7 +115,7 @@ class Flix {
     *
     * Driven by the `--top` option.
     */
-  val defnTimer: DefnTimer = new DefnTimer(() => currentPhaseName)
+  val compilerProfiler: CompilerProfiler = new CompilerProfiler(() => currentPhaseName)
 
   /**
     * The current phase we are in. Initially null.
@@ -455,7 +455,7 @@ class Flix {
     // Reset the phase information.
     phaseTimers = ArrayBuffer.empty
     currentPhaseName = "starting"
-    defnTimer.reset()
+    compilerProfiler.reset()
 
     // Reset the phase list file if relevant
     if (this.options.xprintphases) {

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -112,12 +112,12 @@ class Flix {
 
   /**
     * Optional profiler that records where compile time is spent. Installed
-    * by [[setOptions]] when `--top` is enabled; absent on the default
-    * path so [[profile]] is a no-op with no measurement overhead.
+    * by [[setOptions]] when the compiler profiler is enabled; absent on the
+    * default path so [[profile]] is a no-op with no measurement overhead.
     */
   private var profiler: Option[CompilerProfiler] = None
 
-  /** The live `--top` TUI, if it has been started. */
+  /** The live compiler profiler TUI, if it has been started. */
   private var compilerTop: Option[CompilerTop] = None
 
   /** Returns the currently installed profiler, or `None`. */
@@ -138,8 +138,8 @@ class Flix {
     }
 
   /**
-    * The current phase we are in. Initially `None`. Volatile so the `--top`
-    * renderer thread sees each store made by the compile thread in
+    * The current phase we are in. Initially `None`. Volatile so the compiler
+    * profiler renderer thread sees each store made by the compile thread in
     * [[phase]] / [[phaseNew]].
     */
   @volatile private var currentPhase: Option[PhaseTime] = None
@@ -597,9 +597,9 @@ class Flix {
     // Reset the progress bar.
     progressBar.complete()
 
-    // Stop the live `--top` TUI only if there are errors and no `codeGen`
-    // will follow. On the success path, leave it running so `codeGen` can
-    // continue updating it through the mid-end and backend phases.
+    // Stop the live compiler profiler TUI only if there are errors and no
+    // `codeGen` will follow. On the success path, leave it running so
+    // `codeGen` can continue updating it through the mid-end and backend phases.
     if (errors.nonEmpty) {
       compilerTop.foreach(_.stop())
     }
@@ -694,7 +694,7 @@ class Flix {
     // Reset the progress bar.
     progressBar.complete()
 
-    // Stop the live `--top` TUI, if it is running.
+    // Stop the live compiler profiler TUI, if it is running.
     compilerTop.foreach(_.stop())
 
     // Return the result.

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -118,16 +118,18 @@ class Flix {
   val compilerProfiler: CompilerProfiler = new CompilerProfiler(() => currentPhaseName)
 
   /**
-    * The current phase we are in. Initially null.
+    * The current phase we are in. Initially null. Volatile so the `--top`
+    * renderer thread sees each store made by the compile thread in
+    * [[phase]] / [[phaseNew]].
     */
-  private var currentPhase: PhaseTime = _
+  @volatile private var currentPhase: PhaseTime = _
 
   /**
-    * The name of the phase currently executing. Read by the `--top` renderer
-    * thread, written by whichever thread calls [[phase]] / [[phaseNew]];
-    * volatile so cross-thread reads are visible.
+    * Name of the currently-executing phase, or `None` before the first
+    * phase has started or after [[compile]] has reset state.
     */
-  @volatile var currentPhaseName: String = "starting"
+  def currentPhaseName: Option[String] =
+    Option(currentPhase).map(_.phase)
 
   /**
     * The progress bar.
@@ -454,7 +456,7 @@ class Flix {
 
     // Reset the phase information.
     phaseTimers = ArrayBuffer.empty
-    currentPhaseName = "starting"
+    currentPhase = null
     compilerProfiler.reset()
 
     // Reset the phase list file if relevant
@@ -703,7 +705,6 @@ class Flix {
   def phaseNew[A, B](phase: String)(f: => (A, B))(implicit d: Debug[A]): (A, B) = {
     // Initialize the phase time object.
     currentPhase = PhaseTime(phase, 0)
-    currentPhaseName = phase
 
     if (options.progress) {
       progressBar.observe(currentPhase.phase, "")
@@ -734,7 +735,6 @@ class Flix {
   def phase[A](phase: String)(f: => A)(implicit d: Debug[A]): A = {
     // Initialize the phase time object.
     currentPhase = PhaseTime(phase, 0)
-    currentPhaseName = phase
 
     if (options.progress) {
       progressBar.observe(currentPhase.phase, "")

--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -35,7 +35,7 @@ object ClosureConv {
     * Performs closure conversion on the given AST `root`.
     */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("ClosureConv") {
-    val newDefs = ParOps.parMapValues(root.defs)(visitDef)
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
 
     root.copy(defs = newDefs)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -35,7 +35,7 @@ object ClosureConv {
     * Performs closure conversion on the given AST `root`.
     */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("ClosureConv") {
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
 
     root.copy(defs = newDefs)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -35,7 +35,7 @@ object ClosureConv {
     * Performs closure conversion on the given AST `root`.
     */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("ClosureConv") {
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
 
     root.copy(defs = newDefs)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -35,7 +35,7 @@ object ClosureConv {
     * Performs closure conversion on the given AST `root`.
     */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("ClosureConv") {
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
 
     root.copy(defs = newDefs)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     */
   def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, Unit) = flix.phaseNew("Dependencies") {
     implicit val sctx: SharedContext = SharedContext(new ConcurrentHashMap[(Input, Input), Unit]())
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
     val effects = changeSet.updateStaleValues(root.effects, oldRoot.effects)(ParOps.parMapValues(_)(visitEff))
     val enums = changeSet.updateStaleValues(root.enums, oldRoot.enums)(ParOps.parMapValues(_)(visitEnum))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     */
   def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, Unit) = flix.phaseNew("Dependencies") {
     implicit val sctx: SharedContext = SharedContext(new ConcurrentHashMap[(Input, Input), Unit]())
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
     val effects = changeSet.updateStaleValues(root.effects, oldRoot.effects)(ParOps.parMapValues(_)(visitEff))
     val enums = changeSet.updateStaleValues(root.enums, oldRoot.enums)(ParOps.parMapValues(_)(visitEnum))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     */
   def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, Unit) = flix.phaseNew("Dependencies") {
     implicit val sctx: SharedContext = SharedContext(new ConcurrentHashMap[(Input, Input), Unit]())
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn))))
     val effects = changeSet.updateStaleValues(root.effects, oldRoot.effects)(ParOps.parMapValues(_)(visitEff))
     val enums = changeSet.updateStaleValues(root.enums, oldRoot.enums)(ParOps.parMapValues(_)(visitEnum))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     */
   def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, Unit) = flix.phaseNew("Dependencies") {
     implicit val sctx: SharedContext = SharedContext(new ConcurrentHashMap[(Input, Input), Unit]())
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
     val effects = changeSet.updateStaleValues(root.effects, oldRoot.effects)(ParOps.parMapValues(_)(visitEff))
     val enums = changeSet.updateStaleValues(root.enums, oldRoot.enums)(ParOps.parMapValues(_)(visitEnum))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -53,7 +53,7 @@ object EffectBinder {
     * operand stack.
     */
   def run(root: LiftedAst.Root)(implicit flix: Flix): ReducedAst.Root = flix.phase("EffectBinder") {
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
     val newEnums = ParOps.parMapValues(root.enums)(visitEnum)
     val newStructs = ParOps.parMapValues(root.structs)(visitStruct)
     val newEffects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -53,7 +53,7 @@ object EffectBinder {
     * operand stack.
     */
   def run(root: LiftedAst.Root)(implicit flix: Flix): ReducedAst.Root = flix.phase("EffectBinder") {
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
     val newEnums = ParOps.parMapValues(root.enums)(visitEnum)
     val newStructs = ParOps.parMapValues(root.structs)(visitStruct)
     val newEffects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -53,7 +53,7 @@ object EffectBinder {
     * operand stack.
     */
   def run(root: LiftedAst.Root)(implicit flix: Flix): ReducedAst.Root = flix.phase("EffectBinder") {
-    val newDefs = ParOps.parMapValues(root.defs)(visitDef)
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
     val newEnums = ParOps.parMapValues(root.enums)(visitEnum)
     val newStructs = ParOps.parMapValues(root.structs)(visitStruct)
     val newEffects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -53,7 +53,7 @@ object EffectBinder {
     * operand stack.
     */
   def run(root: LiftedAst.Root)(implicit flix: Flix): ReducedAst.Root = flix.phase("EffectBinder") {
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
     val newEnums = ParOps.parMapValues(root.enums)(visitEnum)
     val newStructs = ParOps.parMapValues(root.structs)(visitStruct)
     val newEffects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -173,7 +173,7 @@ object EntryPoints {
     implicit val sctx: SharedContext = SharedContext.mk()
     implicit val r: TypedAst.Root = root
 
-    ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
 
     // Remove the entrypoint if it is not valid.
     val root1 = if (sctx.invalidMain.get()) root.copy(mainEntryPoint = None) else root

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -173,7 +173,7 @@ object EntryPoints {
     implicit val sctx: SharedContext = SharedContext.mk()
     implicit val r: TypedAst.Root = root
 
-    ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
 
     // Remove the entrypoint if it is not valid.
     val root1 = if (sctx.invalidMain.get()) root.copy(mainEntryPoint = None) else root

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -173,7 +173,7 @@ object EntryPoints {
     implicit val sctx: SharedContext = SharedContext.mk()
     implicit val r: TypedAst.Root = root
 
-    ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
 
     // Remove the entrypoint if it is not valid.
     val root1 = if (sctx.invalidMain.get()) root.copy(mainEntryPoint = None) else root

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -173,7 +173,7 @@ object EntryPoints {
     implicit val sctx: SharedContext = SharedContext.mk()
     implicit val r: TypedAst.Root = root
 
-    ParOps.parMapValues(root.defs)(visitDef(_))
+    ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
 
     // Remove the entrypoint if it is not valid.
     val root1 = if (sctx.invalidMain.get()) root.copy(mainEntryPoint = None) else root

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -42,7 +42,7 @@ object Eraser {
   def run(root: ReducedAst.Root)(implicit flix: Flix): ErasedAst.Root = flix.phase("Eraser") {
     implicit val r: ReducedAst.Root = root
     implicit val ctx: SharedContext = new SharedContext()
-    val newDefs = ParOps.parMapValues(root.defs)(visitDef)
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
     val newEffects = ParOps.parMapValues(root.effects)(visitEffect)
     // Specializations must happen after all other types and expressions are visited.
     val newEnums = specializeEnums(ctx.getEnumSpecializations)

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -42,7 +42,7 @@ object Eraser {
   def run(root: ReducedAst.Root)(implicit flix: Flix): ErasedAst.Root = flix.phase("Eraser") {
     implicit val r: ReducedAst.Root = root
     implicit val ctx: SharedContext = new SharedContext()
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
     val newEffects = ParOps.parMapValues(root.effects)(visitEffect)
     // Specializations must happen after all other types and expressions are visited.
     val newEnums = specializeEnums(ctx.getEnumSpecializations)

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -42,7 +42,7 @@ object Eraser {
   def run(root: ReducedAst.Root)(implicit flix: Flix): ErasedAst.Root = flix.phase("Eraser") {
     implicit val r: ReducedAst.Root = root
     implicit val ctx: SharedContext = new SharedContext()
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
     val newEffects = ParOps.parMapValues(root.effects)(visitEffect)
     // Specializations must happen after all other types and expressions are visited.
     val newEnums = specializeEnums(ctx.getEnumSpecializations)

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -42,7 +42,7 @@ object Eraser {
   def run(root: ReducedAst.Root)(implicit flix: Flix): ErasedAst.Root = flix.phase("Eraser") {
     implicit val r: ReducedAst.Root = root
     implicit val ctx: SharedContext = new SharedContext()
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
     val newEffects = ParOps.parMapValues(root.effects)(visitEffect)
     // Specializations must happen after all other types and expressions are visited.
     val newEnums = specializeEnums(ctx.getEnumSpecializations)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -273,7 +273,7 @@ object Kinder {
     */
   private def visitDefSpecs(root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, KindedAst.Spec] = {
     ParOps.parMapValues(root.defs) {
-      case defn => flix.compilerProfiler.track(defn.sym, defn.loc) {
+      case defn => flix.track(defn.sym, defn.loc) {
         val kenv = getKindEnvFromSpec(defn.spec, KindEnv.empty, root)
         visitSpec(defn.spec, Nil, None, kenv, root)
       }
@@ -298,7 +298,7 @@ object Kinder {
     * Performs kinding on the all the definitions in the given root.
     */
   private def visitDefs(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit rootEnv: RootEnv, sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, KindedAst.Def] = {
-    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn, KindEnv.empty, root))))
+    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn, KindEnv.empty, root))))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -273,7 +273,7 @@ object Kinder {
     */
   private def visitDefSpecs(root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, KindedAst.Spec] = {
     ParOps.parMapValues(root.defs) {
-      case defn => flix.track(defn.sym, defn.loc) {
+      case defn => flix.profile(defn.sym, defn.loc) {
         val kenv = getKindEnvFromSpec(defn.spec, KindEnv.empty, root)
         visitSpec(defn.spec, Nil, None, kenv, root)
       }
@@ -298,7 +298,7 @@ object Kinder {
     * Performs kinding on the all the definitions in the given root.
     */
   private def visitDefs(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit rootEnv: RootEnv, sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, KindedAst.Def] = {
-    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn, KindEnv.empty, root))))
+    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn, KindEnv.empty, root))))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -273,7 +273,7 @@ object Kinder {
     */
   private def visitDefSpecs(root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, KindedAst.Spec] = {
     ParOps.parMapValues(root.defs) {
-      case defn => flix.defnTimer.track(defn.sym, defn.loc) {
+      case defn => flix.compilerProfiler.track(defn.sym, defn.loc) {
         val kenv = getKindEnvFromSpec(defn.spec, KindEnv.empty, root)
         visitSpec(defn.spec, Nil, None, kenv, root)
       }
@@ -298,7 +298,7 @@ object Kinder {
     * Performs kinding on the all the definitions in the given root.
     */
   private def visitDefs(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit rootEnv: RootEnv, sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, KindedAst.Def] = {
-    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn, KindEnv.empty, root))))
+    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn, KindEnv.empty, root))))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -273,9 +273,10 @@ object Kinder {
     */
   private def visitDefSpecs(root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, KindedAst.Spec] = {
     ParOps.parMapValues(root.defs) {
-      case defn =>
+      case defn => flix.defnTimer.track(defn.sym, defn.loc) {
         val kenv = getKindEnvFromSpec(defn.spec, KindEnv.empty, root)
         visitSpec(defn.spec, Nil, None, kenv, root)
+      }
     }
   }
 
@@ -297,7 +298,7 @@ object Kinder {
     * Performs kinding on the all the definitions in the given root.
     */
   private def visitDefs(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit rootEnv: RootEnv, sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, KindedAst.Def] = {
-    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef(_, KindEnv.empty, root)))
+    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn, KindEnv.empty, root))))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -37,7 +37,7 @@ object LambdaLift {
   def run(root: SimplifiedAst.Root)(implicit flix: Flix): LiftedAst.Root = flix.phase("LambdaLift") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -37,7 +37,7 @@ object LambdaLift {
   def run(root: SimplifiedAst.Root)(implicit flix: Flix): LiftedAst.Root = flix.phase("LambdaLift") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -37,7 +37,7 @@ object LambdaLift {
   def run(root: SimplifiedAst.Root)(implicit flix: Flix): LiftedAst.Root = flix.phase("LambdaLift") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -37,7 +37,7 @@ object LambdaLift {
   def run(root: SimplifiedAst.Root)(implicit flix: Flix): LiftedAst.Root = flix.phase("LambdaLift") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
-    val defs = ParOps.parMapValues(root.defs)(visitDef)
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
@@ -614,7 +614,7 @@ object PatMatch2 {
       implicit val r: Root = root
       implicit val sctx: SharedContext = SharedContext.mk()
 
-      val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
+      val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances,
         (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
@@ -614,7 +614,7 @@ object PatMatch2 {
       implicit val r: Root = root
       implicit val sctx: SharedContext = SharedContext.mk()
 
-      val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
+      val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn))))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances,
         (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
@@ -614,7 +614,7 @@ object PatMatch2 {
       implicit val r: Root = root
       implicit val sctx: SharedContext = SharedContext.mk()
 
-      val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
+      val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances,
         (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
@@ -614,7 +614,7 @@ object PatMatch2 {
       implicit val r: Root = root
       implicit val sctx: SharedContext = SharedContext.mk()
 
-      val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
+      val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances,
         (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -42,7 +42,7 @@ object PredDeps {
     // Compute an over-approximation of the dependency graph for all constraints in the program.
     implicit val sctx: SharedContext = SharedContext.mk()
 
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -42,7 +42,7 @@ object PredDeps {
     // Compute an over-approximation of the dependency graph for all constraints in the program.
     implicit val sctx: SharedContext = SharedContext.mk()
 
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -42,7 +42,7 @@ object PredDeps {
     // Compute an over-approximation of the dependency graph for all constraints in the program.
     implicit val sctx: SharedContext = SharedContext.mk()
 
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn))))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -42,7 +42,7 @@ object PredDeps {
     // Compute an over-approximation of the dependency graph for all constraints in the program.
     implicit val sctx: SharedContext = SharedContext.mk()
 
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -42,7 +42,7 @@ object Reducer {
     implicit val r: ErasedAst.Root = root
     implicit val ctx: SharedContext = new SharedContext()
 
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -42,7 +42,7 @@ object Reducer {
     implicit val r: ErasedAst.Root = root
     implicit val ctx: SharedContext = new SharedContext()
 
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -42,7 +42,7 @@ object Reducer {
     implicit val r: ErasedAst.Root = root
     implicit val ctx: SharedContext = new SharedContext()
 
-    val defs = ParOps.parMapValues(root.defs)(visitDef)
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -42,7 +42,7 @@ object Reducer {
     implicit val r: ErasedAst.Root = root
     implicit val ctx: SharedContext = new SharedContext()
 
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -57,7 +57,7 @@ object Redundancy {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     val errorsFromDefs = ParOps.parAgg(root.defs, Used.empty)({
-      case (acc, (sym, decl)) => acc ++ flix.compilerProfiler.track(sym, decl.loc)(visitDef(decl)(sctx, root, flix))
+      case (acc, (sym, decl)) => acc ++ flix.track(sym, decl.loc)(visitDef(decl)(sctx, root, flix))
     }, _ ++ _).errors.toList
 
     val errorsFromSigs = ParOps.parAgg(root.sigs, Used.empty)({

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -57,7 +57,7 @@ object Redundancy {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     val errorsFromDefs = ParOps.parAgg(root.defs, Used.empty)({
-      case (acc, (_, decl)) => acc ++ visitDef(decl)(sctx, root, flix)
+      case (acc, (sym, decl)) => acc ++ flix.defnTimer.track(sym, decl.loc)(visitDef(decl)(sctx, root, flix))
     }, _ ++ _).errors.toList
 
     val errorsFromSigs = ParOps.parAgg(root.sigs, Used.empty)({

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -57,7 +57,7 @@ object Redundancy {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     val errorsFromDefs = ParOps.parAgg(root.defs, Used.empty)({
-      case (acc, (sym, decl)) => acc ++ flix.track(sym, decl.loc)(visitDef(decl)(sctx, root, flix))
+      case (acc, (sym, decl)) => acc ++ flix.profile(sym, decl.loc)(visitDef(decl)(sctx, root, flix))
     }, _ ++ _).errors.toList
 
     val errorsFromSigs = ParOps.parAgg(root.sigs, Used.empty)({

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -57,7 +57,7 @@ object Redundancy {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     val errorsFromDefs = ParOps.parAgg(root.defs, Used.empty)({
-      case (acc, (sym, decl)) => acc ++ flix.defnTimer.track(sym, decl.loc)(visitDef(decl)(sctx, root, flix))
+      case (acc, (sym, decl)) => acc ++ flix.compilerProfiler.track(sym, decl.loc)(visitDef(decl)(sctx, root, flix))
     }, _ ++ _).errors.toList
 
     val errorsFromSigs = ParOps.parAgg(root.sigs, Used.empty)({

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -24,7 +24,7 @@ object Safety {
     implicit val sctx: SharedContext = SharedContext.mk()
     implicit val _r: Root = root
 
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
     val uses = changeSet.updateStaleValueLists(root.uses, oldRoot.uses, (uoi1: UseOrImport, uoi2: UseOrImport) => uoi1 == uoi2)(ParOps.parMapValueList(_)(visitUseOrImport))

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -24,7 +24,7 @@ object Safety {
     implicit val sctx: SharedContext = SharedContext.mk()
     implicit val _r: Root = root
 
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
     val uses = changeSet.updateStaleValueLists(root.uses, oldRoot.uses, (uoi1: UseOrImport, uoi2: UseOrImport) => uoi1 == uoi2)(ParOps.parMapValueList(_)(visitUseOrImport))

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -24,7 +24,7 @@ object Safety {
     implicit val sctx: SharedContext = SharedContext.mk()
     implicit val _r: Root = root
 
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn))))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
     val uses = changeSet.updateStaleValueLists(root.uses, oldRoot.uses, (uoi1: UseOrImport, uoi2: UseOrImport) => uoi1 == uoi2)(ParOps.parMapValueList(_)(visitUseOrImport))

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -24,7 +24,7 @@ object Safety {
     implicit val sctx: SharedContext = SharedContext.mk()
     implicit val _r: Root = root
 
-    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
+    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
     val uses = changeSet.updateStaleValueLists(root.uses, oldRoot.uses, (uoi1: UseOrImport, uoi2: UseOrImport) => uoi1 == uoi2)(ParOps.parMapValueList(_)(visitUseOrImport))

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -37,7 +37,7 @@ object Simplifier {
   def run(root: MonoAst.Root)(implicit flix: Flix): SimplifiedAst.Root = flix.phase("Simplifier") {
     implicit val universe: Set[Symbol.EffSym] = root.effects.keys.toSet
     implicit val r: MonoAst.Root = root
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -37,7 +37,7 @@ object Simplifier {
   def run(root: MonoAst.Root)(implicit flix: Flix): SimplifiedAst.Root = flix.phase("Simplifier") {
     implicit val universe: Set[Symbol.EffSym] = root.effects.keys.toSet
     implicit val r: MonoAst.Root = root
-    val defs = ParOps.parMapValues(root.defs)(visitDef)
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -37,7 +37,7 @@ object Simplifier {
   def run(root: MonoAst.Root)(implicit flix: Flix): SimplifiedAst.Root = flix.phase("Simplifier") {
     implicit val universe: Set[Symbol.EffSym] = root.effects.keys.toSet
     implicit val r: MonoAst.Root = root
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -37,7 +37,7 @@ object Simplifier {
   def run(root: MonoAst.Root)(implicit flix: Flix): SimplifiedAst.Root = flix.phase("Simplifier") {
     implicit val universe: Set[Symbol.EffSym] = root.effects.keys.toSet
     implicit val r: MonoAst.Root = root
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
     val enums = ParOps.parMapValues(root.enums)(visitEnum)
     val structs = ParOps.parMapValues(root.structs)(visitStruct)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -56,7 +56,7 @@ object Stratifier {
     implicit val r: Root = root
 
     // Compute the stratification at every datalog expression in the ast.
-    val ds = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val ds = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
     val is = ParOps.parMapValueList(root.instances)(visitInstance)
     val ts = ParOps.parMapValues(root.traits)(visitTrait)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -56,7 +56,7 @@ object Stratifier {
     implicit val r: Root = root
 
     // Compute the stratification at every datalog expression in the ast.
-    val ds = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val ds = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
     val is = ParOps.parMapValueList(root.instances)(visitInstance)
     val ts = ParOps.parMapValues(root.traits)(visitTrait)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -56,7 +56,7 @@ object Stratifier {
     implicit val r: Root = root
 
     // Compute the stratification at every datalog expression in the ast.
-    val ds = ParOps.parMapValues(root.defs)(visitDef)
+    val ds = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
     val is = ParOps.parMapValueList(root.instances)(visitInstance)
     val ts = ParOps.parMapValues(root.traits)(visitTrait)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -56,7 +56,7 @@ object Stratifier {
     implicit val r: Root = root
 
     // Compute the stratification at every datalog expression in the ast.
-    val ds = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val ds = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
     val is = ParOps.parMapValueList(root.instances)(visitInstance)
     val ts = ParOps.parMapValues(root.traits)(visitTrait)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
@@ -40,7 +40,7 @@ object TailPos {
 
   /** Identifies expressions in tail position in `root`. */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("TailPos") {
-    val defns = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defns = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = defns)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
@@ -40,7 +40,7 @@ object TailPos {
 
   /** Identifies expressions in tail position in `root`. */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("TailPos") {
-    val defns = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defns = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = defns)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
@@ -40,7 +40,7 @@ object TailPos {
 
   /** Identifies expressions in tail position in `root`. */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("TailPos") {
-    val defns = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val defns = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = defns)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
@@ -40,7 +40,7 @@ object TailPos {
 
   /** Identifies expressions in tail position in `root`. */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("TailPos") {
-    val defns = ParOps.parMapValues(root.defs)(visitDef)
+    val defns = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = defns)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
@@ -86,7 +86,7 @@ object Terminator {
       implicit val sctx: SharedContext = SharedContext.mk()
       implicit val _r: Root = root
       val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(
-        ParOps.parMapValues(_)(visitDef))
+        ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(
         ParOps.parMapValues(_)(visitTrait))
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances,

--- a/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
@@ -86,7 +86,7 @@ object Terminator {
       implicit val sctx: SharedContext = SharedContext.mk()
       implicit val _r: Root = root
       val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(
-        ParOps.parMapValues(_)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn))))
+        ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(
         ParOps.parMapValues(_)(visitTrait))
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances,

--- a/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
@@ -86,7 +86,7 @@ object Terminator {
       implicit val sctx: SharedContext = SharedContext.mk()
       implicit val _r: Root = root
       val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(
-        ParOps.parMapValues(_)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn))))
+        ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(
         ParOps.parMapValues(_)(visitTrait))
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances,

--- a/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
@@ -86,7 +86,7 @@ object Terminator {
       implicit val sctx: SharedContext = SharedContext.mk()
       implicit val _r: Root = root
       val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(
-        ParOps.parMapValues(_)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn))))
+        ParOps.parMapValues(_)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn))))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(
         ParOps.parMapValues(_)(visitTrait))
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances,

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -185,7 +185,7 @@ object Typer {
     */
   private def visitDefs(root: KindedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, TypedAst.Def] = {
     changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_) {
-      case defn => flix.compilerProfiler.track(defn.sym, defn.loc) {
+      case defn => flix.track(defn.sym, defn.loc) {
         // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs.
         // If no effect is specified, we assume the function is pure
         val eff1 = defn.spec.eff.getOrElse(Type.Pure)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -185,7 +185,7 @@ object Typer {
     */
   private def visitDefs(root: KindedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, TypedAst.Def] = {
     changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_) {
-      case defn => flix.track(defn.sym, defn.loc) {
+      case defn => flix.profile(defn.sym, defn.loc) {
         // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs.
         // If no effect is specified, we assume the function is pure
         val eff1 = defn.spec.eff.getOrElse(Type.Pure)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -185,12 +185,13 @@ object Typer {
     */
   private def visitDefs(root: KindedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, TypedAst.Def] = {
     changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_) {
-      case defn =>
+      case defn => flix.defnTimer.track(defn.sym, defn.loc) {
         // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs.
         // If no effect is specified, we assume the function is pure
         val eff1 = defn.spec.eff.getOrElse(Type.Pure)
         val enableSubeffects = shouldSubeffect(eff1, Subeffecting.ModDefs)
         visitDef(defn, tconstrs0 = Nil, econstrs0 = Nil, RigidityEnv.empty, root, traitEnv, eqEnv, enableSubeffects)
+      }
     })
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -185,7 +185,7 @@ object Typer {
     */
   private def visitDefs(root: KindedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, TypedAst.Def] = {
     changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_) {
-      case defn => flix.defnTimer.track(defn.sym, defn.loc) {
+      case defn => flix.compilerProfiler.track(defn.sym, defn.loc) {
         // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs.
         // If no effect is specified, we assume the function is pure
         val eff1 = defn.spec.eff.getOrElse(Type.Pure)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -37,19 +37,25 @@ object GenFunAndClosureClasses {
     ParOps.parAgg(defs.values, Map.empty[JvmName, JvmClass])({
 
       case (macc, closure) if isClosure(closure) =>
-        val closureName = JvmOps.getClosureClassName(closure.sym)
-        val code = genClosure(closureName, closure)
-        macc + (closureName -> JvmClass(closureName, code))
+        flix.profile(closure.sym, closure.loc) {
+          val closureName = JvmOps.getClosureClassName(closure.sym)
+          val code = genClosure(closureName, closure)
+          macc + (closureName -> JvmClass(closureName, code))
+        }
 
       case (macc, defn) if isFunction(defn) && isControlPure(defn) =>
-        val functionName = BackendObjType.Defn(defn.sym).jvmName
-        val code = genControlPureFunction(functionName, defn)
-        macc + (functionName -> JvmClass(functionName, code))
+        flix.profile(defn.sym, defn.loc) {
+          val functionName = BackendObjType.Defn(defn.sym).jvmName
+          val code = genControlPureFunction(functionName, defn)
+          macc + (functionName -> JvmClass(functionName, code))
+        }
 
       case (macc, defn) if isFunction(defn) =>
-        val functionName = BackendObjType.Defn(defn.sym).jvmName
-        val code = genControlImpureFunction(functionName, defn)
-        macc + (functionName -> JvmClass(functionName, code))
+        flix.profile(defn.sym, defn.loc) {
+          val functionName = BackendObjType.Defn(defn.sym).jvmName
+          val code = genControlImpureFunction(functionName, defn)
+          macc + (functionName -> JvmClass(functionName, code))
+        }
 
       case (macc, _) =>
         macc

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -330,7 +330,7 @@ object Specialization {
     // We perform specialization in parallel.
     // This will enqueue additional functions for specialization.
     ParOps.parMap(nonParametricDefns) {
-      case (sym, defn) => flix.track(defn.sym, defn.loc) {
+      case (sym, defn) => flix.profile(defn.sym, defn.loc) {
         // We use an empty substitution because the defs are non-parametric.
         // It's important that non-parametric functions keep their symbol to not
         // invalidate the set of entryPoints functions.
@@ -346,7 +346,7 @@ object Specialization {
       // Extract a function from the queue and specializes it w.r.t. its substitution.
       val queue = ctx.dequeueAllSpecializations
       ParOps.parMap(queue) {
-        case (freshSym, defn, subst) => flix.track(defn.sym, defn.loc) {
+        case (freshSym, defn, subst) => flix.profile(defn.sym, defn.loc) {
           val specializedDefn = specializeDef(freshSym, defn, subst)
           val loweredDefn = Lowering.lowerDef(specializedDefn)
           ctx.addSpecializedDef(freshSym, loweredDefn)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -330,7 +330,7 @@ object Specialization {
     // We perform specialization in parallel.
     // This will enqueue additional functions for specialization.
     ParOps.parMap(nonParametricDefns) {
-      case (sym, defn) => flix.compilerProfiler.track(defn.sym, defn.loc) {
+      case (sym, defn) => flix.track(defn.sym, defn.loc) {
         // We use an empty substitution because the defs are non-parametric.
         // It's important that non-parametric functions keep their symbol to not
         // invalidate the set of entryPoints functions.
@@ -346,7 +346,7 @@ object Specialization {
       // Extract a function from the queue and specializes it w.r.t. its substitution.
       val queue = ctx.dequeueAllSpecializations
       ParOps.parMap(queue) {
-        case (freshSym, defn, subst) => flix.compilerProfiler.track(defn.sym, defn.loc) {
+        case (freshSym, defn, subst) => flix.track(defn.sym, defn.loc) {
           val specializedDefn = specializeDef(freshSym, defn, subst)
           val loweredDefn = Lowering.lowerDef(specializedDefn)
           ctx.addSpecializedDef(freshSym, loweredDefn)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -330,13 +330,14 @@ object Specialization {
     // We perform specialization in parallel.
     // This will enqueue additional functions for specialization.
     ParOps.parMap(nonParametricDefns) {
-      case (sym, defn) =>
+      case (sym, defn) => flix.defnTimer.track(defn.sym, defn.loc) {
         // We use an empty substitution because the defs are non-parametric.
         // It's important that non-parametric functions keep their symbol to not
         // invalidate the set of entryPoints functions.
         val specializedDefn = specializeDef(sym, defn, StrictSubstitution.empty)
         val loweredDefn = Lowering.lowerDef(specializedDefn)
         ctx.addSpecializedDef(sym, loweredDefn)
+      }
     }
 
     // Perform function specialization until the queue is empty.
@@ -345,10 +346,11 @@ object Specialization {
       // Extract a function from the queue and specializes it w.r.t. its substitution.
       val queue = ctx.dequeueAllSpecializations
       ParOps.parMap(queue) {
-        case (freshSym, defn, subst) =>
+        case (freshSym, defn, subst) => flix.defnTimer.track(defn.sym, defn.loc) {
           val specializedDefn = specializeDef(freshSym, defn, subst)
           val loweredDefn = Lowering.lowerDef(specializedDefn)
           ctx.addSpecializedDef(freshSym, loweredDefn)
+        }
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -330,7 +330,7 @@ object Specialization {
     // We perform specialization in parallel.
     // This will enqueue additional functions for specialization.
     ParOps.parMap(nonParametricDefns) {
-      case (sym, defn) => flix.defnTimer.track(defn.sym, defn.loc) {
+      case (sym, defn) => flix.compilerProfiler.track(defn.sym, defn.loc) {
         // We use an empty substitution because the defs are non-parametric.
         // It's important that non-parametric functions keep their symbol to not
         // invalidate the set of entryPoints functions.
@@ -346,7 +346,7 @@ object Specialization {
       // Extract a function from the queue and specializes it w.r.t. its substitution.
       val queue = ctx.dequeueAllSpecializations
       ParOps.parMap(queue) {
-        case (freshSym, defn, subst) => flix.defnTimer.track(defn.sym, defn.loc) {
+        case (freshSym, defn, subst) => flix.compilerProfiler.track(defn.sym, defn.loc) {
           val specializedDefn = specializeDef(freshSym, defn, subst)
           val loweredDefn = Lowering.lowerDef(specializedDefn)
           ctx.addSpecializedDef(freshSym, loweredDefn)

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -73,7 +73,7 @@ object Inliner {
   /** Performs inlining on the given AST `root`. */
   def run(root: MonoAst.Root)(implicit flix: Flix): (MonoAst.Root, Set[Symbol.DefnSym]) = {
     val sctx: SharedContext = SharedContext.mk()
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)(sctx, root, flix)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)(sctx, root, flix)))
     val newDelta = sctx.changed.asScala.keys.toSet
     val liveSyms = root.entryPoints ++ sctx.live.asScala.keys.toSet
     val liveDefs = defs.filter(kv => liveSyms.contains(kv._1))

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -73,7 +73,7 @@ object Inliner {
   /** Performs inlining on the given AST `root`. */
   def run(root: MonoAst.Root)(implicit flix: Flix): (MonoAst.Root, Set[Symbol.DefnSym]) = {
     val sctx: SharedContext = SharedContext.mk()
-    val defs = ParOps.parMapValues(root.defs)(visitDef(_)(sctx, root, flix))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)(sctx, root, flix)))
     val newDelta = sctx.changed.asScala.keys.toSet
     val liveSyms = root.entryPoints ++ sctx.live.asScala.keys.toSet
     val liveDefs = defs.filter(kv => liveSyms.contains(kv._1))

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -73,7 +73,7 @@ object Inliner {
   /** Performs inlining on the given AST `root`. */
   def run(root: MonoAst.Root)(implicit flix: Flix): (MonoAst.Root, Set[Symbol.DefnSym]) = {
     val sctx: SharedContext = SharedContext.mk()
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)(sctx, root, flix)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)(sctx, root, flix)))
     val newDelta = sctx.changed.asScala.keys.toSet
     val liveSyms = root.entryPoints ++ sctx.live.asScala.keys.toSet
     val liveDefs = defs.filter(kv => liveSyms.contains(kv._1))

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -73,7 +73,7 @@ object Inliner {
   /** Performs inlining on the given AST `root`. */
   def run(root: MonoAst.Root)(implicit flix: Flix): (MonoAst.Root, Set[Symbol.DefnSym]) = {
     val sctx: SharedContext = SharedContext.mk()
-    val defs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)(sctx, root, flix)))
+    val defs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)(sctx, root, flix)))
     val newDelta = sctx.changed.asScala.keys.toSet
     val liveSyms = root.entryPoints ++ sctx.live.asScala.keys.toSet
     val liveDefs = defs.filter(kv => liveSyms.contains(kv._1))

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
@@ -56,7 +56,7 @@ object LambdaDrop {
 
   /** See [[LambdaDrop]] for documentation. */
   def run(root: MonoAst.Root)(implicit flix: Flix): MonoAst.Root = flix.phase("LambdaDrop") {
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = newDefs)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
@@ -56,7 +56,7 @@ object LambdaDrop {
 
   /** See [[LambdaDrop]] for documentation. */
   def run(root: MonoAst.Root)(implicit flix: Flix): MonoAst.Root = flix.phase("LambdaDrop") {
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = newDefs)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
@@ -56,7 +56,7 @@ object LambdaDrop {
 
   /** See [[LambdaDrop]] for documentation. */
   def run(root: MonoAst.Root)(implicit flix: Flix): MonoAst.Root = flix.phase("LambdaDrop") {
-    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = newDefs)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
@@ -56,7 +56,7 @@ object LambdaDrop {
 
   /** See [[LambdaDrop]] for documentation. */
   def run(root: MonoAst.Root)(implicit flix: Flix): MonoAst.Root = flix.phase("LambdaDrop") {
-    val newDefs = ParOps.parMapValues(root.defs)(visitDef)
+    val newDefs = ParOps.parMapValues(root.defs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = newDefs)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -35,7 +35,7 @@ object OccurrenceAnalyzer {
     */
   def run(root: MonoAst.Root, delta: Set[Symbol.DefnSym])(implicit flix: Flix): MonoAst.Root = {
     val changedDefs = root.defs.filter(kv => delta.contains(kv._1))
-    val visitedDefs = ParOps.parMapValues(changedDefs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
+    val visitedDefs = ParOps.parMapValues(changedDefs)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = root.defs ++ visitedDefs)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -35,7 +35,7 @@ object OccurrenceAnalyzer {
     */
   def run(root: MonoAst.Root, delta: Set[Symbol.DefnSym])(implicit flix: Flix): MonoAst.Root = {
     val changedDefs = root.defs.filter(kv => delta.contains(kv._1))
-    val visitedDefs = ParOps.parMapValues(changedDefs)(visitDef)
+    val visitedDefs = ParOps.parMapValues(changedDefs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = root.defs ++ visitedDefs)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -35,7 +35,7 @@ object OccurrenceAnalyzer {
     */
   def run(root: MonoAst.Root, delta: Set[Symbol.DefnSym])(implicit flix: Flix): MonoAst.Root = {
     val changedDefs = root.defs.filter(kv => delta.contains(kv._1))
-    val visitedDefs = ParOps.parMapValues(changedDefs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
+    val visitedDefs = ParOps.parMapValues(changedDefs)(defn => flix.track(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = root.defs ++ visitedDefs)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -35,7 +35,7 @@ object OccurrenceAnalyzer {
     */
   def run(root: MonoAst.Root, delta: Set[Symbol.DefnSym])(implicit flix: Flix): MonoAst.Root = {
     val changedDefs = root.defs.filter(kv => delta.contains(kv._1))
-    val visitedDefs = ParOps.parMapValues(changedDefs)(defn => flix.defnTimer.track(defn.sym, defn.loc)(visitDef(defn)))
+    val visitedDefs = ParOps.parMapValues(changedDefs)(defn => flix.compilerProfiler.track(defn.sym, defn.loc)(visitDef(defn)))
     root.copy(defs = root.defs ++ visitedDefs)
   }
 

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -22,82 +22,81 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, AtomicReference}
 import scala.jdk.CollectionConverters.*
 
 /**
-  * Per-`DefnSym` statistics: total wall-clock time, number of times the
-  * compiler visited the def, and a per-phase breakdown of where the time
-  * went.
+  * Per-`DefnSym` compile-time profiler.
+  *
+  * [[CompilerProfiler]] tracks cumulative wall-clock time, call counts, and a
+  * per-phase breakdown for each [[Symbol.DefnSym]] the compiler visits. Its
+  * [[CompilerProfiler.track]] entry point is called from inside instrumented
+  * phases and is safe to invoke from multiple threads.
+  *
+  * A fresh sym minted from an existing one via [[Symbol.freshDefnSym]] is
+  * folded back to its source sym (see [[CompilerProfiler.sourceOf]]) so the
+  * user-facing table shows one row per source-level definition rather than
+  * one row per refresh.
+  *
+  * Instrumentation coverage of the compiler pipeline:
+  *
+  * | Phase                                          | Instrumented | Reason                                                                                                                |
+  * | ---------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------- |
+  * | Reader, Lexer, Parser2, Weeder2, Desugar, Namer | No          | Run before any `DefnSym` exists, so there is no key to attribute time to.                                             |
+  * | Resolver                                       | No           | Per-def work is nested inside trait/instance walks rather than a clean `parMapValues` over `root.defs`.               |
+  * | Deriver                                        | No           | Generates new instances from enum derivations; iterates over enums, not existing defs.                                |
+  * | Instances                                      | No           | Per-instance-def work interleaves with trait conformance checks; instrumentable but not a one-line wrap.              |
+  * | Kinder                                         | Yes          | `visitDefSpecs` + `visitDefs`.                                                                                        |
+  * | Typer                                          | Yes          |                                                                                                                       |
+  * | EntryPoints                                    | Yes          |                                                                                                                       |
+  * | PredDeps                                       | Yes          |                                                                                                                       |
+  * | Stratifier                                     | Yes          |                                                                                                                       |
+  * | PatMatch                                       | Yes          |                                                                                                                       |
+  * | Redundancy                                     | Yes          |                                                                                                                       |
+  * | Safety                                         | Yes          |                                                                                                                       |
+  * | Terminator                                     | Yes          |                                                                                                                       |
+  * | Dependencies                                   | Yes          |                                                                                                                       |
+  * | TreeShaker1, TreeShaker2                       | No           | Pure filter passes; no per-def work to time.                                                                          |
+  * | Monomorpher                                    | Yes          | Initial + worklist, keyed by the source generic sym.                                                                  |
+  * | LambdaDrop                                     | Yes          |                                                                                                                       |
+  * | Optimizer                                      | No           | Fixed-point wrapper around `OccurrenceAnalyzer` / `Inliner`; captured transitively through those inner phases.        |
+  * | OccurrenceAnalyzer                             | Yes          |                                                                                                                       |
+  * | Inliner                                        | Yes          |                                                                                                                       |
+  * | Simplifier                                     | Yes          |                                                                                                                       |
+  * | ClosureConv                                    | Yes          |                                                                                                                       |
+  * | LambdaLift                                     | Yes          |                                                                                                                       |
+  * | EffectBinder                                   | Yes          |                                                                                                                       |
+  * | TailPos                                        | Yes          |                                                                                                                       |
+  * | Eraser                                         | Yes          |                                                                                                                       |
+  * | Reducer                                        | Yes          |                                                                                                                       |
+  * | JvmBackend                                     | Partial      | Top-level orchestration is not per-def. The dominant per-def work — closure + control-pure + control-impure cases in `GenFunAndClosureClasses` — is instrumented. |
   */
-final case class DefnStats(
-  sym: Symbol.DefnSym,
-  loc: SourceLocation,
-  totalNanos: Long,
-  callCount: Int,
-  byPhase: Map[String, Long],
-  isActive: Boolean
-) {
-  /** Returns the phase that consumed the most time, or None if empty. */
-  def dominantPhase: Option[String] =
-    if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
+object CompilerProfiler {
+  /**
+    * Per-`DefnSym` statistics: total wall-clock time, number of times the
+    * compiler visited the def, and a per-phase breakdown of where the time
+    * went.
+    */
+  final case class DefnStats(
+    sym: Symbol.DefnSym,
+    loc: SourceLocation,
+    totalNanos: Long,
+    callCount: Int,
+    byPhase: Map[String, Long],
+    isActive: Boolean
+  ) {
+    /** Returns the phase that consumed the most time, or None if empty. */
+    def dominantPhase: Option[String] =
+      if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
+  }
+
+  private final class Counters {
+    val totalNanos = new AtomicLong(0L)
+    val callCount = new AtomicInteger(0)
+    val perPhaseNanos = new ConcurrentHashMap[String, AtomicLong]()
+    /** Set on first `track` call; carries the def-body span so we can show LOC. */
+    val loc = new AtomicReference[SourceLocation](null)
+    /** Number of `track` calls currently in flight for this source sym. */
+    val inProgress = new AtomicInteger(0)
+  }
 }
 
-/**
-  * Tracks cumulative wall-clock time, call counts, and per-phase breakdowns
-  * for each [[Symbol.DefnSym]]. Safe to call from multiple threads.
-  *
-  * `phaseProvider` is consulted at the start of every [[track]] call to
-  * attribute the elapsed time to the currently running phase.
-  *
-  * == Roll-up of refreshed symbols ==
-  *
-  * A fresh [[Symbol.DefnSym]] minted from an existing sym via
-  * [[Symbol.freshDefnSym]] is recorded under that existing sym, not under
-  * its own identity. So every specialization produced by `Monomorpher` and
-  * every closure/local-def lifted out by `LambdaLift` folds back into the
-  * source sym it was derived from, and the user-facing table shows one row
-  * per source-level definition rather than one row per fresh refresh.
-  *
-  * The folding is implemented inside this profiler (see [[sourceOf]]) and
-  * relies on [[Symbol.freshDefnSym]] preserving the source sym's
-  * `(namespace, text, loc)` triple — which is true today across all three
-  * refresh sites (`Specialization`, `LambdaLift` closure lift, `LambdaLift`
-  * local-def lift).
-  *
-  * == Instrumented phases ==
-  *
-  * The following phases call [[track]] and contribute per-`DefnSym` data:
-  *
-  *   - Frontend (10 sites):
-  *     `Kinder` (visitDefSpecs + visitDefs), `Typer`, `EntryPoints`,
-  *     `PredDeps`, `Stratifier`, `PatMatch`, `Redundancy`, `Safety`,
-  *     `Terminator`, `Dependencies`.
-  *   - Backend (16 sites):
-  *     `Monomorpher` (initial + worklist; keyed by source generic sym),
-  *     `LambdaDrop`, `OccurrenceAnalyzer`, `Inliner`, `Simplifier`,
-  *     `ClosureConv`, `LambdaLift`, `EffectBinder`, `TailPos`, `Eraser`,
-  *     `Reducer`, `JvmBackend` (closure + control-pure function +
-  *     control-impure function cases in `GenFunAndClosureClasses`).
-  *
-  * == Uninstrumented phases ==
-  *
-  * These phases run but do not feed the timer:
-  *
-  *   - `Reader`, `Lexer`, `Parser2`, `Weeder2`, `Desugar`, `Namer` —
-  *     pre-`DefnSym`; the symbol does not exist yet.
-  *   - `Resolver` — per-def work is nested inside trait/instance walks
-  *     rather than a clean `parMapValues` over `root.defs`.
-  *   - `Deriver` — generates new instances from enum derivations; iterates
-  *     over enums, not over existing defs.
-  *   - `Instances` — per-instance-def work is interleaved with trait
-  *     conformance checks; instrumentable but not a one-line wrap.
-  *   - `TreeShaker1`, `TreeShaker2` — pure filter passes; no per-def work
-  *     to time.
-  *   - `Optimizer` — a wrapper that re-runs `OccurrenceAnalyzer` and
-  *     `Inliner` in a fixed-point loop. All work is captured transitively
-  *     through those instrumented inner phases.
-  *   - `JvmBackend` — top-level orchestration (namespace classes, runtime
-  *     types, etc.) is not per-def. The dominant per-def work — function
-  *     and closure class generation in `GenFunAndClosureClasses` — *is*
-  *     instrumented (see Backend list above).
-  */
 final class CompilerProfiler(phaseProvider: () => Option[String]) {
 
   private val stats = new ConcurrentHashMap[Symbol.DefnSym, CompilerProfiler.Counters]()
@@ -131,14 +130,14 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
     * Returns an approximate snapshot. Iterators over the underlying maps are
     * weakly consistent, so individual entries may be slightly stale.
     */
-  def snapshot(): Vector[DefnStats] = {
+  def snapshot(): Vector[CompilerProfiler.DefnStats] = {
     val it = stats.entrySet().iterator().asScala
     it.map { e =>
       val c = e.getValue
       val byPhase = c.perPhaseNanos.entrySet().iterator().asScala
         .map(pe => (pe.getKey, pe.getValue.get())).toMap
       val loc = Option(c.loc.get()).getOrElse(e.getKey.loc)
-      DefnStats(e.getKey, loc, c.totalNanos.get(), c.callCount.get(), byPhase,
+      CompilerProfiler.DefnStats(e.getKey, loc, c.totalNanos.get(), c.callCount.get(), byPhase,
         isActive = c.inProgress.get() > 0)
     }.toVector
   }
@@ -170,14 +169,3 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
     else new Symbol.DefnSym(None, sym.namespace, sym.text, sym.loc)
 }
 
-object CompilerProfiler {
-  private final class Counters {
-    val totalNanos = new AtomicLong(0L)
-    val callCount = new AtomicInteger(0)
-    val perPhaseNanos = new ConcurrentHashMap[String, AtomicLong]()
-    /** Set on first `track` call; carries the def-body span so we can show LOC. */
-    val loc = new AtomicReference[SourceLocation](null)
-    /** Number of `track` calls currently in flight for this source sym. */
-    val inProgress = new AtomicInteger(0)
-  }
-}

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -75,32 +75,31 @@ import scala.jdk.CollectionConverters.*
   */
 object CompilerProfiler {
   /**
-    * Per-`DefnSym` statistics: total wall-clock time, number of times the
-    * compiler visited the def, and a per-phase breakdown of where the time
-    * went.
+    * A snapshot of per-`DefnSym` statistics produced by [[CompilerProfiler.snapshot]].
+    *
+    * @param sym        the source-level [[Symbol.DefnSym]] this row aggregates.
+    * @param isActive   true if at least one `track` call is currently in flight for this sym.
+    * @param callCount  number of `track` calls observed for this sym.
+    * @param totalNanos total wall-clock time spent inside `track` calls for this sym, in nanoseconds.
+    * @param byPhase    per-phase breakdown of `totalNanos`, keyed by phase name.
+    * @param loc        the source location of the def's body, used to compute LOC.
     */
-  final case class DefnStats(
-    sym: Symbol.DefnSym,
-    loc: SourceLocation,
-    totalNanos: Long,
-    callCount: Int,
-    byPhase: Map[String, Long],
-    isActive: Boolean
-  ) {
+  final case class DefnStats(sym: Symbol.DefnSym, isActive: Boolean, callCount: Int, totalNanos: Long, byPhase: Map[String, Long], loc: SourceLocation) {
     /** Returns the phase that consumed the most time, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
   }
 
-  private final class Counters {
-    val totalNanos = new AtomicLong(0L)
-    val callCount = new AtomicInteger(0)
-    val perPhaseNanos = new ConcurrentHashMap[String, AtomicLong]()
-    /** Set on first `track` call; carries the def-body span so we can show LOC. */
-    val loc = new AtomicReference[SourceLocation](null)
-    /** Number of `track` calls currently in flight for this source sym. */
-    val inProgress = new AtomicInteger(0)
-  }
+  /**
+    * Mutable per-`DefnSym` accumulators feeding [[DefnStats]].
+    *
+    * @param totalNanos    total wall-clock time spent inside `track` calls for this sym, in nanoseconds.
+    * @param callCount     number of `track` calls observed for this sym.
+    * @param perPhaseNanos per-phase nanosecond accumulator, keyed by phase name.
+    * @param loc           set on first `track` call; carries the def-body span so we can show LOC.
+    * @param inProgress    number of `track` calls currently in flight for this source sym.
+    */
+  private final case class Counters(totalNanos: AtomicLong = new AtomicLong(0L), callCount: AtomicInteger = new AtomicInteger(0), perPhaseNanos: ConcurrentHashMap[String, AtomicLong] = new ConcurrentHashMap[String, AtomicLong](), loc: AtomicReference[SourceLocation] = new AtomicReference[SourceLocation](null), inProgress: AtomicInteger = new AtomicInteger(0))
 }
 
 final class CompilerProfiler(phaseProvider: () => Option[String]) {
@@ -143,8 +142,8 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
       val byPhase = c.perPhaseNanos.entrySet().iterator().asScala
         .map(pe => (pe.getKey, pe.getValue.get())).toMap
       val loc = Option(c.loc.get()).getOrElse(e.getKey.loc)
-      CompilerProfiler.DefnStats(e.getKey, loc, c.totalNanos.get(), c.callCount.get(), byPhase,
-        isActive = c.inProgress.get() > 0)
+      CompilerProfiler.DefnStats(e.getKey, isActive = c.inProgress.get() > 0,
+        c.callCount.get(), c.totalNanos.get(), byPhase, loc)
     }.toVector
   }
 

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -45,6 +45,21 @@ final case class DefnStats(
   * `phaseProvider` is consulted at the start of every [[track]] call to
   * attribute the elapsed time to the currently running phase.
   *
+  * == Roll-up of refreshed symbols ==
+  *
+  * A fresh [[Symbol.DefnSym]] minted from an existing sym via
+  * [[Symbol.freshDefnSym]] is recorded under that existing sym, not under
+  * its own identity. So every specialization produced by `Monomorpher` and
+  * every closure/local-def lifted out by `LambdaLift` folds back into the
+  * source sym it was derived from, and the user-facing table shows one row
+  * per source-level definition rather than one row per fresh refresh.
+  *
+  * The folding is implemented inside this profiler (see [[sourceOf]]) and
+  * relies on [[Symbol.freshDefnSym]] preserving the source sym's
+  * `(namespace, text, loc)` triple — which is true today across all three
+  * refresh sites (`Specialization`, `LambdaLift` closure lift, `LambdaLift`
+  * local-def lift).
+  *
   * == Instrumented phases ==
   *
   * The following phases call [[track]] and contribute per-`DefnSym` data:
@@ -131,7 +146,22 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
   }
 
   private def countersFor(sym: Symbol.DefnSym): CompilerProfiler.Counters =
-    stats.computeIfAbsent(sym, _ => new CompilerProfiler.Counters)
+    stats.computeIfAbsent(sourceOf(sym), _ => new CompilerProfiler.Counters)
+
+  /**
+    * Returns the source-equivalent sym for `sym`: same `(namespace, text,
+    * loc)` triple but with `id = None`, i.e. the sym a user would have
+    * written. A sym that is already a source sym (`id.isEmpty`) is returned
+    * unchanged.
+    *
+    * Correct only as long as [[Symbol.freshDefnSym]] keeps the triple
+    * identical to its argument; if a future change starts varying any of
+    * those three, the roll-up here would silently cross-attribute time
+    * between unrelated defs.
+    */
+  private def sourceOf(sym: Symbol.DefnSym): Symbol.DefnSym =
+    if (sym.id.isEmpty) sym
+    else new Symbol.DefnSym(None, sym.namespace, sym.text, sym.loc)
 }
 
 object CompilerProfiler {

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -130,9 +130,6 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
     n
   }
 
-  /** Removes all recorded statistics. */
-  def reset(): Unit = stats.clear()
-
   private def countersFor(sym: Symbol.DefnSym): CompilerProfiler.Counters =
     stats.computeIfAbsent(sym, _ => new CompilerProfiler.Counters)
 }

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -93,13 +93,13 @@ object CompilerProfiler {
   /**
     * Mutable per-`DefnSym` accumulators feeding [[DefnStats]].
     *
-    * @param totalNanos    total wall-clock time spent inside `track` calls for this sym, in nanoseconds.
+    * @param inProgress    number of `track` calls currently in flight for this source sym.
     * @param callCount     number of `track` calls observed for this sym.
+    * @param totalNanos    total wall-clock time spent inside `track` calls for this sym, in nanoseconds.
     * @param perPhaseNanos per-phase nanosecond accumulator, keyed by phase name.
     * @param loc           set on first `track` call; carries the def-body span so we can show LOC.
-    * @param inProgress    number of `track` calls currently in flight for this source sym.
     */
-  private final case class Counters(totalNanos: AtomicLong = new AtomicLong(0L), callCount: AtomicInteger = new AtomicInteger(0), perPhaseNanos: ConcurrentHashMap[String, AtomicLong] = new ConcurrentHashMap[String, AtomicLong](), loc: AtomicReference[SourceLocation] = new AtomicReference[SourceLocation](null), inProgress: AtomicInteger = new AtomicInteger(0))
+  private final case class Counters(inProgress: AtomicInteger, callCount: AtomicInteger, totalNanos: AtomicLong, perPhaseNanos: ConcurrentHashMap[String, AtomicLong], loc: AtomicReference[SourceLocation])
 }
 
 final class CompilerProfiler(phaseProvider: () => Option[String]) {
@@ -156,7 +156,13 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
   }
 
   private def countersFor(sym: Symbol.DefnSym): CompilerProfiler.Counters =
-    stats.computeIfAbsent(sourceOf(sym), _ => new CompilerProfiler.Counters)
+    stats.computeIfAbsent(sourceOf(sym), _ => CompilerProfiler.Counters(
+      inProgress = new AtomicInteger(0),
+      callCount = new AtomicInteger(0),
+      totalNanos = new AtomicLong(0L),
+      perPhaseNanos = new ConcurrentHashMap[String, AtomicLong](),
+      loc = new AtomicReference[SourceLocation](null)
+    ))
 
   /**
     * Returns the source-equivalent sym for `sym`: same `(namespace, text,

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -80,16 +80,19 @@ final case class DefnStats(
   *     `GenFunAndClosureClasses`; not a `parMap` and would require a
   *     dedicated hook inside the class generator.
   */
-final class CompilerProfiler(phaseProvider: () => String) {
+final class CompilerProfiler(phaseProvider: () => Option[String]) {
 
   private val stats = new ConcurrentHashMap[Symbol.DefnSym, CompilerProfiler.Counters]()
 
   /**
     * Runs `thunk` and records its elapsed wall-clock time against `sym`,
-    * attributed to whatever phase is currently running.
+    * attributed to whatever phase is currently running. If no phase is
+    * active (e.g. before the first phase has started), the time is
+    * bucketed under `"?"` to match the unknown-phase label used by the
+    * renderer.
     */
   def track[A](sym: Symbol.DefnSym, loc: SourceLocation)(thunk: => A): A = {
-    val phase = phaseProvider()
+    val phase = phaseProvider().getOrElse("?")
     val t0 = System.nanoTime()
     try thunk
     finally {

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -36,36 +36,42 @@ import scala.jdk.CollectionConverters.*
   *
   * Instrumentation coverage of the compiler pipeline:
   *
-  * | Phase                                          | Instrumented | Reason                                                                                                                |
-  * | ---------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------- |
-  * | Reader, Lexer, Parser2, Weeder2, Desugar, Namer | No          | Run before any `DefnSym` exists, so there is no key to attribute time to.                                             |
-  * | Resolver                                       | No           | Per-def work is nested inside trait/instance walks rather than a clean `parMapValues` over `root.defs`.               |
-  * | Deriver                                        | No           | Generates new instances from enum derivations; iterates over enums, not existing defs.                                |
-  * | Instances                                      | No           | Per-instance-def work interleaves with trait conformance checks; instrumentable but not a one-line wrap.              |
-  * | Kinder                                         | Yes          | `visitDefSpecs` + `visitDefs`.                                                                                        |
-  * | Typer                                          | Yes          |                                                                                                                       |
-  * | EntryPoints                                    | Yes          |                                                                                                                       |
-  * | PredDeps                                       | Yes          |                                                                                                                       |
-  * | Stratifier                                     | Yes          |                                                                                                                       |
-  * | PatMatch                                       | Yes          |                                                                                                                       |
-  * | Redundancy                                     | Yes          |                                                                                                                       |
-  * | Safety                                         | Yes          |                                                                                                                       |
-  * | Terminator                                     | Yes          |                                                                                                                       |
-  * | Dependencies                                   | Yes          |                                                                                                                       |
-  * | TreeShaker1, TreeShaker2                       | No           | Pure filter passes; no per-def work to time.                                                                          |
-  * | Monomorpher                                    | Yes          | Initial + worklist, keyed by the source generic sym.                                                                  |
-  * | LambdaDrop                                     | Yes          |                                                                                                                       |
-  * | Optimizer                                      | No           | Fixed-point wrapper around `OccurrenceAnalyzer` / `Inliner`; captured transitively through those inner phases.        |
-  * | OccurrenceAnalyzer                             | Yes          |                                                                                                                       |
-  * | Inliner                                        | Yes          |                                                                                                                       |
-  * | Simplifier                                     | Yes          |                                                                                                                       |
-  * | ClosureConv                                    | Yes          |                                                                                                                       |
-  * | LambdaLift                                     | Yes          |                                                                                                                       |
-  * | EffectBinder                                   | Yes          |                                                                                                                       |
-  * | TailPos                                        | Yes          |                                                                                                                       |
-  * | Eraser                                         | Yes          |                                                                                                                       |
-  * | Reducer                                        | Yes          |                                                                                                                       |
-  * | JvmBackend                                     | Partial      | Top-level orchestration is not per-def. The dominant per-def work — closure + control-pure + control-impure cases in `GenFunAndClosureClasses` — is instrumented. |
+  * | Phase              | Instrumented | Reason                                                                                                        |
+  * | ------------------ | ------------ | ------------------------------------------------------------------------------------------------------------- |
+  * | Reader             | No           | Runs before any `DefnSym` exists, so there is no key to attribute time to.                                    |
+  * | Lexer              | No           | -- same --                                                                                                    |
+  * | Parser2            | No           | -- same --                                                                                                    |
+  * | Weeder2            | No           | -- same --                                                                                                    |
+  * | Desugar            | No           | -- same --                                                                                                    |
+  * | Namer              | No           | -- same --                                                                                                    |
+  * | Resolver           | No           | Per-def work is nested inside trait/instance walks rather than a clean `parMapValues` over `root.defs`.       |
+  * | Deriver            | No           | Generates new instances from enum derivations; iterates over enums, not existing defs.                        |
+  * | Instances          | No           | Per-instance-def work interleaves with trait conformance checks; instrumentable but not a one-line wrap.      |
+  * | Kinder             | Yes          | `visitDefSpecs` + `visitDefs`.                                                                                |
+  * | Typer              | Yes          |                                                                                                               |
+  * | EntryPoints        | Yes          |                                                                                                               |
+  * | PredDeps           | Yes          |                                                                                                               |
+  * | Stratifier         | Yes          |                                                                                                               |
+  * | PatMatch           | Yes          |                                                                                                               |
+  * | Redundancy         | Yes          |                                                                                                               |
+  * | Safety             | Yes          |                                                                                                               |
+  * | Terminator         | Yes          |                                                                                                               |
+  * | Dependencies       | Yes          |                                                                                                               |
+  * | TreeShaker1        | No           | Pure filter pass; no per-def work to time.                                                                    |
+  * | Monomorpher        | Yes          | Initial + worklist, keyed by the source generic sym.                                                          |
+  * | LambdaDrop         | Yes          |                                                                                                               |
+  * | Optimizer          | No           | Fixed-point wrapper around `OccurrenceAnalyzer` / `Inliner`; captured transitively through those inner phases.|
+  * | OccurrenceAnalyzer | Yes          |                                                                                                               |
+  * | Inliner            | Yes          |                                                                                                               |
+  * | Simplifier         | Yes          |                                                                                                               |
+  * | ClosureConv        | Yes          |                                                                                                               |
+  * | LambdaLift         | Yes          |                                                                                                               |
+  * | TreeShaker2        | No           | -- same as TreeShaker1 --                                                                                     |
+  * | EffectBinder       | Yes          |                                                                                                               |
+  * | TailPos            | Yes          |                                                                                                               |
+  * | Eraser             | Yes          |                                                                                                               |
+  * | Reducer            | Yes          |                                                                                                               |
+  * | JvmBackend         | Partial      | Only the per-def cases in `GenFunAndClosureClasses` are instrumented; top-level orchestration is not.         |
   */
 object CompilerProfiler {
   /**

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -80,9 +80,9 @@ final case class DefnStats(
   *     `GenFunAndClosureClasses`; not a `parMap` and would require a
   *     dedicated hook inside the class generator.
   */
-final class DefnTimer(phaseProvider: () => String) {
+final class CompilerProfiler(phaseProvider: () => String) {
 
-  private val stats = new ConcurrentHashMap[Symbol.DefnSym, DefnTimer.Counters]()
+  private val stats = new ConcurrentHashMap[Symbol.DefnSym, CompilerProfiler.Counters]()
 
   /**
     * Runs `thunk` and records its elapsed wall-clock time against `sym`,
@@ -130,11 +130,11 @@ final class DefnTimer(phaseProvider: () => String) {
   /** Removes all recorded statistics. */
   def reset(): Unit = stats.clear()
 
-  private def countersFor(sym: Symbol.DefnSym): DefnTimer.Counters =
-    stats.computeIfAbsent(sym, _ => new DefnTimer.Counters)
+  private def countersFor(sym: Symbol.DefnSym): CompilerProfiler.Counters =
+    stats.computeIfAbsent(sym, _ => new CompilerProfiler.Counters)
 }
 
-object DefnTimer {
+object CompilerProfiler {
   private final class Counters {
     val totalNanos = new AtomicLong(0L)
     val callCount = new AtomicInteger(0)

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -68,11 +68,12 @@ final case class DefnStats(
   *     `Kinder` (visitDefSpecs + visitDefs), `Typer`, `EntryPoints`,
   *     `PredDeps`, `Stratifier`, `PatMatch`, `Redundancy`, `Safety`,
   *     `Terminator`, `Dependencies`.
-  *   - Backend (13 sites):
+  *   - Backend (16 sites):
   *     `Monomorpher` (initial + worklist; keyed by source generic sym),
   *     `LambdaDrop`, `OccurrenceAnalyzer`, `Inliner`, `Simplifier`,
   *     `ClosureConv`, `LambdaLift`, `EffectBinder`, `TailPos`, `Eraser`,
-  *     `Reducer`.
+  *     `Reducer`, `JvmBackend` (closure + control-pure function +
+  *     control-impure function cases in `GenFunAndClosureClasses`).
   *
   * == Uninstrumented phases ==
   *
@@ -91,9 +92,10 @@ final case class DefnStats(
   *   - `Optimizer` — a wrapper that re-runs `OccurrenceAnalyzer` and
   *     `Inliner` in a fixed-point loop. All work is captured transitively
   *     through those instrumented inner phases.
-  *   - `JvmBackend` — class-file generation through
-  *     `GenFunAndClosureClasses`; not a `parMap` and would require a
-  *     dedicated hook inside the class generator.
+  *   - `JvmBackend` — top-level orchestration (namespace classes, runtime
+  *     types, etc.) is not per-def. The dominant per-def work — function
+  *     and closure class generation in `GenFunAndClosureClasses` — *is*
+  *     instrumented (see Backend list above).
   */
 final class CompilerProfiler(phaseProvider: () => Option[String]) {
 

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -31,7 +31,8 @@ final case class DefnStats(
   loc: SourceLocation,
   totalNanos: Long,
   callCount: Int,
-  byPhase: Map[String, Long]
+  byPhase: Map[String, Long],
+  isActive: Boolean
 ) {
   /** Returns the phase that consumed the most time, or None if empty. */
   def dominantPhase: Option[String] =
@@ -110,17 +111,19 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
     */
   def track[A](sym: Symbol.DefnSym, loc: SourceLocation)(thunk: => A): A = {
     val phase = phaseProvider().getOrElse("?")
+    val c = countersFor(sym)
+    c.loc.compareAndSet(null, loc)
+    c.inProgress.incrementAndGet()
     val t0 = System.nanoTime()
     try thunk
     finally {
       val elapsed = System.nanoTime() - t0
-      val c = countersFor(sym)
-      c.loc.compareAndSet(null, loc)
       c.totalNanos.addAndGet(elapsed)
       c.callCount.incrementAndGet()
       c.perPhaseNanos
         .computeIfAbsent(phase, _ => new AtomicLong(0L))
         .addAndGet(elapsed)
+      c.inProgress.decrementAndGet()
     }
   }
 
@@ -135,7 +138,8 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
       val byPhase = c.perPhaseNanos.entrySet().iterator().asScala
         .map(pe => (pe.getKey, pe.getValue.get())).toMap
       val loc = Option(c.loc.get()).getOrElse(e.getKey.loc)
-      DefnStats(e.getKey, loc, c.totalNanos.get(), c.callCount.get(), byPhase)
+      DefnStats(e.getKey, loc, c.totalNanos.get(), c.callCount.get(), byPhase,
+        isActive = c.inProgress.get() > 0)
     }.toVector
   }
 
@@ -173,5 +177,7 @@ object CompilerProfiler {
     val perPhaseNanos = new ConcurrentHashMap[String, AtomicLong]()
     /** Set on first `track` call; carries the def-body span so we can show LOC. */
     val loc = new AtomicReference[SourceLocation](null)
+    /** Number of `track` calls currently in flight for this source sym. */
+    val inProgress = new AtomicInteger(0)
   }
 }

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -104,6 +104,7 @@ object CompilerProfiler {
 
 final class CompilerProfiler(phaseProvider: () => Option[String]) {
 
+  /** Per-source-`DefnSym` accumulators, keyed by the sym returned from [[sourceOf]]. */
   private val stats = new ConcurrentHashMap[Symbol.DefnSym, CompilerProfiler.Counters]()
 
   /**
@@ -155,6 +156,10 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
     n
   }
 
+  /**
+    * Returns the [[Counters]] entry for `sym`'s source sym, creating a fresh
+    * zero-initialized entry on first use. Atomic in the underlying map.
+    */
   private def countersFor(sym: Symbol.DefnSym): CompilerProfiler.Counters =
     stats.computeIfAbsent(sourceOf(sym), _ => CompilerProfiler.Counters(
       inProgress = new AtomicInteger(0),

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -148,14 +148,6 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
     }.toVector
   }
 
-  /** Returns the total number of `track` calls made so far across all defs. */
-  def totalCallCount: Long = {
-    var n = 0L
-    val it = stats.values().iterator()
-    while (it.hasNext) n += it.next().callCount.get()
-    n
-  }
-
   /**
     * Returns the [[Counters]] entry for `sym`'s source sym, creating a fresh
     * zero-initialized entry on first use. Atomic in the underlying map.

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -140,7 +140,7 @@ final class CompilerTop(flix: Flix) {
     * Both bars sit beside each other so the eye picks them up as a pair.
     */
   private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int): Unit = {
-    val phase = flix.currentPhaseName
+    val phase = flix.currentPhaseName.getOrElse("starting")
     val group = phaseGroup(phase)
     val total = Phases.size
     val idx = Phases.indexOf(phase)

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -30,13 +30,13 @@ import scala.jdk.CollectionConverters.*
   * top-mover deltas, throughput sparkline, threadpool occupancy, heap usage,
   * GC time, and outlier highlighting.
   *
-  * Reads from [[Flix.defnTimer]] and [[Flix.currentPhaseName]] every
-  * [[TopRenderer.RefreshIntervalMs]] milliseconds and re-renders the screen
+  * Reads from [[Flix.compilerProfiler]] and [[Flix.currentPhaseName]] every
+  * [[CompilerTop.RefreshIntervalMs]] milliseconds and re-renders the screen
   * using ANSI escape codes.
   */
-final class TopRenderer(flix: Flix) {
+final class CompilerTop(flix: Flix) {
 
-  import TopRenderer.*
+  import CompilerTop.*
 
   private val running = new AtomicBoolean(false)
   private var thread: Thread = _
@@ -110,7 +110,7 @@ final class TopRenderer(flix: Flix) {
     // reserving 2 columns for the 1-space left and right table padding.
     val layout = computeLayout((terminalCols() - 2).max(1))
 
-    val snap = flix.defnTimer.snapshot().sortBy(-_.totalNanos)
+    val snap = flix.compilerProfiler.snapshot().sortBy(-_.totalNanos)
     val visible = snap.take(defN)
 
     // Active-threads sparkline: history of thread-pool occupancy.
@@ -345,11 +345,11 @@ final class TopRenderer(flix: Flix) {
   }
 }
 
-object TopRenderer {
+object CompilerTop {
 
   /**
     * Runs `body` with the live `--top` TUI active when `enabled`. When
-    * disabled, `body` runs unchanged. When enabled, a [[TopRenderer]] is
+    * disabled, `body` runs unchanged. When enabled, a [[CompilerTop]] is
     * started before `body` runs and stopped (with a final frame) in a
     * `finally` block, so the terminal is restored on both normal return
     * and exception.
@@ -359,7 +359,7 @@ object TopRenderer {
     */
   def runDuring[A](flix: Flix, enabled: Boolean)(body: => A): A = {
     if (!enabled) return body
-    val r = new TopRenderer(flix)
+    val r = new CompilerTop(flix)
     r.start()
     try body finally r.stop()
   }
@@ -465,7 +465,7 @@ object TopRenderer {
     * `Flix.check` followed by `Flix.codeGen`.
     *
     * Note: appearance here means the phase advances the progress bar; it does
-    * not mean the phase feeds [[DefnTimer]]. See `DefnTimer`'s class-level
+    * not mean the phase feeds [[CompilerProfiler]]. See `CompilerProfiler`'s class-level
     * doc for the list of instrumented vs. uninstrumented phases.
     */
   private val Phases: Vector[String] = Vector(

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -250,7 +250,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
       val locField = rpad(truncate(locStr, layout.locWidth), layout.locWidth)
 
       sb.append(' ')
-      sb.append(symField)
+      sb.append(styleSym(symField, s.totalNanos, locLines))
       sb.append(' ')
       sb.append(dim(locField))
       appendNumericFields(sb, locLines, s.callCount.toLong, phase, s.totalNanos, pctCpu, pctWall, layout)
@@ -413,6 +413,21 @@ object CompilerTop {
     else if (ms >= 200) bold(yellow(formatted))
     else if (ms >= 50) yellow(formatted)
     else formatted
+  }
+
+  /**
+    * Colors the sym name based on `time / locLines` — a "hotness per line"
+    * signal that surfaces small defs which consume time disproportionate
+    * to their body size. Defs with no real source span (`locLines <= 0`,
+    * e.g. lifted closures) are left unstyled because the denominator is
+    * meaningless.
+    */
+  private def styleSym(name: String, nanos: Long, locLines: Int): String = {
+    if (locLines <= 0) return name
+    val msPerLine = (nanos / 1_000_000L).toDouble / locLines
+    if (msPerLine >= 25.0) bold(red(name))
+    else if (msPerLine >= 15.0) yellow(name)
+    else name
   }
 
   /** %cpu = totalNanos / (elapsed × threads). One def's slice of total compute. */

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -28,8 +28,11 @@ object CompilerTop {
   /** How often the screen refreshes, in milliseconds. */
   private val RefreshIntervalMs: Long = 100L
 
-  /** Maximum length of any name in [[Phases]] — used to pad the phase column. Lazy to defer until [[Phases]] is initialized. */
-  private lazy val MaxPhaseLen: Int = Phases.iterator.map(_.length).max
+  /** Total number of phases the compiler runs. Bump when `Flix.check` / `Flix.codeGen` adds or removes a `phase` / `phaseNew` call. */
+  private val TotalPhases: Int = 32
+
+  /** Longest phase-name length, used to pad the phase column. Currently set by `"Dependencies"` / `"EffectBinder"`. */
+  private val MaxPhaseLen: Int = 12
 
   /** Width (in characters) of the phase-progress bar. */
   private val BarWidth: Int = 12
@@ -156,30 +159,6 @@ object CompilerTop {
     else if (ratio >= 0.7) yellow(formatted)
     else green(formatted)
   }
-
-  /**
-    * The compiler phases, in the order they fire.
-    *
-    * Mirrors the calls to `flix.phase` / `flix.phaseNew` in
-    * `Flix.check` followed by `Flix.codeGen`.
-    *
-    * Note: appearance here means the phase advances the progress bar; it does
-    * not mean the phase feeds [[CompilerProfiler]]. See `CompilerProfiler`'s class-level
-    * doc for the list of instrumented vs. uninstrumented phases.
-    */
-  private val Phases: Vector[String] = Vector(
-    // syntax (parsing)
-    "Reader", "Lexer", "Parser2", "Weeder2", "Desugar",
-    // semantic (frontend)
-    "Namer", "Resolver", "Kinder", "Deriver", "Typer", "EntryPoints", "Instances",
-    "PredDeps", "Stratifier", "PatMatch", "Redundancy", "Safety", "Terminator", "Dependencies",
-    // mid-end (lowering and optimization)
-    "TreeShaker1", "Monomorpher", "LambdaDrop", "Optimizer", "Simplifier",
-    "ClosureConv", "LambdaLift", "TreeShaker2", "EffectBinder", "TailPos",
-    "Eraser", "Reducer",
-    // backend
-    "JvmBackend"
-  )
 
   // -- Numeric helpers ----------------------------------------------------
 
@@ -480,10 +459,8 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     */
   private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int): Unit = {
     val phase = flix.getCurrentPhaseName.getOrElse("starting")
-    val total = Phases.size
-    val idx = Phases.indexOf(phase)
-    val done = if (idx < 0) 0 else idx + 1
-    val filled = (BarWidth.toLong * done / total).toInt
+    val done = (flix.phaseTimers.size + 1).min(TotalPhases)
+    val filled = (BarWidth.toLong * done / TotalPhases).toInt
 
     sb.append("  ")
     sb.append(bold(rpad(phase, MaxPhaseLen)))
@@ -492,7 +469,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(green("█" * filled))
     sb.append(dim("░" * (BarWidth - filled)))
     sb.append(dim("] "))
-    sb.append(f"$done%2d/$total%2d")
+    sb.append(f"$done%2d/$TotalPhases%2d")
     sb.append(dim("   threads "))
     sb.append(dim(cyan(renderSparkline(parallelism.toDouble))))
     sb.append(' ')

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -30,11 +30,11 @@ import scala.jdk.CollectionConverters.*
   * top-mover deltas, throughput sparkline, threadpool occupancy, heap usage,
   * GC time, and outlier highlighting.
   *
-  * Reads from [[Flix.compilerProfiler]] and [[Flix.currentPhaseName]] every
+  * Reads from [[Flix.getProfiler]] and [[Flix.currentPhaseName]] every
   * [[CompilerTop.RefreshIntervalMs]] milliseconds and re-renders the screen
   * using ANSI escape codes.
   */
-final class CompilerTop(flix: Flix) {
+final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
 
   import CompilerTop.*
 
@@ -110,7 +110,7 @@ final class CompilerTop(flix: Flix) {
     // reserving 2 columns for the 1-space left and right table padding.
     val layout = computeLayout((terminalCols() - 2).max(1))
 
-    val snap = flix.compilerProfiler.snapshot().sortBy(-_.totalNanos)
+    val snap = profiler.snapshot().sortBy(-_.totalNanos)
     val visible = snap.take(defN)
 
     // Active-threads sparkline: history of thread-pool occupancy.
@@ -359,9 +359,14 @@ object CompilerTop {
     */
   def runDuring[A](flix: Flix, enabled: Boolean)(body: => A): A = {
     if (!enabled) return body
-    val r = new CompilerTop(flix)
+    val profiler = new CompilerProfiler(() => flix.currentPhaseName)
+    flix.setProfiler(Some(profiler))
+    val r = new CompilerTop(flix, profiler)
     r.start()
-    try body finally r.stop()
+    try body finally {
+      r.stop()
+      flix.setProfiler(None)
+    }
   }
 
   /** How often the screen refreshes, in milliseconds. */

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable
   * the most wall-clock time on so far, with a per-phase breakdown, call
   * count, active-threads sparkline, threadpool occupancy, and heap usage.
   *
-  * Reads from [[Flix.getProfiler]] and [[Flix.currentPhaseName]] every
+  * Reads from [[Flix.getProfiler]] and [[Flix.getCurrentPhaseName]] every
   * [[CompilerTop.RefreshIntervalMs]] milliseconds and re-renders the screen
   * using ANSI escape codes.
   */
@@ -139,7 +139,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * Both bars sit beside each other so the eye picks them up as a pair.
     */
   private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int): Unit = {
-    val phase = flix.currentPhaseName.getOrElse("starting")
+    val phase = flix.getCurrentPhaseName.getOrElse("starting")
     val group = phaseGroup(phase)
     val total = Phases.size
     val idx = Phases.indexOf(phase)

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -23,6 +23,365 @@ import org.jline.terminal.{Terminal, TerminalBuilder}
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
 
+object CompilerTop {
+
+  /** How often the screen refreshes, in milliseconds. */
+  private val RefreshIntervalMs: Long = 100L
+
+  /** Maximum length of any name in [[Phases]] — used to pad the phase column. Lazy to defer until [[Phases]] is initialized. */
+  private lazy val MaxPhaseLen: Int = Phases.iterator.map(_.length).max
+
+  /** Maximum length of any group label — `"semantic"` is the longest at 8. */
+  private val MaxGroupLen: Int = 8
+
+  /** Width (in characters) of the phase-progress bar. */
+  private val BarWidth: Int = 12
+
+  /** 1-indexed column where the `progress` label starts on the dashboard. */
+  private lazy val ProgressStartCol: Int = 8 + MaxPhaseLen + MaxGroupLen
+
+  /** 1-indexed column where the `threads` label starts on the dashboard. */
+  private lazy val ThreadsStartCol: Int = ProgressStartCol + 20 + BarWidth
+
+  /** Width of the threads-sparkline. */
+  private val SparkWidth: Int = 12
+
+  /** Block characters used for the sparkline, low → high. */
+  private val SparkChars: Array[Char] = "▁▂▃▄▅▆▇█".toArray
+
+  /** ANSI escape character. */
+  private val ESC: Char = 27.toChar
+
+  /** ANSI sequence that homes the cursor and clears the screen. */
+  private val ClearScreen: String = s"$ESC[H$ESC[2J"
+
+  /**
+    * DEC mode 2026 — Begin Synchronized Update. Terminals that support it
+    * (iTerm2, kitty, alacritty, wezterm, modern xterm, recent VTE) buffer
+    * the bytes between BSU and ESU and swap atomically, eliminating the
+    * flash from clear-and-redraw. Terminals that don't recognize the
+    * sequence silently ignore it.
+    */
+  private val BeginSync: String = s"$ESC[?2026h"
+
+  /** DEC mode 2026 — End Synchronized Update; pair of [[BeginSync]]. */
+  private val EndSync: String = s"$ESC[?2026l"
+
+  // Color codes.
+
+  /** ANSI reset (clears bold, dim, color, etc.). */
+  private val Reset: String = s"$ESC[0m"
+  /** ANSI bold. */
+  private val BoldCode: String = s"$ESC[1m"
+  /** ANSI dim/faint. */
+  private val DimCode: String = s"$ESC[2m"
+  /** ANSI foreground red. */
+  private val Red: String = s"$ESC[31m"
+  /** ANSI foreground green. */
+  private val Green: String = s"$ESC[32m"
+  /** ANSI foreground yellow. */
+  private val Yellow: String = s"$ESC[33m"
+  /** ANSI foreground blue. */
+  private val Blue: String = s"$ESC[34m"
+  /** ANSI foreground magenta. */
+  private val Magenta: String = s"$ESC[35m"
+  /** ANSI foreground cyan. */
+  private val Cyan: String = s"$ESC[36m"
+  /** ANSI foreground bright black (gray). */
+  private val Gray: String = s"$ESC[90m"
+
+  // Wrappers — each takes a string and returns it surrounded by codes.
+
+  /** Wraps `s` in the ANSI color code `c` and a reset suffix. */
+  private def color(s: String, c: String): String = s"$c$s$Reset"
+  /** Wraps `s` in ANSI bold codes. */
+  private def bold(s: String): String = s"$BoldCode$s$Reset"
+  /** Wraps `s` in ANSI dim/faint codes. */
+  private def dim(s: String): String = s"$DimCode$s$Reset"
+  /** Wraps `s` in ANSI red codes. */
+  private def red(s: String): String = color(s, Red)
+  /** Wraps `s` in ANSI yellow codes. */
+  private def yellow(s: String): String = color(s, Yellow)
+  /** Wraps `s` in ANSI green codes. */
+  private def green(s: String): String = color(s, Green)
+  /** Wraps `s` in ANSI cyan codes. */
+  private def cyan(s: String): String = color(s, Cyan)
+
+  // -- Conditional styling -------------------------------------------------
+
+  /** Colors a formatted time field by absolute magnitude (≥1s red bold, ≥200ms yellow bold, ≥50ms yellow). */
+  private def styleTime(formatted: String, nanos: Long): String = {
+    val ms = nanos / 1_000_000L
+    if (ms >= 1000) bold(red(formatted))
+    else if (ms >= 200) bold(yellow(formatted))
+    else if (ms >= 50) yellow(formatted)
+    else formatted
+  }
+
+  /**
+    * Colors the sym name based on `time / locLines` — a "hotness per line"
+    * signal that surfaces small defs which consume time disproportionate
+    * to their body size. Defs with no real source span (`locLines <= 0`,
+    * e.g. lifted closures) are left unstyled because the denominator is
+    * meaningless.
+    */
+  private def styleSym(name: String, nanos: Long, locLines: Int): String = {
+    if (locLines <= 0) return name
+    val msPerLine = (nanos / 1_000_000L).toDouble / locLines
+    if (msPerLine >= 25.0) bold(red(name))
+    else if (msPerLine >= 15.0) yellow(name)
+    else name
+  }
+
+  /** %cpu = totalNanos / (elapsed × threads). One def's slice of total compute. */
+  private def stylePctCpu(formatted: String, pct: Double): String = {
+    if (pct >= 5.0) bold(red(formatted))
+    else if (pct >= 1.0) yellow(formatted)
+    else formatted
+  }
+
+  /** %wall = totalNanos / elapsed. Upper bound on wall-clock savings if removed. */
+  private def stylePctWall(formatted: String, pct: Double): String = {
+    if (pct >= 15.0) bold(red(formatted))
+    else if (pct >= 5.0) yellow(formatted)
+    else formatted
+  }
+
+  /** Colors the active/parallelism field by occupancy: full=green bold, ≥50%=green, idle=gray, else yellow. */
+  private def styleThreads(active: Int, par: Int): String = {
+    val s = f"$active%2d/$par%-2d"
+    if (par <= 0) color(s, Gray)
+    else if (active == par) bold(green(s))
+    else if (active.toDouble / par >= 0.5) green(s)
+    else if (active == 0) color(s, Gray)
+    else yellow(s)
+  }
+
+  /** Colors a formatted heap field by used/max ratio: ≥90% red bold, ≥70% yellow, else green. */
+  private def styleHeap(formatted: String, ratio: Double): String = {
+    if (ratio >= 0.9) bold(red(formatted))
+    else if (ratio >= 0.7) yellow(formatted)
+    else green(formatted)
+  }
+
+  /**
+    * The compiler phases, in the order they fire.
+    *
+    * Mirrors the calls to `flix.phase` / `flix.phaseNew` in
+    * `Flix.check` followed by `Flix.codeGen`.
+    *
+    * Note: appearance here means the phase advances the progress bar; it does
+    * not mean the phase feeds [[CompilerProfiler]]. See `CompilerProfiler`'s class-level
+    * doc for the list of instrumented vs. uninstrumented phases.
+    */
+  private val Phases: Vector[String] = Vector(
+    // syntax (parsing)
+    "Reader", "Lexer", "Parser2", "Weeder2", "Desugar",
+    // semantic (frontend)
+    "Namer", "Resolver", "Kinder", "Deriver", "Typer", "EntryPoints", "Instances",
+    "PredDeps", "Stratifier", "PatMatch", "Redundancy", "Safety", "Terminator", "Dependencies",
+    // mid-end (lowering and optimization)
+    "TreeShaker1", "Monomorpher", "LambdaDrop", "Optimizer", "Simplifier",
+    "ClosureConv", "LambdaLift", "TreeShaker2", "EffectBinder", "TailPos",
+    "Eraser", "Reducer",
+    // backend
+    "JvmBackend"
+  )
+
+  /** Returns the dashboard color-group for `phase` (`syntax`, `semantic`, `midend`, `backend`, or `?`). */
+  private def phaseGroup(phase: String): String = {
+    val idx = Phases.indexOf(phase)
+    if (idx < 0) "?"
+    else if (idx <= 4) "syntax"
+    else if (idx <= 18) "semantic"
+    else if (idx <= 30) "midend"
+    else "backend"
+  }
+
+  /** Returns the ANSI color associated with a phase group. */
+  private def groupColor(group: String): String = group match {
+    case "syntax"   => Blue
+    case "semantic" => Green
+    case "midend"   => Yellow
+    case "backend"  => Magenta
+    case _          => Gray
+  }
+
+  // -- Numeric helpers ----------------------------------------------------
+
+  /** Returns `(usedMb, maxMb)` from the JVM runtime. */
+  private def heapUsage(): (Long, Long) = {
+    val rt = Runtime.getRuntime
+    val used = rt.totalMemory() - rt.freeMemory()
+    val max = rt.maxMemory()
+    (used / (1024L * 1024L), max / (1024L * 1024L))
+  }
+
+  /**
+    * A row in the per-module aggregate table.
+    *
+    * @param module         dot-joined namespace (or `(root)` when empty).
+    * @param totalNanos     summed wall-clock time across the module's defs.
+    * @param totalCallCount summed `track` call counts across the module's defs.
+    * @param totalLocLines  summed source-line counts across the module's defs.
+    * @param byPhase        phase → summed nanoseconds across the module's defs.
+    */
+  private final case class ModuleStats(module: String, totalNanos: Long, totalCallCount: Long, totalLocLines: Int, byPhase: Map[String, Long]) {
+    /** Returns the phase that consumed the most time in this module, or None if empty. */
+    def dominantPhase: Option[String] =
+      if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
+  }
+
+  /** Groups `snap` by namespace, sums each metric, and returns rows sorted by `totalNanos` descending. */
+  private def aggregateByModule(snap: Vector[DefnStats]): Vector[ModuleStats] = {
+    val groups = snap.groupBy { s =>
+      val ns = s.sym.namespace
+      if (ns.isEmpty) "(root)" else ns.mkString(".")
+    }
+    groups.iterator.map { case (mod, defs) =>
+      val totalNanos = defs.iterator.map(_.totalNanos).sum
+      val totalCallCount = defs.iterator.map(_.callCount.toLong).sum
+      val totalLocLines = defs.iterator.map(s => locLineCount(s.loc)).sum
+      val byPhase = defs.foldLeft(Map.empty[String, Long]) { (acc, d) =>
+        d.byPhase.foldLeft(acc) { case (m, (phase, n)) =>
+          m.updated(phase, m.getOrElse(phase, 0L) + n)
+        }
+      }
+      ModuleStats(mod, totalNanos, totalCallCount, totalLocLines, byPhase)
+    }.toVector.sortBy(-_.totalNanos)
+  }
+
+  /** Fallback terminal height when JLine cannot determine the real one. */
+  private val DefaultRows: Int = 24
+
+  /** Fallback terminal width when JLine cannot determine the real one. */
+  private val DefaultCols: Int = 100
+
+  /**
+    * Column layout for the per-frame table render. Computed from the current
+    * terminal width: when the terminal is narrow, the optional LOC / n /
+    * phase columns are dropped in that order (lowest-signal first). When the
+    * terminal is wide, the surplus is distributed between the DefnSym and
+    * location columns proportionally to their default widths.
+    *
+    * @param symWidth   width of the DefnSym column.
+    * @param locWidth   width of the location column.
+    * @param showLOC    whether to render the LOC column.
+    * @param showN      whether to render the call-count (n) column.
+    * @param showPhase  whether to render the dominant-phase column.
+    * @param totalWidth total rendered width of the row, less leading/trailing pad.
+    */
+  private final case class Layout(symWidth: Int, locWidth: Int, showLOC: Boolean, showN: Boolean, showPhase: Boolean, totalWidth: Int)
+
+  /** Default width of the DefnSym column when the terminal is wide enough. */
+  private val DefaultSymWidth: Int = 24
+  /** Default width of the location column when the terminal is wide enough. */
+  private val DefaultLocWidth: Int = 28
+  /** Floor on the DefnSym column width when the terminal is narrow. */
+  private val MinSymWidth: Int = 16
+  /** Floor on the location column width when the terminal is narrow. */
+  private val MinLocWidth: Int = 20
+
+  /** Fixed-width contribution of `time + %cpu + %wall` columns and their separators. */
+  private val FixedTailWidth: Int = 9 + 1 + 6 + 1 + 6 // time(9) + %cpu(6) + %wall(6) with two separators between
+
+  /** Width contribution of the optional LOC column (separator + width). */
+  private val LocColWidth: Int = 1 + 4
+  /** Width contribution of the optional call-count column (separator + width). */
+  private val NColWidth: Int = 1 + 4
+  /** Width contribution of the optional dominant-phase column (separator + width). */
+  private val PhaseColWidth: Int = 1 + 10
+
+  /** Picks a [[Layout]] for the given terminal width by trying tiers in descending feature order. */
+  private def computeLayout(cols: Int): Layout = {
+    // Width contribution of the "fixed" half: separator before time + tail.
+    val tail = 1 + FixedTailWidth
+    // Width of just the text section (sym + 1 + location) at default sizes.
+    def textWidth(symW: Int, locW: Int): Int = symW + 1 + locW
+
+    // Try tiers in descending feature order.
+    val full = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + NColWidth + PhaseColWidth + tail
+    if (cols >= full) {
+      // Surplus → expand sym (~46%) and location (~54%) proportionally.
+      val extra = cols - full
+      val extraSym = extra * 46 / 100
+      val extraLoc = extra - extraSym
+      val symW = DefaultSymWidth + extraSym
+      val locW = DefaultLocWidth + extraLoc
+      return Layout(symW, locW, showLOC = true, showN = true, showPhase = true,
+        totalWidth = textWidth(symW, locW) + LocColWidth + NColWidth + PhaseColWidth + tail)
+    }
+
+    // Tier: drop phase.
+    val noPhase = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + NColWidth + tail
+    if (cols >= noPhase)
+      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showN = true, showPhase = false, noPhase)
+
+    // Tier: drop phase + n.
+    val noPhaseNoN = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + tail
+    if (cols >= noPhaseNoN)
+      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showN = false, showPhase = false, noPhaseNoN)
+
+    // Tier: drop phase + n + LOC.
+    val noOptional = textWidth(DefaultSymWidth, DefaultLocWidth) + tail
+    if (cols >= noOptional)
+      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = false, showN = false, showPhase = false, noOptional)
+
+    // Even minimum tier doesn't fit; shrink sym/locWidth to floors.
+    val available = (cols - tail).max(MinSymWidth + 1 + MinLocWidth)
+    val symW = MinSymWidth.max(available * 46 / 100)
+    val locW = MinLocWidth.max(available - 1 - symW)
+    Layout(symW, locW, showLOC = false, showN = false, showPhase = false,
+      textWidth(symW, locW) + tail)
+  }
+
+  /**
+    * Fixed-overhead rows: blank + 2 dashboard/stats lines + blank + 2 def-chrome +
+    * 1 blank-before-modules + 2 module-chrome + 1 cursor-parking row.
+    */
+  private val ChromeRows: Int = 10
+
+  /** Reserved breathing room above and below the rendered view. */
+  private val RowMargin: Int = 2
+
+  /** Floor on the total data-row budget. */
+  private val MinDataRows: Int = 8
+
+  /** Floor on the def-table row count. */
+  private val MinDefN: Int = 5
+  /** Floor on the module-table row count. */
+  private val MinModuleN: Int = 3
+
+  // -- Formatting helpers -------------------------------------------------
+
+  /** Renders a [[SourceLocation]] as `file:line`, or `?` if synthetic. */
+  private def formatLocation(loc: SourceLocation): String =
+    if (!loc.isReal) "?" else s"${loc.source.name}:${loc.startLine}"
+
+  /** Returns the inclusive line span of `loc`, or 0 if synthetic. */
+  private def locLineCount(loc: SourceLocation): Int =
+    if (!loc.isReal) 0 else (loc.endLine - loc.startLine + 1).max(0)
+
+  /** Formats a nanosecond duration as `Nms` or `N.Ns` (≥10s). */
+  private def formatMillis(nanos: Long): String = {
+    val ms = nanos / 1_000_000L
+    if (ms >= 10_000L) f"${ms / 1000.0}%.1fs"
+    else f"${ms}ms"
+  }
+
+  /** Returns `s` truncated to `width` characters, with a trailing ellipsis when shortened. */
+  private def truncate(s: String, width: Int): String =
+    if (s.length <= width) s else s.take(width - 1) + "…"
+
+  /** Left-pads `s` with spaces to width `w`. */
+  private def lpad(s: String, w: Int): String =
+    if (s.length >= w) s else " " * (w - s.length) + s
+
+  /** Right-pads `s` with spaces to width `w`. */
+  private def rpad(s: String, w: Int): String =
+    if (s.length >= w) s else s + " " * (w - s.length)
+}
+
 /**
   * A live, top(1)-style TUI showing which `DefnSym`s the compiler has spent
   * the most wall-clock time on so far, with a per-phase breakdown, call
@@ -36,8 +395,13 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
 
   import CompilerTop.*
 
+  /** True while the renderer thread should keep looping. */
   private val running = new AtomicBoolean(false)
+
+  /** The renderer thread, or `null` before [[start]] / after [[stop]]. */
   private var thread: Thread = _
+
+  /** Wall-clock start time, used as the denominator for `%wall` and `%cpu`. */
   private val startNanos: Long = System.nanoTime()
 
   /** A JLine terminal handle used to query screen size. May be null if JLine fails. */
@@ -46,6 +410,9 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     try TerminalBuilder.builder().system(true).build()
     catch { case _: Throwable => null }
   }
+
+  /** Rolling history of active-thread counts feeding the dashboard sparkline. Touched only by the renderer thread. */
+  private val threadsHistory = mutable.Queue.empty[Double]
 
   /** Returns the terminal height in rows, or [[DefaultRows]] if unavailable. */
   private def terminalRows(): Int = {
@@ -60,10 +427,6 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     val w = terminal.getWidth
     if (w > 0) w else DefaultCols
   }
-
-  // State carried across frames so we can compute the active-threads
-  // sparkline. Touched only by the renderer thread.
-  private val threadsHistory = mutable.Queue.empty[Double]
 
   /** Starts the renderer on a daemon thread. */
   def start(): Unit = {
@@ -82,6 +445,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     if (terminal != null) try terminal.close() catch { case _: Throwable => () }
   }
 
+  /** Renderer thread body: render, sleep, repeat until [[running]] is false. */
   private def loop(): Unit = {
     while (running.get()) {
       render()
@@ -90,6 +454,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     }
   }
 
+  /** Builds and prints one full frame of the TUI. */
   private def render(): Unit = {
     val now = System.nanoTime()
     val elapsed = now - startNanos
@@ -198,6 +563,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append('\n')
   }
 
+  /** Renders the def-table column header and the divider underneath it. */
   private def renderTableHeader(sb: StringBuilder, layout: Layout): Unit = {
     val header = buildHeader(rpad("Def", layout.symWidth), rpad("location", layout.locWidth), layout)
     sb.append(' ')
@@ -229,6 +595,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.toString
   }
 
+  /** Renders the def-table body (one row per [[DefnStats]]), or a centered placeholder if `visible` is empty. */
   private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int, layout: Layout): Unit = {
     if (visible.isEmpty) {
       val msg = "(no timings yet)"
@@ -263,6 +630,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     }
   }
 
+  /** Renders the per-module aggregate table below the def table; no-op if `modules` is empty. */
   private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int, layout: Layout): Unit = {
     if (modules.isEmpty) return
 
@@ -346,316 +714,4 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     val pad = (SparkWidth - chars.length).max(0)
     " " * pad + new String(chars)
   }
-}
-
-object CompilerTop {
-
-  /** How often the screen refreshes, in milliseconds. */
-  private val RefreshIntervalMs: Long = 100L
-
-  /** Maximum length of any name in [[Phases]] — used to pad the phase column. Lazy to defer until [[Phases]] is initialized. */
-  private lazy val MaxPhaseLen: Int = Phases.iterator.map(_.length).max
-
-  /** Maximum length of any group label — `"semantic"` is the longest at 8. */
-  private val MaxGroupLen: Int = 8
-
-  /** Width (in characters) of the phase-progress bar. */
-  private val BarWidth: Int = 12
-
-  /** 1-indexed column where the `progress` label starts on the dashboard. */
-  private lazy val ProgressStartCol: Int = 8 + MaxPhaseLen + MaxGroupLen
-
-  /** 1-indexed column where the `threads` label starts on the dashboard. */
-  private lazy val ThreadsStartCol: Int = ProgressStartCol + 20 + BarWidth
-
-  /** Width of the threads-sparkline. */
-  private val SparkWidth: Int = 12
-
-  /** Block characters used for the sparkline, low → high. */
-  private val SparkChars: Array[Char] = "▁▂▃▄▅▆▇█".toArray
-
-  /** ANSI escape character. */
-  private val ESC: Char = 27.toChar
-  private val ClearScreen: String = s"$ESC[H$ESC[2J"
-
-  /**
-    * DEC mode 2026 — Begin/End Synchronized Update. Terminals that
-    * support it (iTerm2, kitty, alacritty, wezterm, modern xterm, recent
-    * VTE) buffer the bytes between BSU and ESU and swap atomically,
-    * which eliminates the flash from the clear-and-redraw at each tick.
-    * Terminals that don't recognize the sequence silently ignore it.
-    */
-  private val BeginSync: String = s"$ESC[?2026h"
-  private val EndSync: String = s"$ESC[?2026l"
-
-  // Color codes.
-  private val Reset: String = s"$ESC[0m"
-  private val BoldCode: String = s"$ESC[1m"
-  private val DimCode: String = s"$ESC[2m"
-  private val Red: String = s"$ESC[31m"
-  private val Green: String = s"$ESC[32m"
-  private val Yellow: String = s"$ESC[33m"
-  private val Blue: String = s"$ESC[34m"
-  private val Magenta: String = s"$ESC[35m"
-  private val Cyan: String = s"$ESC[36m"
-  private val Gray: String = s"$ESC[90m"
-
-  // Wrappers — each takes a string and returns it surrounded by codes.
-  private def color(s: String, c: String): String = s"$c$s$Reset"
-  private def bold(s: String): String = s"$BoldCode$s$Reset"
-  private def dim(s: String): String = s"$DimCode$s$Reset"
-  private def red(s: String): String = color(s, Red)
-  private def yellow(s: String): String = color(s, Yellow)
-  private def green(s: String): String = color(s, Green)
-  private def cyan(s: String): String = color(s, Cyan)
-
-  // -- Conditional styling -------------------------------------------------
-
-  private def styleTime(formatted: String, nanos: Long): String = {
-    val ms = nanos / 1_000_000L
-    if (ms >= 1000) bold(red(formatted))
-    else if (ms >= 200) bold(yellow(formatted))
-    else if (ms >= 50) yellow(formatted)
-    else formatted
-  }
-
-  /**
-    * Colors the sym name based on `time / locLines` — a "hotness per line"
-    * signal that surfaces small defs which consume time disproportionate
-    * to their body size. Defs with no real source span (`locLines <= 0`,
-    * e.g. lifted closures) are left unstyled because the denominator is
-    * meaningless.
-    */
-  private def styleSym(name: String, nanos: Long, locLines: Int): String = {
-    if (locLines <= 0) return name
-    val msPerLine = (nanos / 1_000_000L).toDouble / locLines
-    if (msPerLine >= 25.0) bold(red(name))
-    else if (msPerLine >= 15.0) yellow(name)
-    else name
-  }
-
-  /** %cpu = totalNanos / (elapsed × threads). One def's slice of total compute. */
-  private def stylePctCpu(formatted: String, pct: Double): String = {
-    if (pct >= 5.0) bold(red(formatted))
-    else if (pct >= 1.0) yellow(formatted)
-    else formatted
-  }
-
-  /** %wall = totalNanos / elapsed. Upper bound on wall-clock savings if removed. */
-  private def stylePctWall(formatted: String, pct: Double): String = {
-    if (pct >= 15.0) bold(red(formatted))
-    else if (pct >= 5.0) yellow(formatted)
-    else formatted
-  }
-
-  private def styleThreads(active: Int, par: Int): String = {
-    val s = f"$active%2d/$par%-2d"
-    if (par <= 0) color(s, Gray)
-    else if (active == par) bold(green(s))
-    else if (active.toDouble / par >= 0.5) green(s)
-    else if (active == 0) color(s, Gray)
-    else yellow(s)
-  }
-
-  private def styleHeap(formatted: String, ratio: Double): String = {
-    if (ratio >= 0.9) bold(red(formatted))
-    else if (ratio >= 0.7) yellow(formatted)
-    else green(formatted)
-  }
-
-  /**
-    * The compiler phases, in the order they fire.
-    *
-    * Mirrors the calls to `flix.phase` / `flix.phaseNew` in
-    * `Flix.check` followed by `Flix.codeGen`.
-    *
-    * Note: appearance here means the phase advances the progress bar; it does
-    * not mean the phase feeds [[CompilerProfiler]]. See `CompilerProfiler`'s class-level
-    * doc for the list of instrumented vs. uninstrumented phases.
-    */
-  private val Phases: Vector[String] = Vector(
-    // syntax (parsing)
-    "Reader", "Lexer", "Parser2", "Weeder2", "Desugar",
-    // semantic (frontend)
-    "Namer", "Resolver", "Kinder", "Deriver", "Typer", "EntryPoints", "Instances",
-    "PredDeps", "Stratifier", "PatMatch", "Redundancy", "Safety", "Terminator", "Dependencies",
-    // mid-end (lowering and optimization)
-    "TreeShaker1", "Monomorpher", "LambdaDrop", "Optimizer", "Simplifier",
-    "ClosureConv", "LambdaLift", "TreeShaker2", "EffectBinder", "TailPos",
-    "Eraser", "Reducer",
-    // backend
-    "JvmBackend"
-  )
-
-  private def phaseGroup(phase: String): String = {
-    val idx = Phases.indexOf(phase)
-    if (idx < 0) "?"
-    else if (idx <= 4) "syntax"
-    else if (idx <= 18) "semantic"
-    else if (idx <= 30) "midend"
-    else "backend"
-  }
-
-  private def groupColor(group: String): String = group match {
-    case "syntax"   => Blue
-    case "semantic" => Green
-    case "midend"   => Yellow
-    case "backend"  => Magenta
-    case _          => Gray
-  }
-
-  // -- Numeric helpers ----------------------------------------------------
-
-  private def heapUsage(): (Long, Long) = {
-    val rt = Runtime.getRuntime
-    val used = rt.totalMemory() - rt.freeMemory()
-    val max = rt.maxMemory()
-    (used / (1024L * 1024L), max / (1024L * 1024L))
-  }
-
-  private final case class ModuleStats(
-    module: String,
-    totalNanos: Long,
-    totalCallCount: Long,
-    totalLocLines: Int,
-    byPhase: Map[String, Long]
-  ) {
-    def dominantPhase: Option[String] =
-      if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
-  }
-
-  private def aggregateByModule(snap: Vector[DefnStats]): Vector[ModuleStats] = {
-    val groups = snap.groupBy { s =>
-      val ns = s.sym.namespace
-      if (ns.isEmpty) "(root)" else ns.mkString(".")
-    }
-    groups.iterator.map { case (mod, defs) =>
-      val totalNanos = defs.iterator.map(_.totalNanos).sum
-      val totalCallCount = defs.iterator.map(_.callCount.toLong).sum
-      val totalLocLines = defs.iterator.map(s => locLineCount(s.loc)).sum
-      val byPhase = defs.foldLeft(Map.empty[String, Long]) { (acc, d) =>
-        d.byPhase.foldLeft(acc) { case (m, (phase, n)) =>
-          m.updated(phase, m.getOrElse(phase, 0L) + n)
-        }
-      }
-      ModuleStats(mod, totalNanos, totalCallCount, totalLocLines, byPhase)
-    }.toVector.sortBy(-_.totalNanos)
-  }
-
-  /** Fallback terminal height when JLine cannot determine the real one. */
-  private val DefaultRows: Int = 24
-
-  /** Fallback terminal width when JLine cannot determine the real one. */
-  private val DefaultCols: Int = 100
-
-  /**
-    * Column layout for the per-frame table render. Computed from the current
-    * terminal width: when the terminal is narrow, the optional LOC / n /
-    * phase columns are dropped in that order (lowest-signal first). When the
-    * terminal is wide, the surplus is distributed between the DefnSym and
-    * location columns proportionally to their default widths.
-    */
-  private final case class Layout(
-    symWidth: Int,
-    locWidth: Int,
-    showLOC: Boolean,
-    showN: Boolean,
-    showPhase: Boolean,
-    totalWidth: Int
-  )
-
-  /** Default DefnSym/location widths and minimum bounds when the terminal shrinks. */
-  private val DefaultSymWidth: Int = 24
-  private val DefaultLocWidth: Int = 28
-  private val MinSymWidth: Int = 16
-  private val MinLocWidth: Int = 20
-
-  /** Fixed-width contribution of `time + %cpu + %wall` columns and their separators. */
-  private val FixedTailWidth: Int = 9 + 1 + 6 + 1 + 6 // time(9) + %cpu(6) + %wall(6) with two separators between
-
-  /** Width contribution of an optional column (separator + width). */
-  private val LocColWidth: Int = 1 + 4
-  private val NColWidth: Int = 1 + 4
-  private val PhaseColWidth: Int = 1 + 10
-
-  private def computeLayout(cols: Int): Layout = {
-    // Width contribution of the "fixed" half: separator before time + tail.
-    val tail = 1 + FixedTailWidth
-    // Width of just the text section (sym + 1 + location) at default sizes.
-    def textWidth(symW: Int, locW: Int): Int = symW + 1 + locW
-
-    // Try tiers in descending feature order.
-    val full = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + NColWidth + PhaseColWidth + tail
-    if (cols >= full) {
-      // Surplus → expand sym (~46%) and location (~54%) proportionally.
-      val extra = cols - full
-      val extraSym = extra * 46 / 100
-      val extraLoc = extra - extraSym
-      val symW = DefaultSymWidth + extraSym
-      val locW = DefaultLocWidth + extraLoc
-      return Layout(symW, locW, showLOC = true, showN = true, showPhase = true,
-        totalWidth = textWidth(symW, locW) + LocColWidth + NColWidth + PhaseColWidth + tail)
-    }
-
-    // Tier: drop phase.
-    val noPhase = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + NColWidth + tail
-    if (cols >= noPhase)
-      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showN = true, showPhase = false, noPhase)
-
-    // Tier: drop phase + n.
-    val noPhaseNoN = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + tail
-    if (cols >= noPhaseNoN)
-      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showN = false, showPhase = false, noPhaseNoN)
-
-    // Tier: drop phase + n + LOC.
-    val noOptional = textWidth(DefaultSymWidth, DefaultLocWidth) + tail
-    if (cols >= noOptional)
-      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = false, showN = false, showPhase = false, noOptional)
-
-    // Even minimum tier doesn't fit; shrink sym/locWidth to floors.
-    val available = (cols - tail).max(MinSymWidth + 1 + MinLocWidth)
-    val symW = MinSymWidth.max(available * 46 / 100)
-    val locW = MinLocWidth.max(available - 1 - symW)
-    Layout(symW, locW, showLOC = false, showN = false, showPhase = false,
-      textWidth(symW, locW) + tail)
-  }
-
-  /**
-    * Fixed-overhead rows: blank + 2 dashboard/stats lines + blank + 2 def-chrome +
-    * 1 blank-before-modules + 2 module-chrome + 1 cursor-parking row.
-    */
-  private val ChromeRows: Int = 10
-
-  /** Reserved breathing room above and below the rendered view. */
-  private val RowMargin: Int = 2
-
-  /** Floor on the total data-row budget. */
-  private val MinDataRows: Int = 8
-
-  /** Floors on per-table row counts; both tables grow with terminal height. */
-  private val MinDefN: Int = 5
-  private val MinModuleN: Int = 3
-
-  // -- Formatting helpers -------------------------------------------------
-
-  private def formatLocation(loc: SourceLocation): String =
-    if (!loc.isReal) "?" else s"${loc.source.name}:${loc.startLine}"
-
-  private def locLineCount(loc: SourceLocation): Int =
-    if (!loc.isReal) 0 else (loc.endLine - loc.startLine + 1).max(0)
-
-  private def formatMillis(nanos: Long): String = {
-    val ms = nanos / 1_000_000L
-    if (ms >= 10_000L) f"${ms / 1000.0}%.1fs"
-    else f"${ms}ms"
-  }
-
-  private def truncate(s: String, width: Int): String =
-    if (s.length <= width) s else s.take(width - 1) + "…"
-
-  private def lpad(s: String, w: Int): String =
-    if (s.length >= w) s else " " * (w - s.length) + s
-
-  private def rpad(s: String, w: Int): String =
-    if (s.length >= w) s else s + " " * (w - s.length)
 }

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -117,6 +117,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     val modules = aggregateByModule(snap).take(moduleN)
 
     val sb = new StringBuilder
+    sb.append(BeginSync)
     sb.append(ClearScreen)
     sb.append('\n')
 
@@ -127,6 +128,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     renderRows(sb, visible, elapsed, parallelism, layout)
     renderModuleTable(sb, modules, elapsed, parallelism, layout)
 
+    sb.append(EndSync)
     System.out.print(sb)
     System.out.flush()
 
@@ -344,28 +346,6 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
 
 object CompilerTop {
 
-  /**
-    * Runs `body` with the live `--top` TUI active when `enabled`. When
-    * disabled, `body` runs unchanged. When enabled, a [[CompilerTop]] is
-    * started before `body` runs and stopped (with a final frame) in a
-    * `finally` block, so the terminal is restored on both normal return
-    * and exception.
-    *
-    * `body` must not call [[System.exit]] — exit handling stays in the
-    * caller, after the renderer has been stopped.
-    */
-  def runDuring[A](flix: Flix, enabled: Boolean)(body: => A): A = {
-    if (!enabled) return body
-    val profiler = new CompilerProfiler(() => flix.currentPhaseName)
-    flix.setProfiler(Some(profiler))
-    val r = new CompilerTop(flix, profiler)
-    r.start()
-    try body finally {
-      r.stop()
-      flix.setProfiler(None)
-    }
-  }
-
   /** How often the screen refreshes, in milliseconds. */
   private val RefreshIntervalMs: Long = 100L
 
@@ -393,6 +373,16 @@ object CompilerTop {
   /** ANSI escape character. */
   private val ESC: Char = 27.toChar
   private val ClearScreen: String = s"$ESC[H$ESC[2J"
+
+  /**
+    * DEC mode 2026 — Begin/End Synchronized Update. Terminals that
+    * support it (iTerm2, kitty, alacritty, wezterm, modern xterm, recent
+    * VTE) buffer the bytes between BSU and ESU and swap atomically,
+    * which eliminates the flash from the clear-and-redraw at each tick.
+    * Terminals that don't recognize the sequence silently ignore it.
+    */
+  private val BeginSync: String = s"$ESC[?2026h"
+  private val EndSync: String = s"$ESC[?2026l"
 
   // Color codes.
   private val Reset: String = s"$ESC[0m"

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -19,16 +19,13 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
 import org.jline.terminal.{Terminal, TerminalBuilder}
 
-import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.*
 
 /**
   * A live, top(1)-style TUI showing which `DefnSym`s the compiler has spent
-  * the most wall-clock time on so far, with per-phase breakdown, call count,
-  * top-mover deltas, throughput sparkline, threadpool occupancy, heap usage,
-  * GC time, and outlier highlighting.
+  * the most wall-clock time on so far, with a per-phase breakdown, call
+  * count, active-threads sparkline, threadpool occupancy, and heap usage.
   *
   * Reads from [[Flix.getProfiler]] and [[Flix.currentPhaseName]] every
   * [[CompilerTop.RefreshIntervalMs]] milliseconds and re-renders the screen
@@ -178,10 +175,10 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     val heapRatio = if (heapMaxMb <= 0) 0.0 else heapUsedMb.toDouble / heapMaxMb
     val elapsedField = formatMillis(elapsed)
 
-    // "elapsed" (7 chars) right-aligned with "progress" (8 chars) → start at GcStartCol + 1.
-    val elapsedStartCol = GcStartCol + 1
-    // "heap" (4 chars) right-aligned with "threads" (7 chars) → start at HeapStartCol + 3.
-    val heapStartCol = HeapStartCol + 3
+    // "elapsed" (7 chars) right-aligned with "progress" (8 chars) → start at ProgressStartCol + 1.
+    val elapsedStartCol = ProgressStartCol + 1
+    // "heap" (4 chars) right-aligned with "threads" (7 chars) → start at ThreadsStartCol + 3.
+    val heapStartCol = ThreadsStartCol + 3
 
     sb.append("  ")
     sb.append(" " * (elapsedStartCol - 3).max(0))
@@ -381,11 +378,11 @@ object CompilerTop {
   /** Width (in characters) of the phase-progress bar. */
   private val BarWidth: Int = 12
 
-  /** 1-indexed column where the `gc` label starts on the stats line, aligned with `progress` on the dashboard. */
-  private lazy val GcStartCol: Int = 8 + MaxPhaseLen + MaxGroupLen
+  /** 1-indexed column where the `progress` label starts on the dashboard. */
+  private lazy val ProgressStartCol: Int = 8 + MaxPhaseLen + MaxGroupLen
 
-  /** 1-indexed column where the `heap` label starts on the stats line, aligned with `threads` on the dashboard. */
-  private lazy val HeapStartCol: Int = GcStartCol + 20 + BarWidth
+  /** 1-indexed column where the `threads` label starts on the dashboard. */
+  private lazy val ThreadsStartCol: Int = ProgressStartCol + 20 + BarWidth
 
   /** Width of the threads-sparkline. */
   private val SparkWidth: Int = 12
@@ -457,12 +454,6 @@ object CompilerTop {
     else green(formatted)
   }
 
-  private def styleGc(formatted: String, pct: Double): String = {
-    if (pct >= 10.0) bold(red(formatted))
-    else if (pct >= 3.0) yellow(formatted)
-    else green(formatted)
-  }
-
   /**
     * The compiler phases, in the order they fire.
     *
@@ -512,10 +503,6 @@ object CompilerTop {
     val max = rt.maxMemory()
     (used / (1024L * 1024L), max / (1024L * 1024L))
   }
-
-  private def gcMillis(): Long =
-    ManagementFactory.getGarbageCollectorMXBeans.asScala.iterator
-      .map(_.getCollectionTime).filter(_ >= 0L).sum
 
   private final case class ModuleStats(
     module: String,
@@ -656,7 +643,7 @@ object CompilerTop {
     else f"${ms}ms"
   }
 
-private def truncate(s: String, width: Int): String =
+  private def truncate(s: String, width: Int): String =
     if (s.length <= width) s else s.take(width - 1) + "…"
 
   private def lpad(s: String, w: Int): String =

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -246,11 +246,14 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
       val locLines = locLineCount(s.loc)
       val phase = s.dominantPhase.getOrElse("?")
 
-      val symField = rpad(truncate(s.sym.name, layout.symWidth), layout.symWidth)
+      val nameMax = layout.symWidth - 1
+      val nameField = rpad(truncate(s.sym.name, nameMax), nameMax)
       val locField = rpad(truncate(locStr, layout.locWidth), layout.locWidth)
+      val marker = if (s.isActive) yellow("*") else " "
 
       sb.append(' ')
-      sb.append(styleSym(symField, s.totalNanos, locLines))
+      sb.append(styleSym(nameField, s.totalNanos, locLines))
+      sb.append(marker)
       sb.append(' ')
       sb.append(dim(locField))
       appendNumericFields(sb, locLines, s.callCount.toLong, phase, s.totalNanos, pctCpu, pctWall, layout)

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -560,13 +560,14 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
       val phase = s.dominantPhase.getOrElse("?")
 
       val nameMax = layout.symWidth - 1
-      val nameField = rpad(truncate(s.sym.name, nameMax), nameMax)
+      val nameText = truncate(s.sym.name, nameMax)
       val locField = rpad(truncate(locStr, layout.locWidth), layout.locWidth)
       val marker = if (s.isActive) yellow("*") else " "
 
       sb.append(' ')
-      sb.append(styleSym(nameField, s.totalNanos, locLines))
+      sb.append(styleSym(nameText, s.totalNanos, locLines))
       sb.append(marker)
+      sb.append(" " * (nameMax - nameText.length))
       sb.append(' ')
       sb.append(dim(locField))
       appendNumericFields(sb, locLines, s.callCount.toLong, phase, s.totalNanos, pctCpu, pctWall, layout)

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -17,6 +17,7 @@ package ca.uwaterloo.flix.util
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
+import ca.uwaterloo.flix.util.CompilerProfiler.DefnStats
 import org.jline.terminal.{Terminal, TerminalBuilder}
 
 import java.util.concurrent.atomic.AtomicBoolean

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.util
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.util.CompilerProfiler.DefnStats
 import org.jline.terminal.{Terminal, TerminalBuilder}
 
@@ -31,14 +31,11 @@ object CompilerTop {
   /** Maximum length of any name in [[Phases]] — used to pad the phase column. Lazy to defer until [[Phases]] is initialized. */
   private lazy val MaxPhaseLen: Int = Phases.iterator.map(_.length).max
 
-  /** Maximum length of any group label — `"semantic"` is the longest at 8. */
-  private val MaxGroupLen: Int = 8
-
   /** Width (in characters) of the phase-progress bar. */
   private val BarWidth: Int = 12
 
   /** 1-indexed column where the `progress` label starts on the dashboard. */
-  private lazy val ProgressStartCol: Int = 8 + MaxPhaseLen + MaxGroupLen
+  private lazy val ProgressStartCol: Int = 5 + MaxPhaseLen
 
   /** 1-indexed column where the `threads` label starts on the dashboard. */
   private lazy val ThreadsStartCol: Int = ProgressStartCol + 20 + BarWidth
@@ -81,10 +78,6 @@ object CompilerTop {
   private val Green: String = s"$ESC[32m"
   /** ANSI foreground yellow. */
   private val Yellow: String = s"$ESC[33m"
-  /** ANSI foreground blue. */
-  private val Blue: String = s"$ESC[34m"
-  /** ANSI foreground magenta. */
-  private val Magenta: String = s"$ESC[35m"
   /** ANSI foreground cyan. */
   private val Cyan: String = s"$ESC[36m"
   /** ANSI foreground bright black (gray). */
@@ -187,25 +180,6 @@ object CompilerTop {
     // backend
     "JvmBackend"
   )
-
-  /** Returns the dashboard color-group for `phase` (`syntax`, `semantic`, `midend`, `backend`, or `?`). */
-  private def phaseGroup(phase: String): String = {
-    val idx = Phases.indexOf(phase)
-    if (idx < 0) "?"
-    else if (idx <= 4) "syntax"
-    else if (idx <= 18) "semantic"
-    else if (idx <= 30) "midend"
-    else "backend"
-  }
-
-  /** Returns the ANSI color associated with a phase group. */
-  private def groupColor(group: String): String = group match {
-    case "syntax"   => Blue
-    case "semantic" => Green
-    case "midend"   => Yellow
-    case "backend"  => Magenta
-    case _          => Gray
-  }
 
   // -- Numeric helpers ----------------------------------------------------
 
@@ -506,19 +480,13 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     */
   private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int): Unit = {
     val phase = flix.getCurrentPhaseName.getOrElse("starting")
-    val group = phaseGroup(phase)
     val total = Phases.size
     val idx = Phases.indexOf(phase)
     val done = if (idx < 0) 0 else idx + 1
     val filled = (BarWidth.toLong * done / total).toInt
 
     sb.append("  ")
-    sb.append(color(rpad(phase, MaxPhaseLen), groupColor(group)))
-    sb.append(' ')
-    sb.append(dim("("))
-    sb.append(color(group, groupColor(group)))
-    sb.append(dim(")"))
-    sb.append(" " * (MaxGroupLen - group.length).max(0))
+    sb.append(bold(rpad(phase, MaxPhaseLen)))
     sb.append(dim("  progress "))
     sb.append(dim("["))
     sb.append(green("█" * filled))

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -100,8 +100,8 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     // reserving an extra `RowMargin` rows so the view never quite touches
     // the top or bottom edge of the terminal.
     val dataRows = (terminalRows() - ChromeRows - RowMargin).max(MinDataRows)
-    val moduleN = (dataRows / 3).max(MinModuleN).min(MaxModuleN)
-    val defN = (dataRows - moduleN).max(MinDefN).min(MaxDefN)
+    val moduleN = (dataRows / 3).max(MinModuleN)
+    val defN = (dataRows - moduleN).max(MinDefN)
 
     // Compute the column layout based on the current terminal width,
     // reserving 2 columns for the 1-space left and right table padding.
@@ -613,11 +613,9 @@ object CompilerTop {
   /** Floor on the total data-row budget. */
   private val MinDataRows: Int = 8
 
-  /** Bounds on per-table row counts. */
+  /** Floors on per-table row counts; both tables grow with terminal height. */
   private val MinDefN: Int = 5
-  private val MaxDefN: Int = 30
   private val MinModuleN: Int = 3
-  private val MaxModuleN: Int = 10
 
   // -- Formatting helpers -------------------------------------------------
 

--- a/main/src/ca/uwaterloo/flix/util/DefnTimer.scala
+++ b/main/src/ca/uwaterloo/flix/util/DefnTimer.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.util
+
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, AtomicReference}
+import scala.jdk.CollectionConverters.*
+
+/**
+  * Per-`DefnSym` statistics: total wall-clock time, number of times the
+  * compiler visited the def, and a per-phase breakdown of where the time
+  * went.
+  */
+final case class DefnStats(
+  sym: Symbol.DefnSym,
+  loc: SourceLocation,
+  totalNanos: Long,
+  callCount: Int,
+  byPhase: Map[String, Long]
+) {
+  /** Returns the phase that consumed the most time, or None if empty. */
+  def dominantPhase: Option[String] =
+    if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
+}
+
+/**
+  * Tracks cumulative wall-clock time, call counts, and per-phase breakdowns
+  * for each [[Symbol.DefnSym]]. Safe to call from multiple threads.
+  *
+  * `phaseProvider` is consulted at the start of every [[track]] call to
+  * attribute the elapsed time to the currently running phase.
+  *
+  * == Instrumented phases ==
+  *
+  * The following phases call [[track]] and contribute per-`DefnSym` data:
+  *
+  *   - Frontend (10 sites):
+  *     `Kinder` (visitDefSpecs + visitDefs), `Typer`, `EntryPoints`,
+  *     `PredDeps`, `Stratifier`, `PatMatch`, `Redundancy`, `Safety`,
+  *     `Terminator`, `Dependencies`.
+  *   - Backend (13 sites):
+  *     `Monomorpher` (initial + worklist; keyed by source generic sym),
+  *     `LambdaDrop`, `OccurrenceAnalyzer`, `Inliner`, `Simplifier`,
+  *     `ClosureConv`, `LambdaLift`, `EffectBinder`, `TailPos`, `Eraser`,
+  *     `Reducer`.
+  *
+  * == Uninstrumented phases ==
+  *
+  * These phases run but do not feed the timer:
+  *
+  *   - `Reader`, `Lexer`, `Parser2`, `Weeder2`, `Desugar`, `Namer` —
+  *     pre-`DefnSym`; the symbol does not exist yet.
+  *   - `Resolver` — per-def work is nested inside trait/instance walks
+  *     rather than a clean `parMapValues` over `root.defs`.
+  *   - `Deriver` — generates new instances from enum derivations; iterates
+  *     over enums, not over existing defs.
+  *   - `Instances` — per-instance-def work is interleaved with trait
+  *     conformance checks; instrumentable but not a one-line wrap.
+  *   - `TreeShaker1`, `TreeShaker2` — pure filter passes; no per-def work
+  *     to time.
+  *   - `Optimizer` — a wrapper that re-runs `OccurrenceAnalyzer` and
+  *     `Inliner` in a fixed-point loop. All work is captured transitively
+  *     through those instrumented inner phases.
+  *   - `JvmBackend` — class-file generation through
+  *     `GenFunAndClosureClasses`; not a `parMap` and would require a
+  *     dedicated hook inside the class generator.
+  */
+final class DefnTimer(phaseProvider: () => String) {
+
+  private val stats = new ConcurrentHashMap[Symbol.DefnSym, DefnTimer.Counters]()
+
+  /**
+    * Runs `thunk` and records its elapsed wall-clock time against `sym`,
+    * attributed to whatever phase is currently running.
+    */
+  def track[A](sym: Symbol.DefnSym, loc: SourceLocation)(thunk: => A): A = {
+    val phase = phaseProvider()
+    val t0 = System.nanoTime()
+    try thunk
+    finally {
+      val elapsed = System.nanoTime() - t0
+      val c = countersFor(sym)
+      c.loc.compareAndSet(null, loc)
+      c.totalNanos.addAndGet(elapsed)
+      c.callCount.incrementAndGet()
+      c.perPhaseNanos
+        .computeIfAbsent(phase, _ => new AtomicLong(0L))
+        .addAndGet(elapsed)
+    }
+  }
+
+  /**
+    * Returns an approximate snapshot. Iterators over the underlying maps are
+    * weakly consistent, so individual entries may be slightly stale.
+    */
+  def snapshot(): Vector[DefnStats] = {
+    val it = stats.entrySet().iterator().asScala
+    it.map { e =>
+      val c = e.getValue
+      val byPhase = c.perPhaseNanos.entrySet().iterator().asScala
+        .map(pe => (pe.getKey, pe.getValue.get())).toMap
+      val loc = Option(c.loc.get()).getOrElse(e.getKey.loc)
+      DefnStats(e.getKey, loc, c.totalNanos.get(), c.callCount.get(), byPhase)
+    }.toVector
+  }
+
+  /** Returns the total number of `track` calls made so far across all defs. */
+  def totalCallCount: Long = {
+    var n = 0L
+    val it = stats.values().iterator()
+    while (it.hasNext) n += it.next().callCount.get()
+    n
+  }
+
+  /** Removes all recorded statistics. */
+  def reset(): Unit = stats.clear()
+
+  private def countersFor(sym: Symbol.DefnSym): DefnTimer.Counters =
+    stats.computeIfAbsent(sym, _ => new DefnTimer.Counters)
+}
+
+object DefnTimer {
+  private final class Counters {
+    val totalNanos = new AtomicLong(0L)
+    val callCount = new AtomicInteger(0)
+    val perPhaseNanos = new ConcurrentHashMap[String, AtomicLong]()
+    /** Set on first `track` call; carries the def-body span so we can show LOC. */
+    val loc = new AtomicReference[SourceLocation](null)
+  }
+}

--- a/main/src/ca/uwaterloo/flix/util/Options.scala
+++ b/main/src/ca/uwaterloo/flix/util/Options.scala
@@ -36,6 +36,7 @@ object Options {
     outputPath = Path.of("./build/"),
     progress = false,
     threads = Runtime.getRuntime.availableProcessors(),
+    top = false,
     loadClassFiles = true,
     assumeYes = false,
     xprintphases = false,
@@ -83,6 +84,7 @@ object Options {
   * @param outputPath     The path to the output folder.
   * @param progress       print progress during compilation.
   * @param threads        selects the number of threads to use.
+  * @param top            shows a live TUI of the DefnSyms the compiler spends most time on.
   * @param loadClassFiles loads the generated class files into the JVM.
   * @param assumeYes      run non-interactively and assume answer to all prompts is yes.
   */
@@ -97,6 +99,7 @@ case class Options(lib: LibLevel,
                    outputJvm: Boolean,
                    outputPath: Path,
                    threads: Int,
+                   top: Boolean,
                    loadClassFiles: Boolean,
                    assumeYes: Boolean,
                    xprintphases: Boolean,

--- a/main/src/ca/uwaterloo/flix/util/Options.scala
+++ b/main/src/ca/uwaterloo/flix/util/Options.scala
@@ -27,6 +27,7 @@ object Options {
   val Default: Options = Options(
     lib = LibLevel.All,
     build = Build.Development,
+    compilerTop = false,
     entryPoint = None,
     githubToken = None,
     installDeps = false,
@@ -36,7 +37,6 @@ object Options {
     outputPath = Path.of("./build/"),
     progress = false,
     threads = Runtime.getRuntime.availableProcessors(),
-    top = false,
     loadClassFiles = true,
     assumeYes = false,
     xprintphases = false,
@@ -75,6 +75,7 @@ object Options {
   *
   * @param lib            selects the level of libraries to include.
   * @param build          selects development or production mode.
+  * @param compilerTop    shows a live TUI of where the compiler spends its time.
   * @param entryPoint     specifies the main entry point.
   * @param githubToken    the API key to use for GitHub dependency resolution.
   * @param incremental    enables incremental compilation.
@@ -84,12 +85,12 @@ object Options {
   * @param outputPath     The path to the output folder.
   * @param progress       print progress during compilation.
   * @param threads        selects the number of threads to use.
-  * @param top            shows a live TUI of the DefnSyms the compiler spends most time on.
   * @param loadClassFiles loads the generated class files into the JVM.
   * @param assumeYes      run non-interactively and assume answer to all prompts is yes.
   */
 case class Options(lib: LibLevel,
                    build: Build,
+                   compilerTop: Boolean,
                    entryPoint: Option[Symbol.DefnSym],
                    githubToken: Option[String],
                    incremental: Boolean,
@@ -99,7 +100,6 @@ case class Options(lib: LibLevel,
                    outputJvm: Boolean,
                    outputPath: Path,
                    threads: Int,
-                   top: Boolean,
                    loadClassFiles: Boolean,
                    assumeYes: Boolean,
                    xprintphases: Boolean,

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -347,6 +347,23 @@ final class TopRenderer(flix: Flix) {
 
 object TopRenderer {
 
+  /**
+    * Runs `body` with the live `--top` TUI active when `enabled`. When
+    * disabled, `body` runs unchanged. When enabled, a [[TopRenderer]] is
+    * started before `body` runs and stopped (with a final frame) in a
+    * `finally` block, so the terminal is restored on both normal return
+    * and exception.
+    *
+    * `body` must not call [[System.exit]] — exit handling stays in the
+    * caller, after the renderer has been stopped.
+    */
+  def runDuring[A](flix: Flix, enabled: Boolean)(body: => A): A = {
+    if (!enabled) return body
+    val r = new TopRenderer(flix)
+    r.start()
+    try body finally r.stop()
+  }
+
   /** How often the screen refreshes, in milliseconds. */
   private val RefreshIntervalMs: Long = 100L
 

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -156,7 +156,7 @@ final class TopRenderer(flix: Flix) {
     sb.append(" " * (MaxGroupLen - group.length).max(0))
     sb.append(dim("  progress "))
     sb.append(dim("["))
-    sb.append(dim(cyan("█" * filled)))
+    sb.append(green("█" * filled))
     sb.append(dim("░" * (BarWidth - filled)))
     sb.append(dim("] "))
     sb.append(f"$done%2d/$total%2d")
@@ -167,29 +167,34 @@ final class TopRenderer(flix: Flix) {
     sb.append('\n')
   }
 
-  /** Stats line: elapsed · heap · gc. */
+  /**
+    * Stats line: elapsed (right-aligned under `progress`) and heap
+    * (right-aligned under `threads`).
+    */
   private def renderStats(sb: StringBuilder, elapsed: Long): Unit = {
     val (heapUsedMb, heapMaxMb) = heapUsage()
-    val gcMs = gcMillis()
-    val gcPct = 100.0 * gcMs * 1_000_000L / elapsed.max(1L)
-
     val heapUsedField = f"$heapUsedMb%4d MB"
     val heapMaxField = f"$heapMaxMb%4d MB"
     val heapRatio = if (heapMaxMb <= 0) 0.0 else heapUsedMb.toDouble / heapMaxMb
-    val gcField = f"$gcPct%4.1f%% (${gcMs}%5dms)"
-    val sep = dim(" · ")
+    val elapsedField = formatMillis(elapsed)
+
+    // "elapsed" (7 chars) right-aligned with "progress" (8 chars) → start at GcStartCol + 1.
+    val elapsedStartCol = GcStartCol + 1
+    // "heap" (4 chars) right-aligned with "threads" (7 chars) → start at HeapStartCol + 3.
+    val heapStartCol = HeapStartCol + 3
 
     sb.append("  ")
+    sb.append(" " * (elapsedStartCol - 3).max(0))
     sb.append(dim("elapsed "))
-    sb.append(formatMillis(elapsed))
-    sb.append(sep)
+    sb.append(elapsedField)
+
+    val colAfterElapsed = elapsedStartCol + "elapsed ".length + elapsedField.length
+    sb.append(" " * (heapStartCol - colAfterElapsed).max(1))
+
     sb.append(dim("heap "))
     sb.append(styleHeap(heapUsedField, heapRatio))
     sb.append(dim(" / "))
     sb.append(heapMaxField)
-    sb.append(sep)
-    sb.append(dim("gc "))
-    sb.append(styleGc(gcField, gcPct))
     sb.append('\n')
   }
 
@@ -353,6 +358,12 @@ object TopRenderer {
 
   /** Width (in characters) of the phase-progress bar. */
   private val BarWidth: Int = 12
+
+  /** 1-indexed column where the `gc` label starts on the stats line, aligned with `progress` on the dashboard. */
+  private lazy val GcStartCol: Int = 8 + MaxPhaseLen + MaxGroupLen
+
+  /** 1-indexed column where the `heap` label starts on the stats line, aligned with `threads` on the dashboard. */
+  private lazy val HeapStartCol: Int = GcStartCol + 20 + BarWidth
 
   /** Width of the threads-sparkline. */
   private val SparkWidth: Int = 12

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -63,11 +63,9 @@ final class TopRenderer(flix: Flix) {
     if (w > 0) w else DefaultCols
   }
 
-  // State carried across frames so we can compute the throughput sparkline.
-  // Touched only by the renderer thread.
-  private var prevFrameNanos: Long = startNanos
-  private var prevTotalCalls: Long = 0L
-  private val throughputHistory = mutable.Queue.empty[Double]
+  // State carried across frames so we can compute the active-threads
+  // sparkline. Touched only by the renderer thread.
+  private val threadsHistory = mutable.Queue.empty[Double]
 
   /** Starts the renderer on a daemon thread. */
   def start(): Unit = {
@@ -97,9 +95,9 @@ final class TopRenderer(flix: Flix) {
   private def render(): Unit = {
     val now = System.nanoTime()
     val elapsed = now - startNanos
-    val frameDt = (now - prevFrameNanos).max(1L)
     val pool = flix.threadPool
     val parallelism = if (pool == null) flix.options.threads.max(1) else pool.getParallelism.max(1)
+    val activeThreads = if (pool == null) 0 else pool.getActiveThreadCount
 
     // Budget rows for the two tables based on the current terminal height,
     // reserving an extra `RowMargin` rows so the view never quite touches
@@ -115,12 +113,9 @@ final class TopRenderer(flix: Flix) {
     val snap = flix.defnTimer.snapshot().sortBy(-_.totalNanos)
     val visible = snap.take(defN)
 
-    // Throughput sparkline: visits-per-second since last frame.
-    val totalCalls = flix.defnTimer.totalCallCount
-    val callsThisFrame = (totalCalls - prevTotalCalls).max(0L)
-    val throughputPerSec = callsThisFrame.toDouble * 1_000_000_000.0 / frameDt
-    throughputHistory.enqueue(throughputPerSec)
-    while (throughputHistory.size > SparkWidth) throughputHistory.dequeue()
+    // Active-threads sparkline: history of thread-pool occupancy.
+    threadsHistory.enqueue(activeThreads.toDouble)
+    while (threadsHistory.size > SparkWidth) threadsHistory.dequeue()
 
     val modules = aggregateByModule(snap).take(moduleN)
 
@@ -130,7 +125,7 @@ final class TopRenderer(flix: Flix) {
 
     renderHeader(sb, elapsed)
     renderProgressBar(sb)
-    renderResources(sb, elapsed, throughputPerSec)
+    renderResources(sb, elapsed, activeThreads, parallelism)
     sb.append('\n')
     renderTableHeader(sb, layout)
     renderRows(sb, visible, elapsed, parallelism, layout)
@@ -139,18 +134,11 @@ final class TopRenderer(flix: Flix) {
     System.out.print(sb)
     System.out.flush()
 
-    // Update carried state for next frame.
-    prevFrameNanos = now
-    prevTotalCalls = totalCalls
   }
 
   private def renderHeader(sb: StringBuilder, elapsed: Long): Unit = {
     val phase = flix.currentPhaseName
     val group = phaseGroup(phase)
-    val pool = flix.threadPool
-    val (active, par) =
-      if (pool == null) (0, flix.options.threads)
-      else (pool.getActiveThreadCount, pool.getParallelism)
 
     sb.append("  ")
     sb.append(color(rpad(phase, 14), groupColor(group)))
@@ -158,8 +146,6 @@ final class TopRenderer(flix: Flix) {
     sb.append(color(group, groupColor(group)))
     sb.append(dim(")   elapsed: "))
     sb.append(formatMillis(elapsed))
-    sb.append(dim("   threads: "))
-    sb.append(styleThreads(active, par))
     sb.append('\n')
   }
 
@@ -179,7 +165,7 @@ final class TopRenderer(flix: Flix) {
     sb.append('\n')
   }
 
-  private def renderResources(sb: StringBuilder, elapsed: Long, throughputPerSec: Double): Unit = {
+  private def renderResources(sb: StringBuilder, elapsed: Long, activeThreads: Int, parallelism: Int): Unit = {
     val (heapUsedMb, heapMaxMb) = heapUsage()
     val gcMs = gcMillis()
     val gcPct = 100.0 * gcMs * 1_000_000L / elapsed.max(1L)
@@ -196,10 +182,10 @@ final class TopRenderer(flix: Flix) {
     sb.append(heapMaxField)
     sb.append(dim("   gc: "))
     sb.append(styleGc(gcField, gcPct))
-    sb.append(dim("   throughput: "))
-    sb.append(dim(cyan(renderSparkline())))
+    sb.append(dim("   threads: "))
+    sb.append(dim(cyan(renderSparkline(parallelism.toDouble))))
     sb.append(' ')
-    sb.append(formatRate(throughputPerSec))
+    sb.append(styleThreads(activeThreads, parallelism))
     sb.append('\n')
   }
 
@@ -333,14 +319,18 @@ final class TopRenderer(flix: Flix) {
     sb.append(' '); sb.append(stylePctWall(f"$pctWall%5.1f%%", pctWall))
   }
 
-  private def renderSparkline(): String = {
-    if (throughputHistory.isEmpty) return " " * SparkWidth
-    val max = throughputHistory.max.max(1.0)
-    val chars = throughputHistory.iterator.map { v =>
-      val i = math.min(SparkChars.length - 1, math.max(0, (v / max * (SparkChars.length - 1)).round.toInt))
+  /**
+    * Renders the threads-history sparkline at a fixed scale where
+    * `█` ⇔ `maxValue` (typically the threadpool's parallelism). Earlier
+    * samples appear on the left, the most recent on the right.
+    */
+  private def renderSparkline(maxValue: Double): String = {
+    if (threadsHistory.isEmpty) return " " * SparkWidth
+    val safeMax = maxValue.max(1.0)
+    val chars = threadsHistory.iterator.map { v =>
+      val i = math.min(SparkChars.length - 1, math.max(0, (v / safeMax * (SparkChars.length - 1)).round.toInt))
       SparkChars(i)
     }.toArray
-    // Right-align so the most recent sample is at the right edge.
     val pad = (SparkWidth - chars.length).max(0)
     " " * pad + new String(chars)
   }
@@ -623,13 +613,7 @@ object TopRenderer {
     else f"${ms}ms"
   }
 
-  /** Format a per-second rate of count as e.g. "1.2k/s" or "421/s". */
-  private def formatRate(perSec: Double): String = {
-    if (perSec >= 1000.0) f"${perSec / 1000.0}%.1fk/s"
-    else f"${perSec.toInt}%d/s"
-  }
-
-  private def truncate(s: String, width: Int): String =
+private def truncate(s: String, width: Int): String =
     if (s.length <= width) s else s.take(width - 1) + "…"
 
   private def lpad(s: String, w: Int): String =

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.util
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
+
+import java.lang.management.ManagementFactory
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.*
+
+/**
+  * A live, top(1)-style TUI showing which `DefnSym`s the compiler has spent
+  * the most wall-clock time on so far, with per-phase breakdown, call count,
+  * top-mover deltas, throughput sparkline, threadpool occupancy, heap usage,
+  * GC time, and outlier highlighting.
+  *
+  * Reads from [[Flix.defnTimer]] and [[Flix.currentPhaseName]] every
+  * [[TopRenderer.RefreshIntervalMs]] milliseconds and re-renders the screen
+  * using ANSI escape codes.
+  */
+final class TopRenderer(flix: Flix, topN: Int = 20) {
+
+  import TopRenderer.*
+
+  private val running = new AtomicBoolean(false)
+  private var thread: Thread = _
+  private val startNanos: Long = System.nanoTime()
+
+  // State carried across frames so we can compute the throughput sparkline.
+  // Touched only by the renderer thread.
+  private var prevFrameNanos: Long = startNanos
+  private var prevTotalCalls: Long = 0L
+  private val throughputHistory = mutable.Queue.empty[Double]
+
+  /** Starts the renderer on a daemon thread. */
+  def start(): Unit = {
+    if (!running.compareAndSet(false, true)) return
+    thread = new Thread(() => loop(), "flix-top-renderer")
+    thread.setDaemon(true)
+    thread.start()
+  }
+
+  /** Stops the renderer, prints one final frame, and joins the render thread. */
+  def stop(): Unit = {
+    if (!running.compareAndSet(true, false)) return
+    if (thread != null) thread.join()
+    render()
+    System.out.println()
+  }
+
+  private def loop(): Unit = {
+    while (running.get()) {
+      render()
+      try Thread.sleep(RefreshIntervalMs)
+      catch { case _: InterruptedException => return }
+    }
+  }
+
+  private def render(): Unit = {
+    val now = System.nanoTime()
+    val elapsed = now - startNanos
+    val frameDt = (now - prevFrameNanos).max(1L)
+    val pool = flix.threadPool
+    val parallelism = if (pool == null) flix.options.threads.max(1) else pool.getParallelism.max(1)
+
+    val snap = flix.defnTimer.snapshot().sortBy(-_.totalNanos)
+    val visible = snap.take(topN)
+
+    // Throughput sparkline: visits-per-second since last frame.
+    val totalCalls = flix.defnTimer.totalCallCount
+    val callsThisFrame = (totalCalls - prevTotalCalls).max(0L)
+    val throughputPerSec = callsThisFrame.toDouble * 1_000_000_000.0 / frameDt
+    throughputHistory.enqueue(throughputPerSec)
+    while (throughputHistory.size > SparkWidth) throughputHistory.dequeue()
+
+    // Outlier threshold: mean + 2σ of total nanos across visible entries.
+    val outlierThreshold = computeOutlierThreshold(visible)
+
+    val sb = new StringBuilder
+    sb.append(ClearScreen)
+
+    renderHeader(sb, elapsed)
+    renderProgressBar(sb)
+    renderResources(sb, elapsed, throughputPerSec)
+    sb.append('\n')
+    renderTableHeader(sb)
+    renderRows(sb, visible, elapsed, parallelism, outlierThreshold)
+    renderLegend(sb)
+
+    System.out.print(sb)
+    System.out.flush()
+
+    // Update carried state for next frame.
+    prevFrameNanos = now
+    prevTotalCalls = totalCalls
+  }
+
+  private def renderHeader(sb: StringBuilder, elapsed: Long): Unit = {
+    val phase = flix.currentPhaseName
+    val group = phaseGroup(phase)
+    val pool = flix.threadPool
+    val (active, par) =
+      if (pool == null) (0, flix.options.threads)
+      else (pool.getActiveThreadCount, pool.getParallelism)
+
+    sb.append(color(rpad(phase, 14), groupColor(group)))
+    sb.append(dim(" ("))
+    sb.append(color(group, groupColor(group)))
+    sb.append(dim(")   elapsed: "))
+    sb.append(formatMillis(elapsed))
+    sb.append(dim("   threads: "))
+    sb.append(styleThreads(active, par))
+    sb.append('\n')
+  }
+
+  private def renderProgressBar(sb: StringBuilder): Unit = {
+    val phase = flix.currentPhaseName
+    val total = Phases.size
+    val idx = Phases.indexOf(phase)
+    val done = if (idx < 0) 0 else idx + 1
+    val filled = (BarWidth.toLong * done / total).toInt
+
+    sb.append(dim("["))
+    sb.append(cyan("█" * filled))
+    sb.append(dim("░" * (BarWidth - filled)))
+    sb.append(dim("] "))
+    sb.append(f"$done%2d/$total%2d")
+    sb.append('\n')
+  }
+
+  private def renderResources(sb: StringBuilder, elapsed: Long, throughputPerSec: Double): Unit = {
+    val (heapUsedMb, heapMaxMb) = heapUsage()
+    val gcMs = gcMillis()
+    val gcPct = 100.0 * gcMs * 1_000_000L / elapsed.max(1L)
+
+    val heapUsedField = f"$heapUsedMb%4d MB"
+    val heapMaxField = f"$heapMaxMb%4d MB"
+    val heapRatio = if (heapMaxMb <= 0) 0.0 else heapUsedMb.toDouble / heapMaxMb
+    val gcField = f"$gcPct%4.1f%% (${gcMs}%5dms)"
+
+    sb.append(dim("heap: "))
+    sb.append(styleHeap(heapUsedField, heapRatio))
+    sb.append(dim(" / "))
+    sb.append(heapMaxField)
+    sb.append(dim("   gc: "))
+    sb.append(styleGc(gcField, gcPct))
+    sb.append(dim("   throughput: "))
+    sb.append(cyan(renderSparkline()))
+    sb.append(' ')
+    sb.append(formatRate(throughputPerSec))
+    sb.append('\n')
+  }
+
+  private def renderTableHeader(sb: StringBuilder): Unit = {
+    val header = f"${"DefnSym"}%-38s ${"location"}%-22s ${"LOC"}%4s ${"n"}%4s ${"phase"}%-12s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
+    sb.append(bold(cyan(header)))
+    sb.append('\n')
+    sb.append(dim("─" * header.length))
+    sb.append('\n')
+  }
+
+  private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int, outlierThreshold: Long): Unit = {
+    if (visible.isEmpty) {
+      sb.append(dim("(no DefnSyms have been timed yet)\n"))
+      return
+    }
+    val safeElapsed = elapsed.max(1L).toDouble
+    for (s <- visible) {
+      val pctWall = 100.0 * s.totalNanos / safeElapsed
+      val pctCpu = pctWall / parallelism
+      val locStr = formatLocation(s.loc)
+      val locLines = locLineCount(s.loc)
+      val phase = s.dominantPhase.getOrElse("?")
+      val isOutlier = s.totalNanos >= outlierThreshold
+
+      val symField = rpad(truncate(s.sym.toString, 38), 38)
+      val locField = rpad(truncate(locStr, 22), 22)
+      val locCntField = lpad(if (locLines > 0) locLines.toString else "-", 4)
+      val nField = lpad(s.callCount.toString, 4)
+      val phaseField = rpad(truncate(phase, 12), 12)
+      val timeField = lpad(formatMillis(s.totalNanos), 9)
+      val pctCpuField = f"$pctCpu%5.1f%%"
+      val pctWallField = f"$pctWall%5.1f%%"
+
+      sb.append(if (isOutlier) bold(red(symField)) else symField)
+      sb.append(' ')
+      sb.append(dim(locField))
+      sb.append(' ')
+      sb.append(locCntField)
+      sb.append(' ')
+      sb.append(nField)
+      sb.append(' ')
+      sb.append(phaseField)
+      sb.append(' ')
+      sb.append(styleTime(timeField, s.totalNanos))
+      sb.append(' ')
+      sb.append(stylePctCpu(pctCpuField, pctCpu))
+      sb.append(' ')
+      sb.append(stylePctWall(pctWallField, pctWall))
+      sb.append('\n')
+    }
+  }
+
+  private def renderLegend(sb: StringBuilder): Unit = {
+    sb.append('\n')
+    sb.append(dim("bold red sym = outlier (>µ+2σ)    %cpu = totalNanos / (elapsed × threads)    %wall = totalNanos / elapsed"))
+    sb.append('\n')
+  }
+
+  private def renderSparkline(): String = {
+    if (throughputHistory.isEmpty) return " " * SparkWidth
+    val max = throughputHistory.max.max(1.0)
+    val chars = throughputHistory.iterator.map { v =>
+      val i = math.min(SparkChars.length - 1, math.max(0, (v / max * (SparkChars.length - 1)).round.toInt))
+      SparkChars(i)
+    }.toArray
+    // Right-align so the most recent sample is at the right edge.
+    val pad = (SparkWidth - chars.length).max(0)
+    " " * pad + new String(chars)
+  }
+}
+
+object TopRenderer {
+
+  /** How often the screen refreshes, in milliseconds. */
+  private val RefreshIntervalMs: Long = 100L
+
+  /** Width (in characters) of the phase-progress bar. */
+  private val BarWidth: Int = 32
+
+  /** Width of the throughput sparkline. */
+  private val SparkWidth: Int = 24
+
+  /** Block characters used for the sparkline, low → high. */
+  private val SparkChars: Array[Char] = "▁▂▃▄▅▆▇█".toArray
+
+  /** ANSI escape character. */
+  private val ESC: Char = 27.toChar
+  private val ClearScreen: String = s"$ESC[H$ESC[2J"
+
+  // Color codes.
+  private val Reset: String = s"$ESC[0m"
+  private val BoldCode: String = s"$ESC[1m"
+  private val DimCode: String = s"$ESC[2m"
+  private val Red: String = s"$ESC[31m"
+  private val Green: String = s"$ESC[32m"
+  private val Yellow: String = s"$ESC[33m"
+  private val Blue: String = s"$ESC[34m"
+  private val Magenta: String = s"$ESC[35m"
+  private val Cyan: String = s"$ESC[36m"
+  private val Gray: String = s"$ESC[90m"
+
+  // Wrappers — each takes a string and returns it surrounded by codes.
+  private def color(s: String, c: String): String = s"$c$s$Reset"
+  private def bold(s: String): String = s"$BoldCode$s$Reset"
+  private def dim(s: String): String = s"$DimCode$s$Reset"
+  private def red(s: String): String = color(s, Red)
+  private def yellow(s: String): String = color(s, Yellow)
+  private def green(s: String): String = color(s, Green)
+  private def cyan(s: String): String = color(s, Cyan)
+
+  // -- Conditional styling -------------------------------------------------
+
+  private def styleTime(formatted: String, nanos: Long): String = {
+    val ms = nanos / 1_000_000L
+    if (ms >= 1000) bold(red(formatted))
+    else if (ms >= 200) bold(yellow(formatted))
+    else if (ms >= 50) yellow(formatted)
+    else formatted
+  }
+
+  /** %cpu = totalNanos / (elapsed × threads). One def's slice of total compute. */
+  private def stylePctCpu(formatted: String, pct: Double): String = {
+    if (pct >= 5.0) bold(red(formatted))
+    else if (pct >= 1.0) yellow(formatted)
+    else formatted
+  }
+
+  /** %wall = totalNanos / elapsed. Upper bound on wall-clock savings if removed. */
+  private def stylePctWall(formatted: String, pct: Double): String = {
+    if (pct >= 15.0) bold(red(formatted))
+    else if (pct >= 5.0) yellow(formatted)
+    else formatted
+  }
+
+  private def styleThreads(active: Int, par: Int): String = {
+    val s = f"$active%2d/$par%-2d"
+    if (par <= 0) color(s, Gray)
+    else if (active == par) bold(green(s))
+    else if (active.toDouble / par >= 0.5) green(s)
+    else if (active == 0) color(s, Gray)
+    else yellow(s)
+  }
+
+  private def styleHeap(formatted: String, ratio: Double): String = {
+    if (ratio >= 0.9) bold(red(formatted))
+    else if (ratio >= 0.7) yellow(formatted)
+    else green(formatted)
+  }
+
+  private def styleGc(formatted: String, pct: Double): String = {
+    if (pct >= 10.0) bold(red(formatted))
+    else if (pct >= 3.0) yellow(formatted)
+    else green(formatted)
+  }
+
+  /**
+    * The compiler phases, in the order they fire.
+    *
+    * Mirrors the calls to `flix.phase` / `flix.phaseNew` in
+    * `Flix.check` followed by `Flix.codeGen`.
+    *
+    * Note: appearance here means the phase advances the progress bar; it does
+    * not mean the phase feeds [[DefnTimer]]. See `DefnTimer`'s class-level
+    * doc for the list of instrumented vs. uninstrumented phases.
+    */
+  private val Phases: Vector[String] = Vector(
+    // syntax (parsing)
+    "Reader", "Lexer", "Parser2", "Weeder2", "Desugar",
+    // semantic (frontend)
+    "Namer", "Resolver", "Kinder", "Deriver", "Typer", "EntryPoints", "Instances",
+    "PredDeps", "Stratifier", "PatMatch", "Redundancy", "Safety", "Terminator", "Dependencies",
+    // mid-end (lowering and optimization)
+    "TreeShaker1", "Monomorpher", "LambdaDrop", "Optimizer", "Simplifier",
+    "ClosureConv", "LambdaLift", "TreeShaker2", "EffectBinder", "TailPos",
+    "Eraser", "Reducer",
+    // backend
+    "JvmBackend"
+  )
+
+  private def phaseGroup(phase: String): String = {
+    val idx = Phases.indexOf(phase)
+    if (idx < 0) "?"
+    else if (idx <= 4) "syntax"
+    else if (idx <= 18) "semantic"
+    else if (idx <= 30) "midend"
+    else "backend"
+  }
+
+  private def groupColor(group: String): String = group match {
+    case "syntax"   => Blue
+    case "semantic" => Green
+    case "midend"   => Yellow
+    case "backend"  => Magenta
+    case _          => Gray
+  }
+
+  // -- Numeric helpers ----------------------------------------------------
+
+  private def heapUsage(): (Long, Long) = {
+    val rt = Runtime.getRuntime
+    val used = rt.totalMemory() - rt.freeMemory()
+    val max = rt.maxMemory()
+    (used / (1024L * 1024L), max / (1024L * 1024L))
+  }
+
+  private def gcMillis(): Long =
+    ManagementFactory.getGarbageCollectorMXBeans.asScala.iterator
+      .map(_.getCollectionTime).filter(_ >= 0L).sum
+
+  private def computeOutlierThreshold(stats: Vector[DefnStats]): Long = {
+    if (stats.length < 3) return Long.MaxValue
+    val xs = stats.map(_.totalNanos.toDouble).toArray
+    val mean = xs.sum / xs.length
+    val variance = xs.map(x => (x - mean) * (x - mean)).sum / xs.length
+    val stdev = math.sqrt(variance)
+    (mean + 2.0 * stdev).toLong
+  }
+
+  // -- Formatting helpers -------------------------------------------------
+
+  private def formatLocation(loc: SourceLocation): String =
+    if (!loc.isReal) "?" else s"${loc.source.name}:${loc.startLine}"
+
+  private def locLineCount(loc: SourceLocation): Int =
+    if (!loc.isReal) 0 else (loc.endLine - loc.startLine + 1).max(0)
+
+  private def formatMillis(nanos: Long): String = {
+    val ms = nanos / 1_000_000L
+    if (ms >= 10_000L) f"${ms / 1000.0}%.1fs"
+    else f"${ms}ms"
+  }
+
+  /** Format a per-second rate of count as e.g. "1.2k/s" or "421/s". */
+  private def formatRate(perSec: Double): String = {
+    if (perSec >= 1000.0) f"${perSec / 1000.0}%.1fk/s"
+    else f"${perSec.toInt}%d/s"
+  }
+
+  private def truncate(s: String, width: Int): String =
+    if (s.length <= width) s else s.take(width - 1) + "…"
+
+  private def lpad(s: String, w: Int): String =
+    if (s.length >= w) s else " " * (w - s.length) + s
+
+  private def rpad(s: String, w: Int): String =
+    if (s.length >= w) s else s + " " * (w - s.length)
+}

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -234,7 +234,7 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
     if (modules.isEmpty) return
 
     sb.append('\n')
-    val header = f"${"Module"}%-24s ${"LOC"}%6s ${"phase"}%-10s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
+    val header = f"${"Module"}%-53s ${"LOC"}%4s ${"n"}%4s ${"phase"}%-10s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
     sb.append(bold(cyan(header)))
     sb.append('\n')
     sb.append(dim("─" * header.length))
@@ -247,8 +247,9 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
       val phase = m.dominantPhase.getOrElse("?")
       val isOutlier = m.totalNanos >= outlierThreshold
 
-      val modField = rpad(truncate(m.module, 24), 24)
-      val locField = lpad(if (m.totalLocLines > 0) m.totalLocLines.toString else "-", 6)
+      val modField = rpad(truncate(m.module, 53), 53)
+      val locCntField = lpad(if (m.totalLocLines > 0) m.totalLocLines.toString else "-", 4)
+      val nField = lpad(m.totalCallCount.toString, 4)
       val phaseField = rpad(truncate(phase, 10), 10)
       val timeField = lpad(formatMillis(m.totalNanos), 9)
       val pctCpuField = f"$pctCpu%5.1f%%"
@@ -256,7 +257,9 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
 
       sb.append(if (isOutlier) bold(red(modField)) else modField)
       sb.append(' ')
-      sb.append(locField)
+      sb.append(locCntField)
+      sb.append(' ')
+      sb.append(nField)
       sb.append(' ')
       sb.append(phaseField)
       sb.append(' ')
@@ -432,6 +435,7 @@ object TopRenderer {
   private final case class ModuleStats(
     module: String,
     totalNanos: Long,
+    totalCallCount: Long,
     totalLocLines: Int,
     byPhase: Map[String, Long]
   ) {
@@ -446,13 +450,14 @@ object TopRenderer {
     }
     groups.iterator.map { case (mod, defs) =>
       val totalNanos = defs.iterator.map(_.totalNanos).sum
+      val totalCallCount = defs.iterator.map(_.callCount.toLong).sum
       val totalLocLines = defs.iterator.map(s => locLineCount(s.loc)).sum
       val byPhase = defs.foldLeft(Map.empty[String, Long]) { (acc, d) =>
         d.byPhase.foldLeft(acc) { case (m, (phase, n)) =>
           m.updated(phase, m.getOrElse(phase, 0L) + n)
         }
       }
-      ModuleStats(mod, totalNanos, totalLocLines, byPhase)
+      ModuleStats(mod, totalNanos, totalCallCount, totalLocLines, byPhase)
     }.toVector.sortBy(-_.totalNanos)
   }
 

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -33,7 +33,7 @@ import scala.jdk.CollectionConverters.*
   * [[TopRenderer.RefreshIntervalMs]] milliseconds and re-renders the screen
   * using ANSI escape codes.
   */
-final class TopRenderer(flix: Flix, topN: Int = 20) {
+final class TopRenderer(flix: Flix, topN: Int = 10) {
 
   import TopRenderer.*
 
@@ -89,18 +89,23 @@ final class TopRenderer(flix: Flix, topN: Int = 20) {
     while (throughputHistory.size > SparkWidth) throughputHistory.dequeue()
 
     // Outlier threshold: mean + 2σ of total nanos across visible entries.
-    val outlierThreshold = computeOutlierThreshold(visible)
+    val defOutlierThreshold = computeOutlierThreshold(visible.map(_.totalNanos))
+
+    // Aggregate by module for the second table.
+    val modules = aggregateByModule(snap).take(ModuleTopN)
+    val moduleOutlierThreshold = computeOutlierThreshold(modules.map(_.totalNanos))
 
     val sb = new StringBuilder
     sb.append(ClearScreen)
+    sb.append('\n')
 
     renderHeader(sb, elapsed)
     renderProgressBar(sb)
     renderResources(sb, elapsed, throughputPerSec)
     sb.append('\n')
     renderTableHeader(sb)
-    renderRows(sb, visible, elapsed, parallelism, outlierThreshold)
-    renderLegend(sb)
+    renderRows(sb, visible, elapsed, parallelism, defOutlierThreshold)
+    renderModuleTable(sb, modules, elapsed, parallelism, moduleOutlierThreshold)
 
     System.out.print(sb)
     System.out.flush()
@@ -118,6 +123,7 @@ final class TopRenderer(flix: Flix, topN: Int = 20) {
       if (pool == null) (0, flix.options.threads)
       else (pool.getActiveThreadCount, pool.getParallelism)
 
+    sb.append("  ")
     sb.append(color(rpad(phase, 14), groupColor(group)))
     sb.append(dim(" ("))
     sb.append(color(group, groupColor(group)))
@@ -135,8 +141,9 @@ final class TopRenderer(flix: Flix, topN: Int = 20) {
     val done = if (idx < 0) 0 else idx + 1
     val filled = (BarWidth.toLong * done / total).toInt
 
+    sb.append("  ")
     sb.append(dim("["))
-    sb.append(cyan("█" * filled))
+    sb.append(dim(cyan("█" * filled)))
     sb.append(dim("░" * (BarWidth - filled)))
     sb.append(dim("] "))
     sb.append(f"$done%2d/$total%2d")
@@ -153,6 +160,7 @@ final class TopRenderer(flix: Flix, topN: Int = 20) {
     val heapRatio = if (heapMaxMb <= 0) 0.0 else heapUsedMb.toDouble / heapMaxMb
     val gcField = f"$gcPct%4.1f%% (${gcMs}%5dms)"
 
+    sb.append("  ")
     sb.append(dim("heap: "))
     sb.append(styleHeap(heapUsedField, heapRatio))
     sb.append(dim(" / "))
@@ -160,14 +168,14 @@ final class TopRenderer(flix: Flix, topN: Int = 20) {
     sb.append(dim("   gc: "))
     sb.append(styleGc(gcField, gcPct))
     sb.append(dim("   throughput: "))
-    sb.append(cyan(renderSparkline()))
+    sb.append(dim(cyan(renderSparkline())))
     sb.append(' ')
     sb.append(formatRate(throughputPerSec))
     sb.append('\n')
   }
 
   private def renderTableHeader(sb: StringBuilder): Unit = {
-    val header = f"${"DefnSym"}%-38s ${"location"}%-22s ${"LOC"}%4s ${"n"}%4s ${"phase"}%-12s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
+    val header = f"${"DefnSym"}%-24s ${"location"}%-28s ${"LOC"}%4s ${"n"}%4s ${"phase"}%-10s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
     sb.append(bold(cyan(header)))
     sb.append('\n')
     sb.append(dim("─" * header.length))
@@ -176,7 +184,13 @@ final class TopRenderer(flix: Flix, topN: Int = 20) {
 
   private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int, outlierThreshold: Long): Unit = {
     if (visible.isEmpty) {
-      sb.append(dim("(no DefnSyms have been timed yet)\n"))
+      val msg = "(no timings yet)"
+      val pad = ((DefTableWidth - msg.length) / 2).max(0)
+      sb.append('\n')
+      sb.append('\n')
+      sb.append(" " * pad)
+      sb.append(dim(msg))
+      sb.append('\n')
       return
     }
     val safeElapsed = elapsed.max(1L).toDouble
@@ -188,11 +202,11 @@ final class TopRenderer(flix: Flix, topN: Int = 20) {
       val phase = s.dominantPhase.getOrElse("?")
       val isOutlier = s.totalNanos >= outlierThreshold
 
-      val symField = rpad(truncate(s.sym.toString, 38), 38)
-      val locField = rpad(truncate(locStr, 22), 22)
+      val symField = rpad(truncate(s.sym.name, 24), 24)
+      val locField = rpad(truncate(locStr, 28), 28)
       val locCntField = lpad(if (locLines > 0) locLines.toString else "-", 4)
       val nField = lpad(s.callCount.toString, 4)
-      val phaseField = rpad(truncate(phase, 12), 12)
+      val phaseField = rpad(truncate(phase, 10), 10)
       val timeField = lpad(formatMillis(s.totalNanos), 9)
       val pctCpuField = f"$pctCpu%5.1f%%"
       val pctWallField = f"$pctWall%5.1f%%"
@@ -216,10 +230,43 @@ final class TopRenderer(flix: Flix, topN: Int = 20) {
     }
   }
 
-  private def renderLegend(sb: StringBuilder): Unit = {
+  private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int, outlierThreshold: Long): Unit = {
+    if (modules.isEmpty) return
+
     sb.append('\n')
-    sb.append(dim("bold red sym = outlier (>µ+2σ)    %cpu = totalNanos / (elapsed × threads)    %wall = totalNanos / elapsed"))
+    val header = f"${"Module"}%-24s ${"LOC"}%6s ${"phase"}%-10s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
+    sb.append(bold(cyan(header)))
     sb.append('\n')
+    sb.append(dim("─" * header.length))
+    sb.append('\n')
+
+    val safeElapsed = elapsed.max(1L).toDouble
+    for (m <- modules) {
+      val pctWall = 100.0 * m.totalNanos / safeElapsed
+      val pctCpu = pctWall / parallelism
+      val phase = m.dominantPhase.getOrElse("?")
+      val isOutlier = m.totalNanos >= outlierThreshold
+
+      val modField = rpad(truncate(m.module, 24), 24)
+      val locField = lpad(if (m.totalLocLines > 0) m.totalLocLines.toString else "-", 6)
+      val phaseField = rpad(truncate(phase, 10), 10)
+      val timeField = lpad(formatMillis(m.totalNanos), 9)
+      val pctCpuField = f"$pctCpu%5.1f%%"
+      val pctWallField = f"$pctWall%5.1f%%"
+
+      sb.append(if (isOutlier) bold(red(modField)) else modField)
+      sb.append(' ')
+      sb.append(locField)
+      sb.append(' ')
+      sb.append(phaseField)
+      sb.append(' ')
+      sb.append(styleTime(timeField, m.totalNanos))
+      sb.append(' ')
+      sb.append(stylePctCpu(pctCpuField, pctCpu))
+      sb.append(' ')
+      sb.append(stylePctWall(pctWallField, pctWall))
+      sb.append('\n')
+    }
   }
 
   private def renderSparkline(): String = {
@@ -373,14 +420,47 @@ object TopRenderer {
     ManagementFactory.getGarbageCollectorMXBeans.asScala.iterator
       .map(_.getCollectionTime).filter(_ >= 0L).sum
 
-  private def computeOutlierThreshold(stats: Vector[DefnStats]): Long = {
-    if (stats.length < 3) return Long.MaxValue
-    val xs = stats.map(_.totalNanos.toDouble).toArray
+  private def computeOutlierThreshold(values: Iterable[Long]): Long = {
+    val xs = values.iterator.map(_.toDouble).toArray
+    if (xs.length < 3) return Long.MaxValue
     val mean = xs.sum / xs.length
     val variance = xs.map(x => (x - mean) * (x - mean)).sum / xs.length
     val stdev = math.sqrt(variance)
     (mean + 2.0 * stdev).toLong
   }
+
+  private final case class ModuleStats(
+    module: String,
+    totalNanos: Long,
+    totalLocLines: Int,
+    byPhase: Map[String, Long]
+  ) {
+    def dominantPhase: Option[String] =
+      if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
+  }
+
+  private def aggregateByModule(snap: Vector[DefnStats]): Vector[ModuleStats] = {
+    val groups = snap.groupBy { s =>
+      val ns = s.sym.namespace
+      if (ns.isEmpty) "(root)" else ns.mkString(".")
+    }
+    groups.iterator.map { case (mod, defs) =>
+      val totalNanos = defs.iterator.map(_.totalNanos).sum
+      val totalLocLines = defs.iterator.map(s => locLineCount(s.loc)).sum
+      val byPhase = defs.foldLeft(Map.empty[String, Long]) { (acc, d) =>
+        d.byPhase.foldLeft(acc) { case (m, (phase, n)) =>
+          m.updated(phase, m.getOrElse(phase, 0L) + n)
+        }
+      }
+      ModuleStats(mod, totalNanos, totalLocLines, byPhase)
+    }.toVector.sortBy(-_.totalNanos)
+  }
+
+  /** Top N modules to display in the module-aggregate table. */
+  private val ModuleTopN: Int = 5
+
+  /** Width of the def-table border (sum of column widths plus separators). */
+  private val DefTableWidth: Int = 98
 
   // -- Formatting helpers -------------------------------------------------
 

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -88,12 +88,7 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
     throughputHistory.enqueue(throughputPerSec)
     while (throughputHistory.size > SparkWidth) throughputHistory.dequeue()
 
-    // Outlier threshold: mean + 2σ of total nanos across visible entries.
-    val defOutlierThreshold = computeOutlierThreshold(visible.map(_.totalNanos))
-
-    // Aggregate by module for the second table.
     val modules = aggregateByModule(snap).take(ModuleTopN)
-    val moduleOutlierThreshold = computeOutlierThreshold(modules.map(_.totalNanos))
 
     val sb = new StringBuilder
     sb.append(ClearScreen)
@@ -104,8 +99,8 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
     renderResources(sb, elapsed, throughputPerSec)
     sb.append('\n')
     renderTableHeader(sb)
-    renderRows(sb, visible, elapsed, parallelism, defOutlierThreshold)
-    renderModuleTable(sb, modules, elapsed, parallelism, moduleOutlierThreshold)
+    renderRows(sb, visible, elapsed, parallelism)
+    renderModuleTable(sb, modules, elapsed, parallelism)
 
     System.out.print(sb)
     System.out.flush()
@@ -175,18 +170,17 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
   }
 
   private def renderTableHeader(sb: StringBuilder): Unit = {
-    val header = f"${"DefnSym"}%-24s ${"location"}%-28s ${"LOC"}%4s ${"n"}%4s ${"phase"}%-10s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
+    val header = f"${"Def"}%-24s ${"location"}%-28s ${"LOC"}%4s ${"n"}%4s ${"phase"}%-10s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
     sb.append(bold(cyan(header)))
     sb.append('\n')
     sb.append(dim("─" * header.length))
     sb.append('\n')
   }
 
-  private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int, outlierThreshold: Long): Unit = {
+  private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int): Unit = {
     if (visible.isEmpty) {
       val msg = "(no timings yet)"
       val pad = ((DefTableWidth - msg.length) / 2).max(0)
-      sb.append('\n')
       sb.append('\n')
       sb.append(" " * pad)
       sb.append(dim(msg))
@@ -200,7 +194,6 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
       val locStr = formatLocation(s.loc)
       val locLines = locLineCount(s.loc)
       val phase = s.dominantPhase.getOrElse("?")
-      val isOutlier = s.totalNanos >= outlierThreshold
 
       val symField = rpad(truncate(s.sym.name, 24), 24)
       val locField = rpad(truncate(locStr, 28), 28)
@@ -211,7 +204,7 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
       val pctCpuField = f"$pctCpu%5.1f%%"
       val pctWallField = f"$pctWall%5.1f%%"
 
-      sb.append(if (isOutlier) bold(red(symField)) else symField)
+      sb.append(symField)
       sb.append(' ')
       sb.append(dim(locField))
       sb.append(' ')
@@ -230,7 +223,7 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
     }
   }
 
-  private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int, outlierThreshold: Long): Unit = {
+  private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int): Unit = {
     if (modules.isEmpty) return
 
     sb.append('\n')
@@ -245,7 +238,6 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
       val pctWall = 100.0 * m.totalNanos / safeElapsed
       val pctCpu = pctWall / parallelism
       val phase = m.dominantPhase.getOrElse("?")
-      val isOutlier = m.totalNanos >= outlierThreshold
 
       val modField = rpad(truncate(m.module, 53), 53)
       val locCntField = lpad(if (m.totalLocLines > 0) m.totalLocLines.toString else "-", 4)
@@ -255,7 +247,7 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
       val pctCpuField = f"$pctCpu%5.1f%%"
       val pctWallField = f"$pctWall%5.1f%%"
 
-      sb.append(if (isOutlier) bold(red(modField)) else modField)
+      sb.append(modField)
       sb.append(' ')
       sb.append(locCntField)
       sb.append(' ')
@@ -422,15 +414,6 @@ object TopRenderer {
   private def gcMillis(): Long =
     ManagementFactory.getGarbageCollectorMXBeans.asScala.iterator
       .map(_.getCollectionTime).filter(_ >= 0L).sum
-
-  private def computeOutlierThreshold(values: Iterable[Long]): Long = {
-    val xs = values.iterator.map(_.toDouble).toArray
-    if (xs.length < 3) return Long.MaxValue
-    val mean = xs.sum / xs.length
-    val variance = xs.map(x => (x - mean) * (x - mean)).sum / xs.length
-    val stdev = math.sqrt(variance)
-    (mean + 2.0 * stdev).toLong
-  }
 
   private final case class ModuleStats(
     module: String,

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -17,6 +17,7 @@ package ca.uwaterloo.flix.util
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
+import org.jline.terminal.{Terminal, TerminalBuilder}
 
 import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.AtomicBoolean
@@ -33,13 +34,34 @@ import scala.jdk.CollectionConverters.*
   * [[TopRenderer.RefreshIntervalMs]] milliseconds and re-renders the screen
   * using ANSI escape codes.
   */
-final class TopRenderer(flix: Flix, topN: Int = 10) {
+final class TopRenderer(flix: Flix) {
 
   import TopRenderer.*
 
   private val running = new AtomicBoolean(false)
   private var thread: Thread = _
   private val startNanos: Long = System.nanoTime()
+
+  /** A JLine terminal handle used to query screen size. May be null if JLine fails. */
+  private val terminal: Terminal = {
+    java.util.logging.Logger.getLogger("org.jline").setLevel(java.util.logging.Level.OFF)
+    try TerminalBuilder.builder().system(true).build()
+    catch { case _: Throwable => null }
+  }
+
+  /** Returns the terminal height in rows, or [[DefaultRows]] if unavailable. */
+  private def terminalRows(): Int = {
+    if (terminal == null) return DefaultRows
+    val h = terminal.getHeight
+    if (h > 0) h else DefaultRows
+  }
+
+  /** Returns the terminal width in columns, or [[DefaultCols]] if unavailable. */
+  private def terminalCols(): Int = {
+    if (terminal == null) return DefaultCols
+    val w = terminal.getWidth
+    if (w > 0) w else DefaultCols
+  }
 
   // State carried across frames so we can compute the throughput sparkline.
   // Touched only by the renderer thread.
@@ -61,6 +83,7 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
     if (thread != null) thread.join()
     render()
     System.out.println()
+    if (terminal != null) try terminal.close() catch { case _: Throwable => () }
   }
 
   private def loop(): Unit = {
@@ -78,8 +101,16 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
     val pool = flix.threadPool
     val parallelism = if (pool == null) flix.options.threads.max(1) else pool.getParallelism.max(1)
 
+    // Budget rows for the two tables based on the current terminal height.
+    val dataRows = (terminalRows() - ChromeRows).max(MinDataRows)
+    val moduleN = (dataRows / 3).max(MinModuleN).min(MaxModuleN)
+    val defN = (dataRows - moduleN).max(MinDefN).min(MaxDefN)
+
+    // Compute the column layout based on the current terminal width.
+    val layout = computeLayout(terminalCols())
+
     val snap = flix.defnTimer.snapshot().sortBy(-_.totalNanos)
-    val visible = snap.take(topN)
+    val visible = snap.take(defN)
 
     // Throughput sparkline: visits-per-second since last frame.
     val totalCalls = flix.defnTimer.totalCallCount
@@ -88,7 +119,7 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
     throughputHistory.enqueue(throughputPerSec)
     while (throughputHistory.size > SparkWidth) throughputHistory.dequeue()
 
-    val modules = aggregateByModule(snap).take(ModuleTopN)
+    val modules = aggregateByModule(snap).take(moduleN)
 
     val sb = new StringBuilder
     sb.append(ClearScreen)
@@ -98,9 +129,9 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
     renderProgressBar(sb)
     renderResources(sb, elapsed, throughputPerSec)
     sb.append('\n')
-    renderTableHeader(sb)
-    renderRows(sb, visible, elapsed, parallelism)
-    renderModuleTable(sb, modules, elapsed, parallelism)
+    renderTableHeader(sb, layout)
+    renderRows(sb, visible, elapsed, parallelism, layout)
+    renderModuleTable(sb, modules, elapsed, parallelism, layout)
 
     System.out.print(sb)
     System.out.flush()
@@ -169,18 +200,37 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
     sb.append('\n')
   }
 
-  private def renderTableHeader(sb: StringBuilder): Unit = {
-    val header = f"${"Def"}%-24s ${"location"}%-28s ${"LOC"}%4s ${"n"}%4s ${"phase"}%-10s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
+  private def renderTableHeader(sb: StringBuilder, layout: Layout): Unit = {
+    val header = buildHeader(rpad("Def", layout.symWidth), rpad("location", layout.locWidth), layout)
     sb.append(bold(cyan(header)))
     sb.append('\n')
     sb.append(dim("─" * header.length))
     sb.append('\n')
   }
 
-  private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int): Unit = {
+  /**
+    * Builds a table header (or any row's left side) given the formatted text
+    * for the first two columns. Numeric columns are conditionally appended
+    * per the layout's visibility flags.
+    */
+  private def buildHeader(firstCol: String, secondCol: String, layout: Layout): String = {
+    val sb = new StringBuilder
+    sb.append(firstCol)
+    sb.append(' ')
+    sb.append(secondCol)
+    if (layout.showLOC) { sb.append(' '); sb.append(lpad("LOC", 4)) }
+    if (layout.showN) { sb.append(' '); sb.append(lpad("n", 4)) }
+    if (layout.showPhase) { sb.append(' '); sb.append(rpad("phase", 10)) }
+    sb.append(' '); sb.append(lpad("time", 9))
+    sb.append(' '); sb.append(lpad("%cpu", 6))
+    sb.append(' '); sb.append(lpad("%wall", 6))
+    sb.toString
+  }
+
+  private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int, layout: Layout): Unit = {
     if (visible.isEmpty) {
       val msg = "(no timings yet)"
-      val pad = ((DefTableWidth - msg.length) / 2).max(0)
+      val pad = ((layout.totalWidth - msg.length) / 2).max(0)
       sb.append('\n')
       sb.append(" " * pad)
       sb.append(dim(msg))
@@ -195,39 +245,23 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
       val locLines = locLineCount(s.loc)
       val phase = s.dominantPhase.getOrElse("?")
 
-      val symField = rpad(truncate(s.sym.name, 24), 24)
-      val locField = rpad(truncate(locStr, 28), 28)
-      val locCntField = lpad(if (locLines > 0) locLines.toString else "-", 4)
-      val nField = lpad(s.callCount.toString, 4)
-      val phaseField = rpad(truncate(phase, 10), 10)
-      val timeField = lpad(formatMillis(s.totalNanos), 9)
-      val pctCpuField = f"$pctCpu%5.1f%%"
-      val pctWallField = f"$pctWall%5.1f%%"
+      val symField = rpad(truncate(s.sym.name, layout.symWidth), layout.symWidth)
+      val locField = rpad(truncate(locStr, layout.locWidth), layout.locWidth)
 
       sb.append(symField)
       sb.append(' ')
       sb.append(dim(locField))
-      sb.append(' ')
-      sb.append(locCntField)
-      sb.append(' ')
-      sb.append(nField)
-      sb.append(' ')
-      sb.append(phaseField)
-      sb.append(' ')
-      sb.append(styleTime(timeField, s.totalNanos))
-      sb.append(' ')
-      sb.append(stylePctCpu(pctCpuField, pctCpu))
-      sb.append(' ')
-      sb.append(stylePctWall(pctWallField, pctWall))
+      appendNumericFields(sb, locLines, s.callCount.toLong, phase, s.totalNanos, pctCpu, pctWall, layout)
       sb.append('\n')
     }
   }
 
-  private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int): Unit = {
+  private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int, layout: Layout): Unit = {
     if (modules.isEmpty) return
 
     sb.append('\n')
-    val header = f"${"Module"}%-53s ${"LOC"}%4s ${"n"}%4s ${"phase"}%-10s ${"time"}%9s ${"%cpu"}%6s ${"%wall"}%6s"
+    val modWidth = layout.symWidth + 1 + layout.locWidth
+    val header = buildModuleHeader(rpad("Module", modWidth), layout)
     sb.append(bold(cyan(header)))
     sb.append('\n')
     sb.append(dim("─" * header.length))
@@ -239,29 +273,49 @@ final class TopRenderer(flix: Flix, topN: Int = 10) {
       val pctCpu = pctWall / parallelism
       val phase = m.dominantPhase.getOrElse("?")
 
-      val modField = rpad(truncate(m.module, 53), 53)
-      val locCntField = lpad(if (m.totalLocLines > 0) m.totalLocLines.toString else "-", 4)
-      val nField = lpad(m.totalCallCount.toString, 4)
-      val phaseField = rpad(truncate(phase, 10), 10)
-      val timeField = lpad(formatMillis(m.totalNanos), 9)
-      val pctCpuField = f"$pctCpu%5.1f%%"
-      val pctWallField = f"$pctWall%5.1f%%"
+      val modField = rpad(truncate(m.module, modWidth), modWidth)
 
       sb.append(modField)
-      sb.append(' ')
-      sb.append(locCntField)
-      sb.append(' ')
-      sb.append(nField)
-      sb.append(' ')
-      sb.append(phaseField)
-      sb.append(' ')
-      sb.append(styleTime(timeField, m.totalNanos))
-      sb.append(' ')
-      sb.append(stylePctCpu(pctCpuField, pctCpu))
-      sb.append(' ')
-      sb.append(stylePctWall(pctWallField, pctWall))
+      appendNumericFields(sb, m.totalLocLines, m.totalCallCount, phase, m.totalNanos, pctCpu, pctWall, layout)
       sb.append('\n')
     }
+  }
+
+  /** Module-table header: single wide first column, then the same numeric columns as the def table. */
+  private def buildModuleHeader(firstCol: String, layout: Layout): String = {
+    val sb = new StringBuilder
+    sb.append(firstCol)
+    if (layout.showLOC) { sb.append(' '); sb.append(lpad("LOC", 4)) }
+    if (layout.showN) { sb.append(' '); sb.append(lpad("n", 4)) }
+    if (layout.showPhase) { sb.append(' '); sb.append(rpad("phase", 10)) }
+    sb.append(' '); sb.append(lpad("time", 9))
+    sb.append(' '); sb.append(lpad("%cpu", 6))
+    sb.append(' '); sb.append(lpad("%wall", 6))
+    sb.toString
+  }
+
+  /**
+    * Appends the trailing numeric columns (LOC, n, phase, time, %cpu, %wall)
+    * to a row, honoring the layout's visibility flags. Always emits a leading
+    * separator before each column it writes.
+    */
+  private def appendNumericFields(sb: StringBuilder, locLines: Int, callCount: Long, phase: String,
+                                   nanos: Long, pctCpu: Double, pctWall: Double, layout: Layout): Unit = {
+    if (layout.showLOC) {
+      sb.append(' ')
+      sb.append(lpad(if (locLines > 0) locLines.toString else "-", 4))
+    }
+    if (layout.showN) {
+      sb.append(' ')
+      sb.append(lpad(callCount.toString, 4))
+    }
+    if (layout.showPhase) {
+      sb.append(' ')
+      sb.append(rpad(truncate(phase, 10), 10))
+    }
+    sb.append(' '); sb.append(styleTime(lpad(formatMillis(nanos), 9), nanos))
+    sb.append(' '); sb.append(stylePctCpu(f"$pctCpu%5.1f%%", pctCpu))
+    sb.append(' '); sb.append(stylePctWall(f"$pctWall%5.1f%%", pctWall))
   }
 
   private def renderSparkline(): String = {
@@ -444,11 +498,98 @@ object TopRenderer {
     }.toVector.sortBy(-_.totalNanos)
   }
 
-  /** Top N modules to display in the module-aggregate table. */
-  private val ModuleTopN: Int = 5
+  /** Fallback terminal height when JLine cannot determine the real one. */
+  private val DefaultRows: Int = 24
 
-  /** Width of the def-table border (sum of column widths plus separators). */
-  private val DefTableWidth: Int = 98
+  /** Fallback terminal width when JLine cannot determine the real one. */
+  private val DefaultCols: Int = 100
+
+  /**
+    * Column layout for the per-frame table render. Computed from the current
+    * terminal width: when the terminal is narrow, the optional LOC / n /
+    * phase columns are dropped in that order (lowest-signal first). When the
+    * terminal is wide, the surplus is distributed between the DefnSym and
+    * location columns proportionally to their default widths.
+    */
+  private final case class Layout(
+    symWidth: Int,
+    locWidth: Int,
+    showLOC: Boolean,
+    showN: Boolean,
+    showPhase: Boolean,
+    totalWidth: Int
+  )
+
+  /** Default DefnSym/location widths and minimum bounds when the terminal shrinks. */
+  private val DefaultSymWidth: Int = 24
+  private val DefaultLocWidth: Int = 28
+  private val MinSymWidth: Int = 16
+  private val MinLocWidth: Int = 20
+
+  /** Fixed-width contribution of `time + %cpu + %wall` columns and their separators. */
+  private val FixedTailWidth: Int = 9 + 1 + 6 + 1 + 6 // time(9) + %cpu(6) + %wall(6) with two separators between
+
+  /** Width contribution of an optional column (separator + width). */
+  private val LocColWidth: Int = 1 + 4
+  private val NColWidth: Int = 1 + 4
+  private val PhaseColWidth: Int = 1 + 10
+
+  private def computeLayout(cols: Int): Layout = {
+    // Width contribution of the "fixed" half: separator before time + tail.
+    val tail = 1 + FixedTailWidth
+    // Width of just the text section (sym + 1 + location) at default sizes.
+    def textWidth(symW: Int, locW: Int): Int = symW + 1 + locW
+
+    // Try tiers in descending feature order.
+    val full = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + NColWidth + PhaseColWidth + tail
+    if (cols >= full) {
+      // Surplus → expand sym (~46%) and location (~54%) proportionally.
+      val extra = cols - full
+      val extraSym = extra * 46 / 100
+      val extraLoc = extra - extraSym
+      val symW = DefaultSymWidth + extraSym
+      val locW = DefaultLocWidth + extraLoc
+      return Layout(symW, locW, showLOC = true, showN = true, showPhase = true,
+        totalWidth = textWidth(symW, locW) + LocColWidth + NColWidth + PhaseColWidth + tail)
+    }
+
+    // Tier: drop phase.
+    val noPhase = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + NColWidth + tail
+    if (cols >= noPhase)
+      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showN = true, showPhase = false, noPhase)
+
+    // Tier: drop phase + n.
+    val noPhaseNoN = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + tail
+    if (cols >= noPhaseNoN)
+      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showN = false, showPhase = false, noPhaseNoN)
+
+    // Tier: drop phase + n + LOC.
+    val noOptional = textWidth(DefaultSymWidth, DefaultLocWidth) + tail
+    if (cols >= noOptional)
+      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = false, showN = false, showPhase = false, noOptional)
+
+    // Even minimum tier doesn't fit; shrink sym/locWidth to floors.
+    val available = (cols - tail).max(MinSymWidth + 1 + MinLocWidth)
+    val symW = MinSymWidth.max(available * 46 / 100)
+    val locW = MinLocWidth.max(available - 1 - symW)
+    Layout(symW, locW, showLOC = false, showN = false, showPhase = false,
+      textWidth(symW, locW) + tail)
+  }
+
+  /**
+    * Fixed-overhead rows: blank + 3 header lines + blank + 2 def-chrome +
+    * 1 blank-before-modules + 2 module-chrome + 1 cursor-parking row.
+    */
+  private val ChromeRows: Int = 11
+
+  /** Floor on the total data-row budget. */
+  private val MinDataRows: Int = 8
+
+  /** Bounds on per-table row counts. */
+  private val MinDefN: Int = 5
+  private val MaxDefN: Int = 30
+  private val MinModuleN: Int = 3
+  private val MaxModuleN: Int = 10
 
   // -- Formatting helpers -------------------------------------------------
 

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -123,9 +123,8 @@ final class TopRenderer(flix: Flix) {
     sb.append(ClearScreen)
     sb.append('\n')
 
-    renderHeader(sb, elapsed)
-    renderProgressBar(sb)
-    renderResources(sb, elapsed, activeThreads, parallelism)
+    renderDashboard(sb, activeThreads, parallelism)
+    renderStats(sb, elapsed)
     sb.append('\n')
     renderTableHeader(sb, layout)
     renderRows(sb, visible, elapsed, parallelism, layout)
@@ -136,36 +135,40 @@ final class TopRenderer(flix: Flix) {
 
   }
 
-  private def renderHeader(sb: StringBuilder, elapsed: Long): Unit = {
+  /**
+    * Top dashboard line: current phase + progress bar + active-threads bar.
+    * Both bars sit beside each other so the eye picks them up as a pair.
+    */
+  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int): Unit = {
     val phase = flix.currentPhaseName
     val group = phaseGroup(phase)
-
-    sb.append("  ")
-    sb.append(color(rpad(phase, 14), groupColor(group)))
-    sb.append(dim(" ("))
-    sb.append(color(group, groupColor(group)))
-    sb.append(dim(")   elapsed: "))
-    sb.append(formatMillis(elapsed))
-    sb.append('\n')
-  }
-
-  private def renderProgressBar(sb: StringBuilder): Unit = {
-    val phase = flix.currentPhaseName
     val total = Phases.size
     val idx = Phases.indexOf(phase)
     val done = if (idx < 0) 0 else idx + 1
     val filled = (BarWidth.toLong * done / total).toInt
 
     sb.append("  ")
+    sb.append(color(rpad(phase, MaxPhaseLen), groupColor(group)))
+    sb.append(' ')
+    sb.append(dim("("))
+    sb.append(color(group, groupColor(group)))
+    sb.append(dim(")"))
+    sb.append(" " * (MaxGroupLen - group.length).max(0))
+    sb.append(dim("  progress "))
     sb.append(dim("["))
     sb.append(dim(cyan("█" * filled)))
     sb.append(dim("░" * (BarWidth - filled)))
     sb.append(dim("] "))
     sb.append(f"$done%2d/$total%2d")
+    sb.append(dim("   threads "))
+    sb.append(dim(cyan(renderSparkline(parallelism.toDouble))))
+    sb.append(' ')
+    sb.append(styleThreads(activeThreads, parallelism))
     sb.append('\n')
   }
 
-  private def renderResources(sb: StringBuilder, elapsed: Long, activeThreads: Int, parallelism: Int): Unit = {
+  /** Stats line: elapsed · heap · gc. */
+  private def renderStats(sb: StringBuilder, elapsed: Long): Unit = {
     val (heapUsedMb, heapMaxMb) = heapUsage()
     val gcMs = gcMillis()
     val gcPct = 100.0 * gcMs * 1_000_000L / elapsed.max(1L)
@@ -174,18 +177,19 @@ final class TopRenderer(flix: Flix) {
     val heapMaxField = f"$heapMaxMb%4d MB"
     val heapRatio = if (heapMaxMb <= 0) 0.0 else heapUsedMb.toDouble / heapMaxMb
     val gcField = f"$gcPct%4.1f%% (${gcMs}%5dms)"
+    val sep = dim(" · ")
 
     sb.append("  ")
-    sb.append(dim("heap: "))
+    sb.append(dim("elapsed "))
+    sb.append(formatMillis(elapsed))
+    sb.append(sep)
+    sb.append(dim("heap "))
     sb.append(styleHeap(heapUsedField, heapRatio))
     sb.append(dim(" / "))
     sb.append(heapMaxField)
-    sb.append(dim("   gc: "))
+    sb.append(sep)
+    sb.append(dim("gc "))
     sb.append(styleGc(gcField, gcPct))
-    sb.append(dim("   threads: "))
-    sb.append(dim(cyan(renderSparkline(parallelism.toDouble))))
-    sb.append(' ')
-    sb.append(styleThreads(activeThreads, parallelism))
     sb.append('\n')
   }
 
@@ -341,11 +345,17 @@ object TopRenderer {
   /** How often the screen refreshes, in milliseconds. */
   private val RefreshIntervalMs: Long = 100L
 
-  /** Width (in characters) of the phase-progress bar. */
-  private val BarWidth: Int = 32
+  /** Maximum length of any name in [[Phases]] — used to pad the phase column. Lazy to defer until [[Phases]] is initialized. */
+  private lazy val MaxPhaseLen: Int = Phases.iterator.map(_.length).max
 
-  /** Width of the throughput sparkline. */
-  private val SparkWidth: Int = 24
+  /** Maximum length of any group label — `"semantic"` is the longest at 8. */
+  private val MaxGroupLen: Int = 8
+
+  /** Width (in characters) of the phase-progress bar. */
+  private val BarWidth: Int = 12
+
+  /** Width of the threads-sparkline. */
+  private val SparkWidth: Int = 12
 
   /** Block characters used for the sparkline, low → high. */
   private val SparkChars: Array[Char] = "▁▂▃▄▅▆▇█".toArray
@@ -582,10 +592,10 @@ object TopRenderer {
   }
 
   /**
-    * Fixed-overhead rows: blank + 3 header lines + blank + 2 def-chrome +
+    * Fixed-overhead rows: blank + 2 dashboard/stats lines + blank + 2 def-chrome +
     * 1 blank-before-modules + 2 module-chrome + 1 cursor-parking row.
     */
-  private val ChromeRows: Int = 11
+  private val ChromeRows: Int = 10
 
   /** Reserved breathing room above and below the rendered view. */
   private val RowMargin: Int = 2

--- a/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
+++ b/main/src/ca/uwaterloo/flix/util/TopRenderer.scala
@@ -101,13 +101,16 @@ final class TopRenderer(flix: Flix) {
     val pool = flix.threadPool
     val parallelism = if (pool == null) flix.options.threads.max(1) else pool.getParallelism.max(1)
 
-    // Budget rows for the two tables based on the current terminal height.
-    val dataRows = (terminalRows() - ChromeRows).max(MinDataRows)
+    // Budget rows for the two tables based on the current terminal height,
+    // reserving an extra `RowMargin` rows so the view never quite touches
+    // the top or bottom edge of the terminal.
+    val dataRows = (terminalRows() - ChromeRows - RowMargin).max(MinDataRows)
     val moduleN = (dataRows / 3).max(MinModuleN).min(MaxModuleN)
     val defN = (dataRows - moduleN).max(MinDefN).min(MaxDefN)
 
-    // Compute the column layout based on the current terminal width.
-    val layout = computeLayout(terminalCols())
+    // Compute the column layout based on the current terminal width,
+    // reserving 2 columns for the 1-space left and right table padding.
+    val layout = computeLayout((terminalCols() - 2).max(1))
 
     val snap = flix.defnTimer.snapshot().sortBy(-_.totalNanos)
     val visible = snap.take(defN)
@@ -202,9 +205,13 @@ final class TopRenderer(flix: Flix) {
 
   private def renderTableHeader(sb: StringBuilder, layout: Layout): Unit = {
     val header = buildHeader(rpad("Def", layout.symWidth), rpad("location", layout.locWidth), layout)
+    sb.append(' ')
     sb.append(bold(cyan(header)))
+    sb.append(' ')
     sb.append('\n')
+    sb.append(' ')
     sb.append(dim("─" * header.length))
+    sb.append(' ')
     sb.append('\n')
   }
 
@@ -230,7 +237,7 @@ final class TopRenderer(flix: Flix) {
   private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int, layout: Layout): Unit = {
     if (visible.isEmpty) {
       val msg = "(no timings yet)"
-      val pad = ((layout.totalWidth - msg.length) / 2).max(0)
+      val pad = (((layout.totalWidth + 2) - msg.length) / 2).max(0)
       sb.append('\n')
       sb.append(" " * pad)
       sb.append(dim(msg))
@@ -248,10 +255,12 @@ final class TopRenderer(flix: Flix) {
       val symField = rpad(truncate(s.sym.name, layout.symWidth), layout.symWidth)
       val locField = rpad(truncate(locStr, layout.locWidth), layout.locWidth)
 
+      sb.append(' ')
       sb.append(symField)
       sb.append(' ')
       sb.append(dim(locField))
       appendNumericFields(sb, locLines, s.callCount.toLong, phase, s.totalNanos, pctCpu, pctWall, layout)
+      sb.append(' ')
       sb.append('\n')
     }
   }
@@ -262,9 +271,13 @@ final class TopRenderer(flix: Flix) {
     sb.append('\n')
     val modWidth = layout.symWidth + 1 + layout.locWidth
     val header = buildModuleHeader(rpad("Module", modWidth), layout)
+    sb.append(' ')
     sb.append(bold(cyan(header)))
+    sb.append(' ')
     sb.append('\n')
+    sb.append(' ')
     sb.append(dim("─" * header.length))
+    sb.append(' ')
     sb.append('\n')
 
     val safeElapsed = elapsed.max(1L).toDouble
@@ -275,8 +288,10 @@ final class TopRenderer(flix: Flix) {
 
       val modField = rpad(truncate(m.module, modWidth), modWidth)
 
+      sb.append(' ')
       sb.append(modField)
       appendNumericFields(sb, m.totalLocLines, m.totalCallCount, phase, m.totalNanos, pctCpu, pctWall, layout)
+      sb.append(' ')
       sb.append('\n')
     }
   }
@@ -581,6 +596,9 @@ object TopRenderer {
     * 1 blank-before-modules + 2 module-chrome + 1 cursor-parking row.
     */
   private val ChromeRows: Int = 11
+
+  /** Reserved breathing room above and below the rendered view. */
+  private val RowMargin: Int = 2
 
   /** Floor on the total data-row budget. */
   private val MinDataRows: Int = 8


### PR DESCRIPTION
## Summary
- Adds a `--top` flag that shows a live, top(1)-style TUI of the DefnSyms the compiler is spending the most time on, with a per-phase breakdown, call counts, source locations, and per-module aggregation.
- Instruments 23 phases (10 frontend + 13 backend, including Monomorpher keyed by source generic sym) with a one-line `flix.defnTimer.track(defn.sym, defn.loc) { ... }` wrap. Pre-symbol phases (Reader/Lexer/Parser2/Weeder2/Desugar/Namer), filter-only passes (TreeShaker1/2), Resolver/Deriver/Instances, and JvmBackend are deliberately not instrumented — see `DefnTimer.scala`'s class doc for the full rationale.
- The TUI adapts to terminal size via JLine: row count is split between the def and module tables based on `getHeight`; column widths and visibility (LOC, n, phase) tier down based on `getWidth`. Two side-by-side bars (phase progress + active-threads sparkline) sit on a dashboard line, with `elapsed` and `heap` right-aligned beneath.
- Two `%` columns for each row: `%cpu = totalNanos / (elapsed × threads)` (share of CPU budget, sums ≤100%) and `%wall = totalNanos / elapsed` (Amdahl-style speedup ceiling).

## Test plan
- [x] `./mill flix.compile` compiles cleanly.
- [x] `touch out/empty.flix && ./mill flix.run out/empty.flix` — std lib still compiles.
- [x] `./mill flix.run --top out/empty.flix` renders the TUI; progress bar reaches 32/32 at end-of-compile; threads sparkline shows full-height bars during parallel phases and dips at boundaries.
- [x] Resize the terminal mid-compile — table row count and column widths re-flow.
- [x] `./mill flix.test.testForked "-oC"` — full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)