### PR TITLE
refactor: rename asRes handlers to handleWithResult/runWithResult

### DIFF
--- a/main/src/library/KeyNotFound.flix
+++ b/main/src/library/KeyNotFound.flix
@@ -27,13 +27,26 @@ eff KeyNotFound {
 
 pub mod KeyNotFound {
 
-    /// Turns the `KeyNotFound` effect into `Err(msg)`.
+    ///
+    /// Handles the `KeyNotFound` effect of the given function `f` by converting
+    /// key-not-found errors to `Result` values.
+    ///
+    /// Returns `Ok(f(x))` if the computation completes successfully.
+    /// Returns `Err(msg)` if the computation raises `keyNotFound(msg)`.
+    ///
     @Experimental
-    pub def asRes(f: a -> b \ ef): (a -> Result[String, b] \ ef - KeyNotFound) = {
-        x ->
-            run Ok(f(x)) with handler KeyNotFound {
-                def keyNotFound(msg, _) = Err(msg)
-            }
-    }
+    pub def handleWithResult(f: a -> b \ ef): a -> Result[String, b] \ (ef - KeyNotFound) = x ->
+        run Ok(f(x)) with handler KeyNotFound {
+            def keyNotFound(msg, _k) = Err(msg)
+        }
+
+    ///
+    /// Runs the `KeyNotFound` effect of the given function `f`.
+    ///
+    /// Returns `Ok(f())` if the computation completes successfully.
+    /// Returns `Err(msg)` if the computation raises `keyNotFound(msg)`.
+    ///
+    @Experimental
+    pub def runWithResult(f: Unit -> a \ ef): Result[String, a] \ (ef - KeyNotFound) = handleWithResult(f)()
 
 }

--- a/main/src/library/OutOfBounds.flix
+++ b/main/src/library/OutOfBounds.flix
@@ -27,12 +27,26 @@ eff OutOfBounds {
 
 pub mod OutOfBounds {
 
-    /// Turns the `OutOfBounds` effect into `Err(msg)`.
+    ///
+    /// Handles the `OutOfBounds` effect of the given function `f` by converting
+    /// out-of-bounds errors to `Result` values.
+    ///
+    /// Returns `Ok(f(x))` if the computation completes successfully.
+    /// Returns `Err(msg)` if the computation raises `outOfBounds(msg)`.
+    ///
     @Experimental
-    pub def asRes(f: a -> b \ ef): (a -> Result[String, b] \ ef - OutOfBounds) = {
-        x -> run Ok(f(x)) with handler OutOfBounds {
-            def outOfBounds(msg, _) = Err(msg)
+    pub def handleWithResult(f: a -> b \ ef): a -> Result[String, b] \ (ef - OutOfBounds) = x ->
+        run Ok(f(x)) with handler OutOfBounds {
+            def outOfBounds(msg, _k) = Err(msg)
         }
-    }
+
+    ///
+    /// Runs the `OutOfBounds` effect of the given function `f`.
+    ///
+    /// Returns `Ok(f())` if the computation completes successfully.
+    /// Returns `Err(msg)` if the computation raises `outOfBounds(msg)`.
+    ///
+    @Experimental
+    pub def runWithResult(f: Unit -> a \ ef): Result[String, a] \ (ef - OutOfBounds) = handleWithResult(f)()
 
 }


### PR DESCRIPTION
## Summary
- Rename `OutOfBounds.asRes` and `KeyNotFound.asRes` to follow the standard-library handler naming convention
- The current shape (`a -> b \ ef`) is named `handleWithResult`, matching `Abort.handleWithResult`
- A sibling `runWithResult` (`Unit -> a \ ef`) is added as the convenience wrapper, matching `Abort.runWithResult`
- No callers needed updating — these were unreferenced

## Test plan
- [x] Standard library compiles (`./mill flix.run out/empty.flix`)
- [x] Full test suite (`./mill flix.test.testForked "-oC"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)