### PR TITLE
chore: reformat stdlib (batch 8) 

### DIFF
--- a/main/src/library/Debug.flix
+++ b/main/src/library/Debug.flix
@@ -29,10 +29,10 @@ pub mod Debug {
     import java.lang.Object
     import java.lang.Short
     import java.lang.System
-    import java.lang.{Class => JClass} // needed for getClass() method resolution
-    import java.lang.{String => JString} // needed for instanceof on Object
-    import java.math.{BigDecimal => JBigDecimal} // needed for instanceof on Object
-    import java.math.{BigInteger => JBigInteger} // needed for instanceof on Object
+    import java.lang.{Class => JClass}
+    import java.lang.{String => JString}
+    import java.math.{BigDecimal => JBigDecimal}
+    import java.math.{BigInteger => JBigInteger}
     import java.util.Arrays
     import java.util.Objects
 

--- a/main/src/library/Debug.flix
+++ b/main/src/library/Debug.flix
@@ -29,10 +29,10 @@ pub mod Debug {
     import java.lang.Object
     import java.lang.Short
     import java.lang.System
-    import java.lang.{Class => JClass}             // needed for getClass() method resolution
-    import java.lang.{String => JString}           // needed for instanceof on Object
-    import java.math.{BigDecimal => JBigDecimal}   // needed for instanceof on Object
-    import java.math.{BigInteger => JBigInteger}   // needed for instanceof on Object
+    import java.lang.{Class => JClass} // needed for getClass() method resolution
+    import java.lang.{String => JString} // needed for instanceof on Object
+    import java.math.{BigDecimal => JBigDecimal} // needed for instanceof on Object
+    import java.math.{BigInteger => JBigInteger} // needed for instanceof on Object
     import java.util.Arrays
     import java.util.Objects
 
@@ -73,15 +73,15 @@ pub mod Debug {
     pub def stringify(x: a): String = unsafe IO {
         use Reflect.JvmValue;
         match Reflect.reflectValue(x) {
-            case JvmValue.JvmBool(b)      => if (b) "true" else "false"
-            case JvmValue.JvmChar(c)      => "'" + escape("${(c: Char)}") + "'"
-            case JvmValue.JvmFloat32(y)   => Float.toString(y) + "f32"
-            case JvmValue.JvmFloat64(y)   => Double.toString(y)
-            case JvmValue.JvmInt8(y)      => Byte.toString(y) + "i8"
-            case JvmValue.JvmInt16(y)     => Short.toString(y) + "i16"
-            case JvmValue.JvmInt32(y)     => Integer.toString(y)
-            case JvmValue.JvmInt64(y)     => Long.toString(y) + "i64"
-            case JvmValue.JvmObject(obj)  =>
+            case JvmValue.JvmBool(b)    => if (b) "true" else "false"
+            case JvmValue.JvmChar(c)    => "'" + escape("${(c: Char)}") + "'"
+            case JvmValue.JvmFloat32(y) => Float.toString(y) + "f32"
+            case JvmValue.JvmFloat64(y) => Double.toString(y)
+            case JvmValue.JvmInt8(y)    => Byte.toString(y) + "i8"
+            case JvmValue.JvmInt16(y)   => Short.toString(y) + "i16"
+            case JvmValue.JvmInt32(y)   => Integer.toString(y)
+            case JvmValue.JvmInt64(y)   => Long.toString(y) + "i64"
+            case JvmValue.JvmObject(obj) =>
                 if (Objects.isNull(obj)) {
                     "null"
                 } else if (obj instanceof JString) {
@@ -108,14 +108,14 @@ pub mod Debug {
                 let name = componentType.getName();
                 match name {
                     case "boolean" => Arrays.toString(unchecked_cast(obj as Array[Bool, Static]))
-                    case "char" => Arrays.toString(unchecked_cast(obj as Array[Char, Static]))
-                    case "float" => Arrays.toString(unchecked_cast(obj as Array[Float32, Static]))
-                    case "double" => Arrays.toString(unchecked_cast(obj as Array[Float64, Static]))
-                    case "byte" => Arrays.toString(unchecked_cast(obj as Array[Int8, Static]))
-                    case "short" => Arrays.toString(unchecked_cast(obj as Array[Int16, Static]))
-                    case "int" => Arrays.toString(unchecked_cast(obj as Array[Int32, Static]))
-                    case "long" => Arrays.toString(unchecked_cast(obj as Array[Int64, Static]))
-                    case _ => Objects.toString(obj)
+                    case "char"    => Arrays.toString(unchecked_cast(obj as Array[Char, Static]))
+                    case "float"   => Arrays.toString(unchecked_cast(obj as Array[Float32, Static]))
+                    case "double"  => Arrays.toString(unchecked_cast(obj as Array[Float64, Static]))
+                    case "byte"    => Arrays.toString(unchecked_cast(obj as Array[Int8, Static]))
+                    case "short"   => Arrays.toString(unchecked_cast(obj as Array[Int16, Static]))
+                    case "int"     => Arrays.toString(unchecked_cast(obj as Array[Int32, Static]))
+                    case "long"    => Arrays.toString(unchecked_cast(obj as Array[Int64, Static]))
+                    case _         => Objects.toString(obj)
                 }
             } else {
                 Arrays.deepToString(unchecked_cast(obj as Array[Object, Static]))

--- a/main/src/library/Fixpoint3/Boxable.flix
+++ b/main/src/library/Fixpoint3/Boxable.flix
@@ -22,17 +22,16 @@ pub mod Fixpoint3.Boxable {
     ///
     /// Boxes the given `x`.
     ///
-    @Inline
-    @LoweringTarget
+    @Inline @LoweringTarget
     pub def box(x: a): Boxed with Order[a] = {
         use Reflect.JvmValue;
         match Reflect.reflectValue(x) {
-            case JvmValue.JvmBool(v)  => Boxed.BoxedBool(v)
-            case JvmValue.JvmChar(v)  => Boxed.BoxedChar(v)
-            case JvmValue.JvmInt8(v)  => Boxed.BoxedInt8(v)
-            case JvmValue.JvmInt16(v) => Boxed.BoxedInt16(v)
-            case JvmValue.JvmInt32(v) => Boxed.BoxedInt32(v)
-            case JvmValue.JvmInt64(v) => Boxed.BoxedInt64(v)
+            case JvmValue.JvmBool(v)    => Boxed.BoxedBool(v)
+            case JvmValue.JvmChar(v)    => Boxed.BoxedChar(v)
+            case JvmValue.JvmInt8(v)    => Boxed.BoxedInt8(v)
+            case JvmValue.JvmInt16(v)   => Boxed.BoxedInt16(v)
+            case JvmValue.JvmInt32(v)   => Boxed.BoxedInt32(v)
+            case JvmValue.JvmInt64(v)   => Boxed.BoxedInt64(v)
             case JvmValue.JvmFloat32(v) => Boxed.BoxedFloat32(v)
             case JvmValue.JvmFloat64(v) => Boxed.BoxedFloat64(v)
             case JvmValue.JvmObject(v) =>

--- a/main/src/library/Fixpoint3/Phase/Simplifier.flix
+++ b/main/src/library/Fixpoint3/Phase/Simplifier.flix
@@ -43,10 +43,11 @@ pub mod Fixpoint3.Phase.Simplifier {
         match program {
             case RamProgram.Program(stmt, facts, predicates, index, typeInfo) =>
                 // Compute the a set of all relations which are initialized with facts, i.e. have some EDB facts.
-                let filterOutEmpty = fact -> fact
-                    |> Map.filter(x -> (not BPlusTree.isEmpty(x)))
-                    |> Map.foldRightWithKey(k -> _ -> Set.insert(k), Set#{})
-                    |> Set.map(rel -> getRelSymAsType(rel, PredType.Full, predicates));
+                let filterOutEmpty = fact ->
+                    fact
+                        |> Map.filter(x -> (not BPlusTree.isEmpty(x)))
+                        |> Map.foldRightWithKey(k -> _ -> Set.insert(k), Set#{})
+                        |> Set.map(rel -> getRelSymAsType(rel, PredType.Full, predicates));
                 let nonEmpty = filterOutEmpty(fst(facts)) `Set.union` filterOutEmpty(snd(facts));
                 RamProgram.Program(simplifyStmt(stmt, nonEmpty, predicates), facts, predicates, index, typeInfo)
         }
@@ -83,8 +84,8 @@ pub mod Fixpoint3.Phase.Simplifier {
     ///
     def simplifyHelper(nonEmpty: Set[RelSym], predicates: Predicates, inUntil: Bool, stmt: RamStmt): Option[RamStmt] = match stmt {
         case RamStmt.Insert(op) =>
-            simplifyOp(nonEmpty, predicates, inUntil, Set#{}, op) |>
-                Option.map(RamStmt.Insert)
+            simplifyOp(nonEmpty, predicates, inUntil, Set#{}, op)
+                |> Option.map(RamStmt.Insert)
         case RamStmt.MergeInto(_, _) => Some(stmt)
         case RamStmt.Swap(_, _)      => Some(stmt)
         case RamStmt.Purge(_)        => Some(stmt)
@@ -98,7 +99,7 @@ pub mod Fixpoint3.Phase.Simplifier {
                 |> Some
         case RamStmt.Until(test, body) =>
             match simplifyHelper(nonEmpty, predicates, true, body) {
-                case None                 => None
+                case None => None
                 case Some(simplifiedBody) =>
                     if (isOnlyMergeSwapPurge(simplifiedBody)) {
                         None
@@ -106,7 +107,7 @@ pub mod Fixpoint3.Phase.Simplifier {
                         Some(RamStmt.Until(test, simplifiedBody))
                     }
             }
-        case RamStmt.Comment(_) => Some(stmt)
+        case RamStmt.Comment(_)      => Some(stmt)
     }
 
     ///
@@ -159,26 +160,26 @@ pub mod Fixpoint3.Phase.Simplifier {
                 let (memberOf, rest) = test
                     // Delete checks of the form `x[i] == x[i]`.
                     |> Vector.filter(e -> match e {
-                        case BoolExp.Eq(RowLoad(lhs1, lhs2, _, _), RowLoad(rhs1, rhs2, _, _)) =>
-                            (lhs1, lhs2) != (rhs1, rhs2)
-                        case _ => true
-                    })
+                            case BoolExp.Eq(RowLoad(lhs1, lhs2, _, _), RowLoad(rhs1, rhs2, _, _)) =>
+                                (lhs1, lhs2) != (rhs1, rhs2)
+                            case _ => true
+                        })
                     // Partition into membership tests and rest.
                     |> Vector.partition(e -> match e {
-                        case BoolExp.NotMemberOf(_, _, _) => true
-                        case _                            => false
-                    });
+                            case BoolExp.NotMemberOf(_, _, _) => true
+                            case _                            => false
+                        });
                 let newTest = rest ++ memberOf;
                 // Simplify `if () then body` to `body`.
                 match recurse(then) {
-                    case None          => None
+                    case None => None
                     case Some(newThen) =>
                         if (Vector.isEmpty(newTest))
                             Some(newThen)
                         else
                             Some(RelOp.If(newTest, newThen))
                 }
-    }
+        }
 
     ///
     /// Returns true if `r` is a `Merge`, `Swap`, or `Purge` statement or contains any one

--- a/main/src/library/Fixpoint3/Phase/Stratifier.flix
+++ b/main/src/library/Fixpoint3/Phase/Stratifier.flix
@@ -74,7 +74,7 @@ pub mod Fixpoint3.Phase.Stratifier {
     def addDepEdges(graph: MutGraph[r], d: Datalog): Unit \ r = match d {
         case Datalog(_, rules) => Vector.forEach(precedenceHelper(graph), rules)
         case Model(_)          => ()
-        case Join(d1, d2)      =>
+        case Join(d1, d2) =>
             addDepEdges(graph, d1);
             addDepEdges(graph, d2)
         case Provenance(_, _)  => ()

--- a/main/src/library/Fixpoint3/Phase/Stratifier.flix
+++ b/main/src/library/Fixpoint3/Phase/Stratifier.flix
@@ -99,10 +99,10 @@ pub mod Fixpoint3.Phase.Stratifier {
         case (HeadAtom(PredSym.PredSym(_, dstId), _, _), BodyAtom(PredSym.PredSym(_, srcId), _, _, _, _)) => {
             if (dstId != srcId) {
                 MutGraph.addEdge(toInt32(srcId), toInt32(dstId), graph)
-            } else (
+            } else {
                 // We still register the vertex, as it is needed later.
                 MutGraph.addVertex(toInt32(dstId), graph)
-            )
+            }
         }
         case _ => ()
     }

--- a/main/src/library/Fixpoint3/PrecedenceGraph/MutGraph.flix
+++ b/main/src/library/Fixpoint3/PrecedenceGraph/MutGraph.flix
@@ -193,9 +193,7 @@ pub mod Fixpoint3.PrecedenceGraph.MutGraph {
         let time = Counter.fresh(rc);
         foreach (u <- getVertices(g)) {
             if (Array.get(u, disc) == -1) {
-                stronglyConnectedComponentsVisit(
-                    components, stack, disc, low, onStack, time, g, u
-                )
+                stronglyConnectedComponentsVisit(components, stack, disc, low, onStack, time, g, u)
             }
         };
         MutList.toList(components)
@@ -241,9 +239,7 @@ pub mod Fixpoint3.PrecedenceGraph.MutGraph {
 
         foreach (v <- getNeighbors(u, g)) {
             if (Array.get(v, disc) == -1) {
-                stronglyConnectedComponentsVisit(
-                    components, stack, disc, low, onStack, time, g, v
-                );
+                stronglyConnectedComponentsVisit(components, stack, disc, low, onStack, time, g, v);
                 let uLow = Array.get(u, low);
                 let vLow = Array.get(v, low);
                 Array.put(Int32.min(uLow, vLow), u, low)

--- a/main/src/library/Fixpoint3/PrecedenceGraph/MutGraph.flix
+++ b/main/src/library/Fixpoint3/PrecedenceGraph/MutGraph.flix
@@ -26,7 +26,7 @@ pub mod Fixpoint3.PrecedenceGraph.MutGraph {
     ///
     pub struct MutGraph[r] {
         vertices: MutSet[Vertex, r],
-        adjList: MutMap[Vertex, Set[Vertex], r]
+        adjList:  MutMap[Vertex, Set[Vertex], r]
     }
 
     ///
@@ -36,8 +36,8 @@ pub mod Fixpoint3.PrecedenceGraph.MutGraph {
     /// and `Black` if it and all of its neighbors have been visited.
     ///
     enum Color with Eq {
-        case White,
-        case Gray,
+        case White
+        case Gray
         case Black
     }
 
@@ -99,9 +99,10 @@ pub mod Fixpoint3.PrecedenceGraph.MutGraph {
     /// Returns a string representation of `g`.
     ///
     pub def toString(g: MutGraph[r]): String \ r =
-        let edges = g->adjList |>
-            MutMap.joinWith(u -> vSet ->
-                Set.joinWith(v -> "\n ${u} -> ${v}", ",", vSet), ","
+        let edges = g->adjList
+            |> MutMap.joinWith(u -> vSet ->
+                    Set.joinWith(v -> "\n ${u} -> ${v}", ",", vSet),
+                ","
             );
         "MutGraph(${edges})"
 
@@ -135,10 +136,9 @@ pub mod Fixpoint3.PrecedenceGraph.MutGraph {
             |> Map.map(Set.find(_ -> true) >> getOrCrash);
         topologicalSort(condensation)
             |> List.map(u ->
-                componentMap
-                    |> MutMap.get(getOrCrash(Map.get(u, inverseRootMap)))
-                    |> getOrCrash
-        )
+                    componentMap
+                        |> MutMap.get(getOrCrash(Map.get(u, inverseRootMap)))
+                        |> getOrCrash)
     }
 
     ///

--- a/main/src/library/Fixpoint3/Predicate.flix
+++ b/main/src/library/Fixpoint3/Predicate.flix
@@ -60,8 +60,8 @@ pub mod Fixpoint3.Predicate {
     /// `New` relations contains, in iteration `i`, all facts computed in iteration `i` in fixpoints computations.
     ///
     pub enum PredType with Eq {
-        case Full,
-        case Delta,
+        case Full
+        case Delta
         case New
     }
 
@@ -99,9 +99,9 @@ pub mod Fixpoint3.Predicate {
     ///
     def fullIdtoPredType(id: Int64, wantedType: PredType, max: Int64): Int64 =
         match wantedType {
-            case PredType.Full => id
+            case PredType.Full  => id
             case PredType.Delta => id + max
-            case PredType.New => id + max * 2i64
+            case PredType.New   => id + max * 2i64
         }
 
     ///
@@ -225,10 +225,10 @@ pub mod Fixpoint3.Predicate {
             let set3 = relSymsOfDb(db);
             let set = (set1 `Set.union` set2) `Set.union` set3;
             let fullRels = Set.toList(set);
-            let optMax = fullRels |>
-                List.maximumBy(match RelSym.Symbol(PredSym.PredSym(_, id1), _, _) -> match RelSym.Symbol(PredSym.PredSym(_, id2), _, _) -> id1 <=> id2);
+            let optMax = fullRels
+                |> List.maximumBy(match RelSym.Symbol(PredSym.PredSym(_, id1), _, _) -> match RelSym.Symbol(PredSym.PredSym(_, id2), _, _) -> id1 <=> id2);
             let max = match optMax {
-                case None => 0i64
+                case None      => 0i64
                 case Some(max) => toId(max) + 1i64
             };
             let deltaRels = List.map(x -> fullRelSymToTypeInternal(x, PredType.Delta, max), fullRels);
@@ -249,13 +249,19 @@ pub mod Fixpoint3.Predicate {
     ///
     def relSymsOf(constraints: Vector[Constraint]): Set[RelSym] =
         Vector.foldLeft(match set -> match Constraint(headAtom, body) -> {
-            let setWithHead = Set.insert(headAtomToFullRelSym(headAtom), set);
-            Vector.foldLeft(setBody -> bodyConstraint -> match bodyConstraint {
-                case BodyAtom(_, _, _, _, _) =>
-                    Set.insert(bodyAtomToFullRelSym(bodyConstraint), setBody)
-                case _ => setBody
-            }, setWithHead, body)
-        }, Set#{}, constraints)
+                let setWithHead = Set.insert(headAtomToFullRelSym(headAtom), set);
+                Vector.foldLeft(setBody -> bodyConstraint -> match bodyConstraint {
+                        case BodyAtom(_, _, _, _, _) =>
+                            Set.insert(bodyAtomToFullRelSym(bodyConstraint), setBody)
+                        case _ => setBody
+                    },
+                    setWithHead,
+                    body
+                )
+            },
+            Set#{},
+            constraints
+        )
 
     ///
     /// Returns the full `RelSym` associated with the `PredSym` in `head`.

--- a/main/src/library/Fixpoint3/UniqueInts.flix
+++ b/main/src/library/Fixpoint3/UniqueInts.flix
@@ -31,7 +31,7 @@ pub mod Fixpoint3.UniqueInts {
     /// the value, which `UniqueInts` assigned index `i`.
     ///
     pub struct UniqueInts[k: Type, r: Region] {
-        map: MutMap[k, Int32, r],
+        map:     MutMap[k, Int32, r],
         counter: Counter[r]
     }
 

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -14,21 +14,19 @@
  *  limitations under the License.
  */
 
-
 ///
 /// A Vector data type which is fundamentally like Array but is immutable.
 ///
-
 instance Indexable[Vector[a]] {
     type Idx = Int32
     type Elm = a
     type Aef = OutOfBounds
 
     pub def get(t: Vector[a], i: Int32): a \ OutOfBounds = {
-        if (0 <= i and i < Vector.length(t)) Vector.get(i, t)
-        else OutOfBounds.outOfBounds(
-            "index ${i} is out of bounds for Vector of length ${Vector.length(t)}"
-        )
+        if (0 <= i and i < Vector.length(t))
+            Vector.get(i, t)
+        else
+            OutOfBounds.outOfBounds("index ${i} is out of bounds for Vector of length ${Vector.length(t)}")
     }
 }
 
@@ -62,12 +60,12 @@ instance Functor[Vector] {
 }
 
 instance Applicative[Vector] {
-    pub def point(a: a) : Vector[a] = Vector.singleton(a)
-    pub def ap(f: Vector[a -> b \ ef], v: Vector[a]) : Vector[b] \ ef = Vector.ap(f, v)
+    pub def point(a: a): Vector[a] = Vector.singleton(a)
+    pub def ap(f: Vector[a -> b \ ef], v: Vector[a]): Vector[b] \ ef = Vector.ap(f, v)
 }
 
 instance Monad[Vector] {
-    pub def flatMap(f: a -> Vector[b] \ ef, v : Vector[a]) : Vector[b] \ ef = Vector.flatMap(f, v)
+    pub def flatMap(f: a -> Vector[b] \ ef, v: Vector[a]): Vector[b] \ ef = Vector.flatMap(f, v)
 }
 
 instance MonadZero[Vector] {
@@ -152,11 +150,12 @@ pub mod Vector {
             if (l <= r) {
                 let m = (l + r) `Int32.rightShift` 1; // Shifting by 1 is slightly faster than dividing by 2.
                 match get(m, v) <=> x {
-                    case Comparison.LessThan => f(m+1, r)
-                    case Comparison.GreaterThan => f(l, m-1)
-                    case Comparison.EqualTo => Some(m)
+                    case Comparison.LessThan    => f(m + 1, r)
+                    case Comparison.GreaterThan => f(l, m - 1)
+                    case Comparison.EqualTo     => Some(m)
                 }
-            } else None
+            } else
+                None
         };
         let len = length(v);
         f(0, len - 1)
@@ -201,11 +200,11 @@ pub mod Vector {
             if (wi >= end or ri >= subLen)
                 ()
             else if (wi < 0)
-                loop(ri+1, wi+1)
+                loop(ri + 1, wi + 1)
             else {
                 let x = get(ri, sub);
                 Array.put(x, wi, arr);
-                loop(ri+1, wi+1)
+                loop(ri + 1, wi + 1)
             }
         };
         loop(0, i)
@@ -274,7 +273,6 @@ pub mod Vector {
         forEachWithIndex((i, x) -> Array.put(x, i, arr), v);
         arr
 
-
     ///
     /// Returns the vector `v` as a list.
     ///
@@ -336,7 +334,6 @@ pub mod Vector {
         arrayUpdateSeqV(length(v1), v2, arr);
         Array.toVector(arr)
     }
-
 
     ///
     /// Returns `true` if and only if `v` contains the element `x`.
@@ -481,14 +478,15 @@ pub mod Vector {
             // We handle the first element twice.
             MutList.push(Vector.get(0, v), l);
             discard {
-                (Vector.get(0, v), v) ||> Vector.foldLeft(head -> cur -> {
-                    if (f(head, cur)) {
-                        head
-                    } else {
-                        MutList.push(cur, l);
-                        cur
-                    }
-                })
+                (Vector.get(0, v), v)
+                    ||> Vector.foldLeft(head -> cur -> {
+                            if (f(head, cur)) {
+                                head
+                            } else {
+                                MutList.push(cur, l);
+                                cur
+                            }
+                        })
             };
             MutList.toVector(l)
         }
@@ -520,7 +518,7 @@ pub mod Vector {
         let step = (i, x) -> {
             let s1 = f(Ref.get(acc), x);
             Ref.put(s1, acc);
-            Array.put(s1, i+1, arr)
+            Array.put(s1, i + 1, arr)
         };
         forEachWithIndex(step, v);
         Array.toVector(arr)
@@ -578,7 +576,7 @@ pub mod Vector {
                 k(Applicative.point(arr))
             else {
                 let mx = get(i, v);
-                loop(i+1, karr -> k(putA(mx, i, karr)))
+                loop(i + 1, karr -> k(putA(mx, i, karr)))
             }
         };
         Functor.map(Array.toVector, loop(0, x -> checked_ecast(x)))
@@ -596,7 +594,7 @@ pub mod Vector {
                 k(Applicative.point(arr))
             else {
                 let x = get(i, v);
-                loop(i+1, karr -> k(putA(f(x), i, karr)))
+                loop(i + 1, karr -> k(putA(f(x), i, karr)))
             }
         };
         Functor.map(Array.toVector, loop(0, x -> checked_ecast(x)))
@@ -608,7 +606,7 @@ pub mod Vector {
     def putA(mx: m[a], i: Int32, marr: m[Array[a, r]]): m[Array[a, r]] \ r with Applicative[m] =
         use Functor.{<$>};
         use Applicative.{<*>};
-        (((x, arr) -> {Array.put(x, i, arr); arr}) <$> mx) <*> marr
+        (((x, arr) -> { Array.put(x, i, arr); arr }) <$> mx) <*> marr
 
     ///
     /// Generalize `zipWith` to an applicative functor `f`.
@@ -622,7 +620,7 @@ pub mod Vector {
             else {
                 let x = get(i, v1);
                 let y = get(i, v2);
-                loop(i+1, karr -> k(putA(f(x, y), i, karr)))
+                loop(i + 1, karr -> k(putA(f(x, y), i, karr)))
             }
         };
         Functor.map(Array.toVector, loop(0, x -> checked_ecast(x)))
@@ -633,7 +631,7 @@ pub mod Vector {
     /// For `f = f1, f2, ...` and `x = x1, x2, ...` the results appear in the order
     /// `f1(x1), f1(x2), ..., f2(x1), f2(x2), ...`.
     ///
-    pub def ap(f: Vector[a -> b \ ef], v: Vector[a]) : Vector[b] \ ef =
+    pub def ap(f: Vector[a -> b \ ef], v: Vector[a]): Vector[b] \ ef =
         map(g -> map(g, v), f) |> flatten
 
     ///
@@ -647,7 +645,7 @@ pub mod Vector {
     ///
     pub def reverse(v: Vector[a]): Vector[a] =
         let len = length(v);
-        init(ix -> get(len - (ix+1), v), len)
+        init(ix -> get(len - (ix + 1), v), len)
 
     ///
     /// Rotate the contents of vector `v` by `n` steps to the left.
@@ -656,11 +654,10 @@ pub mod Vector {
         let len = length(v);
         if (len < 1)
             empty()
+        else if (n < 0)
+            rotateRightHelper(Int32.abs(n), v)
         else
-            if (n < 0)
-                rotateRightHelper(Int32.abs(n), v)
-            else
-                rotateLeftHelper(n, v)
+            rotateLeftHelper(n, v)
 
     ///
     /// Helper function for `rotateLeft` and `rotateRight`.
@@ -671,9 +668,8 @@ pub mod Vector {
     ///
     def rotateLeftHelper(n: Int32, v: Vector[a]): Vector[a] =
         let len = length(v);
-        let f = ix -> {let readIx = Int32.modulo(ix + n, len); get(readIx, v)};
+        let f = ix -> { let readIx = Int32.modulo(ix + n, len); get(readIx, v) };
         init(f, len)
-
 
     ///
     /// Rotate the contents of vector `v` by `n` steps to the right.
@@ -681,11 +677,10 @@ pub mod Vector {
     pub def rotateRight(n: Int32, v: Vector[a]): Vector[a] =
         if (length(v) < 1)
             empty()
+        else if (n < 0)
+            rotateLeftHelper(Int32.abs(n), v)
         else
-            if (n < 0)
-                rotateLeftHelper(Int32.abs(n), v)
-            else
-                rotateRightHelper(n, v)
+            rotateRightHelper(n, v)
 
     ///
     /// Helper function for `rotateRight` and `rotateLeft`.
@@ -696,7 +691,7 @@ pub mod Vector {
     ///
     def rotateRightHelper(n: Int32, v: Vector[a]): Vector[a] =
         let len = length(v);
-        let f = ix -> {let readIx = Int32.modulo(ix - n, len); get(readIx, v)};
+        let f = ix -> { let readIx = Int32.modulo(ix - n, len); get(readIx, v) };
         init(f, len)
 
     ///
@@ -730,7 +725,7 @@ pub mod Vector {
         let f = ix -> match ix {
             case 0                               => get(0, v)
             case n if Int32.remainder(n, 2) != 0 => sep
-            case n                               => {let i = n / 2; get(i, v)}
+            case n                               => { let i = n / 2; get(i, v) }
         };
         init(f, len2)
 
@@ -839,9 +834,9 @@ pub mod Vector {
         if (j >= len2)
             false
         else if (get(0, a) == get(j, b))
-            isInfixOfCheck(a, b, len1, len2, 1, j+1)
+            isInfixOfCheck(a, b, len1, len2, 1, j + 1)
         else
-            isInfixOfSearch(a, b, len1, len2, j+1)
+            isInfixOfSearch(a, b, len1, len2, j + 1)
 
     ///
     /// Helper function for `isInfixOf` - `a` has started matching, scan to see if it all matches.
@@ -854,9 +849,9 @@ pub mod Vector {
             // `b` exhausted, `a` still trying to match, so failure
             false
         else if (get(i, a) == get(j, b))
-            isInfixOfCheck(a, b, len1, len2, i+1, j+1)
+            isInfixOfCheck(a, b, len1, len2, i + 1, j + 1)
         else
-            isInfixOfSearch(a, b, len1, len2, j+1)
+            isInfixOfSearch(a, b, len1, len2, j + 1)
 
     ///
     /// Returns `true` if and only if `a` is a suffix of `b`.
@@ -979,10 +974,12 @@ pub mod Vector {
         let pos = Ref.fresh(rc, 0);
         let arr = Array.empty(rc, len);
         forEach(v -> {
-            let i = Ref.get(pos);
-            Ref.put(i + length(v), pos);
-            arrayUpdateSeqV(i, v, arr)
-        }, vs);
+                let i = Ref.get(pos);
+                Ref.put(i + length(v), pos);
+                arrayUpdateSeqV(i, v, arr)
+            },
+            vs
+        );
         Array.toVector(arr)
     }
 
@@ -1036,9 +1033,10 @@ pub mod Vector {
     /// `v2` contains all elements of `v` that do not satisfy the predicate `f`.
     ///
     pub def partition(f: a -> Bool \ ef, v: Vector[a]): (Vector[a], Vector[a]) \ ef =
-        let step = { (x, acc) ->
-            let (a1, a2) = acc;
-            if (f(x)) (x :: a1, a2) else (a1, x :: a2)
+        let step = {
+            (x, acc) ->
+                let (a1, a2) = acc;
+                if (f(x)) (x :: a1, a2) else (a1, x :: a2)
         };
         let (xs, ys) = foldRight(step, (Nil, Nil), v);
         (List.toVector(xs), List.toVector(ys))
@@ -1066,7 +1064,7 @@ pub mod Vector {
     ///
     /// Returns an empty vector if `n > length(v)`.
     ///
-    pub def dropLeft( n: Int32, v: Vector[a]): Vector[a] =
+    pub def dropLeft(n: Int32, v: Vector[a]): Vector[a] =
         let len = length(v);
         if (n > len)
             empty()
@@ -1144,7 +1142,7 @@ pub mod Vector {
         else {
             let len = length(v);
             let start = if (n > len) 0 else len - n;
-            slice( start = start, end = len, v)
+            slice(start = start, end = len, v)
         }
 
     ///
@@ -1209,7 +1207,7 @@ pub mod Vector {
     /// Helper function for `groupWith`.
     ///
     def groupByHelper(f: (a, a) -> Bool, xs: List[a], ac: List[Vector[a]]): List[Vector[a]] = match xs {
-        case Nil     => List.reverse(ac)
+        case Nil => List.reverse(ac)
         case x :: rs =>
             let (r1, r2) = extractHelper(f, rs, Nel.singleton(x), Nil);
             groupByHelper(f, r2, r1 :: ac)
@@ -1250,7 +1248,6 @@ pub mod Vector {
         let len = Int32.min(length(a), length(b));
         init(i -> f(get(i, a), get(i, b)), len)
 
-
     ///
     /// Returns a pair of vectors, the first containing all first components in `v`
     /// and the second containing all second components in `v`.
@@ -1260,10 +1257,12 @@ pub mod Vector {
         let arr = Array.empty(rc, len);
         let brr = Array.empty(rc, len);
         forEachWithIndex((i, x) -> {
-            let (l, r) = x;
-            Array.put(l, i, arr);
-            Array.put(r, i, brr)
-            }, v);
+                let (l, r) = x;
+                Array.put(l, i, arr);
+                Array.put(r, i, brr)
+            },
+            v
+        );
         (Array.toVector(arr), Array.toVector(brr))
     }
 
@@ -1308,8 +1307,13 @@ pub mod Vector {
     ///
     pub def filterMap(f: a -> Option[b] \ ef, v: Vector[a]): Vector[b] \ ef =
         foldRight((x, xs) -> match f(x) {
-            case None    => xs
-            case Some(b) => b :: xs }, Nil, v) |> List.toVector
+                case None    => xs
+                case Some(b) => b :: xs
+            },
+            Nil,
+            v
+        )
+            |> List.toVector
 
     ///
     /// Returns the first non-None result of applying the partial function `f` to each element of `v`.


### PR DESCRIPTION
As discussed in PR https://github.com/flix/flix/pull/12692.

The files that are formatted:
- Fixpoint3/Phase/Simplifier
- Fixpoint3/Phase/Stratifier -- but fix comment
- Fixpoint3/Phase/PrecedenceGraph/MutGraph -- but fix comment
- Fixpoint3/Phase/Boxable -- but fix comment
- Fixpoint3/Phase/Predicate
- Fixpoint3/Phase/UniqueInts
- Debug
- Vector

It is to note, two experimental formatting rules were added:
- Line break preservation for `with` in the function signature
- In MultiLine mode the first Argument now will be on the same line as the open Paren. 

Otherwise, the manual reformatting discussed in the PR https://github.com/flix/flix/pull/12692 was included.