### PR TITLE
feat: extend --top with interactive filtering and sorting

### DIFF
--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -77,14 +77,15 @@ object CompilerProfiler {
   /**
     * A snapshot of per-`DefnSym` statistics produced by [[CompilerProfiler.snapshot]].
     *
-    * @param sym        the source-level [[Symbol.DefnSym]] this row aggregates.
-    * @param isActive   true if at least one `track` call is currently in flight for this sym.
-    * @param callCount  number of `track` calls observed for this sym.
-    * @param totalNanos total wall-clock time spent inside `track` calls for this sym, in nanoseconds.
-    * @param byPhase    per-phase breakdown of `totalNanos`, keyed by phase name.
-    * @param loc        the source location of the def's body, used to compute LOC.
+    * @param sym          the source-level [[Symbol.DefnSym]] this row aggregates.
+    * @param isActive     true if at least one `track` call is currently in flight for this sym.
+    * @param callCount    number of `track` calls observed for this sym.
+    * @param totalNanos   total wall-clock time spent inside `track` calls for this sym, in nanoseconds.
+    * @param byPhase      per-phase breakdown of `totalNanos`, keyed by phase name.
+    * @param byPhaseCount per-phase breakdown of `callCount`, keyed by phase name.
+    * @param loc          the source location of the def's body, used to compute LOC.
     */
-  final case class DefnStats(sym: Symbol.DefnSym, isActive: Boolean, callCount: Int, totalNanos: Long, byPhase: Map[String, Long], loc: SourceLocation) {
+  final case class DefnStats(sym: Symbol.DefnSym, isActive: Boolean, callCount: Int, totalNanos: Long, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], loc: SourceLocation) {
     /** Returns the phase that consumed the most time, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
@@ -97,9 +98,10 @@ object CompilerProfiler {
     * @param callCount     number of `track` calls observed for this sym.
     * @param totalNanos    total wall-clock time spent inside `track` calls for this sym, in nanoseconds.
     * @param perPhaseNanos per-phase nanosecond accumulator, keyed by phase name.
+    * @param perPhaseCount per-phase call-count accumulator, keyed by phase name.
     * @param loc           set on first `track` call; carries the def-body span so we can show LOC.
     */
-  private final case class Counters(inProgress: AtomicInteger, callCount: AtomicInteger, totalNanos: AtomicLong, perPhaseNanos: ConcurrentHashMap[String, AtomicLong], loc: AtomicReference[SourceLocation])
+  private final case class Counters(inProgress: AtomicInteger, callCount: AtomicInteger, totalNanos: AtomicLong, perPhaseNanos: ConcurrentHashMap[String, AtomicLong], perPhaseCount: ConcurrentHashMap[String, AtomicLong], loc: AtomicReference[SourceLocation])
 }
 
 final class CompilerProfiler(phaseProvider: () => Option[String]) {
@@ -128,6 +130,9 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
       c.perPhaseNanos
         .computeIfAbsent(phase, _ => new AtomicLong(0L))
         .addAndGet(elapsed)
+      c.perPhaseCount
+        .computeIfAbsent(phase, _ => new AtomicLong(0L))
+        .incrementAndGet()
       c.inProgress.decrementAndGet()
     }
   }
@@ -142,9 +147,11 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
       val c = e.getValue
       val byPhase = c.perPhaseNanos.entrySet().iterator().asScala
         .map(pe => (pe.getKey, pe.getValue.get())).toMap
+      val byPhaseCount = c.perPhaseCount.entrySet().iterator().asScala
+        .map(pe => (pe.getKey, pe.getValue.get())).toMap
       val loc = Option(c.loc.get()).getOrElse(e.getKey.loc)
       CompilerProfiler.DefnStats(e.getKey, isActive = c.inProgress.get() > 0,
-        c.callCount.get(), c.totalNanos.get(), byPhase, loc)
+        c.callCount.get(), c.totalNanos.get(), byPhase, byPhaseCount, loc)
     }.toVector
   }
 
@@ -158,6 +165,7 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) {
       callCount = new AtomicInteger(0),
       totalNanos = new AtomicLong(0L),
       perPhaseNanos = new ConcurrentHashMap[String, AtomicLong](),
+      perPhaseCount = new ConcurrentHashMap[String, AtomicLong](),
       loc = new AtomicReference[SourceLocation](null)
     ))
 

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -351,6 +351,26 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
   /** True while the renderer thread should keep looping. */
   private val running = new AtomicBoolean(false)
 
+  /**
+    * Flips to true when [[stop]] is first called. Drives the dashboard's
+    * "done — press q to quit" mode and guards [[stop]] against re-entry from
+    * both the error path in `Flix.check` and the success path in `Flix.compile`.
+    */
+  private val completed = new AtomicBoolean(false)
+
+  /**
+    * Elapsed nanos at the moment compilation finished. Captured by [[stop]]
+    * before flipping [[completed]] so the dashboard can freeze the field
+    * instead of advancing it during the wait-for-quit phase.
+    */
+  @volatile private var frozenElapsedNanos: Long = 0L
+
+  /** Active-thread count captured at the same instant as [[frozenElapsedNanos]]. */
+  @volatile private var frozenActiveThreads: Int = 0
+
+  /** `(usedMb, maxMb)` heap snapshot captured at the same instant as [[frozenElapsedNanos]]. */
+  @volatile private var frozenHeap: (Long, Long) = (0L, 0L)
+
   /** The renderer thread, or `null` before [[start]] / after [[stop]]. */
   private var thread: Thread = _
 
@@ -389,12 +409,44 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     thread.start()
   }
 
-  /** Stops the renderer, prints one final frame, and joins the render thread. */
+  /**
+    * Marks compilation done, blocks until the user presses `q` (or hits EOF /
+    * Ctrl-C), then tears the renderer down and clears the screen so whatever
+    * Main prints next (errors, runtime output) starts on a clean slate.
+    *
+    * Idempotent: the second caller — both error and success paths in `Flix`
+    * may fire — returns immediately rather than blocking again.
+    */
   def stop(): Unit = {
+    // Snapshot live values BEFORE flipping `completed`. The renderer reads
+    // `completed` first and uses the snapshot when it sees true; the volatile
+    // writes here happen-before the AtomicBoolean store via JMM.
+    frozenElapsedNanos = System.nanoTime() - startNanos
+    frozenActiveThreads = if (flix.threadPool == null) 0 else flix.threadPool.getActiveThreadCount
+    frozenHeap = heapUsage()
+
+    if (!completed.compareAndSet(false, true)) return
+
+    // Block until the user dismisses the TUI. The renderer keeps drawing the
+    // "press q to quit" hint while we wait.
+    if (terminal != null) {
+      val attrs = terminal.enterRawMode()
+      try {
+        val r = terminal.reader()
+        var quit = false
+        while (!quit) {
+          val c = r.read()
+          if (c == -1 || c == 'q' || c == 'Q' || c == 3) quit = true
+        }
+      } finally {
+        try terminal.setAttributes(attrs) catch { case _: Throwable => () }
+      }
+    }
+
     if (!running.compareAndSet(true, false)) return
     if (thread != null) thread.join()
-    render()
-    System.out.println()
+    System.out.print(ClearScreen)
+    System.out.flush()
     if (terminal != null) try terminal.close() catch { case _: Throwable => () }
   }
 
@@ -409,11 +461,15 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
 
   /** Builds and prints one full frame of the TUI. */
   private def render(): Unit = {
+    val isDone = completed.get()
     val now = System.nanoTime()
-    val elapsed = now - startNanos
     val pool = flix.threadPool
     val parallelism = if (pool == null) flix.options.threads.max(1) else pool.getParallelism.max(1)
-    val activeThreads = if (pool == null) 0 else pool.getActiveThreadCount
+    // Once compilation is done, freeze elapsed + active threads at their
+    // snapshot values so the dashboard reflects the state at completion
+    // rather than ticking forward during the wait-for-quit phase.
+    val elapsed = if (isDone) frozenElapsedNanos else now - startNanos
+    val activeThreads = if (isDone) frozenActiveThreads else (if (pool == null) 0 else pool.getActiveThreadCount)
 
     // Budget rows for the two tables based on the current terminal height,
     // reserving an extra `RowMargin` rows so the view never quite touches
@@ -429,9 +485,13 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     val snap = profiler.snapshot().sortBy(-_.totalNanos)
     val visible = snap.take(defN)
 
-    // Active-threads sparkline: history of thread-pool occupancy.
-    threadsHistory.enqueue(activeThreads.toDouble)
-    while (threadsHistory.size > SparkWidth) threadsHistory.dequeue()
+    // Active-threads sparkline: history of thread-pool occupancy. Stops
+    // updating once compilation is done so the bar reflects the work, not
+    // a long tail of zero-occupancy samples while waiting for `q`.
+    if (!isDone) {
+      threadsHistory.enqueue(activeThreads.toDouble)
+      while (threadsHistory.size > SparkWidth) threadsHistory.dequeue()
+    }
 
     val modules = aggregateByModule(snap).take(moduleN)
 
@@ -458,8 +518,12 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * Both bars sit beside each other so the eye picks them up as a pair.
     */
   private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int): Unit = {
-    val phase = flix.getCurrentPhaseName.getOrElse("starting")
-    val done = (flix.phaseTimers.size + 1).min(TotalPhases)
+    val isDone = completed.get()
+    val phase = if (isDone) "done" else flix.getCurrentPhaseName.getOrElse("starting")
+    // Once compilation has finished, force the bar to 100% rather than relying
+    // on `phaseTimers.size + 1` (which is +1 ahead of reality during execution
+    // and would still under-fill if any phase is uninstrumented).
+    val done = if (isDone) TotalPhases else (flix.phaseTimers.size + 1).min(TotalPhases)
     val filled = (BarWidth.toLong * done / TotalPhases).toInt
 
     sb.append("  ")
@@ -474,6 +538,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(dim(cyan(renderSparkline(parallelism.toDouble))))
     sb.append(' ')
     sb.append(styleThreads(activeThreads, parallelism))
+    if (isDone) sb.append(dim("   press q to quit"))
     sb.append('\n')
   }
 
@@ -482,7 +547,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * (right-aligned under `threads`).
     */
   private def renderStats(sb: StringBuilder, elapsed: Long): Unit = {
-    val (heapUsedMb, heapMaxMb) = heapUsage()
+    val (heapUsedMb, heapMaxMb) = if (completed.get()) frozenHeap else heapUsage()
     val heapUsedField = f"$heapUsedMb%4d MB"
     val heapMaxField = f"$heapMaxMb%4d MB"
     val heapRatio = if (heapMaxMb <= 0) 0.0 else heapUsedMb.toDouble / heapMaxMb

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -76,8 +76,8 @@ object CompilerTop {
     case object Hotness extends Sort
   }
 
-  /** How often the screen refreshes, in milliseconds. */
-  private val RefreshIntervalMs: Long = 100L
+  /** How often the screen refreshes, in milliseconds (5 FPS). */
+  private val RefreshIntervalMs: Long = 200L
 
   /** Poll interval for the input thread (ms); doubles as how fast `running=false` is observed. */
   private val InputPollMs: Long = 100L

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -170,7 +170,6 @@ object CompilerTop {
   private val HeapYellowThresholdRatio:        Double = 0.7
   private val HotnessRedThresholdMsPerLine:    Double = 25.0
   private val HotnessYellowThresholdMsPerLine: Double = 15.0
-  private val LocRedThreshold:                 Int    = 250
   private val PctCpuRedThreshold:              Double = 5.0
   private val PctCpuYellowThreshold:           Double = 1.0
   private val PctWallRedThreshold:             Double = 15.0
@@ -232,12 +231,6 @@ object CompilerTop {
     if (ratio >= HeapRedThresholdRatio) bold(red(formatted))
     else if (ratio >= HeapYellowThresholdRatio) yellow(formatted)
     else green(formatted)
-  }
-
-  /** Colors a formatted LOC field — large definition. */
-  private def styleLoc(formatted: String, locLines: Int): String = {
-    if (locLines >= LocRedThreshold) bold(red(formatted))
-    else formatted
   }
 
   /** Colors a formatted call-count field — high re-visit count. */
@@ -936,10 +929,10 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * to a row, honoring the layout's visibility flags. Always emits a leading
     * separator before each column it writes.
     *
-    * `aggregate` controls whether LOC and n carry warning colors. The
-    * `styleLoc` / `styleN` thresholds were picked for individual defs;
-    * module rows are sums-across-defs and would trip the thresholds
-    * unconditionally, so they render those columns plain.
+    * `aggregate` skips all warning colors. The `style*` thresholds are
+    * calibrated for individual defs; at module scale, sums-across-defs
+    * would trip the thresholds unconditionally and the colors become
+    * noise rather than signal.
     */
   private def appendNumericFields(sb: StringBuilder, locLines: Int, callCount: Long, phase: String,
                                    nanos: Long, pctCpu: Double, pctWall: Double, layout: Layout,
@@ -947,8 +940,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     if (layout.showLOC) {
       sb.append(' ')
       val locStr = if (locLines > 0) locLines.toString else "-"
-      val padded = lpad(locStr, 4)
-      sb.append(if (aggregate) padded else styleLoc(padded, locLines))
+      sb.append(lpad(locStr, 4))
     }
     if (layout.showN) {
       sb.append(' ')
@@ -959,9 +951,12 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
       sb.append(' ')
       sb.append(rpad(truncate(phase, 10), 10))
     }
-    sb.append(' '); sb.append(styleTime(lpad(formatMillis(nanos), 9), nanos))
-    sb.append(' '); sb.append(stylePctCpu(f"$pctCpu%5.1f%%", pctCpu))
-    sb.append(' '); sb.append(stylePctWall(f"$pctWall%5.1f%%", pctWall))
+    val timeField = lpad(formatMillis(nanos), 9)
+    val cpuField  = f"$pctCpu%5.1f%%"
+    val wallField = f"$pctWall%5.1f%%"
+    sb.append(' '); sb.append(if (aggregate) timeField else styleTime(timeField, nanos))
+    sb.append(' '); sb.append(if (aggregate) cpuField else stylePctCpu(cpuField, pctCpu))
+    sb.append(' '); sb.append(if (aggregate) wallField else stylePctWall(wallField, pctWall))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -61,6 +61,21 @@ object CompilerTop {
     case Filter.Backend  => phase != "?" && !FrontendPhases.contains(phase)
   }
 
+  /**
+    * Selects the descending sort key applied to the def and module tables.
+    * Each option surfaces a different kind of suspect, so the same def can
+    * top one ranking and not another.
+    */
+  sealed trait Sort
+  object Sort {
+    /** Slowest defs first. The default. */
+    case object Time extends Sort
+    /** Most-revisited defs first (monomorph explosions, inliner re-entry). */
+    case object Count extends Sort
+    /** Hottest-per-line defs first — small defs that burn disproportionate time. */
+    case object Hotness extends Sort
+  }
+
   /** How often the screen refreshes, in milliseconds. */
   private val RefreshIntervalMs: Long = 100L
 
@@ -237,8 +252,8 @@ object CompilerTop {
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
   }
 
-  /** Groups `snap` by namespace, sums each metric, and returns rows sorted by `totalNanos` descending. */
-  private def aggregateByModule(snap: Vector[DefnStats]): Vector[ModuleStats] = {
+  /** Groups `snap` by namespace, sums each metric, and returns rows sorted by `srt` descending. */
+  private def aggregateByModule(snap: Vector[DefnStats], srt: Sort): Vector[ModuleStats] = {
     val groups = snap.groupBy { s =>
       val ns = s.sym.namespace
       if (ns.isEmpty) "(root)" else ns.mkString(".")
@@ -253,7 +268,27 @@ object CompilerTop {
         }
       }
       ModuleStats(mod, totalNanos, totalCallCount, totalLocLines, byPhase)
-    }.toVector.sortBy(-_.totalNanos)
+    }.toVector.sortBy(m => -moduleSortKey(m, srt))
+  }
+
+  /**
+    * Returns the descending sort key for a def under the given sort mode.
+    * `Hotness` (time / LOC) is 0 for synthetic defs with no real source
+    * span (`locLines <= 0`) so they sink to the bottom rather than dominating.
+    */
+  private def defSortKey(s: DefnStats, srt: Sort): Double = srt match {
+    case Sort.Time    => s.totalNanos.toDouble
+    case Sort.Count   => s.callCount.toDouble
+    case Sort.Hotness =>
+      val lines = locLineCount(s.loc)
+      if (lines <= 0) 0.0 else s.totalNanos.toDouble / lines
+  }
+
+  /** Module-level analogue of [[defSortKey]], applied after summing across each module's defs. */
+  private def moduleSortKey(m: ModuleStats, srt: Sort): Double = srt match {
+    case Sort.Time    => m.totalNanos.toDouble
+    case Sort.Count   => m.totalCallCount.toDouble
+    case Sort.Hotness => if (m.totalLocLines <= 0) 0.0 else m.totalNanos.toDouble / m.totalLocLines
   }
 
   /** Fallback terminal height when JLine cannot determine the real one. */
@@ -430,6 +465,12 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
   private val filter = new AtomicReference[Filter](Filter.All)
 
   /**
+    * Active sort for the def / module tables. Written by the input thread,
+    * read by the renderer thread. Default is [[Sort.Time]].
+    */
+  private val sort = new AtomicReference[Sort](Sort.Time)
+
+  /**
     * Counted down by the input thread when the user presses `q` (only after
     * [[completed]] is set). [[stop]] awaits it before tearing the renderer
     * down so the user can keep toggling the filter post-compile.
@@ -529,6 +570,9 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
         case 'f' | 'F' => filter.set(Filter.Frontend)
         case 'b' | 'B' => filter.set(Filter.Backend)
         case 'a' | 'A' => filter.set(Filter.All)
+        case 't' | 'T' => sort.set(Sort.Time)
+        case 'n' | 'N' => sort.set(Sort.Count)
+        case 'h' | 'H' => sort.set(Sort.Hotness)
         case _         => // ignored
       }
     }
@@ -604,7 +648,8 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     val layout = computeLayout((terminalCols() - 2).max(1))
 
     val activeFilter = filter.get()
-    val snap = applyFilter(profiler.snapshot(), activeFilter).sortBy(-_.totalNanos)
+    val activeSort = sort.get()
+    val snap = applyFilter(profiler.snapshot(), activeFilter).sortBy(s => -defSortKey(s, activeSort))
     val visible = snap.take(defN)
 
     // Active-threads sparkline: history of thread-pool occupancy. Stops
@@ -615,14 +660,14 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
       while (threadsHistory.size > SparkWidth) threadsHistory.dequeue()
     }
 
-    val modules = aggregateByModule(snap).take(moduleN)
+    val modules = aggregateByModule(snap, activeSort).take(moduleN)
 
     val sb = new StringBuilder
     sb.append(BeginSync)
     sb.append(ClearScreen)
     sb.append('\n')
 
-    renderDashboard(sb, activeThreads, parallelism, activeFilter)
+    renderDashboard(sb, activeThreads, parallelism, activeFilter, activeSort)
     renderStats(sb, elapsed)
     sb.append('\n')
     renderTableHeader(sb, layout)
@@ -639,7 +684,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * Top dashboard line: current phase + progress bar + active-threads bar.
     * Both bars sit beside each other so the eye picks them up as a pair.
     */
-  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int, activeFilter: Filter): Unit = {
+  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int, activeFilter: Filter, activeSort: Sort): Unit = {
     val isDone = completed.get()
     val phase = if (isDone) "done" else flix.getCurrentPhaseName.getOrElse("starting")
     // Once compilation has finished, force the bar to 100% rather than relying
@@ -662,6 +707,8 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(styleThreads(activeThreads, parallelism))
     sb.append("   ")
     sb.append(renderFilterLegend(activeFilter))
+    sb.append(' ')
+    sb.append(renderSortLegend(activeSort))
     if (isDone) sb.append(dim("   press q to quit"))
     sb.append('\n')
   }
@@ -679,6 +726,22 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(if (active == Filter.Frontend) bold(cyan("f")) else dim("f"))
     sb.append(dim("|"))
     sb.append(if (active == Filter.Backend) bold(cyan("b")) else dim("b"))
+    sb.append(dim("]"))
+    sb.toString
+  }
+
+  /**
+    * Renders the `[t|n|h]` sort-key legend with the active letter highlighted
+    * in bold cyan. `t` = time, `n` = call count, `h` = hotness (time/LOC).
+    */
+  private def renderSortLegend(active: Sort): String = {
+    val sb = new StringBuilder
+    sb.append(dim("["))
+    sb.append(if (active == Sort.Time) bold(cyan("t")) else dim("t"))
+    sb.append(dim("|"))
+    sb.append(if (active == Sort.Count) bold(cyan("n")) else dim("n"))
+    sb.append(dim("|"))
+    sb.append(if (active == Sort.Hotness) bold(cyan("h")) else dim("h"))
     sb.append(dim("]"))
     sb.toString
   }

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -715,9 +715,16 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(dim("] "))
     sb.append(f"$done%2d/$TotalPhases%2d")
     sb.append(dim("   threads "))
-    sb.append(dim(cyan(renderSparkline(parallelism.toDouble))))
-    sb.append(' ')
-    sb.append(styleThreads(activeThreads, parallelism))
+    // With parallelism=1 ForkJoin runs work inline on the submitter, leaving
+    // `getActiveThreadCount` at 0 most of the time — sparkline goes flat,
+    // field reads `0/1` continuously. Show a label instead.
+    if (parallelism > 1) {
+      sb.append(dim(cyan(renderSparkline(parallelism.toDouble))))
+      sb.append(' ')
+      sb.append(styleThreads(activeThreads, parallelism))
+    } else {
+      sb.append(dim("single-threaded"))
+    }
     sb.append("   ")
     sb.append(renderFilterLegend(activeFilter))
     sb.append(' ')

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -160,6 +160,19 @@ object CompilerTop {
     else green(formatted)
   }
 
+  /** Colors a formatted LOC field: ≥250 lines red bold (large definition). */
+  private def styleLoc(formatted: String, locLines: Int): String = {
+    if (locLines >= 250) bold(red(formatted))
+    else formatted
+  }
+
+  /** Colors a formatted call-count field: ≥500 red bold, ≥50 yellow (high re-visit count). */
+  private def styleN(formatted: String, callCount: Long): String = {
+    if (callCount >= 500) bold(red(formatted))
+    else if (callCount >= 50) yellow(formatted)
+    else formatted
+  }
+
   // -- Numeric helpers ----------------------------------------------------
 
   /** Returns `(usedMb, maxMb)` from the JVM runtime. */
@@ -695,11 +708,12 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
                                    nanos: Long, pctCpu: Double, pctWall: Double, layout: Layout): Unit = {
     if (layout.showLOC) {
       sb.append(' ')
-      sb.append(lpad(if (locLines > 0) locLines.toString else "-", 4))
+      val locStr = if (locLines > 0) locLines.toString else "-"
+      sb.append(styleLoc(lpad(locStr, 4), locLines))
     }
     if (layout.showN) {
       sb.append(' ')
-      sb.append(lpad(callCount.toString, 4))
+      sb.append(styleN(lpad(callCount.toString, 4), callCount))
     }
     if (layout.showPhase) {
       sb.append(' ')

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -157,14 +157,34 @@ object CompilerTop {
   /** Wraps `s` in ANSI cyan codes. */
   private def cyan(s: String): String = color(s, Cyan)
 
+  // -- Warning thresholds --------------------------------------------------
+  //
+  // Per-column tier cutoffs consumed by the `style*` functions below. Naming:
+  // `<Column><Tier>Threshold[<Unit>]`. Sorted alphabetically — keep new
+  // entries in order. Adjusting a number here is a UX call; please don't
+  // bury it inside one of the styling functions.
+
+  private val CallCountRedThreshold:           Long   = 500L
+  private val CallCountYellowThreshold:        Long   = 50L
+  private val HeapRedThresholdRatio:           Double = 0.9
+  private val HeapYellowThresholdRatio:        Double = 0.7
+  private val HotnessRedThresholdMsPerLine:    Double = 25.0
+  private val HotnessYellowThresholdMsPerLine: Double = 15.0
+  private val LocRedThreshold:                 Int    = 250
+  private val PctCpuRedThreshold:              Double = 5.0
+  private val PctCpuYellowThreshold:           Double = 1.0
+  private val PctWallRedThreshold:             Double = 15.0
+  private val PctWallYellowThreshold:          Double = 5.0
+  private val TimeRedThresholdMs:              Long   = 1000L
+  private val TimeYellowThresholdMs:           Long   = 50L
+
   // -- Conditional styling -------------------------------------------------
 
-  /** Colors a formatted time field by absolute magnitude (≥1s red bold, ≥200ms yellow bold, ≥50ms yellow). */
+  /** Colors a formatted time field by absolute magnitude. */
   private def styleTime(formatted: String, nanos: Long): String = {
     val ms = nanos / 1_000_000L
-    if (ms >= 1000) bold(red(formatted))
-    else if (ms >= 200) bold(yellow(formatted))
-    else if (ms >= 50) yellow(formatted)
+    if (ms >= TimeRedThresholdMs) bold(red(formatted))
+    else if (ms >= TimeYellowThresholdMs) yellow(formatted)
     else formatted
   }
 
@@ -178,22 +198,22 @@ object CompilerTop {
   private def styleSym(name: String, nanos: Long, locLines: Int): String = {
     if (locLines <= 0) return name
     val msPerLine = (nanos / 1_000_000L).toDouble / locLines
-    if (msPerLine >= 25.0) bold(red(name))
-    else if (msPerLine >= 15.0) yellow(name)
+    if (msPerLine >= HotnessRedThresholdMsPerLine) bold(red(name))
+    else if (msPerLine >= HotnessYellowThresholdMsPerLine) yellow(name)
     else name
   }
 
   /** %cpu = totalNanos / (elapsed × threads). One def's slice of total compute. */
   private def stylePctCpu(formatted: String, pct: Double): String = {
-    if (pct >= 5.0) bold(red(formatted))
-    else if (pct >= 1.0) yellow(formatted)
+    if (pct >= PctCpuRedThreshold) bold(red(formatted))
+    else if (pct >= PctCpuYellowThreshold) yellow(formatted)
     else formatted
   }
 
   /** %wall = totalNanos / elapsed. Upper bound on wall-clock savings if removed. */
   private def stylePctWall(formatted: String, pct: Double): String = {
-    if (pct >= 15.0) bold(red(formatted))
-    else if (pct >= 5.0) yellow(formatted)
+    if (pct >= PctWallRedThreshold) bold(red(formatted))
+    else if (pct >= PctWallYellowThreshold) yellow(formatted)
     else formatted
   }
 
@@ -207,23 +227,23 @@ object CompilerTop {
     else yellow(s)
   }
 
-  /** Colors a formatted heap field by used/max ratio: ≥90% red bold, ≥70% yellow, else green. */
+  /** Colors a formatted heap field by used/max ratio. */
   private def styleHeap(formatted: String, ratio: Double): String = {
-    if (ratio >= 0.9) bold(red(formatted))
-    else if (ratio >= 0.7) yellow(formatted)
+    if (ratio >= HeapRedThresholdRatio) bold(red(formatted))
+    else if (ratio >= HeapYellowThresholdRatio) yellow(formatted)
     else green(formatted)
   }
 
-  /** Colors a formatted LOC field: ≥250 lines red bold (large definition). */
+  /** Colors a formatted LOC field — large definition. */
   private def styleLoc(formatted: String, locLines: Int): String = {
-    if (locLines >= 250) bold(red(formatted))
+    if (locLines >= LocRedThreshold) bold(red(formatted))
     else formatted
   }
 
-  /** Colors a formatted call-count field: ≥500 red bold, ≥50 yellow (high re-visit count). */
+  /** Colors a formatted call-count field — high re-visit count. */
   private def styleN(formatted: String, callCount: Long): String = {
-    if (callCount >= 500) bold(red(formatted))
-    else if (callCount >= 50) yellow(formatted)
+    if (callCount >= CallCountRedThreshold) bold(red(formatted))
+    else if (callCount >= CallCountYellowThreshold) yellow(formatted)
     else formatted
   }
 

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -18,15 +18,54 @@ package ca.uwaterloo.flix.util
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.util.CompilerProfiler.DefnStats
-import org.jline.terminal.{Terminal, TerminalBuilder}
+import org.jline.terminal.{Attributes, Terminal, TerminalBuilder}
 
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.collection.mutable
 
 object CompilerTop {
 
+  /**
+    * Restricts which phases' time the dashboard accounts for. Toggled
+    * interactively via the input thread (`f` / `b` / `a`). The split tracks
+    * `Flix.check` (frontend) vs the phases that follow in `Flix.compile`'s
+    * `codeGen` (backend) — see [[FrontendPhases]].
+    */
+  sealed trait Filter
+  object Filter {
+    case object All extends Filter
+    case object Frontend extends Filter
+    case object Backend extends Filter
+  }
+
+  /**
+    * Phase-name strings that count as "frontend" — i.e. phases that run
+    * inside `Flix.check`. Strings must match the literals each phase passes
+    * to `flix.phase("…")` / `flix.phaseNew("…")`. Verified against the
+    * `run` methods under `main/src/ca/uwaterloo/flix/language/phase`.
+    *
+    * Phases not in this set (and not the unknown-phase fallback `"?"`) are
+    * treated as backend.
+    */
+  private val FrontendPhases: Set[String] = Set(
+    "Reader", "Lexer", "Parser2", "Weeder2", "Desugar", "Namer", "Resolver",
+    "Kinder", "Deriver", "Typer", "EntryPoints", "Instances", "PredDeps",
+    "Stratifier", "PatMatch", "Redundancy", "Safety", "Terminator", "Dependencies",
+  )
+
+  /** True if `phase` should be accounted for under the current `f`. */
+  private def matchesFilter(phase: String, f: Filter): Boolean = f match {
+    case Filter.All      => true
+    case Filter.Frontend => FrontendPhases.contains(phase)
+    case Filter.Backend  => phase != "?" && !FrontendPhases.contains(phase)
+  }
+
   /** How often the screen refreshes, in milliseconds. */
   private val RefreshIntervalMs: Long = 100L
+
+  /** Poll interval for the input thread (ms); doubles as how fast `running=false` is observed. */
+  private val InputPollMs: Long = 100L
 
   /** Total number of phases the compiler runs. Bump when `Flix.check` / `Flix.codeGen` adds or removes a `phase` / `phaseNew` call. */
   private val TotalPhases: Int = 32
@@ -384,8 +423,31 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
   /** `(usedMb, maxMb)` heap snapshot captured at the same instant as [[frozenElapsedNanos]]. */
   @volatile private var frozenHeap: (Long, Long) = (0L, 0L)
 
+  /**
+    * Active filter for the def / module tables. Written by the input thread,
+    * read by the renderer thread. Default is [[Filter.All]] (no filtering).
+    */
+  private val filter = new AtomicReference[Filter](Filter.All)
+
+  /**
+    * Counted down by the input thread when the user presses `q` (only after
+    * [[completed]] is set). [[stop]] awaits it before tearing the renderer
+    * down so the user can keep toggling the filter post-compile.
+    */
+  private val quitLatch = new CountDownLatch(1)
+
+  /**
+    * Terminal attributes captured before entering raw mode in [[start]].
+    * Restored by [[stop]] so the user's shell isn't left with line buffering
+    * and echo disabled if anything goes wrong further down the teardown.
+    */
+  private var savedAttrs: Attributes = _
+
   /** The renderer thread, or `null` before [[start]] / after [[stop]]. */
   private var thread: Thread = _
+
+  /** The input thread that reads keypresses (filter toggles + quit), or `null` before [[start]] / after [[stop]]. */
+  private var inputThread: Thread = _
 
   /** Wall-clock start time, used as the denominator for `%wall` and `%cpu`. */
   private val startNanos: Long = System.nanoTime()
@@ -414,12 +476,62 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     if (w > 0) w else DefaultCols
   }
 
-  /** Starts the renderer on a daemon thread. */
+  /**
+    * Starts the renderer + input threads on daemon threads. Enters raw mode
+    * once at startup so the input thread can read individual keystrokes
+    * during compilation as well as after it finishes.
+    */
   def start(): Unit = {
     if (!running.compareAndSet(false, true)) return
+
+    // Enter raw mode for the lifetime of the TUI so keypresses (f/b/a/q)
+    // are delivered immediately rather than line-buffered.
+    if (terminal != null) {
+      try savedAttrs = terminal.enterRawMode()
+      catch { case _: Throwable => savedAttrs = null }
+    }
+
     thread = new Thread(() => loop(), "flix-top-renderer")
     thread.setDaemon(true)
     thread.start()
+
+    inputThread = new Thread(() => inputLoop(), "flix-top-input")
+    inputThread.setDaemon(true)
+    inputThread.start()
+  }
+
+  /**
+    * Input-thread body: reads keypresses with a [[InputPollMs]] timeout so
+    * shutdown is responsive to `running.get() == false`.
+    *
+    *   - `f` / `F` → filter to frontend phases
+    *   - `b` / `B` → filter to backend phases
+    *   - `a` / `A` → reset to all phases
+    *   - `q` / `Q` / Ctrl-C / EOF → if compilation has completed, signal
+    *     [[stop]] to finish teardown; otherwise ignored (pressing `q`
+    *     mid-compile must not abort the build).
+    *   - Any other key is ignored.
+    */
+  private def inputLoop(): Unit = {
+    if (terminal == null) return
+    val r = terminal.reader()
+    while (running.get()) {
+      val c =
+        try r.read(InputPollMs)
+        catch { case _: InterruptedException => return; case _: Throwable => -1 }
+      c match {
+        case -2 => // timeout — loop and re-check `running`
+        case -1 | 3 | 'q' | 'Q' =>
+          if (completed.get()) {
+            quitLatch.countDown()
+            return
+          }
+        case 'f' | 'F' => filter.set(Filter.Frontend)
+        case 'b' | 'B' => filter.set(Filter.Backend)
+        case 'a' | 'A' => filter.set(Filter.All)
+        case _         => // ignored
+      }
+    }
   }
 
   /**
@@ -440,24 +552,20 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
 
     if (!completed.compareAndSet(false, true)) return
 
-    // Block until the user dismisses the TUI. The renderer keeps drawing the
-    // "press q to quit" hint while we wait.
+    // Block until the input thread observes `q`. The renderer keeps drawing
+    // the "press q to quit" hint and the user can keep toggling f/b/a in
+    // the meantime.
     if (terminal != null) {
-      val attrs = terminal.enterRawMode()
-      try {
-        val r = terminal.reader()
-        var quit = false
-        while (!quit) {
-          val c = r.read()
-          if (c == -1 || c == 'q' || c == 'Q' || c == 3) quit = true
-        }
-      } finally {
-        try terminal.setAttributes(attrs) catch { case _: Throwable => () }
-      }
+      try quitLatch.await()
+      catch { case _: InterruptedException => () }
     }
 
     if (!running.compareAndSet(true, false)) return
     if (thread != null) thread.join()
+    if (inputThread != null) inputThread.join()
+    if (terminal != null && savedAttrs != null) {
+      try terminal.setAttributes(savedAttrs) catch { case _: Throwable => () }
+    }
     System.out.print(ClearScreen)
     System.out.flush()
     if (terminal != null) try terminal.close() catch { case _: Throwable => () }
@@ -495,7 +603,8 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     // reserving 2 columns for the 1-space left and right table padding.
     val layout = computeLayout((terminalCols() - 2).max(1))
 
-    val snap = profiler.snapshot().sortBy(-_.totalNanos)
+    val activeFilter = filter.get()
+    val snap = applyFilter(profiler.snapshot(), activeFilter).sortBy(-_.totalNanos)
     val visible = snap.take(defN)
 
     // Active-threads sparkline: history of thread-pool occupancy. Stops
@@ -513,7 +622,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(ClearScreen)
     sb.append('\n')
 
-    renderDashboard(sb, activeThreads, parallelism)
+    renderDashboard(sb, activeThreads, parallelism, activeFilter)
     renderStats(sb, elapsed)
     sb.append('\n')
     renderTableHeader(sb, layout)
@@ -530,7 +639,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * Top dashboard line: current phase + progress bar + active-threads bar.
     * Both bars sit beside each other so the eye picks them up as a pair.
     */
-  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int): Unit = {
+  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int, activeFilter: Filter): Unit = {
     val isDone = completed.get()
     val phase = if (isDone) "done" else flix.getCurrentPhaseName.getOrElse("starting")
     // Once compilation has finished, force the bar to 100% rather than relying
@@ -551,8 +660,48 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(dim(cyan(renderSparkline(parallelism.toDouble))))
     sb.append(' ')
     sb.append(styleThreads(activeThreads, parallelism))
+    sb.append("   ")
+    sb.append(renderFilterLegend(activeFilter))
     if (isDone) sb.append(dim("   press q to quit"))
     sb.append('\n')
+  }
+
+  /**
+    * Renders the `[f|b|a]` legend with the active letter highlighted in
+    * bold cyan when the filter is non-default. Always visible so the user
+    * sees the available toggles whether the filter is active or not.
+    */
+  private def renderFilterLegend(active: Filter): String = {
+    val sb = new StringBuilder
+    sb.append(dim("["))
+    sb.append(if (active == Filter.All) bold(cyan("a")) else dim("a"))
+    sb.append(dim("|"))
+    sb.append(if (active == Filter.Frontend) bold(cyan("f")) else dim("f"))
+    sb.append(dim("|"))
+    sb.append(if (active == Filter.Backend) bold(cyan("b")) else dim("b"))
+    sb.append(dim("]"))
+    sb.toString
+  }
+
+  /**
+    * Projects each [[DefnStats]] through the active filter: keep only the
+    * `byPhase` and `byPhaseCount` entries whose phase matches, and recompute
+    * `totalNanos` and `callCount` as the sum over the kept phases. Module
+    * aggregation re-rolls from these filtered defs, so module rows track
+    * the filter automatically.
+    *
+    * `loc` isn't per-phase and passes through unchanged.
+    */
+  private def applyFilter(snap: Vector[DefnStats], f: Filter): Vector[DefnStats] = {
+    if (f == Filter.All) return snap
+    snap.map { s =>
+      val keptPhases = s.byPhase.filter { case (p, _) => matchesFilter(p, f) }
+      val keptCounts = s.byPhaseCount.filter { case (p, _) => matchesFilter(p, f) }
+      val keptTotal = keptPhases.values.sum
+      // Sum of per-phase counts cannot overflow Int in any realistic build.
+      val keptCount = keptCounts.values.sum.toInt
+      s.copy(totalNanos = keptTotal, callCount = keptCount, byPhase = keptPhases, byPhaseCount = keptCounts)
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -648,7 +648,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
       sb.append(" " * (nameMax - nameText.length))
       sb.append(' ')
       sb.append(dim(locField))
-      appendNumericFields(sb, locLines, s.callCount.toLong, phase, s.totalNanos, pctCpu, pctWall, layout)
+      appendNumericFields(sb, locLines, s.callCount.toLong, phase, s.totalNanos, pctCpu, pctWall, layout, aggregate = false)
       sb.append(' ')
       sb.append('\n')
     }
@@ -680,7 +680,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
 
       sb.append(' ')
       sb.append(modField)
-      appendNumericFields(sb, m.totalLocLines, m.totalCallCount, phase, m.totalNanos, pctCpu, pctWall, layout)
+      appendNumericFields(sb, m.totalLocLines, m.totalCallCount, phase, m.totalNanos, pctCpu, pctWall, layout, aggregate = true)
       sb.append(' ')
       sb.append('\n')
     }
@@ -703,17 +703,25 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * Appends the trailing numeric columns (LOC, n, phase, time, %cpu, %wall)
     * to a row, honoring the layout's visibility flags. Always emits a leading
     * separator before each column it writes.
+    *
+    * `aggregate` controls whether LOC and n carry warning colors. The
+    * `styleLoc` / `styleN` thresholds were picked for individual defs;
+    * module rows are sums-across-defs and would trip the thresholds
+    * unconditionally, so they render those columns plain.
     */
   private def appendNumericFields(sb: StringBuilder, locLines: Int, callCount: Long, phase: String,
-                                   nanos: Long, pctCpu: Double, pctWall: Double, layout: Layout): Unit = {
+                                   nanos: Long, pctCpu: Double, pctWall: Double, layout: Layout,
+                                   aggregate: Boolean): Unit = {
     if (layout.showLOC) {
       sb.append(' ')
       val locStr = if (locLines > 0) locLines.toString else "-"
-      sb.append(styleLoc(lpad(locStr, 4), locLines))
+      val padded = lpad(locStr, 4)
+      sb.append(if (aggregate) padded else styleLoc(padded, locLines))
     }
     if (layout.showN) {
       sb.append(' ')
-      sb.append(styleN(lpad(callCount.toString, 4), callCount))
+      val padded = lpad(callCount.toString, 4)
+      sb.append(if (aggregate) padded else styleN(padded, callCount))
     }
     if (layout.showPhase) {
       sb.append(' ')

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -32,11 +32,11 @@ object CompilerTop {
     * `Flix.check` (frontend) vs the phases that follow in `Flix.compile`'s
     * `codeGen` (backend) — see [[FrontendPhases]].
     */
-  sealed trait Filter
-  object Filter {
-    case object All extends Filter
-    case object Frontend extends Filter
-    case object Backend extends Filter
+  sealed trait PhaseFilter
+  object PhaseFilter {
+    case object All extends PhaseFilter
+    case object Frontend extends PhaseFilter
+    case object Backend extends PhaseFilter
   }
 
   /**
@@ -55,10 +55,10 @@ object CompilerTop {
   )
 
   /** True if `phase` should be accounted for under the current `f`. */
-  private def matchesFilter(phase: String, f: Filter): Boolean = f match {
-    case Filter.All      => true
-    case Filter.Frontend => FrontendPhases.contains(phase)
-    case Filter.Backend  => phase != "?" && !FrontendPhases.contains(phase)
+  private def matchesFilter(phase: String, f: PhaseFilter): Boolean = f match {
+    case PhaseFilter.All      => true
+    case PhaseFilter.Frontend => FrontendPhases.contains(phase)
+    case PhaseFilter.Backend  => phase != "?" && !FrontendPhases.contains(phase)
   }
 
   /**
@@ -473,9 +473,9 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
 
   /**
     * Active filter for the def / module tables. Written by the input thread,
-    * read by the renderer thread. Default is [[Filter.All]] (no filtering).
+    * read by the renderer thread. Default is [[PhaseFilter.All]] (no filtering).
     */
-  private val filter = new AtomicReference[Filter](Filter.All)
+  private val filter = new AtomicReference[PhaseFilter](PhaseFilter.All)
 
   /**
     * Active sort for the def / module tables. Written by the input thread,
@@ -580,9 +580,9 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
             quitLatch.countDown()
             return
           }
-        case 'f' | 'F' => filter.set(Filter.Frontend)
-        case 'b' | 'B' => filter.set(Filter.Backend)
-        case 'a' | 'A' => filter.set(Filter.All)
+        case 'f' | 'F' => filter.set(PhaseFilter.Frontend)
+        case 'b' | 'B' => filter.set(PhaseFilter.Backend)
+        case 'a' | 'A' => filter.set(PhaseFilter.All)
         case 't' | 'T' => sort.set(Sort.Time)
         case 'n' | 'N' => sort.set(Sort.Count)
         case 'h' | 'H' => sort.set(Sort.Hotness)
@@ -697,7 +697,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * Top dashboard line: current phase + progress bar + active-threads bar.
     * Both bars sit beside each other so the eye picks them up as a pair.
     */
-  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int, activeFilter: Filter, activeSort: Sort): Unit = {
+  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int, activeFilter: PhaseFilter, activeSort: Sort): Unit = {
     val isDone = completed.get()
     val phase = if (isDone) "done" else flix.getCurrentPhaseName.getOrElse("starting")
     // Once compilation has finished, force the bar to 100% rather than relying
@@ -738,14 +738,14 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * bold cyan when the filter is non-default. Always visible so the user
     * sees the available toggles whether the filter is active or not.
     */
-  private def renderFilterLegend(active: Filter): String = {
+  private def renderFilterLegend(active: PhaseFilter): String = {
     val sb = new StringBuilder
     sb.append(dim("["))
-    sb.append(if (active == Filter.All) bold(cyan("a")) else dim("a"))
+    sb.append(if (active == PhaseFilter.All) bold(cyan("a")) else dim("a"))
     sb.append(dim("|"))
-    sb.append(if (active == Filter.Frontend) bold(cyan("f")) else dim("f"))
+    sb.append(if (active == PhaseFilter.Frontend) bold(cyan("f")) else dim("f"))
     sb.append(dim("|"))
-    sb.append(if (active == Filter.Backend) bold(cyan("b")) else dim("b"))
+    sb.append(if (active == PhaseFilter.Backend) bold(cyan("b")) else dim("b"))
     sb.append(dim("]"))
     sb.toString
   }
@@ -775,8 +775,8 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     *
     * `loc` isn't per-phase and passes through unchanged.
     */
-  private def applyFilter(snap: Vector[DefnStats], f: Filter): Vector[DefnStats] = {
-    if (f == Filter.All) return snap
+  private def applyFilter(snap: Vector[DefnStats], f: PhaseFilter): Vector[DefnStats] = {
+    if (f == PhaseFilter.All) return snap
     snap.map { s =>
       val keptPhases = s.byPhase.filter { case (p, _) => matchesFilter(p, f) }
       val keptCounts = s.byPhaseCount.filter { case (p, _) => matchesFilter(p, f) }


### PR DESCRIPTION
## Summary

- **Interactive controls** during and after compilation: `f` / `b` / `a` filter the def and module tables by frontend-phase, backend-phase, or all time; `t` / `n` / `h` sort by total time, call count, or hotness (time per source line); `q` dismisses the TUI once compilation has finished.
- **TUI persists after compile completion** until the user presses `q`, with elapsed time, active threads, sparkline, and heap frozen at the moment of completion. The dashboard switches to a `done   press q to quit` indicator.
- **Visual polish**: warning thresholds extracted into 12 named constants (alphabetically sorted block); every warning column uses a uniform two-tier `plain → yellow → bold red` ladder (the bold-yellow middle tier in `time` was dropped); module rows render plain in their numeric columns since the def-calibrated thresholds trip unconditionally on sums-across-defs; refresh rate dropped to 5 FPS; `--threads 1` shows a `single-threaded` label instead of a flat sparkline and `0/1` (ForkJoinPool runs work inline on the submitter at parallelism=1, so `getActiveThreadCount` is meaningless).
- **Profiler enhancement**: `CompilerProfiler` now tracks per-phase call counts in addition to per-phase nanos, so the `n` column stays accurate under a frontend/backend filter rather than showing the unfiltered total. One extra `AtomicLong.incrementAndGet` per `track()` call — only paid when `--top` is enabled.

## Test plan

- [x] `./mill flix.run --top <file.flix>` — confirm the TUI persists after compile, `q` dismisses it cleanly, output below the TUI lands on a clean screen.
- [x] Press `f` / `b` / `a` mid-compile — tables retoggle and re-rank; legend `[a|f|b]` updates with active letter bold cyan.
- [x] Press `t` / `n` / `h` mid-compile — sort key changes; legend `[t|n|h]` reflects active key. Module table tracks the same key.
- [x] After compile finishes, all six keys still toggle; `q` quits.
- [x] `./mill flix.run --top --threads 1 <file.flix>` — threads section reads `single-threaded`, no flat sparkline.
- [x] `./mill flix.run <file.flix>` (no `--top`) — unchanged behavior, no profiler overhead.
- [x] `./mill flix.test.testForked "-oC"` — full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)