### PR TITLE
feat: --top mono / opt / cls counts and inline sort-key hints

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -29,7 +29,7 @@ import ca.uwaterloo.flix.tools.*
 import ca.uwaterloo.flix.tools.pkg.PackageModules
 import ca.uwaterloo.flix.util.*
 
-import java.io.{File, PrintStream}
+import java.io.{File, OutputStream, PrintStream}
 import java.net.BindException
 import java.nio.file.Paths
 
@@ -104,7 +104,12 @@ object Main {
     // check if command was passed.
     try {
       implicit val formatter: Formatter = Formatter.getDefault
-      implicit val out: PrintStream = System.err
+      // In --top mode the live TUI owns the screen; suppressing the Bootstrap
+      // status banner ("Found flix.toml…", dependency-resolution chatter)
+      // avoids it flashing under the TUI before the first repaint.
+      implicit val out: PrintStream =
+        if (cmdOpts.top) new PrintStream(OutputStream.nullOutputStream())
+        else System.err
 
       cmdOpts.command match {
         case Command.None =>

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -29,7 +29,7 @@ import ca.uwaterloo.flix.tools.*
 import ca.uwaterloo.flix.tools.pkg.PackageModules
 import ca.uwaterloo.flix.util.*
 
-import java.io.{File, OutputStream, PrintStream}
+import java.io.{File, PrintStream}
 import java.net.BindException
 import java.nio.file.Paths
 
@@ -104,12 +104,7 @@ object Main {
     // check if command was passed.
     try {
       implicit val formatter: Formatter = Formatter.getDefault
-      // In --top mode the live TUI owns the screen; suppressing the Bootstrap
-      // status banner ("Found flix.toml…", dependency-resolution chatter)
-      // avoids it flashing under the TUI before the first repaint.
-      implicit val out: PrintStream =
-        if (cmdOpts.top) new PrintStream(OutputStream.nullOutputStream())
-        else System.err
+      implicit val out: PrintStream = System.err
 
       cmdOpts.command match {
         case Command.None =>

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -164,8 +164,6 @@ object CompilerTop {
   // entries in order. Adjusting a number here is a UX call; please don't
   // bury it inside one of the styling functions.
 
-  private val CallCountRedThreshold:           Long   = 500L
-  private val CallCountYellowThreshold:        Long   = 50L
   private val HeapRedThresholdRatio:           Double = 0.9
   private val HeapYellowThresholdRatio:        Double = 0.7
   private val HotnessRedThresholdMsPerLine:    Double = 25.0
@@ -233,12 +231,6 @@ object CompilerTop {
     else green(formatted)
   }
 
-  /** Colors a formatted call-count field — high re-visit count. */
-  private def styleN(formatted: String, callCount: Long): String = {
-    if (callCount >= CallCountRedThreshold) bold(red(formatted))
-    else if (callCount >= CallCountYellowThreshold) yellow(formatted)
-    else formatted
-  }
 
   // -- Numeric helpers ----------------------------------------------------
 
@@ -258,8 +250,9 @@ object CompilerTop {
     * @param totalCallCount summed `track` call counts across the module's defs.
     * @param totalLocLines  summed source-line counts across the module's defs.
     * @param byPhase        phase → summed nanoseconds across the module's defs.
+    * @param byPhaseCount   phase → summed track-call counts across the module's defs.
     */
-  private final case class ModuleStats(module: String, totalNanos: Long, totalCallCount: Long, totalLocLines: Int, byPhase: Map[String, Long]) {
+  private final case class ModuleStats(module: String, totalNanos: Long, totalCallCount: Long, totalLocLines: Int, byPhase: Map[String, Long], byPhaseCount: Map[String, Long]) {
     /** Returns the phase that consumed the most time in this module, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
@@ -280,9 +273,25 @@ object CompilerTop {
           m.updated(phase, m.getOrElse(phase, 0L) + n)
         }
       }
-      ModuleStats(mod, totalNanos, totalCallCount, totalLocLines, byPhase)
+      val byPhaseCount = defs.foldLeft(Map.empty[String, Long]) { (acc, d) =>
+        d.byPhaseCount.foldLeft(acc) { case (m, (phase, n)) =>
+          m.updated(phase, m.getOrElse(phase, 0L) + n)
+        }
+      }
+      ModuleStats(mod, totalNanos, totalCallCount, totalLocLines, byPhase, byPhaseCount)
     }.toVector.sortBy(m => -moduleSortKey(m, srt))
   }
+
+  /** Phases whose `track` count maps to the `mono` column — number of monomorphic instances created. */
+  private val MonoCountPhases: Set[String] = Set("Monomorpher")
+  /** Phases whose `track` count maps to the `opt` column — optimizer fixed-point re-visits. */
+  private val OptCountPhases: Set[String] = Set("Optimizer", "LambdaDrop")
+  /** Phases whose `track` count maps to the `cls` column — class files emitted post-specialization. */
+  private val ClsCountPhases: Set[String] = Set("JvmBackend")
+
+  /** Sums `byPhaseCount` entries for the given phase set. */
+  private def sumPhaseCounts(byPhaseCount: Map[String, Long], phases: Set[String]): Long =
+    byPhaseCount.iterator.collect { case (p, n) if phases.contains(p) => n }.sum
 
   /**
     * Returns the descending sort key for a def under the given sort mode.
@@ -312,19 +321,19 @@ object CompilerTop {
 
   /**
     * Column layout for the per-frame table render. Computed from the current
-    * terminal width: when the terminal is narrow, the optional LOC / n /
+    * terminal width: when the terminal is narrow, the optional LOC / counts /
     * phase columns are dropped in that order (lowest-signal first). When the
     * terminal is wide, the surplus is distributed between the DefnSym and
     * location columns proportionally to their default widths.
     *
-    * @param symWidth   width of the DefnSym column.
-    * @param locWidth   width of the location column.
-    * @param showLOC    whether to render the LOC column.
-    * @param showN      whether to render the call-count (n) column.
-    * @param showPhase  whether to render the dominant-phase column.
-    * @param totalWidth total rendered width of the row, less leading/trailing pad.
+    * @param symWidth    width of the DefnSym column.
+    * @param locWidth    width of the location column.
+    * @param showLOC     whether to render the LOC column.
+    * @param showCounts  whether to render the mono / opt / cls per-phase count columns.
+    * @param showPhase   whether to render the dominant-phase column.
+    * @param totalWidth  total rendered width of the row, less leading/trailing pad.
     */
-  private final case class Layout(symWidth: Int, locWidth: Int, showLOC: Boolean, showN: Boolean, showPhase: Boolean, totalWidth: Int)
+  private final case class Layout(symWidth: Int, locWidth: Int, showLOC: Boolean, showCounts: Boolean, showPhase: Boolean, totalWidth: Int)
 
   /** Default width of the DefnSym column when the terminal is wide enough. */
   private val DefaultSymWidth: Int = 24
@@ -340,8 +349,8 @@ object CompilerTop {
 
   /** Width contribution of the optional LOC column (separator + width). */
   private val LocColWidth: Int = 1 + 4
-  /** Width contribution of the optional call-count column (separator + width). */
-  private val NColWidth: Int = 1 + 4
+  /** Width contribution of the optional mono / opt / cls per-phase count columns (3 × separator + width). */
+  private val CountsColWidth: Int = 3 * (1 + 4)
   /** Width contribution of the optional dominant-phase column (separator + width). */
   private val PhaseColWidth: Int = 1 + 10
 
@@ -353,7 +362,7 @@ object CompilerTop {
     def textWidth(symW: Int, locW: Int): Int = symW + 1 + locW
 
     // Try tiers in descending feature order.
-    val full = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + NColWidth + PhaseColWidth + tail
+    val full = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + CountsColWidth + PhaseColWidth + tail
     if (cols >= full) {
       // Surplus → expand sym (~46%) and location (~54%) proportionally.
       val extra = cols - full
@@ -361,30 +370,30 @@ object CompilerTop {
       val extraLoc = extra - extraSym
       val symW = DefaultSymWidth + extraSym
       val locW = DefaultLocWidth + extraLoc
-      return Layout(symW, locW, showLOC = true, showN = true, showPhase = true,
-        totalWidth = textWidth(symW, locW) + LocColWidth + NColWidth + PhaseColWidth + tail)
+      return Layout(symW, locW, showLOC = true, showCounts = true, showPhase = true,
+        totalWidth = textWidth(symW, locW) + LocColWidth + CountsColWidth + PhaseColWidth + tail)
     }
 
     // Tier: drop phase.
-    val noPhase = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + NColWidth + tail
+    val noPhase = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + CountsColWidth + tail
     if (cols >= noPhase)
-      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showN = true, showPhase = false, noPhase)
+      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showCounts = true, showPhase = false, noPhase)
 
-    // Tier: drop phase + n.
-    val noPhaseNoN = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + tail
-    if (cols >= noPhaseNoN)
-      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showN = false, showPhase = false, noPhaseNoN)
+    // Tier: drop phase + counts.
+    val noPhaseNoCounts = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + tail
+    if (cols >= noPhaseNoCounts)
+      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = true, showCounts = false, showPhase = false, noPhaseNoCounts)
 
-    // Tier: drop phase + n + LOC.
+    // Tier: drop phase + counts + LOC.
     val noOptional = textWidth(DefaultSymWidth, DefaultLocWidth) + tail
     if (cols >= noOptional)
-      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = false, showN = false, showPhase = false, noOptional)
+      return Layout(DefaultSymWidth, DefaultLocWidth, showLOC = false, showCounts = false, showPhase = false, noOptional)
 
     // Even minimum tier doesn't fit; shrink sym/locWidth to floors.
     val available = (cols - tail).max(MinSymWidth + 1 + MinLocWidth)
     val symW = MinSymWidth.max(available * 46 / 100)
     val locW = MinLocWidth.max(available - 1 - symW)
-    Layout(symW, locW, showLOC = false, showN = false, showPhase = false,
+    Layout(symW, locW, showLOC = false, showCounts = false, showPhase = false,
       textWidth(symW, locW) + tail)
   }
 
@@ -842,7 +851,11 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(' ')
     sb.append(secondCol)
     if (layout.showLOC) { sb.append(' '); sb.append(lpad("LOC", 4)) }
-    if (layout.showN) { sb.append(' '); sb.append(lpad("n", 4)) }
+    if (layout.showCounts) {
+      sb.append(' '); sb.append(lpad("mono", 4))
+      sb.append(' '); sb.append(lpad("opt", 4))
+      sb.append(' '); sb.append(lpad("cls", 4))
+    }
     if (layout.showPhase) { sb.append(' '); sb.append(rpad("phase", 10)) }
     sb.append(' '); sb.append(lpad("time", 9))
     sb.append(' '); sb.append(lpad("%cpu", 6))
@@ -880,7 +893,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
       sb.append(" " * (nameMax - nameText.length))
       sb.append(' ')
       sb.append(dim(locField))
-      appendNumericFields(sb, locLines, s.callCount.toLong, phase, s.totalNanos, pctCpu, pctWall, layout, aggregate = false)
+      appendNumericFields(sb, locLines, s.byPhaseCount, phase, s.totalNanos, pctCpu, pctWall, layout, aggregate = false)
       sb.append(' ')
       sb.append('\n')
     }
@@ -912,7 +925,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
 
       sb.append(' ')
       sb.append(modField)
-      appendNumericFields(sb, m.totalLocLines, m.totalCallCount, phase, m.totalNanos, pctCpu, pctWall, layout, aggregate = true)
+      appendNumericFields(sb, m.totalLocLines, m.byPhaseCount, phase, m.totalNanos, pctCpu, pctWall, layout, aggregate = true)
       sb.append(' ')
       sb.append('\n')
     }
@@ -923,7 +936,11 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     val sb = new StringBuilder
     sb.append(firstCol)
     if (layout.showLOC) { sb.append(' '); sb.append(lpad("LOC", 4)) }
-    if (layout.showN) { sb.append(' '); sb.append(lpad("n", 4)) }
+    if (layout.showCounts) {
+      sb.append(' '); sb.append(lpad("mono", 4))
+      sb.append(' '); sb.append(lpad("opt", 4))
+      sb.append(' '); sb.append(lpad("cls", 4))
+    }
     if (layout.showPhase) { sb.append(' '); sb.append(rpad("phase", 10)) }
     sb.append(' '); sb.append(lpad("time", 9))
     sb.append(' '); sb.append(lpad("%cpu", 6))
@@ -932,16 +949,17 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
   }
 
   /**
-    * Appends the trailing numeric columns (LOC, n, phase, time, %cpu, %wall)
-    * to a row, honoring the layout's visibility flags. Always emits a leading
-    * separator before each column it writes.
+    * Appends the trailing numeric columns (LOC, mono / opt / cls, phase,
+    * time, %cpu, %wall) to a row, honoring the layout's visibility flags.
+    * Always emits a leading separator before each column it writes.
     *
-    * `aggregate` skips all warning colors. The `style*` thresholds are
-    * calibrated for individual defs; at module scale, sums-across-defs
-    * would trip the thresholds unconditionally and the colors become
-    * noise rather than signal.
+    * `aggregate` skips all warning colors on `time` / `%cpu` / `%wall`. The
+    * `style*` thresholds are calibrated for individual defs; at module
+    * scale, sums-across-defs trip the thresholds unconditionally and the
+    * colors become noise. Counts (mono / opt / cls) render plain in both
+    * tables.
     */
-  private def appendNumericFields(sb: StringBuilder, locLines: Int, callCount: Long, phase: String,
+  private def appendNumericFields(sb: StringBuilder, locLines: Int, byPhaseCount: Map[String, Long], phase: String,
                                    nanos: Long, pctCpu: Double, pctWall: Double, layout: Layout,
                                    aggregate: Boolean): Unit = {
     if (layout.showLOC) {
@@ -949,10 +967,13 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
       val locStr = if (locLines > 0) locLines.toString else "-"
       sb.append(lpad(locStr, 4))
     }
-    if (layout.showN) {
-      sb.append(' ')
-      val padded = lpad(callCount.toString, 4)
-      sb.append(if (aggregate) padded else styleN(padded, callCount))
+    if (layout.showCounts) {
+      val mono = sumPhaseCounts(byPhaseCount, MonoCountPhases)
+      val opt  = sumPhaseCounts(byPhaseCount, OptCountPhases)
+      val cls  = sumPhaseCounts(byPhaseCount, ClsCountPhases)
+      sb.append(' '); sb.append(lpad(mono.toString, 4))
+      sb.append(' '); sb.append(lpad(opt.toString, 4))
+      sb.append(' '); sb.append(lpad(cls.toString, 4))
     }
     if (layout.showPhase) {
       sb.append(' ')

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -70,10 +70,14 @@ object CompilerTop {
   object Sort {
     /** Slowest defs first. The default. */
     case object Time extends Sort
-    /** Most-revisited defs first (monomorph explosions, inliner re-entry). */
-    case object Count extends Sort
     /** Hottest-per-line defs first — small defs that burn disproportionate time. */
     case object Hotness extends Sort
+    /** Most monomorphic instances first — surfaces generic-explosion hotspots. */
+    case object Mono extends Sort
+    /** Most optimizer fixed-point re-visits first — surfaces inliner / occurrence-analyzer thrashing. */
+    case object Opt extends Sort
+    /** Most class files emitted first — surfaces JVM fan-out from polymorphism / closures. */
+    case object Cls extends Sort
   }
 
   /** How often the screen refreshes, in milliseconds (5 FPS). */
@@ -129,6 +133,10 @@ object CompilerTop {
   private val BoldCode: String = s"$ESC[1m"
   /** ANSI dim/faint. */
   private val DimCode: String = s"$ESC[2m"
+  /** ANSI underline on (paired with [[NoUnderlineCode]] — surgical, leaves bold/color intact). */
+  private val UnderlineCode: String = s"$ESC[4m"
+  /** ANSI underline off; cancels [[UnderlineCode]] without disturbing bold/color. */
+  private val NoUnderlineCode: String = s"$ESC[24m"
   /** ANSI foreground red. */
   private val Red: String = s"$ESC[31m"
   /** ANSI foreground green. */
@@ -156,6 +164,25 @@ object CompilerTop {
   private def green(s: String): String = color(s, Green)
   /** Wraps `s` in ANSI cyan codes. */
   private def cyan(s: String): String = color(s, Cyan)
+
+  /**
+    * Renders a column header with one keystroke letter underlined. Active
+    * sort columns are bold yellow; the rest are bold cyan. The label string
+    * is taken as-is (already padded by the caller) and the keystroke
+    * position is given as a 0-based index into it. Visible width is
+    * unchanged — only ANSI codes are inserted around the keystroke char.
+    */
+  private def keyHeader(paddedLabel: String, keyIdx: Int, active: Boolean): String = {
+    val c = if (active) Yellow else Cyan
+    val before = paddedLabel.take(keyIdx)
+    val key = paddedLabel.slice(keyIdx, keyIdx + 1)
+    val after = paddedLabel.drop(keyIdx + 1)
+    s"$BoldCode$c$before$UnderlineCode$key$NoUnderlineCode$after$Reset"
+  }
+
+  /** Renders a non-sort column header (no underlined keystroke) in bold cyan. */
+  private def plainHeader(paddedLabel: String): String =
+    s"$BoldCode$Cyan$paddedLabel$Reset"
 
   // -- Warning thresholds --------------------------------------------------
   //
@@ -300,17 +327,21 @@ object CompilerTop {
     */
   private def defSortKey(s: DefnStats, srt: Sort): Double = srt match {
     case Sort.Time    => s.totalNanos.toDouble
-    case Sort.Count   => s.callCount.toDouble
     case Sort.Hotness =>
       val lines = locLineCount(s.loc)
       if (lines <= 0) 0.0 else s.totalNanos.toDouble / lines
+    case Sort.Mono => sumPhaseCounts(s.byPhaseCount, MonoCountPhases).toDouble
+    case Sort.Opt  => sumPhaseCounts(s.byPhaseCount, OptCountPhases).toDouble
+    case Sort.Cls  => sumPhaseCounts(s.byPhaseCount, ClsCountPhases).toDouble
   }
 
   /** Module-level analogue of [[defSortKey]], applied after summing across each module's defs. */
   private def moduleSortKey(m: ModuleStats, srt: Sort): Double = srt match {
     case Sort.Time    => m.totalNanos.toDouble
-    case Sort.Count   => m.totalCallCount.toDouble
     case Sort.Hotness => if (m.totalLocLines <= 0) 0.0 else m.totalNanos.toDouble / m.totalLocLines
+    case Sort.Mono => sumPhaseCounts(m.byPhaseCount, MonoCountPhases).toDouble
+    case Sort.Opt  => sumPhaseCounts(m.byPhaseCount, OptCountPhases).toDouble
+    case Sort.Cls  => sumPhaseCounts(m.byPhaseCount, ClsCountPhases).toDouble
   }
 
   /** Fallback terminal height when JLine cannot determine the real one. */
@@ -593,8 +624,10 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
         case 'b' | 'B' => filter.set(PhaseFilter.Backend)
         case 'a' | 'A' => filter.set(PhaseFilter.All)
         case 't' | 'T' => sort.set(Sort.Time)
-        case 'n' | 'N' => sort.set(Sort.Count)
         case 'h' | 'H' => sort.set(Sort.Hotness)
+        case 'm' | 'M' => sort.set(Sort.Mono)
+        case 'o' | 'O' => sort.set(Sort.Opt)
+        case 'c' | 'C' => sort.set(Sort.Cls)
         case _         => // ignored
       }
     }
@@ -689,12 +722,12 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(ClearScreen)
     sb.append('\n')
 
-    renderDashboard(sb, activeThreads, parallelism, activeFilter, activeSort)
+    renderDashboard(sb, activeThreads, parallelism, activeFilter)
     renderStats(sb, elapsed)
     sb.append('\n')
-    renderTableHeader(sb, layout)
+    renderTableHeader(sb, layout, activeSort)
     renderRows(sb, visible, elapsed, parallelism, layout)
-    renderModuleTable(sb, modules, elapsed, parallelism, layout)
+    renderModuleTable(sb, modules, elapsed, parallelism, layout, activeSort)
 
     sb.append(EndSync)
     System.out.print(sb)
@@ -706,7 +739,7 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     * Top dashboard line: current phase + progress bar + active-threads bar.
     * Both bars sit beside each other so the eye picks them up as a pair.
     */
-  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int, activeFilter: PhaseFilter, activeSort: Sort): Unit = {
+  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int, activeFilter: PhaseFilter): Unit = {
     val isDone = completed.get()
     val phase = if (isDone) "done" else flix.getCurrentPhaseName.getOrElse("starting")
     // Once compilation has finished, force the bar to 100% rather than relying
@@ -736,8 +769,6 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     }
     sb.append("   ")
     sb.append(renderFilterLegend(activeFilter))
-    sb.append(' ')
-    sb.append(renderSortLegend(activeSort))
     if (isDone) sb.append(dim("   press q to quit"))
     sb.append('\n')
   }
@@ -755,22 +786,6 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     sb.append(if (active == PhaseFilter.Frontend) bold(cyan("f")) else dim("f"))
     sb.append(dim("|"))
     sb.append(if (active == PhaseFilter.Backend) bold(cyan("b")) else dim("b"))
-    sb.append(dim("]"))
-    sb.toString
-  }
-
-  /**
-    * Renders the `[t|n|h]` sort-key legend with the active letter highlighted
-    * in bold cyan. `t` = time, `n` = call count, `h` = hotness (time/LOC).
-    */
-  private def renderSortLegend(active: Sort): String = {
-    val sb = new StringBuilder
-    sb.append(dim("["))
-    sb.append(if (active == Sort.Time) bold(cyan("t")) else dim("t"))
-    sb.append(dim("|"))
-    sb.append(if (active == Sort.Count) bold(cyan("n")) else dim("n"))
-    sb.append(dim("|"))
-    sb.append(if (active == Sort.Hotness) bold(cyan("h")) else dim("h"))
     sb.append(dim("]"))
     sb.toString
   }
@@ -828,38 +843,47 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
   }
 
   /** Renders the def-table column header and the divider underneath it. */
-  private def renderTableHeader(sb: StringBuilder, layout: Layout): Unit = {
-    val header = buildHeader(rpad("Def", layout.symWidth), rpad("location", layout.locWidth), layout)
+  private def renderTableHeader(sb: StringBuilder, layout: Layout, activeSort: Sort): Unit = {
     sb.append(' ')
-    sb.append(bold(cyan(header)))
+    sb.append(buildHeader(layout, activeSort))
     sb.append(' ')
     sb.append('\n')
     sb.append(' ')
-    sb.append(dim("─" * header.length))
+    sb.append(dim("─" * layout.totalWidth))
     sb.append(' ')
     sb.append('\n')
   }
 
   /**
-    * Builds a table header (or any row's left side) given the formatted text
-    * for the first two columns. Numeric columns are conditionally appended
-    * per the layout's visibility flags.
+    * Builds the def-table header. Each sortable column underlines its
+    * keystroke letter (`m̲ono`, `o̲pt`, `c̲ls`, `t̲ime`) and the Def header
+    * carries a tiny `(h̲ot)` annotation marking the hotness sort key.
+    * The active column is rendered bold yellow; the rest bold cyan.
     */
-  private def buildHeader(firstCol: String, secondCol: String, layout: Layout): String = {
+  private def buildHeader(layout: Layout, activeSort: Sort): String = {
     val sb = new StringBuilder
-    sb.append(firstCol)
+
+    // First column: "Def (hot)" — the 'h' (index 5) is the hotness keystroke.
+    val defPadded = rpad("Def (hot)", layout.symWidth)
+    sb.append(keyHeader(defPadded, 5, activeSort == Sort.Hotness))
+
     sb.append(' ')
-    sb.append(secondCol)
-    if (layout.showLOC) { sb.append(' '); sb.append(lpad("LOC", 4)) }
-    if (layout.showCounts) {
-      sb.append(' '); sb.append(lpad("mono", 4))
-      sb.append(' '); sb.append(lpad("opt", 4))
-      sb.append(' '); sb.append(lpad("cls", 4))
+    sb.append(plainHeader(rpad("location", layout.locWidth)))
+
+    if (layout.showLOC) {
+      sb.append(' '); sb.append(plainHeader(lpad("LOC", 4)))
     }
-    if (layout.showPhase) { sb.append(' '); sb.append(rpad("phase", 10)) }
-    sb.append(' '); sb.append(lpad("time", 9))
-    sb.append(' '); sb.append(lpad("%cpu", 6))
-    sb.append(' '); sb.append(lpad("%wall", 6))
+    if (layout.showCounts) {
+      val monoP = lpad("mono", 4); sb.append(' '); sb.append(keyHeader(monoP, monoP.indexOf('m'), activeSort == Sort.Mono))
+      val optP  = lpad("opt", 4);  sb.append(' '); sb.append(keyHeader(optP,  optP.indexOf('o'),  activeSort == Sort.Opt))
+      val clsP  = lpad("cls", 4);  sb.append(' '); sb.append(keyHeader(clsP,  clsP.indexOf('c'),  activeSort == Sort.Cls))
+    }
+    if (layout.showPhase) {
+      sb.append(' '); sb.append(plainHeader(rpad("phase", 10)))
+    }
+    val timeP = lpad("time", 9); sb.append(' '); sb.append(keyHeader(timeP, timeP.indexOf('t'), activeSort == Sort.Time))
+    sb.append(' '); sb.append(plainHeader(lpad("%cpu", 6)))
+    sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
     sb.toString
   }
 
@@ -900,18 +924,17 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
   }
 
   /** Renders the per-module aggregate table below the def table; no-op if `modules` is empty. */
-  private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int, layout: Layout): Unit = {
+  private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int, layout: Layout, activeSort: Sort): Unit = {
     if (modules.isEmpty) return
 
     sb.append('\n')
     val modWidth = layout.symWidth + 1 + layout.locWidth
-    val header = buildModuleHeader(rpad("Module", modWidth), layout)
     sb.append(' ')
-    sb.append(bold(cyan(header)))
+    sb.append(buildModuleHeader(layout, activeSort))
     sb.append(' ')
     sb.append('\n')
     sb.append(' ')
-    sb.append(dim("─" * header.length))
+    sb.append(dim("─" * layout.totalWidth))
     sb.append(' ')
     sb.append('\n')
 
@@ -931,20 +954,33 @@ final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
     }
   }
 
-  /** Module-table header: single wide first column, then the same numeric columns as the def table. */
-  private def buildModuleHeader(firstCol: String, layout: Layout): String = {
+  /**
+    * Module-table header: single wide first column, then the same numeric
+    * columns as the def table. Mirrors [[buildHeader]]'s underline / active
+    * styling so the same sort keys are discoverable in both tables.
+    */
+  private def buildModuleHeader(layout: Layout, activeSort: Sort): String = {
     val sb = new StringBuilder
-    sb.append(firstCol)
-    if (layout.showLOC) { sb.append(' '); sb.append(lpad("LOC", 4)) }
-    if (layout.showCounts) {
-      sb.append(' '); sb.append(lpad("mono", 4))
-      sb.append(' '); sb.append(lpad("opt", 4))
-      sb.append(' '); sb.append(lpad("cls", 4))
+    val modWidth = layout.symWidth + 1 + layout.locWidth
+
+    // First column: "Module (hot)" — the 'h' (index 8) is the hotness keystroke.
+    val modPadded = rpad("Module (hot)", modWidth)
+    sb.append(keyHeader(modPadded, 8, activeSort == Sort.Hotness))
+
+    if (layout.showLOC) {
+      sb.append(' '); sb.append(plainHeader(lpad("LOC", 4)))
     }
-    if (layout.showPhase) { sb.append(' '); sb.append(rpad("phase", 10)) }
-    sb.append(' '); sb.append(lpad("time", 9))
-    sb.append(' '); sb.append(lpad("%cpu", 6))
-    sb.append(' '); sb.append(lpad("%wall", 6))
+    if (layout.showCounts) {
+      val monoP = lpad("mono", 4); sb.append(' '); sb.append(keyHeader(monoP, monoP.indexOf('m'), activeSort == Sort.Mono))
+      val optP  = lpad("opt", 4);  sb.append(' '); sb.append(keyHeader(optP,  optP.indexOf('o'),  activeSort == Sort.Opt))
+      val clsP  = lpad("cls", 4);  sb.append(' '); sb.append(keyHeader(clsP,  clsP.indexOf('c'),  activeSort == Sort.Cls))
+    }
+    if (layout.showPhase) {
+      sb.append(' '); sb.append(plainHeader(rpad("phase", 10)))
+    }
+    val timeP = lpad("time", 9); sb.append(' '); sb.append(keyHeader(timeP, timeP.indexOf('t'), activeSort == Sort.Time))
+    sb.append(' '); sb.append(plainHeader(lpad("%cpu", 6)))
+    sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
     sb.toString
   }
 


### PR DESCRIPTION
## Summary

- **Replace the `n` column with three per-phase counters**: `mono` (Specialization hits — monomorphic instances created), `opt` (Optimizer + LambdaDrop revisits — inliner / occurrence-analyzer thrashing), `cls` (JvmBackend hits — class files emitted post-specialization). Each surfaces a different cost driver that the single `n` column collapsed together.
- **Three new sort keys** mapped to those columns: press `m`, `o`, or `c` to sort by mono / opt / cls. The old `n` sort key is removed; `t` (time) and `h` (hotness) remain.
- **Inline sort-key hints in the column headers** — each sortable header underlines its keystroke letter (`m̲ono`, `o̲pt`, `c̲ls`, `t̲ime`) and the Def / Module headers gain a small `(h̲ot)` annotation. The active sort renders bold yellow; the rest bold cyan. The standalone `[t|n|h]` legend is gone; the `[a|f|b]` filter legend stays.

## Test plan

- [ ] `./mill flix.run --top <file.flix>` — confirm `mono / opt / cls` columns replace `n`, headers show the underlined keystroke letters, and the active sort is bold yellow.
- [ ] Press `t` / `h` / `m` / `o` / `c` mid-compile — the table re-ranks and the active column flips to bold yellow.
- [ ] `./mill flix.test.testForked "-oC"` — full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)