### PR TITLE
refactor: simplify Reducible.takeWhile and dropWhile

### DIFF
--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -209,25 +209,21 @@ pub mod Reducible {
         /// Returns `t` as a list without the longest prefix that satisfies the predicate `f`.
         ///
         pub def dropWhile(f: a -> Bool \ ef, t: t[a]): List[a] \ ef =
-            (Reducible.foldLeft((acc, a) -> {
-                let (c, k) = acc;
-                if (c and f(a))
-                    (true, k)
-                else
-                    (false, ks -> k(a :: ks))
-            }, (true, identity), t) |> snd)(Nil)
+            Reducible.foldLeft((acc, a) -> {
+                let (c, xs) = acc;
+                if (c and f(a)) (true, xs)
+                else            (false, a :: xs)
+            }, (true, Nil), t) |> snd |> List.reverse
 
         ///
         /// Returns the longest prefix of `t` as a list that satisfies the predicate `f`.
         ///
         pub def takeWhile(f: a -> Bool \ ef, t: t[a]): List[a] \ ef =
-            (Reducible.foldLeft((acc, a) -> {
-                let (c, k) = acc;
-                if (c and f(a))
-                    (true, ks -> k(a :: ks))
-                else
-                    (false, k)
-            }, (true, identity), t) |> snd)(Nil)
+            Reducible.foldLeft((acc, a) -> {
+                let (c, xs) = acc;
+                if (c and f(a)) (true, a :: xs)
+                else            (false, xs)
+            }, (true, Nil), t) |> snd |> List.reverse
 
         ///
         /// Returns `t` as a list with `a` inserted between every two adjacent elements.

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -209,21 +209,23 @@ pub mod Reducible {
         /// Returns `t` as a list without the longest prefix that satisfies the predicate `f`.
         ///
         pub def dropWhile(f: a -> Bool \ ef, t: t[a]): List[a] \ ef =
-            Reducible.foldLeft((acc, a) -> {
+            def step(acc, a) = {
                 let (c, xs) = acc;
                 if (c and f(a)) (true, xs)
                 else            (false, a :: xs)
-            }, (true, Nil), t) |> snd |> List.reverse
+            };
+            Reducible.foldLeft(step, (true, Nil), t) |> snd |> List.reverse
 
         ///
         /// Returns the longest prefix of `t` as a list that satisfies the predicate `f`.
         ///
         pub def takeWhile(f: a -> Bool \ ef, t: t[a]): List[a] \ ef =
-            Reducible.foldLeft((acc, a) -> {
+            def step(acc, a) = {
                 let (c, xs) = acc;
                 if (c and f(a)) (true, a :: xs)
                 else            (false, xs)
-            }, (true, Nil), t) |> snd |> List.reverse
+            };
+            Reducible.foldLeft(step, (true, Nil), t) |> snd |> List.reverse
 
         ///
         /// Returns `t` as a list with `a` inserted between every two adjacent elements.


### PR DESCRIPTION
## Summary
- Drop the CPS continuation accumulator in `Reducible.takeWhile` and `Reducible.dropWhile` in favour of a reversed `List[a]` accumulator + a final `List.reverse`.
- Short-circuiting on the predicate is preserved via `c and f(a)`, so effect order and the set of elements `f` is applied to are unchanged.

## Test plan
- [x] `touch out/empty.flix && ./mill flix.run out/empty.flix` (stdlib compiles)
- [x] `./mill flix.test.testOnly ca.uwaterloo.flix.StandardLibrarySuite` — all 14 `TestReducible.takeWhile*`/`dropWhile*` cases pass; 13,800 succeeded, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)