### PR TITLE
refactor: remove Result.tryCatch in favor of inline try/catch

### DIFF
--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -622,13 +622,12 @@ pub mod Regex {
     /// The internal state of the matcher is updated.
     ///
     def findFrom(pos: Int32, m: Matcher[r]): Bool \ r =
-        Result.tryCatch(
-            _ -> {
-                let Matcher(m1) = m;
-                unsafe IO as r { m1.find(pos) }
-            }
-        )
-            |> Result.getWithDefault(false)
+        try {
+            let Matcher(m1) = m;
+            unsafe IO as r { m1.find(pos) }
+        } catch {
+            case _: Exception => false
+        }
 
     ///
     /// Attempt to find the last match by iterating through the input string.
@@ -663,34 +662,35 @@ pub mod Regex {
     /// Set the bounds of the matcher's region.
     ///
     def setBounds(start: {start = Int32}, end: {end = Int32}, m: Matcher[r]): Result[String, Unit] \ r =
-        Result.tryCatch(
-            _ -> {
-                let Matcher(m1) = m;
-                unsafe IO as r { discard m1.$region(start#start, end#end) }
-            }
-        )
+        try {
+            let Matcher(m1) = m;
+            unsafe IO as r { discard m1.$region(start#start, end#end) };
+            Ok(())
+        } catch {
+            case e: Exception => Err(e.getMessage())
+        }
 
     ///
     /// Return the start position of the current match of Matcher `m`.
     ///
     def matcherStart(m: Matcher[r]): Result[String, Int32] \ r =
-        Result.tryCatch(
-            _ -> {
-                let Matcher(m1) = m;
-                unsafe IO as r { m1.start() }
-            }
-        )
+        try {
+            let Matcher(m1) = m;
+            Ok(unsafe IO as r { m1.start() })
+        } catch {
+            case e: Exception => Err(e.getMessage())
+        }
 
     ///
     /// Return the end position of the current match of Matcher `m`.
     ///
     def matcherEnd(m: Matcher[r]): Result[String, Int32] \ r =
-        Result.tryCatch(
-            _ -> {
-                let Matcher(m1) = m;
-                unsafe IO as r { m1.end() }
-            }
-        )
+        try {
+            let Matcher(m1) = m;
+            Ok(unsafe IO as r { m1.end() })
+        } catch {
+            case e: Exception => Err(e.getMessage())
+        }
 
     ///
     /// Return the start and end positions of the matcher `m`.
@@ -705,23 +705,23 @@ pub mod Regex {
     /// Return the text content of the current match of matcher `m`.
     ///
     def matcherContent(m: Matcher[r]): Result[String, String] \ r =
-        Result.tryCatch(
-            _ -> {
-                let Matcher(m1) = m;
-                unsafe IO as r { m1.group() }
-            }
-        )
+        try {
+            let Matcher(m1) = m;
+            Ok(unsafe IO as r { m1.group() })
+        } catch {
+            case e: Exception => Err(e.getMessage())
+        }
 
     ///
     /// Return the text content of the current groups in matcher `m`.
     ///
     def matcherGroup(m: Matcher[r], i: Int32): Result[String, String] \ r =
-        Result.tryCatch(
-            _ -> {
-                let Matcher(m1) = m;
-                unsafe IO as r { if (not Object.isNull(m1.group(i))) m1.group(i) else "" }
-            }
-        )
+        try {
+            let Matcher(m1) = m;
+            Ok(unsafe IO as r { if (not Object.isNull(m1.group(i))) m1.group(i) else "" })
+        } catch {
+            case e: Exception => Err(e.getMessage())
+        }
 
     ///
     /// Return the number of groups in matcher `m`.

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -16,8 +16,6 @@
 
 pub mod Result {
 
-    import java.lang.Exception
-
     ///
     /// The Result type.
     ///
@@ -434,18 +432,5 @@ pub mod Result {
         case Err(_) => Iterator.empty(rc)
         case Ok(x)  => Iterator.singleton(rc, x)
     }
-
-    ///
-    /// Returns `Ok(x)` if `f` was invoked without throwing an exception.
-    ///
-    /// If `f` throws a Java `Exception`, `Err(e)` is returned
-    /// where `e` is the error message.
-    ///
-    pub def tryCatch(f: Unit -> a \ ef): Result[String, a] \ ef =
-        try {
-            Ok(f())
-        } catch {
-            case e: Exception => Err(e.getMessage())
-        }
 
 }

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -16,6 +16,7 @@
 
 pub mod String {
 
+    import java.lang.Exception
     import java.lang.System
     import java.lang.{String => JString}
     import java.nio.charset.StandardCharsets
@@ -178,9 +179,11 @@ pub mod String {
     /// Regex literals are checked at compile time.
     ///
     pub def toRegex(regex: String): Result[String, Regex] =
-        Result.tryCatch(_ -> {
-            Pattern.compile(regex)
-        })
+        try {
+            Ok(Pattern.compile(regex))
+        } catch {
+            case e: Exception => Err(e.getMessage())
+        }
 
 
     ///
@@ -193,9 +196,11 @@ pub mod String {
     /// `java.util.regex.Pattern` for guidance on enabling flags with embedded flag expressions.
     ///
     pub def toRegexWithFlags(flags: Set[Flag], regex: String): Result[String, Regex] =
-        Result.tryCatch(_ -> {
-            Pattern.compile(regex, Regex.sumFlags(flags))
-        })
+        try {
+            Ok(Pattern.compile(regex, Regex.sumFlags(flags)))
+        } catch {
+            case e: Exception => Err(e.getMessage())
+        }
 
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -833,17 +833,4 @@ mod TestResult {
         assertEq(expected = (1 :: 2 :: 3 :: Nil) :: Nil, Ok(1 :: 2 :: 3 :: Nil) |> Result.iterator(rc) |> Iterator.toList)
     }
 
-    /////////////////////////////////////////////////////////////////////////////
-    // tryCatch                                                                //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @Test
-    def tryCatch01(): Unit \ Assert = assertEq(expected = Ok(1), Result.tryCatch(_ -> 1 / 1))
-
-    @Test
-    def tryCatch02(): Unit \ Assert = region rc {
-        let arr = Array#{0} @ rc;
-        assertEq(expected = true, Result.tryCatch(_ -> Array.get(10, arr)) |> Result.isErr)
-    }
-
 }


### PR DESCRIPTION
## Summary
- Inlined `try { Ok(...) } catch { case e: Exception => Err(e.getMessage()) }` at all 8 call sites (6 in `Regex.flix`, 2 in `String.flix`) and deleted `Result.tryCatch`.
- `Regex.findFrom` previously wrapped a `Bool` in `Result` only to strip it via `Result.getWithDefault(false)`; it now returns `Bool` directly.
- Removed the dedicated `tryCatch01` / `tryCatch02` tests in `TestResult.flix`; behavior is still exercised by `TestRegex` / `TestString`.

## Test plan
- [x] `./mill flix.run out/empty.flix` (stdlib compiles)
- [x] `./mill flix.test.testForked "-oC"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)