### PR TITLE
refactor: narrow Exception/Throwable catches in stdlib

### DIFF
--- a/main/src/library/CodePoint.flix
+++ b/main/src/library/CodePoint.flix
@@ -24,8 +24,7 @@
 pub mod CodePoint {
 
     import java.lang.Character
-    import java.lang.Exception
-    import java.lang.Throwable
+    import java.lang.IllegalArgumentException
 
     ///
     /// Returns the minimum integer value of a Unicode code point.
@@ -196,7 +195,7 @@ pub mod CodePoint {
         try {
             Character.getName(cp) |> Object.toOption
         } catch {
-            case _: Exception => None
+            case _: IllegalArgumentException => None
         }
 
     ///
@@ -236,7 +235,7 @@ pub mod CodePoint {
             Array.toVector(arr) |> Vector.takeLeft(size) |> Some
         }
     } catch {
-        case _: Throwable => None
+        case _: IllegalArgumentException => None
     }
 
     ///
@@ -253,7 +252,7 @@ pub mod CodePoint {
                 None
         }
     } catch {
-        case _: Exception => None
+        case _: IllegalArgumentException => None
     }
 
     ///
@@ -270,7 +269,7 @@ pub mod CodePoint {
                 None
         }
     } catch {
-        case _: Exception => None
+        case _: IllegalArgumentException => None
     }
 
     ///
@@ -280,7 +279,7 @@ pub mod CodePoint {
         try {
             Character.toString(cp)
         } catch {
-            case _: Exception => ""
+            case _: IllegalArgumentException => ""
         }
 
     ///

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -32,8 +32,10 @@
 pub mod Regex {
 
     import java.util.regex.Pattern
+    import java.util.regex.PatternSyntaxException
     import java.util.regex.{Matcher => JMatcher}
-    import java.lang.Exception
+    import java.lang.IllegalStateException
+    import java.lang.IndexOutOfBoundsException
 
     use Regex.Flag
     use Regex.Flag.{
@@ -119,7 +121,7 @@ pub mod Regex {
         try {
             Pattern.compile("^\\b$")
         } catch {
-            case _: Exception => unreachable!()
+            case _: PatternSyntaxException => unreachable!()
         }
 
     ///
@@ -626,7 +628,7 @@ pub mod Regex {
             let Matcher(m1) = m;
             unsafe IO as r { m1.find(pos) }
         } catch {
-            case _: Exception => false
+            case _: IndexOutOfBoundsException => false
         }
 
     ///
@@ -667,7 +669,7 @@ pub mod Regex {
             unsafe IO as r { discard m1.$region(start#start, end#end) };
             Ok(())
         } catch {
-            case e: Exception => Err(e.getMessage())
+            case e: IndexOutOfBoundsException => Err(e.getMessage())
         }
 
     ///
@@ -678,7 +680,7 @@ pub mod Regex {
             let Matcher(m1) = m;
             Ok(unsafe IO as r { m1.start() })
         } catch {
-            case e: Exception => Err(e.getMessage())
+            case e: IllegalStateException => Err(e.getMessage())
         }
 
     ///
@@ -689,7 +691,7 @@ pub mod Regex {
             let Matcher(m1) = m;
             Ok(unsafe IO as r { m1.end() })
         } catch {
-            case e: Exception => Err(e.getMessage())
+            case e: IllegalStateException => Err(e.getMessage())
         }
 
     ///
@@ -709,7 +711,7 @@ pub mod Regex {
             let Matcher(m1) = m;
             Ok(unsafe IO as r { m1.group() })
         } catch {
-            case e: Exception => Err(e.getMessage())
+            case e: IllegalStateException => Err(e.getMessage())
         }
 
     ///
@@ -720,7 +722,8 @@ pub mod Regex {
             let Matcher(m1) = m;
             Ok(unsafe IO as r { if (not Object.isNull(m1.group(i))) m1.group(i) else "" })
         } catch {
-            case e: Exception => Err(e.getMessage())
+            case e: IllegalStateException     => Err(e.getMessage())
+            case e: IndexOutOfBoundsException => Err(e.getMessage())
         }
 
     ///

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -182,7 +182,7 @@ pub mod String {
             Ok(Pattern.compile(regex))
         } catch {
             case e: PatternSyntaxException =>
-                Err(unchecked_cast(e.getMessage() as _ \ {}))
+                Err(unsafe IO { e.getMessage() })
         }
 
 
@@ -200,7 +200,7 @@ pub mod String {
             Ok(Pattern.compile(regex, Regex.sumFlags(flags)))
         } catch {
             case e: PatternSyntaxException =>
-                Err(unchecked_cast(e.getMessage() as _ \ {}))
+                Err(unsafe IO { e.getMessage() })
         }
 
 

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -16,7 +16,6 @@
 
 pub mod String {
 
-    import java.lang.Exception
     import java.lang.System
     import java.lang.{String => JString}
     import java.nio.charset.StandardCharsets
@@ -182,7 +181,8 @@ pub mod String {
         try {
             Ok(Pattern.compile(regex))
         } catch {
-            case e: Exception => Err(e.getMessage())
+            case e: PatternSyntaxException =>
+                Err(unchecked_cast(e.getMessage() as _ \ {}))
         }
 
 
@@ -199,7 +199,8 @@ pub mod String {
         try {
             Ok(Pattern.compile(regex, Regex.sumFlags(flags)))
         } catch {
-            case e: Exception => Err(e.getMessage())
+            case e: PatternSyntaxException =>
+                Err(unchecked_cast(e.getMessage() as _ \ {}))
         }
 
 


### PR DESCRIPTION
## Summary
- In `Regex`, `String`, and `CodePoint`, several try/catch blocks caught broad `java.lang.Exception` (and once `Throwable`) where the wrapped operation only ever throws a specific JDK exception. Narrowed each catch to the documented type:
  - `Pattern.compile` → `PatternSyntaxException`
  - `Matcher.find(int)` / `Matcher.region(...)` → `IndexOutOfBoundsException`
  - `Matcher.start` / `end` / `group()` → `IllegalStateException`
  - `Matcher.group(i)` → `IllegalStateException` + `IndexOutOfBoundsException`
  - `Character.getName` / `Character.toChars` / `Character.toString` → `IllegalArgumentException`
- In `String.toRegex` / `toRegexWithFlags`, `PatternSyntaxException.getMessage()` is treated as IO (override of the parent), so the public pure signature is preserved with `unchecked_cast(... as _ \ {})`.

## Test plan
- [x] `./mill flix.run out/empty.flix` (stdlib compiles)
- [x] Smoke test exercising happy + error paths for `String.toRegex`, `CodePoint.getName`, `toString`, `toBmpChar`, `toSupplementaryChars`, `toChars`
- [x] `./mill flix.test.testForked "-oC"` (16251 succeeded, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)