### PR TITLE
refactor: narrow Exception catches in Sys.Env

### DIFF
--- a/main/src/library/Sys/Env.flix
+++ b/main/src/library/Sys/Env.flix
@@ -19,8 +19,9 @@ pub mod Sys.Env {
     use Sys.Env
 
     import dev.flix.runtime.Global
-    import java.lang.Exception
+    import java.lang.NullPointerException
     import java.lang.Runtime
+    import java.lang.SecurityException
     import java.lang.System
     import java.io.{File => JFile}
     import java.util.{Iterator => JIterator}
@@ -130,7 +131,7 @@ pub mod Sys.Env {
                     let iter: JIterator[Entry[String, String]] = unsafe IO as rc { System.getenv().entrySet().iterator() };
                     k(getEnvHelper(iter, Map.empty()))
                 } catch {
-                    case _: Exception => k(Map.empty())
+                    case _: SecurityException => k(Map.empty())
                 }
             }
 
@@ -139,7 +140,8 @@ pub mod Sys.Env {
                     let result = System.getenv(name);
                     k(Object.toOption(result))
                 } catch {
-                    case _: Exception => k(None)
+                    case _: SecurityException    => k(None)
+                    case _: NullPointerException => k(None)
                 }
 
             def getProp(name, k)              = k(getPropHelper(name))
@@ -180,7 +182,8 @@ pub mod Sys.Env {
             let result = System.getProperty(name);
             Object.toOption(result)
         } catch {
-            case _: Exception => None
+            case _: SecurityException    => None
+            case _: NullPointerException => None
         }
 
     def getEnvHelper(iter: JIterator[Entry[String, String]], m: Map[String, String]): Map[String, String] \ IO =


### PR DESCRIPTION
## Summary
- Three try/catch sites in `Sys/Env.flix` previously caught the broad `java.lang.Exception` around `System.getenv` / `System.getProperty` calls. Replaced with the JDK-documented exception types:
  - `getEnv` → `SecurityException` (no name argument, so no `NullPointerException` to consider)
  - `getVar` (`System.getenv(name)`) → `SecurityException` + `NullPointerException`
  - `getPropHelper` (`System.getProperty(name)`) → `SecurityException` + `NullPointerException`

Follow-up to #12721 (same refactor pattern, separate branch).

## Test plan
- [x] `./mill flix.run out/empty.flix` (stdlib compiles)
- [x] Smoke test exercising `Sys.Env.getEnv`, `getVar` (present + missing), `getProp` (present + missing)
- [x] `./mill flix.test.testForked "-oC"` (16251 succeeded, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)