### PR TITLE
refactor: rename JvmBackend to CodeGen

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.shared.{AvailableClasses, Input, SecurityC
 import ca.uwaterloo.flix.language.dbg.AstPrinter
 import ca.uwaterloo.flix.language.fmt.FormatOptions
 import ca.uwaterloo.flix.language.phase.*
-import ca.uwaterloo.flix.language.phase.jvm.{JvmBackend, JvmLoader, JvmWriter}
+import ca.uwaterloo.flix.language.phase.jvm.{CodeGen, JvmLoader, JvmWriter}
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization
 import ca.uwaterloo.flix.language.phase.optimizer.{LambdaDrop, Optimizer}
 import ca.uwaterloo.flix.language.{CompilationMessage, GenSym}
@@ -678,7 +678,7 @@ class Flix {
     eraserAst = null // Explicitly null-out such that the memory becomes eligible for GC.
 
     // Generate JVM classes.
-    val bytecodeAst = JvmBackend.run(reducerAst)
+    val bytecodeAst = CodeGen.run(reducerAst)
     reducerAst = null // Explicitly null-out such that the memory becomes eligible for GC.
 
     val totalTime = flix.getTotalTime

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -25,10 +25,10 @@ import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.MapOps
 
 
-object JvmBackend {
+object CodeGen {
 
   /** Emits JVM bytecode for `root`. */
-  def run(root: Root)(implicit flix: Flix): BytecodeAst.Root = flix.phase("JvmBackend") {
+  def run(root: Root)(implicit flix: Flix): BytecodeAst.Root = flix.phase("CodeGen") {
     implicit val r: Root = root
 
     // Types/classes required for Flix runtime.

--- a/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerProfiler.scala
@@ -73,7 +73,7 @@ import scala.jdk.CollectionConverters.*
   * | TailPos            | Yes          |                                                                                                               |
   * | Eraser             | Yes          |                                                                                                               |
   * | Reducer            | Yes          |                                                                                                               |
-  * | JvmBackend         | Partial      | Only the per-def cases in `GenFunAndClosureClasses` are instrumented; top-level orchestration is not.         |
+  * | CodeGen            | Partial      | Only the per-def cases in `GenFunAndClosureClasses` are instrumented; top-level orchestration is not.         |
   */
 object CompilerProfiler {
   /**

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -330,7 +330,7 @@ object CompilerTop {
   /** Phases whose `track` count maps to the `opt` column — optimizer fixed-point re-visits. */
   private val OptCountPhases: Set[String] = Set("Optimizer", "LambdaDrop")
   /** Phases whose `track` count maps to the `cls` column — class files emitted post-specialization. */
-  private val ClsCountPhases: Set[String] = Set("JvmBackend")
+  private val ClsCountPhases: Set[String] = Set("CodeGen")
 
   /** Sums `byPhaseCount` entries for the given phase set. */
   private def sumPhaseCounts(byPhaseCount: Map[String, Long], phases: Set[String]): Long =


### PR DESCRIPTION
## Summary
- Rename the `JvmBackend` object (and its file) to `CodeGen`, and update the three call sites that reference it (`Flix.scala`, `CompilerProfiler.scala`, `CompilerTop.scala`).
- Phase label passed to `flix.phase(...)` is renamed accordingly, so profiler/top output now reports `CodeGen` instead of `JvmBackend`.

## Test plan
- [x] `./mill flix.compile`
- [x] `./mill flix.test.testForked "-oC"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)