### PR TITLE
refactor: move CompilerProfiler into compilertop package as Profiler

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -27,6 +27,7 @@ import ca.uwaterloo.flix.language.phase.optimizer.{LambdaDrop, Optimizer}
 import ca.uwaterloo.flix.language.{CompilationMessage, GenSym}
 import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.tools.Summary
+import ca.uwaterloo.flix.tools.compilertop.Profiler
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.Formatter.NoFormatter
 import ca.uwaterloo.flix.util.collection.{Chain, MultiMap}
@@ -115,16 +116,16 @@ class Flix {
     * by [[setOptions]] when the compiler profiler is enabled; absent on the
     * default path so [[profile]] is a no-op with no measurement overhead.
     */
-  private var profiler: Option[CompilerProfiler] = None
+  private var profiler: Option[Profiler] = None
 
   /** The live compiler profiler TUI, if it has been started. */
   private var compilerTop: Option[CompilerTop] = None
 
   /** Returns the currently installed profiler, or `None`. */
-  def getProfiler: Option[CompilerProfiler] = profiler
+  def getProfiler: Option[Profiler] = profiler
 
   /** Installs (or removes, when `None`) the profiler that backs [[profile]]. */
-  def setProfiler(p: Option[CompilerProfiler]): Unit = profiler = p
+  def setProfiler(p: Option[Profiler]): Unit = profiler = p
 
   /**
     * Records the time spent running `thunk` against `sym`, attributed to
@@ -437,7 +438,7 @@ class Flix {
       throw new IllegalArgumentException("'opts' must be non-null.")
     options = opts
     if (opts.compilerTop && compilerTop.isEmpty) {
-      val p = new CompilerProfiler(() => getCurrentPhaseName)
+      val p = new Profiler(() => getCurrentPhaseName)
       setProfiler(Some(p))
       // The profiler subscribes to compiler events (e.g. NewConstraintsDef)
       // to track signals that are awkward to thread through `track()`.

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.tools.compilertop
 
 import ca.uwaterloo.flix.tools.compilertop.Formatting.locLineCount
 import ca.uwaterloo.flix.tools.compilertop.Model.*
-import ca.uwaterloo.flix.util.CompilerProfiler.DefnStats
+import ca.uwaterloo.flix.tools.compilertop.Profiler.DefnStats
 
 /**
   * Pure filter / sort / module-rollup logic for compiler-top stat snapshots.

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ca.uwaterloo.flix.util
+package ca.uwaterloo.flix.tools.compilertop
 
 import ca.uwaterloo.flix.api.{FlixEvent, FlixListener}
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type}
@@ -26,13 +26,13 @@ import scala.jdk.CollectionConverters.*
 /**
   * Per-`DefnSym` compile-time profiler.
   *
-  * [[CompilerProfiler]] tracks cumulative wall-clock time, call counts, and a
+  * [[Profiler]] tracks cumulative wall-clock time, call counts, and a
   * per-phase breakdown for each [[Symbol.DefnSym]] the compiler visits. Its
-  * [[CompilerProfiler.track]] entry point is called from inside instrumented
+  * [[Profiler.track]] entry point is called from inside instrumented
   * phases and is safe to invoke from multiple threads.
   *
   * A fresh sym minted from an existing one via [[Symbol.freshDefnSym]] is
-  * folded back to its source sym (see [[CompilerProfiler.sourceOf]]) so the
+  * folded back to its source sym (see [[Profiler.sourceOf]]) so the
   * user-facing table shows one row per source-level definition rather than
   * one row per refresh.
   *
@@ -75,9 +75,9 @@ import scala.jdk.CollectionConverters.*
   * | Reducer            | Yes          |                                                                                                               |
   * | CodeGen            | Partial      | Only the per-def cases in `GenFunAndClosureClasses` are instrumented; top-level orchestration is not.         |
   */
-object CompilerProfiler {
+object Profiler {
   /**
-    * A snapshot of per-`DefnSym` statistics produced by [[CompilerProfiler.snapshot]].
+    * A snapshot of per-`DefnSym` statistics produced by [[Profiler.snapshot]].
     *
     * @param sym          the source-level [[Symbol.DefnSym]] this row aggregates.
     * @param isActive     true if at least one `track` call is currently in flight for this sym.
@@ -165,10 +165,10 @@ object CompilerProfiler {
   }
 }
 
-final class CompilerProfiler(phaseProvider: () => Option[String]) extends FlixListener {
+final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
 
-  /** Per-source-`DefnSym` accumulators, keyed by [[CompilerProfiler.DefnSymWithLoc]] so that defs at distinct locations don't aggregate. */
-  private val stats = new ConcurrentHashMap[CompilerProfiler.DefnSymWithLoc, CompilerProfiler.Counters]()
+  /** Per-source-`DefnSym` accumulators, keyed by [[Profiler.DefnSymWithLoc]] so that defs at distinct locations don't aggregate. */
+  private val stats = new ConcurrentHashMap[Profiler.DefnSymWithLoc, Profiler.Counters]()
 
   /**
     * Subscribes the profiler to compiler events emitted via `Flix.emitEvent`.
@@ -184,7 +184,7 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) extends FlixLi
       // constraints / variables, and an incremental rebuild that re-types the
       // def shouldn't make the column appear to grow.
       c.constraints.set(tconstrs.size.toLong)
-      val (tv, ev) = CompilerProfiler.countVars(tconstrs)
+      val (tv, ev) = Profiler.countVars(tconstrs)
       c.tvars.set(tv)
       c.evars.set(ev)
     case _ => ()
@@ -222,7 +222,7 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) extends FlixLi
     * Returns an approximate snapshot. Iterators over the underlying maps are
     * weakly consistent, so individual entries may be slightly stale.
     */
-  def snapshot(): Vector[CompilerProfiler.DefnStats] = {
+  def snapshot(): Vector[Profiler.DefnStats] = {
     val it = stats.entrySet().iterator().asScala
     it.map { e =>
       val key = e.getKey
@@ -232,7 +232,7 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) extends FlixLi
       val byPhaseCount = c.perPhaseCount.entrySet().iterator().asScala
         .map(pe => (pe.getKey, pe.getValue.get())).toMap
       val loc = Option(c.loc.get()).getOrElse(key.loc)
-      CompilerProfiler.DefnStats(key.sym, isActive = c.inProgress.get() > 0,
+      Profiler.DefnStats(key.sym, isActive = c.inProgress.get() > 0,
         c.callCount.get(), c.totalNanos.get(), byPhase, byPhaseCount,
         c.constraints.get(), c.tvars.get(), c.evars.get(), loc)
     }.toVector
@@ -242,8 +242,8 @@ final class CompilerProfiler(phaseProvider: () => Option[String]) extends FlixLi
     * Returns the [[Counters]] entry for `sym`'s source sym, creating a fresh
     * zero-initialized entry on first use. Atomic in the underlying map.
     */
-  private def countersFor(sym: Symbol.DefnSym): CompilerProfiler.Counters =
-    stats.computeIfAbsent(CompilerProfiler.DefnSymWithLoc(sourceOf(sym), sym.loc), _ => CompilerProfiler.Counters(
+  private def countersFor(sym: Symbol.DefnSym): Profiler.Counters =
+    stats.computeIfAbsent(Profiler.DefnSymWithLoc(sourceOf(sym), sym.loc), _ => Profiler.Counters(
       inProgress = new AtomicInteger(0),
       callCount = new AtomicInteger(0),
       totalNanos = new AtomicLong(0L),

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -21,8 +21,9 @@ import ca.uwaterloo.flix.tools.compilertop.Ansi.*
 import ca.uwaterloo.flix.tools.compilertop.Formatting.*
 import ca.uwaterloo.flix.tools.compilertop.Layout
 import ca.uwaterloo.flix.tools.compilertop.Model.*
+import ca.uwaterloo.flix.tools.compilertop.Profiler
+import ca.uwaterloo.flix.tools.compilertop.Profiler.DefnStats
 import ca.uwaterloo.flix.tools.compilertop.Styling.*
-import ca.uwaterloo.flix.util.CompilerProfiler.DefnStats
 import org.jline.terminal.{Attributes, Terminal, TerminalBuilder}
 
 import java.util.concurrent.CountDownLatch
@@ -94,7 +95,7 @@ object CompilerTop {
   * [[CompilerTop.RefreshIntervalMs]] milliseconds and re-renders the screen
   * using ANSI escape codes.
   */
-final class CompilerTop(flix: Flix, profiler: CompilerProfiler) {
+final class CompilerTop(flix: Flix, profiler: Profiler) {
 
   import CompilerTop.*
 


### PR DESCRIPTION
## Summary

Continues the breakup of the compiler-top TUI (after #12724, #12726).

- `git mv util/CompilerProfiler.scala tools/compilertop/Profiler.scala` — history preserved (93% similarity).
- Class + companion renamed `CompilerProfiler` → `Profiler`. The `Compiler` prefix becomes redundant now that the file lives in the `compilertop` package.
- Three consumer files updated:
  - **`api/Flix.scala`** — explicit `import Profiler` added (couldn't rely on the `util.*` wildcard anymore); 4 type references renamed.
  - **`util/CompilerTop.scala`** — `DefnStats` import re-pointed; constructor param type renamed; added bare `Profiler` import for the type reference.
  - **`tools/compilertop/Aggregation.scala`** — `DefnStats` import re-pointed.

Pure code move + rename, no behavior change.

## Test plan

- [x] `./mill flix.compile`
- [x] `./mill flix.run out/empty.flix` (stdlib smoke-test — `Flix.scala` was touched)
- [x] Smoke-test the TUI with `--top` on a real build (visual only — no behavior changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)