### PR TITLE
refactor: extract Renderer + FrameState into compilertop package

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -61,6 +61,30 @@ final case class FrameState(parallelism: Int,
                             visible: Vector[DefnStats],
                             modules: Vector[ModuleStats])
 
+object Renderer {
+
+  /** Total number of phases the compiler runs. Bump when `Flix.check` / `Flix.codeGen` adds or removes a `phase` / `phaseNew` call. */
+  private val TotalPhases: Int = 32
+
+  /** Longest phase-name length, used to pad the phase column. Currently set by `"Dependencies"` / `"EffectBinder"`. */
+  private val MaxPhaseLen: Int = 12
+
+  /** Width (in characters) of the phase-progress bar. */
+  private val BarWidth: Int = 12
+
+  /** 1-indexed column where the `progress` label starts on the dashboard. */
+  private lazy val ProgressStartCol: Int = 5 + MaxPhaseLen
+
+  /** 1-indexed column where the `threads` label starts on the dashboard. */
+  private lazy val ThreadsStartCol: Int = ProgressStartCol + 20 + BarWidth
+
+  /** Width of the threads-sparkline. */
+  private val SparkWidth: Int = 12
+
+  /** Block characters used for the sparkline, low → high. */
+  private val SparkChars: Array[Char] = "▁▂▃▄▅▆▇█".toArray
+}
+
 /**
   * Frame builder for the compiler-top TUI. Each instance owns one piece of
   * mutable state — the rolling thread-occupancy history that feeds the
@@ -417,28 +441,4 @@ final class Renderer {
     val pad = (SparkWidth - chars.length).max(0)
     " " * pad + new String(chars)
   }
-}
-
-object Renderer {
-
-  /** Total number of phases the compiler runs. Bump when `Flix.check` / `Flix.codeGen` adds or removes a `phase` / `phaseNew` call. */
-  private val TotalPhases: Int = 32
-
-  /** Longest phase-name length, used to pad the phase column. Currently set by `"Dependencies"` / `"EffectBinder"`. */
-  private val MaxPhaseLen: Int = 12
-
-  /** Width (in characters) of the phase-progress bar. */
-  private val BarWidth: Int = 12
-
-  /** 1-indexed column where the `progress` label starts on the dashboard. */
-  private lazy val ProgressStartCol: Int = 5 + MaxPhaseLen
-
-  /** 1-indexed column where the `threads` label starts on the dashboard. */
-  private lazy val ThreadsStartCol: Int = ProgressStartCol + 20 + BarWidth
-
-  /** Width of the threads-sparkline. */
-  private val SparkWidth: Int = 12
-
-  /** Block characters used for the sparkline, low → high. */
-  private val SparkChars: Array[Char] = "▁▂▃▄▅▆▇█".toArray
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.tools.compilertop
+
+import ca.uwaterloo.flix.tools.compilertop.Aggregation.*
+import ca.uwaterloo.flix.tools.compilertop.Ansi.*
+import ca.uwaterloo.flix.tools.compilertop.Formatting.*
+import ca.uwaterloo.flix.tools.compilertop.Model.*
+import ca.uwaterloo.flix.tools.compilertop.Profiler.DefnStats
+import ca.uwaterloo.flix.tools.compilertop.Styling.*
+
+import scala.collection.mutable
+
+/**
+  * Per-frame inputs consumed by [[Renderer.render]]. CompilerTop builds one
+  * of these per tick from its terminal handle, the live profiler snapshot,
+  * and the user-toggled filter / sort knobs. The renderer is a pure
+  * function of this record (plus its own private sparkline history).
+  *
+  * @param parallelism     the threadpool's parallelism (≥ 1).
+  * @param isDone          true once compilation has finished; freezes the
+  *                        elapsed / threads / heap fields and switches the
+  *                        progress bar to its "done" rendering.
+  * @param elapsed         wall-clock nanos since the TUI started.
+  * @param activeThreads   threadpool active-thread count for the dashboard.
+  * @param heap            `(usedMb, maxMb)` from the JVM at frame time.
+  * @param currentPhase    already-resolved phase label (e.g. `"Typer"`,
+  *                        `"done"`, or `"starting"`).
+  * @param phaseTimersSize raw `flix.phaseTimers.size`; the renderer caps to
+  *                        [[Renderer.TotalPhases]] for the progress bar.
+  * @param activeFilter    user-toggled phase filter (drives the legend).
+  * @param activeSort      user-toggled sort key (drives header underlines).
+  * @param layout          column layout produced by [[Layout.compute]].
+  * @param visible         def-table rows, already filtered / sorted / trimmed.
+  * @param modules         module-table rows, already aggregated / sorted /
+  *                        trimmed.
+  */
+final case class FrameState(parallelism: Int,
+                            isDone: Boolean,
+                            elapsed: Long,
+                            activeThreads: Int,
+                            heap: (Long, Long),
+                            currentPhase: String,
+                            phaseTimersSize: Int,
+                            activeFilter: PhaseFilter,
+                            activeSort: Sort,
+                            layout: Layout,
+                            visible: Vector[DefnStats],
+                            modules: Vector[ModuleStats])
+
+/**
+  * Frame builder for the compiler-top TUI. Each instance owns one piece of
+  * mutable state — the rolling thread-occupancy history that feeds the
+  * dashboard sparkline. Everything else flows in via [[FrameState]] so the
+  * renderer can be exercised without a live `Flix`.
+  */
+final class Renderer {
+
+  import Renderer.*
+
+  /** Rolling history of active-thread counts feeding the dashboard sparkline. */
+  private val threadsHistory = mutable.Queue.empty[Double]
+
+  /** Builds one full frame from the given state and returns the bytes to print. */
+  def render(state: FrameState): String = {
+    // Active-threads sparkline: history of thread-pool occupancy. Stops
+    // updating once compilation is done so the bar reflects the work, not
+    // a long tail of zero-occupancy samples while waiting for `q`.
+    if (!state.isDone) {
+      threadsHistory.enqueue(state.activeThreads.toDouble)
+      while (threadsHistory.size > SparkWidth) threadsHistory.dequeue()
+    }
+
+    val sb = new StringBuilder
+    sb.append(BeginSync)
+    sb.append(ClearScreen)
+    sb.append('\n')
+
+    renderDashboard(sb, state)
+    renderStats(sb, state)
+    sb.append('\n')
+    renderTableHeader(sb, state.layout, state.activeSort)
+    renderRows(sb, state.visible, state.elapsed, state.parallelism, state.layout)
+    renderModuleTable(sb, state.modules, state.elapsed, state.parallelism, state.layout, state.activeSort)
+
+    sb.append(EndSync)
+    sb.toString
+  }
+
+  /**
+    * Top dashboard line: current phase + progress bar + active-threads bar.
+    * Both bars sit beside each other so the eye picks them up as a pair.
+    */
+  private def renderDashboard(sb: StringBuilder, state: FrameState): Unit = {
+    // Once compilation has finished, force the bar to 100% rather than relying
+    // on `phaseTimers.size + 1` (which is +1 ahead of reality during execution
+    // and would still under-fill if any phase is uninstrumented).
+    val done = if (state.isDone) TotalPhases else (state.phaseTimersSize + 1).min(TotalPhases)
+    val filled = (BarWidth.toLong * done / TotalPhases).toInt
+
+    sb.append("  ")
+    sb.append(bold(rpad(state.currentPhase, MaxPhaseLen)))
+    sb.append(dim("  progress "))
+    sb.append(dim("["))
+    // Blue while compilation is in progress; green once finished so the bar
+    // doubles as a "done" indicator.
+    val filledBar = "█" * filled
+    sb.append(if (state.isDone) green(filledBar) else blue(filledBar))
+    sb.append(dim("░" * (BarWidth - filled)))
+    sb.append(dim("] "))
+    sb.append(f"$done%2d/$TotalPhases%2d")
+    sb.append(dim("   threads "))
+    // With parallelism=1 ForkJoin runs work inline on the submitter, leaving
+    // `getActiveThreadCount` at 0 most of the time — sparkline goes flat,
+    // field reads `0/1` continuously. Show a label instead.
+    if (state.parallelism > 1) {
+      sb.append(dim(cyan(renderSparkline(state.parallelism.toDouble))))
+      sb.append(' ')
+      sb.append(styleThreads(state.activeThreads, state.parallelism))
+    } else {
+      sb.append(dim("single-threaded"))
+    }
+    sb.append("   ")
+    sb.append(renderFilterLegend(state.activeFilter))
+    sb.append('\n')
+  }
+
+  /**
+    * Renders the `[f|b|a]` legend with the active letter highlighted in
+    * bold cyan when the filter is non-default. Always visible so the user
+    * sees the available toggles whether the filter is active or not.
+    */
+  private def renderFilterLegend(active: PhaseFilter): String = {
+    val sb = new StringBuilder
+    sb.append(dim("["))
+    sb.append(filterLegendEntry("all",      active == PhaseFilter.All))
+    sb.append(dim("|"))
+    sb.append(filterLegendEntry("frontend", active == PhaseFilter.Frontend))
+    sb.append(dim("|"))
+    sb.append(filterLegendEntry("backend",  active == PhaseFilter.Backend))
+    sb.append(dim("]"))
+    sb.toString
+  }
+
+  /**
+    * Renders one filter-legend entry: the first letter is the keystroke,
+    * underlined. The whole word is bold cyan when this is the active filter,
+    * dim otherwise. Underline state is toggled surgically so the inactive
+    * dim styling and the active bold+cyan styling pass through unchanged on
+    * the remaining letters.
+    */
+  private def filterLegendEntry(label: String, active: Boolean): String = {
+    val key = label.head.toString
+    val rest = label.tail
+    if (active) s"$BoldCode$Yellow$UnderlineCode$key$NoUnderlineCode$rest$Reset"
+    else s"$DimCode$UnderlineCode$key$NoUnderlineCode$rest$Reset"
+  }
+
+  /**
+    * Stats line: elapsed (right-aligned under `progress`) and heap
+    * (right-aligned under `threads`).
+    */
+  private def renderStats(sb: StringBuilder, state: FrameState): Unit = {
+    val (heapUsedMb, heapMaxMb) = state.heap
+    val heapUsedField = f"$heapUsedMb%4d MB"
+    val heapMaxField = f"$heapMaxMb%4d MB"
+    val heapRatio = if (heapMaxMb <= 0) 0.0 else heapUsedMb.toDouble / heapMaxMb
+    val elapsedField = formatMillis(state.elapsed)
+
+    // "elapsed" (7 chars) right-aligned with "progress" (8 chars) → start at ProgressStartCol + 1.
+    val elapsedStartCol = ProgressStartCol + 1
+    // "heap" (4 chars) right-aligned with "threads" (7 chars) → start at ThreadsStartCol + 3.
+    val heapStartCol = ThreadsStartCol + 3
+
+    sb.append("  ")
+    sb.append(" " * (elapsedStartCol - 3).max(0))
+    sb.append(dim("elapsed "))
+    sb.append(elapsedField)
+
+    val colAfterElapsed = elapsedStartCol + "elapsed ".length + elapsedField.length
+    sb.append(" " * (heapStartCol - colAfterElapsed).max(1))
+
+    sb.append(dim("heap "))
+    sb.append(styleHeap(heapUsedField, heapRatio))
+    sb.append(dim(" / "))
+    sb.append(heapMaxField)
+    sb.append('\n')
+  }
+
+  /** Renders the def-table column header and the divider underneath it. */
+  private def renderTableHeader(sb: StringBuilder, layout: Layout, activeSort: Sort): Unit = {
+    sb.append(' ')
+    sb.append(buildHeader(layout, activeSort))
+    sb.append(' ')
+    sb.append('\n')
+    sb.append(' ')
+    sb.append(dim("─" * layout.totalWidth))
+    sb.append(' ')
+    sb.append('\n')
+  }
+
+  /**
+    * Builds the def-table header. Each sortable column underlines its
+    * keystroke letter (`m̲ono`, `o̲pt`, `c̲ls`, `t̲ime`) and the Def header
+    * carries a tiny `(h̲ot)` annotation marking the hotness sort key.
+    * The active column is rendered bold yellow; the rest bold cyan.
+    */
+  private def buildHeader(layout: Layout, activeSort: Sort): String = {
+    val sb = new StringBuilder
+
+    // First column: "Def (hot)" — the 'h' (index 5) is the hotness keystroke.
+    val defPadded = rpad("Def (hot)", layout.symWidth)
+    sb.append(keyHeader(defPadded, 5, activeSort == Sort.Hotness))
+
+    sb.append(' ')
+    sb.append(plainHeader(rpad("location", layout.locWidth)))
+
+    if (layout.showLOC) {
+      sb.append(' '); sb.append(plainHeader(lpad("LOC", 4)))
+    }
+    if (layout.showCounts) {
+      val monoP = lpad("mono", 4); sb.append(' '); sb.append(keyHeader(monoP, monoP.indexOf('m'), activeSort == Sort.Mono))
+      val optP  = lpad("opt", 4);  sb.append(' '); sb.append(keyHeader(optP,  optP.indexOf('o'),  activeSort == Sort.Opt))
+      val clsP  = lpad("cls", 4);  sb.append(' '); sb.append(keyHeader(clsP,  clsP.indexOf('c'),  activeSort == Sort.Cls))
+    }
+    if (layout.showCns) {
+      val cnsP = lpad("cns", 5)
+      sb.append(' '); sb.append(keyHeader(cnsP, cnsP.indexOf('n'), activeSort == Sort.Cns))
+      val tvP  = lpad("tv",  4)
+      sb.append(' '); sb.append(keyHeader(tvP,  tvP.indexOf('v'),  activeSort == Sort.Tvars))
+      val evP  = lpad("ev",  4)
+      sb.append(' '); sb.append(keyHeader(evP,  evP.indexOf('e'),  activeSort == Sort.Evars))
+    }
+    if (layout.showPhase) {
+      sb.append(' '); sb.append(plainHeader(rpad("phase", 10)))
+    }
+    val timeP = lpad("time", 9); sb.append(' '); sb.append(keyHeader(timeP, timeP.indexOf('t'), activeSort == Sort.Time))
+    sb.append(' '); sb.append(plainHeader(lpad("%cpu", 6)))
+    sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
+    sb.toString
+  }
+
+  /** Renders the def-table body (one row per [[DefnStats]]), or a centered placeholder if `visible` is empty. */
+  private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int, layout: Layout): Unit = {
+    if (visible.isEmpty) {
+      val msg = "(no timings yet)"
+      val pad = (((layout.totalWidth + 2) - msg.length) / 2).max(0)
+      sb.append('\n')
+      sb.append(" " * pad)
+      sb.append(dim(msg))
+      sb.append('\n')
+      return
+    }
+    val safeElapsed = elapsed.max(1L).toDouble
+    for (s <- visible) {
+      val pctWall = 100.0 * s.totalNanos / safeElapsed
+      val pctCpu = pctWall / parallelism
+      val locStr = formatLocation(s.loc)
+      val locLines = locLineCount(s.loc)
+      val phase = s.dominantPhase.getOrElse("?")
+
+      val nameMax = layout.symWidth - 1
+      val nameText = truncate(s.sym.name, nameMax)
+      val locField = rpad(truncate(locStr, layout.locWidth), layout.locWidth)
+      val marker = if (s.isActive) yellow("*") else " "
+
+      sb.append(' ')
+      sb.append(styleSym(nameText, s.totalNanos, locLines))
+      sb.append(marker)
+      sb.append(" " * (nameMax - nameText.length))
+      sb.append(' ')
+      sb.append(dim(locField))
+      appendNumericFields(sb, locLines, s.byPhaseCount, s.cns, s.tvars.toLong, s.evars.toLong, phase, s.totalNanos, pctCpu, pctWall, layout, aggregate = false)
+      sb.append(' ')
+      sb.append('\n')
+    }
+  }
+
+  /** Renders the per-module aggregate table below the def table; no-op if `modules` is empty. */
+  private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int, layout: Layout, activeSort: Sort): Unit = {
+    if (modules.isEmpty) return
+
+    sb.append('\n')
+    val modWidth = layout.symWidth + 1 + layout.locWidth
+    sb.append(' ')
+    sb.append(buildModuleHeader(layout, activeSort))
+    sb.append(' ')
+    sb.append('\n')
+    sb.append(' ')
+    sb.append(dim("─" * layout.totalWidth))
+    sb.append(' ')
+    sb.append('\n')
+
+    val safeElapsed = elapsed.max(1L).toDouble
+    for (m <- modules) {
+      val pctWall = 100.0 * m.totalNanos / safeElapsed
+      val pctCpu = pctWall / parallelism
+      val phase = m.dominantPhase.getOrElse("?")
+
+      val modField = rpad(truncate(m.module, modWidth), modWidth)
+
+      sb.append(' ')
+      sb.append(modField)
+      appendNumericFields(sb, m.totalLocLines, m.byPhaseCount, m.totalCns, m.totalTvars, m.totalEvars, phase, m.totalNanos, pctCpu, pctWall, layout, aggregate = true)
+      sb.append(' ')
+      sb.append('\n')
+    }
+  }
+
+  /**
+    * Module-table header: single wide first column, then the same numeric
+    * columns as the def table. Mirrors [[buildHeader]]'s underline / active
+    * styling so the same sort keys are discoverable in both tables.
+    */
+  private def buildModuleHeader(layout: Layout, activeSort: Sort): String = {
+    val sb = new StringBuilder
+    val modWidth = layout.symWidth + 1 + layout.locWidth
+
+    // First column: "Module (hot)" — the 'h' (index 8) is the hotness keystroke.
+    val modPadded = rpad("Module (hot)", modWidth)
+    sb.append(keyHeader(modPadded, 8, activeSort == Sort.Hotness))
+
+    if (layout.showLOC) {
+      sb.append(' '); sb.append(plainHeader(lpad("LOC", 4)))
+    }
+    if (layout.showCounts) {
+      val monoP = lpad("mono", 4); sb.append(' '); sb.append(keyHeader(monoP, monoP.indexOf('m'), activeSort == Sort.Mono))
+      val optP  = lpad("opt", 4);  sb.append(' '); sb.append(keyHeader(optP,  optP.indexOf('o'),  activeSort == Sort.Opt))
+      val clsP  = lpad("cls", 4);  sb.append(' '); sb.append(keyHeader(clsP,  clsP.indexOf('c'),  activeSort == Sort.Cls))
+    }
+    if (layout.showCns) {
+      val cnsP = lpad("cns", 5)
+      sb.append(' '); sb.append(keyHeader(cnsP, cnsP.indexOf('n'), activeSort == Sort.Cns))
+      val tvP  = lpad("tv",  4)
+      sb.append(' '); sb.append(keyHeader(tvP,  tvP.indexOf('v'),  activeSort == Sort.Tvars))
+      val evP  = lpad("ev",  4)
+      sb.append(' '); sb.append(keyHeader(evP,  evP.indexOf('e'),  activeSort == Sort.Evars))
+    }
+    if (layout.showPhase) {
+      sb.append(' '); sb.append(plainHeader(rpad("phase", 10)))
+    }
+    val timeP = lpad("time", 9); sb.append(' '); sb.append(keyHeader(timeP, timeP.indexOf('t'), activeSort == Sort.Time))
+    sb.append(' '); sb.append(plainHeader(lpad("%cpu", 6)))
+    sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
+    sb.toString
+  }
+
+  /**
+    * Appends the trailing numeric columns (LOC, mono / opt / cls, cns,
+    * phase, time, %cpu, %wall) to a row, honoring the layout's visibility
+    * flags. Always emits a leading separator before each column it writes.
+    *
+    * `aggregate` skips all warning colors on `time` / `%cpu` / `%wall`. The
+    * `style*` thresholds are calibrated for individual defs; at module
+    * scale, sums-across-defs trip the thresholds unconditionally and the
+    * colors become noise. Counts (mono / opt / cls / cns) render plain in
+    * both tables.
+    */
+  private def appendNumericFields(sb: StringBuilder, locLines: Int, byPhaseCount: Map[String, Long], cns: Long, tvars: Long, evars: Long, phase: String,
+                                   nanos: Long, pctCpu: Double, pctWall: Double, layout: Layout,
+                                   aggregate: Boolean): Unit = {
+    if (layout.showLOC) {
+      sb.append(' ')
+      val locStr = if (locLines > 0) locLines.toString else "-"
+      sb.append(lpad(locStr, 4))
+    }
+    if (layout.showCounts) {
+      val mono = sumPhaseCounts(byPhaseCount, MonoCountPhases)
+      val opt  = sumPhaseCounts(byPhaseCount, OptCountPhases)
+      val cls  = sumPhaseCounts(byPhaseCount, ClsCountPhases)
+      sb.append(' '); sb.append(lpad(mono.toString, 4))
+      sb.append(' '); sb.append(lpad(opt.toString, 4))
+      sb.append(' '); sb.append(lpad(cls.toString, 4))
+    }
+    if (layout.showCns) {
+      sb.append(' '); sb.append(lpad(cns.toString, 5))
+      sb.append(' '); sb.append(lpad(tvars.toString, 4))
+      sb.append(' '); sb.append(lpad(evars.toString, 4))
+    }
+    if (layout.showPhase) {
+      sb.append(' ')
+      sb.append(rpad(truncate(phase, 10), 10))
+    }
+    val timeField = lpad(formatMillis(nanos), 9)
+    val cpuField  = f"$pctCpu%5.1f%%"
+    val wallField = f"$pctWall%5.1f%%"
+    sb.append(' '); sb.append(if (aggregate) timeField else styleTime(timeField, nanos))
+    sb.append(' '); sb.append(if (aggregate) cpuField else stylePctCpu(cpuField, pctCpu))
+    sb.append(' '); sb.append(if (aggregate) wallField else stylePctWall(wallField, pctWall))
+  }
+
+  /**
+    * Renders the threads-history sparkline at a fixed scale where
+    * `█` ⇔ `maxValue` (typically the threadpool's parallelism). Earlier
+    * samples appear on the left, the most recent on the right.
+    */
+  private def renderSparkline(maxValue: Double): String = {
+    if (threadsHistory.isEmpty) return " " * SparkWidth
+    val safeMax = maxValue.max(1.0)
+    val chars = threadsHistory.iterator.map { v =>
+      val i = math.min(SparkChars.length - 1, math.max(0, (v / safeMax * (SparkChars.length - 1)).round.toInt))
+      SparkChars(i)
+    }.toArray
+    val pad = (SparkWidth - chars.length).max(0)
+    " " * pad + new String(chars)
+  }
+}
+
+object Renderer {
+
+  /** Total number of phases the compiler runs. Bump when `Flix.check` / `Flix.codeGen` adds or removes a `phase` / `phaseNew` call. */
+  private val TotalPhases: Int = 32
+
+  /** Longest phase-name length, used to pad the phase column. Currently set by `"Dependencies"` / `"EffectBinder"`. */
+  private val MaxPhaseLen: Int = 12
+
+  /** Width (in characters) of the phase-progress bar. */
+  private val BarWidth: Int = 12
+
+  /** 1-indexed column where the `progress` label starts on the dashboard. */
+  private lazy val ProgressStartCol: Int = 5 + MaxPhaseLen
+
+  /** 1-indexed column where the `threads` label starts on the dashboard. */
+  private lazy val ThreadsStartCol: Int = ProgressStartCol + 20 + BarWidth
+
+  /** Width of the threads-sparkline. */
+  private val SparkWidth: Int = 12
+
+  /** Block characters used for the sparkline, low → high. */
+  private val SparkChars: Array[Char] = "▁▂▃▄▅▆▇█".toArray
+}

--- a/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/util/CompilerTop.scala
@@ -22,13 +22,11 @@ import ca.uwaterloo.flix.tools.compilertop.Formatting.*
 import ca.uwaterloo.flix.tools.compilertop.Layout
 import ca.uwaterloo.flix.tools.compilertop.Model.*
 import ca.uwaterloo.flix.tools.compilertop.Profiler
-import ca.uwaterloo.flix.tools.compilertop.Profiler.DefnStats
-import ca.uwaterloo.flix.tools.compilertop.Styling.*
+import ca.uwaterloo.flix.tools.compilertop.{FrameState, Renderer}
 import org.jline.terminal.{Attributes, Terminal, TerminalBuilder}
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
-import scala.collection.mutable
 
 object CompilerTop {
 
@@ -37,28 +35,6 @@ object CompilerTop {
 
   /** Poll interval for the input thread (ms); doubles as how fast `running=false` is observed. */
   private val InputPollMs: Long = 100L
-
-  /** Total number of phases the compiler runs. Bump when `Flix.check` / `Flix.codeGen` adds or removes a `phase` / `phaseNew` call. */
-  private val TotalPhases: Int = 32
-
-  /** Longest phase-name length, used to pad the phase column. Currently set by `"Dependencies"` / `"EffectBinder"`. */
-  private val MaxPhaseLen: Int = 12
-
-  /** Width (in characters) of the phase-progress bar. */
-  private val BarWidth: Int = 12
-
-  /** 1-indexed column where the `progress` label starts on the dashboard. */
-  private lazy val ProgressStartCol: Int = 5 + MaxPhaseLen
-
-  /** 1-indexed column where the `threads` label starts on the dashboard. */
-  private lazy val ThreadsStartCol: Int = ProgressStartCol + 20 + BarWidth
-
-  /** Width of the threads-sparkline. */
-  private val SparkWidth: Int = 12
-
-  /** Block characters used for the sparkline, low → high. */
-  private val SparkChars: Array[Char] = "▁▂▃▄▅▆▇█".toArray
-
 
   /** Fallback terminal height when JLine cannot determine the real one. */
   private val DefaultRows: Int = 24
@@ -164,8 +140,8 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     catch { case _: Throwable => null }
   }
 
-  /** Rolling history of active-thread counts feeding the dashboard sparkline. Touched only by the renderer thread. */
-  private val threadsHistory = mutable.Queue.empty[Double]
+  /** Owns the dashboard sparkline history; otherwise a pure function of [[FrameState]]. */
+  private val renderer = new Renderer()
 
   /** Returns the terminal height in rows, or [[DefaultRows]] if unavailable. */
   private def terminalRows(): Int = {
@@ -295,15 +271,30 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
 
   /** Builds and prints one full frame of the TUI. */
   private def render(): Unit = {
+    val frame = renderer.render(buildFrameState())
+    System.out.print(frame)
+    System.out.flush()
+  }
+
+  /**
+    * Snapshots everything the renderer needs into a [[FrameState]]: live
+    * vs. frozen elapsed / threads / heap, the user-toggled filter and sort,
+    * the column layout from the current terminal width, and the
+    * already-filtered / sorted / trimmed def + module views.
+    */
+  private def buildFrameState(): FrameState = {
     val isDone = completed.get()
     val now = System.nanoTime()
     val pool = flix.threadPool
     val parallelism = if (pool == null) flix.options.threads.max(1) else pool.getParallelism.max(1)
-    // Once compilation is done, freeze elapsed + active threads at their
-    // snapshot values so the dashboard reflects the state at completion
-    // rather than ticking forward during the wait-for-quit phase.
+    // Once compilation is done, freeze elapsed + active threads + heap at
+    // their snapshot values so the dashboard reflects the state at
+    // completion rather than ticking forward during the wait-for-quit phase.
     val elapsed = if (isDone) frozenElapsedNanos else now - startNanos
     val activeThreads = if (isDone) frozenActiveThreads else (if (pool == null) 0 else pool.getActiveThreadCount)
+    val heap = if (isDone) frozenHeap else heapUsage()
+    val currentPhase = if (isDone) "done" else flix.getCurrentPhaseName.getOrElse("starting")
+    val phaseTimersSize = flix.phaseTimers.size
 
     // Budget rows for the two tables based on the current terminal height,
     // reserving an extra `RowMargin` rows so the view never quite touches
@@ -323,352 +314,9 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
 
     val snap = applyFilter(profiler.snapshot(), activeFilter).sortBy(s => -defSortKey(s, activeSort))
     val visible = snap.take(defN)
-
-    // Active-threads sparkline: history of thread-pool occupancy. Stops
-    // updating once compilation is done so the bar reflects the work, not
-    // a long tail of zero-occupancy samples while waiting for `q`.
-    if (!isDone) {
-      threadsHistory.enqueue(activeThreads.toDouble)
-      while (threadsHistory.size > SparkWidth) threadsHistory.dequeue()
-    }
-
     val modules = aggregateByModule(snap, activeSort).take(moduleN)
 
-    val sb = new StringBuilder
-    sb.append(BeginSync)
-    sb.append(ClearScreen)
-    sb.append('\n')
-
-    renderDashboard(sb, activeThreads, parallelism, activeFilter)
-    renderStats(sb, elapsed)
-    sb.append('\n')
-    renderTableHeader(sb, layout, activeSort)
-    renderRows(sb, visible, elapsed, parallelism, layout)
-    renderModuleTable(sb, modules, elapsed, parallelism, layout, activeSort)
-
-    sb.append(EndSync)
-    System.out.print(sb)
-    System.out.flush()
-
+    FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, layout, visible, modules)
   }
 
-  /**
-    * Top dashboard line: current phase + progress bar + active-threads bar.
-    * Both bars sit beside each other so the eye picks them up as a pair.
-    */
-  private def renderDashboard(sb: StringBuilder, activeThreads: Int, parallelism: Int, activeFilter: PhaseFilter): Unit = {
-    val isDone = completed.get()
-    val phase = if (isDone) "done" else flix.getCurrentPhaseName.getOrElse("starting")
-    // Once compilation has finished, force the bar to 100% rather than relying
-    // on `phaseTimers.size + 1` (which is +1 ahead of reality during execution
-    // and would still under-fill if any phase is uninstrumented).
-    val done = if (isDone) TotalPhases else (flix.phaseTimers.size + 1).min(TotalPhases)
-    val filled = (BarWidth.toLong * done / TotalPhases).toInt
-
-    sb.append("  ")
-    sb.append(bold(rpad(phase, MaxPhaseLen)))
-    sb.append(dim("  progress "))
-    sb.append(dim("["))
-    // Blue while compilation is in progress; green once finished so the bar
-    // doubles as a "done" indicator.
-    val filledBar = "█" * filled
-    sb.append(if (isDone) green(filledBar) else blue(filledBar))
-    sb.append(dim("░" * (BarWidth - filled)))
-    sb.append(dim("] "))
-    sb.append(f"$done%2d/$TotalPhases%2d")
-    sb.append(dim("   threads "))
-    // With parallelism=1 ForkJoin runs work inline on the submitter, leaving
-    // `getActiveThreadCount` at 0 most of the time — sparkline goes flat,
-    // field reads `0/1` continuously. Show a label instead.
-    if (parallelism > 1) {
-      sb.append(dim(cyan(renderSparkline(parallelism.toDouble))))
-      sb.append(' ')
-      sb.append(styleThreads(activeThreads, parallelism))
-    } else {
-      sb.append(dim("single-threaded"))
-    }
-    sb.append("   ")
-    sb.append(renderFilterLegend(activeFilter))
-    sb.append('\n')
-  }
-
-  /**
-    * Renders the `[f|b|a]` legend with the active letter highlighted in
-    * bold cyan when the filter is non-default. Always visible so the user
-    * sees the available toggles whether the filter is active or not.
-    */
-  private def renderFilterLegend(active: PhaseFilter): String = {
-    val sb = new StringBuilder
-    sb.append(dim("["))
-    sb.append(filterLegendEntry("all",      active == PhaseFilter.All))
-    sb.append(dim("|"))
-    sb.append(filterLegendEntry("frontend", active == PhaseFilter.Frontend))
-    sb.append(dim("|"))
-    sb.append(filterLegendEntry("backend",  active == PhaseFilter.Backend))
-    sb.append(dim("]"))
-    sb.toString
-  }
-
-  /**
-    * Renders one filter-legend entry: the first letter is the keystroke,
-    * underlined. The whole word is bold cyan when this is the active filter,
-    * dim otherwise. Underline state is toggled surgically so the inactive
-    * dim styling and the active bold+cyan styling pass through unchanged on
-    * the remaining letters.
-    */
-  private def filterLegendEntry(label: String, active: Boolean): String = {
-    val key = label.head.toString
-    val rest = label.tail
-    if (active) s"$BoldCode$Yellow$UnderlineCode$key$NoUnderlineCode$rest$Reset"
-    else s"$DimCode$UnderlineCode$key$NoUnderlineCode$rest$Reset"
-  }
-
-  /**
-    * Stats line: elapsed (right-aligned under `progress`) and heap
-    * (right-aligned under `threads`).
-    */
-  private def renderStats(sb: StringBuilder, elapsed: Long): Unit = {
-    val (heapUsedMb, heapMaxMb) = if (completed.get()) frozenHeap else heapUsage()
-    val heapUsedField = f"$heapUsedMb%4d MB"
-    val heapMaxField = f"$heapMaxMb%4d MB"
-    val heapRatio = if (heapMaxMb <= 0) 0.0 else heapUsedMb.toDouble / heapMaxMb
-    val elapsedField = formatMillis(elapsed)
-
-    // "elapsed" (7 chars) right-aligned with "progress" (8 chars) → start at ProgressStartCol + 1.
-    val elapsedStartCol = ProgressStartCol + 1
-    // "heap" (4 chars) right-aligned with "threads" (7 chars) → start at ThreadsStartCol + 3.
-    val heapStartCol = ThreadsStartCol + 3
-
-    sb.append("  ")
-    sb.append(" " * (elapsedStartCol - 3).max(0))
-    sb.append(dim("elapsed "))
-    sb.append(elapsedField)
-
-    val colAfterElapsed = elapsedStartCol + "elapsed ".length + elapsedField.length
-    sb.append(" " * (heapStartCol - colAfterElapsed).max(1))
-
-    sb.append(dim("heap "))
-    sb.append(styleHeap(heapUsedField, heapRatio))
-    sb.append(dim(" / "))
-    sb.append(heapMaxField)
-    sb.append('\n')
-  }
-
-  /** Renders the def-table column header and the divider underneath it. */
-  private def renderTableHeader(sb: StringBuilder, layout: Layout, activeSort: Sort): Unit = {
-    sb.append(' ')
-    sb.append(buildHeader(layout, activeSort))
-    sb.append(' ')
-    sb.append('\n')
-    sb.append(' ')
-    sb.append(dim("─" * layout.totalWidth))
-    sb.append(' ')
-    sb.append('\n')
-  }
-
-  /**
-    * Builds the def-table header. Each sortable column underlines its
-    * keystroke letter (`m̲ono`, `o̲pt`, `c̲ls`, `t̲ime`) and the Def header
-    * carries a tiny `(h̲ot)` annotation marking the hotness sort key.
-    * The active column is rendered bold yellow; the rest bold cyan.
-    */
-  private def buildHeader(layout: Layout, activeSort: Sort): String = {
-    val sb = new StringBuilder
-
-    // First column: "Def (hot)" — the 'h' (index 5) is the hotness keystroke.
-    val defPadded = rpad("Def (hot)", layout.symWidth)
-    sb.append(keyHeader(defPadded, 5, activeSort == Sort.Hotness))
-
-    sb.append(' ')
-    sb.append(plainHeader(rpad("location", layout.locWidth)))
-
-    if (layout.showLOC) {
-      sb.append(' '); sb.append(plainHeader(lpad("LOC", 4)))
-    }
-    if (layout.showCounts) {
-      val monoP = lpad("mono", 4); sb.append(' '); sb.append(keyHeader(monoP, monoP.indexOf('m'), activeSort == Sort.Mono))
-      val optP  = lpad("opt", 4);  sb.append(' '); sb.append(keyHeader(optP,  optP.indexOf('o'),  activeSort == Sort.Opt))
-      val clsP  = lpad("cls", 4);  sb.append(' '); sb.append(keyHeader(clsP,  clsP.indexOf('c'),  activeSort == Sort.Cls))
-    }
-    if (layout.showCns) {
-      val cnsP = lpad("cns", 5)
-      sb.append(' '); sb.append(keyHeader(cnsP, cnsP.indexOf('n'), activeSort == Sort.Cns))
-      val tvP  = lpad("tv",  4)
-      sb.append(' '); sb.append(keyHeader(tvP,  tvP.indexOf('v'),  activeSort == Sort.Tvars))
-      val evP  = lpad("ev",  4)
-      sb.append(' '); sb.append(keyHeader(evP,  evP.indexOf('e'),  activeSort == Sort.Evars))
-    }
-    if (layout.showPhase) {
-      sb.append(' '); sb.append(plainHeader(rpad("phase", 10)))
-    }
-    val timeP = lpad("time", 9); sb.append(' '); sb.append(keyHeader(timeP, timeP.indexOf('t'), activeSort == Sort.Time))
-    sb.append(' '); sb.append(plainHeader(lpad("%cpu", 6)))
-    sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
-    sb.toString
-  }
-
-  /** Renders the def-table body (one row per [[DefnStats]]), or a centered placeholder if `visible` is empty. */
-  private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int, layout: Layout): Unit = {
-    if (visible.isEmpty) {
-      val msg = "(no timings yet)"
-      val pad = (((layout.totalWidth + 2) - msg.length) / 2).max(0)
-      sb.append('\n')
-      sb.append(" " * pad)
-      sb.append(dim(msg))
-      sb.append('\n')
-      return
-    }
-    val safeElapsed = elapsed.max(1L).toDouble
-    for (s <- visible) {
-      val pctWall = 100.0 * s.totalNanos / safeElapsed
-      val pctCpu = pctWall / parallelism
-      val locStr = formatLocation(s.loc)
-      val locLines = locLineCount(s.loc)
-      val phase = s.dominantPhase.getOrElse("?")
-
-      val nameMax = layout.symWidth - 1
-      val nameText = truncate(s.sym.name, nameMax)
-      val locField = rpad(truncate(locStr, layout.locWidth), layout.locWidth)
-      val marker = if (s.isActive) yellow("*") else " "
-
-      sb.append(' ')
-      sb.append(styleSym(nameText, s.totalNanos, locLines))
-      sb.append(marker)
-      sb.append(" " * (nameMax - nameText.length))
-      sb.append(' ')
-      sb.append(dim(locField))
-      appendNumericFields(sb, locLines, s.byPhaseCount, s.cns, s.tvars.toLong, s.evars.toLong, phase, s.totalNanos, pctCpu, pctWall, layout, aggregate = false)
-      sb.append(' ')
-      sb.append('\n')
-    }
-  }
-
-  /** Renders the per-module aggregate table below the def table; no-op if `modules` is empty. */
-  private def renderModuleTable(sb: StringBuilder, modules: Vector[ModuleStats], elapsed: Long, parallelism: Int, layout: Layout, activeSort: Sort): Unit = {
-    if (modules.isEmpty) return
-
-    sb.append('\n')
-    val modWidth = layout.symWidth + 1 + layout.locWidth
-    sb.append(' ')
-    sb.append(buildModuleHeader(layout, activeSort))
-    sb.append(' ')
-    sb.append('\n')
-    sb.append(' ')
-    sb.append(dim("─" * layout.totalWidth))
-    sb.append(' ')
-    sb.append('\n')
-
-    val safeElapsed = elapsed.max(1L).toDouble
-    for (m <- modules) {
-      val pctWall = 100.0 * m.totalNanos / safeElapsed
-      val pctCpu = pctWall / parallelism
-      val phase = m.dominantPhase.getOrElse("?")
-
-      val modField = rpad(truncate(m.module, modWidth), modWidth)
-
-      sb.append(' ')
-      sb.append(modField)
-      appendNumericFields(sb, m.totalLocLines, m.byPhaseCount, m.totalCns, m.totalTvars, m.totalEvars, phase, m.totalNanos, pctCpu, pctWall, layout, aggregate = true)
-      sb.append(' ')
-      sb.append('\n')
-    }
-  }
-
-  /**
-    * Module-table header: single wide first column, then the same numeric
-    * columns as the def table. Mirrors [[buildHeader]]'s underline / active
-    * styling so the same sort keys are discoverable in both tables.
-    */
-  private def buildModuleHeader(layout: Layout, activeSort: Sort): String = {
-    val sb = new StringBuilder
-    val modWidth = layout.symWidth + 1 + layout.locWidth
-
-    // First column: "Module (hot)" — the 'h' (index 8) is the hotness keystroke.
-    val modPadded = rpad("Module (hot)", modWidth)
-    sb.append(keyHeader(modPadded, 8, activeSort == Sort.Hotness))
-
-    if (layout.showLOC) {
-      sb.append(' '); sb.append(plainHeader(lpad("LOC", 4)))
-    }
-    if (layout.showCounts) {
-      val monoP = lpad("mono", 4); sb.append(' '); sb.append(keyHeader(monoP, monoP.indexOf('m'), activeSort == Sort.Mono))
-      val optP  = lpad("opt", 4);  sb.append(' '); sb.append(keyHeader(optP,  optP.indexOf('o'),  activeSort == Sort.Opt))
-      val clsP  = lpad("cls", 4);  sb.append(' '); sb.append(keyHeader(clsP,  clsP.indexOf('c'),  activeSort == Sort.Cls))
-    }
-    if (layout.showCns) {
-      val cnsP = lpad("cns", 5)
-      sb.append(' '); sb.append(keyHeader(cnsP, cnsP.indexOf('n'), activeSort == Sort.Cns))
-      val tvP  = lpad("tv",  4)
-      sb.append(' '); sb.append(keyHeader(tvP,  tvP.indexOf('v'),  activeSort == Sort.Tvars))
-      val evP  = lpad("ev",  4)
-      sb.append(' '); sb.append(keyHeader(evP,  evP.indexOf('e'),  activeSort == Sort.Evars))
-    }
-    if (layout.showPhase) {
-      sb.append(' '); sb.append(plainHeader(rpad("phase", 10)))
-    }
-    val timeP = lpad("time", 9); sb.append(' '); sb.append(keyHeader(timeP, timeP.indexOf('t'), activeSort == Sort.Time))
-    sb.append(' '); sb.append(plainHeader(lpad("%cpu", 6)))
-    sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
-    sb.toString
-  }
-
-  /**
-    * Appends the trailing numeric columns (LOC, mono / opt / cls, cns,
-    * phase, time, %cpu, %wall) to a row, honoring the layout's visibility
-    * flags. Always emits a leading separator before each column it writes.
-    *
-    * `aggregate` skips all warning colors on `time` / `%cpu` / `%wall`. The
-    * `style*` thresholds are calibrated for individual defs; at module
-    * scale, sums-across-defs trip the thresholds unconditionally and the
-    * colors become noise. Counts (mono / opt / cls / cns) render plain in
-    * both tables.
-    */
-  private def appendNumericFields(sb: StringBuilder, locLines: Int, byPhaseCount: Map[String, Long], cns: Long, tvars: Long, evars: Long, phase: String,
-                                   nanos: Long, pctCpu: Double, pctWall: Double, layout: Layout,
-                                   aggregate: Boolean): Unit = {
-    if (layout.showLOC) {
-      sb.append(' ')
-      val locStr = if (locLines > 0) locLines.toString else "-"
-      sb.append(lpad(locStr, 4))
-    }
-    if (layout.showCounts) {
-      val mono = sumPhaseCounts(byPhaseCount, MonoCountPhases)
-      val opt  = sumPhaseCounts(byPhaseCount, OptCountPhases)
-      val cls  = sumPhaseCounts(byPhaseCount, ClsCountPhases)
-      sb.append(' '); sb.append(lpad(mono.toString, 4))
-      sb.append(' '); sb.append(lpad(opt.toString, 4))
-      sb.append(' '); sb.append(lpad(cls.toString, 4))
-    }
-    if (layout.showCns) {
-      sb.append(' '); sb.append(lpad(cns.toString, 5))
-      sb.append(' '); sb.append(lpad(tvars.toString, 4))
-      sb.append(' '); sb.append(lpad(evars.toString, 4))
-    }
-    if (layout.showPhase) {
-      sb.append(' ')
-      sb.append(rpad(truncate(phase, 10), 10))
-    }
-    val timeField = lpad(formatMillis(nanos), 9)
-    val cpuField  = f"$pctCpu%5.1f%%"
-    val wallField = f"$pctWall%5.1f%%"
-    sb.append(' '); sb.append(if (aggregate) timeField else styleTime(timeField, nanos))
-    sb.append(' '); sb.append(if (aggregate) cpuField else stylePctCpu(cpuField, pctCpu))
-    sb.append(' '); sb.append(if (aggregate) wallField else stylePctWall(wallField, pctWall))
-  }
-
-  /**
-    * Renders the threads-history sparkline at a fixed scale where
-    * `█` ⇔ `maxValue` (typically the threadpool's parallelism). Earlier
-    * samples appear on the left, the most recent on the right.
-    */
-  private def renderSparkline(maxValue: Double): String = {
-    if (threadsHistory.isEmpty) return " " * SparkWidth
-    val safeMax = maxValue.max(1.0)
-    val chars = threadsHistory.iterator.map { v =>
-      val i = math.min(SparkChars.length - 1, math.max(0, (v / safeMax * (SparkChars.length - 1)).round.toInt))
-      SparkChars(i)
-    }.toArray
-    val pad = (SparkWidth - chars.length).max(0)
-    " " * pad + new String(chars)
-  }
 }


### PR DESCRIPTION
## Summary

Splits the render-side of `CompilerTop` into its own file. Continues the breakup of the compiler-top TUI (after #12724, #12726, #12727).

- New **`class Renderer`** owns the rolling thread-occupancy history — the only mutable state on the render path. All `render*` / `build*` / `append*` methods and the dashboard / sparkline constants (`TotalPhases`, `MaxPhaseLen`, `BarWidth`, `ProgressStartCol`, `ThreadsStartCol`, `SparkWidth`, `SparkChars`) move here.
- New **`FrameState`** case class is the renderer's input — a 12-field snapshot of everything needed to paint one frame (`parallelism`, `isDone`, `elapsed`, `activeThreads`, `heap`, `currentPhase`, `phaseTimersSize`, `activeFilter`, `activeSort`, `layout`, `visible`, `modules`). Renderer is now a pure function of state and can be exercised without a live `Flix`.
- `CompilerTop` shrinks from 674 → ~320 lines, scoped to lifecycle + snapshotting (threads, JLine, raw mode, atomics, `frozen*` values, `start` / `stop` / `inputLoop` / `loop`). Gains a `buildFrameState()` that snapshots once per tick.

## Subtle improvement

`buildFrameState()` reads `completed.get()` once and uses it consistently for `elapsed` / `threads` / `heap`. Previously `renderStats` re-read it independently, which could in principle flip between reads within a single frame.

## Test plan

- [x] `./mill flix.compile`
- [x] `./mill flix.run out/empty.flix` (stdlib smoke-test)
- [x] Smoke-test the TUI with `--top` on a real build (visual — dashboard, progress bar, sparkline, filter/sort toggles, freeze-on-done)

## What's left

Only mechanical work remaining: moving `CompilerTop.scala` itself into the `compilertop/` package. After that, every component of the TUI lives in `tools/compilertop/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)