### PR TITLE
refactor: move CompilerTop into the compilertop package

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -27,7 +27,7 @@ import ca.uwaterloo.flix.language.phase.optimizer.{LambdaDrop, Optimizer}
 import ca.uwaterloo.flix.language.{CompilationMessage, GenSym}
 import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.tools.Summary
-import ca.uwaterloo.flix.tools.compilertop.Profiler
+import ca.uwaterloo.flix.tools.compilertop.{CompilerTop, Profiler}
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.Formatter.NoFormatter
 import ca.uwaterloo.flix.util.collection.{Chain, MultiMap}

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -13,16 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ca.uwaterloo.flix.util
+package ca.uwaterloo.flix.tools.compilertop
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.tools.compilertop.Aggregation.*
 import ca.uwaterloo.flix.tools.compilertop.Ansi.*
 import ca.uwaterloo.flix.tools.compilertop.Formatting.*
-import ca.uwaterloo.flix.tools.compilertop.Layout
 import ca.uwaterloo.flix.tools.compilertop.Model.*
-import ca.uwaterloo.flix.tools.compilertop.Profiler
-import ca.uwaterloo.flix.tools.compilertop.{FrameState, Renderer}
 import org.jline.terminal.{Attributes, Terminal, TerminalBuilder}
 
 import java.util.concurrent.CountDownLatch


### PR DESCRIPTION
## Summary

Final step of the compiler-top breakup (#12724, #12726, #12727, #12728).

- `git mv util/CompilerTop.scala tools/compilertop/CompilerTop.scala` — history preserved (98% similarity).
- The class itself is unchanged. It's already small (~320 lines of lifecycle + frame snapshotting) after the prior extractions.
- Package line: `ca.uwaterloo.flix.util` → `ca.uwaterloo.flix.tools.compilertop`.
- Dropped four redundant same-package imports (`Layout`, `Profiler`, `FrameState`, `Renderer`) — top-level types in the package are accessible without explicit import from sibling files. Wildcard member imports (`Aggregation.*`, `Ansi.*`, `Formatting.*`, `Model.*`) stay; those bring members into scope.
- `Flix.scala`: extended the existing `Profiler` import to also import `CompilerTop`, since the `util.*` wildcard no longer covers it.

## State after this PR

Every component of the compiler-top TUI lives in `main/src/ca/uwaterloo/flix/tools/compilertop/`:

```
compilertop/
├── Aggregation.scala  — filter / sort / module rollup
├── Ansi.scala         — escape codes + wrappers
├── CompilerTop.scala  — public TUI lifecycle (entry point)
├── Formatting.scala   — text / numeric helpers
├── Layout.scala       — column layout + algorithm
├── Model.scala        — PhaseFilter, Sort, ModuleStats, phase classifications
├── Profiler.scala     — per-DefnSym stats collection (FlixListener)
├── Renderer.scala     — frame builder + FrameState
└── Styling.scala      — threshold-driven coloring
```

The `util/` package no longer references any compiler-top internals.

## Test plan

- [x] `./mill flix.compile`
- [x] `./mill flix.run out/empty.flix` (stdlib smoke-test — `Flix.scala` was touched)
- [x] Smoke-test the TUI with `--top` on a real build (visual only — no behavior changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)