### PR TITLE
refactor: push key letters onto Sort / PhaseFilter ADTs

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -204,18 +204,15 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
             quitLatch.countDown()
             return
           }
-        case 'f' | 'F' => filter.set(PhaseFilter.Frontend)
-        case 'b' | 'B' => filter.set(PhaseFilter.Backend)
-        case 'a' | 'A' => filter.set(PhaseFilter.All)
-        case 't' | 'T' => sort.set(Sort.Time)
-        case 'h' | 'H' => sort.set(Sort.Hotness)
-        case 'm' | 'M' => sort.set(Sort.Mono)
-        case 'o' | 'O' => sort.set(Sort.Opt)
-        case 'c' | 'C' => sort.set(Sort.Cls)
-        case 'n' | 'N' => sort.set(Sort.Cns)
-        case 'v' | 'V' => sort.set(Sort.Tvars)
-        case 'e' | 'E' => sort.set(Sort.Evars)
-        case _         => // ignored
+        case ch if ch > 0 =>
+          // Dispatch via the Sort / PhaseFilter ADTs so the key ↔ value
+          // mapping lives in one place ([[Model.Sort.fromKey]],
+          // [[Model.PhaseFilter.fromKey]]) rather than being duplicated
+          // across this match and the renderer's header / legend code.
+          val char = ch.toChar
+          Sort.fromKey(char).foreach(sort.set)
+          PhaseFilter.fromKey(char).foreach(filter.set)
+        case _ => // ignored
       }
     }
   }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -27,12 +27,26 @@ object Model {
     * interactively via the input thread (`f` / `b` / `a`). The split tracks
     * `Flix.check` (frontend) vs the phases that follow in `Flix.compile`'s
     * `codeGen` (backend) — see [[FrontendPhases]].
+    *
+    * `label` is the legend word; `key` is the keystroke that selects this
+    * filter (by convention the first character of `label`). The renderer
+    * derives the legend from these fields and the input loop dispatches via
+    * [[PhaseFilter.fromKey]] — neither encodes the mapping inline.
     */
-  sealed trait PhaseFilter
+  sealed trait PhaseFilter {
+    def label: String
+    final def key: Char = label.head
+  }
   object PhaseFilter {
-    case object All extends PhaseFilter
-    case object Frontend extends PhaseFilter
-    case object Backend extends PhaseFilter
+    case object All      extends PhaseFilter { val label = "all" }
+    case object Frontend extends PhaseFilter { val label = "frontend" }
+    case object Backend  extends PhaseFilter { val label = "backend" }
+
+    /** All filter values in legend display order. */
+    val all: List[PhaseFilter] = List(All, Frontend, Backend)
+
+    /** The filter whose `key` matches `c` (case-insensitive), or `None`. */
+    def fromKey(c: Char): Option[PhaseFilter] = all.find(_.key == c.toLower)
   }
 
   /**
@@ -54,25 +68,37 @@ object Model {
     * Selects the descending sort key applied to the def and module tables.
     * Each option surfaces a different kind of suspect, so the same def can
     * top one ranking and not another.
+    *
+    * `key` is the keystroke that selects this sort. Stored lowercase; the
+    * input loop normalizes via `c.toLower` before dispatching. The renderer
+    * also reads `key` when deciding which character in a column header to
+    * underline — adding a new sort needs only a single line here and one
+    * `sortableColumn(...)` call in the renderer.
     */
-  sealed trait Sort
+  sealed trait Sort { def key: Char }
   object Sort {
     /** Slowest defs first. The default. */
-    case object Time extends Sort
+    case object Time    extends Sort { val key = 't' }
     /** Hottest-per-line defs first — small defs that burn disproportionate time. */
-    case object Hotness extends Sort
+    case object Hotness extends Sort { val key = 'h' }
     /** Most monomorphic instances first — surfaces generic-explosion hotspots. */
-    case object Mono extends Sort
+    case object Mono    extends Sort { val key = 'm' }
     /** Most optimizer fixed-point re-visits first — surfaces inliner / occurrence-analyzer thrashing. */
-    case object Opt extends Sort
+    case object Opt     extends Sort { val key = 'o' }
     /** Most class files emitted first — surfaces JVM fan-out from polymorphism / closures. */
-    case object Cls extends Sort
-    /** Most type constraints first — surfaces type-checking-heavy defs. */
-    case object Cns extends Sort
+    case object Cls     extends Sort { val key = 'c' }
+    /** Most type constraints first — surfaces type-checking-heavy defs. The key is `n` (not `c`, which is taken by [[Cls]]). */
+    case object Cns     extends Sort { val key = 'n' }
     /** Most type variables first — surfaces broadly polymorphic defs. */
-    case object Tvars extends Sort
+    case object Tvars   extends Sort { val key = 'v' }
     /** Most effect variables first — surfaces effect-polymorphic defs. */
-    case object Evars extends Sort
+    case object Evars   extends Sort { val key = 'e' }
+
+    /** All sort values. */
+    val all: List[Sort] = List(Time, Hotness, Mono, Opt, Cls, Cns, Tvars, Evars)
+
+    /** The sort whose `key` matches `c` (case-insensitive), or `None`. */
+    def fromKey(c: Char): Option[Sort] = all.find(_.key == c.toLower)
   }
 
   /** Phases whose `track` count maps to the `mono` column — number of monomorphic instances created. */

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -163,34 +163,29 @@ final class Renderer {
   }
 
   /**
-    * Renders the `[f|b|a]` legend with the active letter highlighted in
-    * bold cyan when the filter is non-default. Always visible so the user
-    * sees the available toggles whether the filter is active or not.
+    * Renders the `[a|f|b]` legend with the active filter highlighted in
+    * bold yellow. Always visible so the user sees the available toggles
+    * whether the filter is active or not. Driven entirely by
+    * [[PhaseFilter.all]]: adding a new filter is a one-line change in
+    * [[Model]] and the legend follows automatically.
     */
   private def renderFilterLegend(active: PhaseFilter): String = {
-    val sb = new StringBuilder
-    sb.append(dim("["))
-    sb.append(filterLegendEntry("all",      active == PhaseFilter.All))
-    sb.append(dim("|"))
-    sb.append(filterLegendEntry("frontend", active == PhaseFilter.Frontend))
-    sb.append(dim("|"))
-    sb.append(filterLegendEntry("backend",  active == PhaseFilter.Backend))
-    sb.append(dim("]"))
-    sb.toString
+    val entries = PhaseFilter.all.map(f => filterLegendEntry(f, f == active))
+    s"${dim("[")}${entries.mkString(dim("|"))}${dim("]")}"
   }
 
   /**
-    * Renders one filter-legend entry: the first letter is the keystroke,
-    * underlined. The whole word is bold cyan when this is the active filter,
-    * dim otherwise. Underline state is toggled surgically so the inactive
-    * dim styling and the active bold+cyan styling pass through unchanged on
-    * the remaining letters.
+    * Renders one filter-legend entry: the keystroke letter is underlined.
+    * The whole word is bold yellow when this is the active filter, dim
+    * otherwise. Underline state is toggled surgically so the inactive
+    * dim styling and the active bold+yellow styling pass through unchanged
+    * on the remaining letters.
     */
-  private def filterLegendEntry(label: String, active: Boolean): String = {
-    val key = label.head.toString
-    val rest = label.tail
+  private def filterLegendEntry(f: PhaseFilter, active: Boolean): String = {
+    val key = f.key.toString
+    val rest = f.label.tail
     if (active) s"$BoldCode$Yellow$UnderlineCode$key$NoUnderlineCode$rest$Reset"
-    else s"$DimCode$UnderlineCode$key$NoUnderlineCode$rest$Reset"
+    else        s"$DimCode$UnderlineCode$key$NoUnderlineCode$rest$Reset"
   }
 
   /**
@@ -245,9 +240,9 @@ final class Renderer {
   private def buildHeader(layout: Layout, activeSort: Sort): String = {
     val sb = new StringBuilder
 
-    // First column: "Def (hot)" — the 'h' (index 5) is the hotness keystroke.
-    val defPadded = rpad("Def (hot)", layout.symWidth)
-    sb.append(keyHeader(defPadded, 5, activeSort == Sort.Hotness))
+    // First column: "Def (hot)" — the parenthesized "(hot)" annotation
+    // carries the Hotness keystroke ('h').
+    sb.append(sortableColumn(rpad("Def (hot)", layout.symWidth), Sort.Hotness, activeSort))
 
     sb.append(' ')
     sb.append(plainHeader(rpad("location", layout.locWidth)))
@@ -256,26 +251,33 @@ final class Renderer {
       sb.append(' '); sb.append(plainHeader(lpad("LOC", 4)))
     }
     if (layout.showCounts) {
-      val monoP = lpad("mono", 4); sb.append(' '); sb.append(keyHeader(monoP, monoP.indexOf('m'), activeSort == Sort.Mono))
-      val optP  = lpad("opt", 4);  sb.append(' '); sb.append(keyHeader(optP,  optP.indexOf('o'),  activeSort == Sort.Opt))
-      val clsP  = lpad("cls", 4);  sb.append(' '); sb.append(keyHeader(clsP,  clsP.indexOf('c'),  activeSort == Sort.Cls))
+      sb.append(' '); sb.append(sortableColumn(lpad("mono", 4), Sort.Mono, activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("opt",  4), Sort.Opt,  activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("cls",  4), Sort.Cls,  activeSort))
     }
     if (layout.showCns) {
-      val cnsP = lpad("cns", 5)
-      sb.append(' '); sb.append(keyHeader(cnsP, cnsP.indexOf('n'), activeSort == Sort.Cns))
-      val tvP  = lpad("tv",  4)
-      sb.append(' '); sb.append(keyHeader(tvP,  tvP.indexOf('v'),  activeSort == Sort.Tvars))
-      val evP  = lpad("ev",  4)
-      sb.append(' '); sb.append(keyHeader(evP,  evP.indexOf('e'),  activeSort == Sort.Evars))
+      sb.append(' '); sb.append(sortableColumn(lpad("cns", 5), Sort.Cns,   activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("tv",  4), Sort.Tvars, activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("ev",  4), Sort.Evars, activeSort))
     }
     if (layout.showPhase) {
       sb.append(' '); sb.append(plainHeader(rpad("phase", 10)))
     }
-    val timeP = lpad("time", 9); sb.append(' '); sb.append(keyHeader(timeP, timeP.indexOf('t'), activeSort == Sort.Time))
+    sb.append(' '); sb.append(sortableColumn(lpad("time", 9), Sort.Time, activeSort))
     sb.append(' '); sb.append(plainHeader(lpad("%cpu", 6)))
     sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
     sb.toString
   }
+
+  /**
+    * Renders one sortable column header — the first occurrence of
+    * [[Sort.key]] in `padded` is underlined, and the whole label is bold
+    * yellow when `sort == activeSort`, bold cyan otherwise. The key letter
+    * comes from [[Sort]] itself so there is no separate keystroke
+    * declaration to keep in sync with the input loop.
+    */
+  private def sortableColumn(padded: String, sort: Sort, activeSort: Sort): String =
+    keyHeader(padded, padded.indexOf(sort.key), activeSort == sort)
 
   /** Renders the def-table body (one row per [[DefnStats]]), or a centered placeholder if `visible` is empty. */
   private def renderRows(sb: StringBuilder, visible: Vector[DefnStats], elapsed: Long, parallelism: Int, layout: Layout): Unit = {
@@ -353,30 +355,27 @@ final class Renderer {
     val sb = new StringBuilder
     val modWidth = layout.symWidth + 1 + layout.locWidth
 
-    // First column: "Module (hot)" — the 'h' (index 8) is the hotness keystroke.
-    val modPadded = rpad("Module (hot)", modWidth)
-    sb.append(keyHeader(modPadded, 8, activeSort == Sort.Hotness))
+    // First column: "Module (hot)" — the parenthesized "(hot)" annotation
+    // carries the Hotness keystroke ('h').
+    sb.append(sortableColumn(rpad("Module (hot)", modWidth), Sort.Hotness, activeSort))
 
     if (layout.showLOC) {
       sb.append(' '); sb.append(plainHeader(lpad("LOC", 4)))
     }
     if (layout.showCounts) {
-      val monoP = lpad("mono", 4); sb.append(' '); sb.append(keyHeader(monoP, monoP.indexOf('m'), activeSort == Sort.Mono))
-      val optP  = lpad("opt", 4);  sb.append(' '); sb.append(keyHeader(optP,  optP.indexOf('o'),  activeSort == Sort.Opt))
-      val clsP  = lpad("cls", 4);  sb.append(' '); sb.append(keyHeader(clsP,  clsP.indexOf('c'),  activeSort == Sort.Cls))
+      sb.append(' '); sb.append(sortableColumn(lpad("mono", 4), Sort.Mono, activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("opt",  4), Sort.Opt,  activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("cls",  4), Sort.Cls,  activeSort))
     }
     if (layout.showCns) {
-      val cnsP = lpad("cns", 5)
-      sb.append(' '); sb.append(keyHeader(cnsP, cnsP.indexOf('n'), activeSort == Sort.Cns))
-      val tvP  = lpad("tv",  4)
-      sb.append(' '); sb.append(keyHeader(tvP,  tvP.indexOf('v'),  activeSort == Sort.Tvars))
-      val evP  = lpad("ev",  4)
-      sb.append(' '); sb.append(keyHeader(evP,  evP.indexOf('e'),  activeSort == Sort.Evars))
+      sb.append(' '); sb.append(sortableColumn(lpad("cns", 5), Sort.Cns,   activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("tv",  4), Sort.Tvars, activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("ev",  4), Sort.Evars, activeSort))
     }
     if (layout.showPhase) {
       sb.append(' '); sb.append(plainHeader(rpad("phase", 10)))
     }
-    val timeP = lpad("time", 9); sb.append(' '); sb.append(keyHeader(timeP, timeP.indexOf('t'), activeSort == Sort.Time))
+    sb.append(' '); sb.append(sortableColumn(lpad("time", 9), Sort.Time, activeSort))
     sb.append(' '); sb.append(plainHeader(lpad("%cpu", 6)))
     sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
     sb.toString


### PR DESCRIPTION
## Summary

The character that selects a sort or filter via the `--top` input thread was duplicated across three sites:

1. A giant `match` in `CompilerTop.inputLoop` mapping `'t' | 'T' => sort.set(Sort.Time)` and so on.
2. The `keyHeader(lpad(...), padded.indexOf('m'), activeSort == Sort.Mono)` calls in both `buildHeader` and `buildModuleHeader`, each underlining the same letter inline.
3. The "first letter of label" convention in `renderFilterLegend` / `filterLegendEntry`.

Adding a sort meant editing all three. The `Cns → 'n'` irregularity in particular had to be remembered separately at each site (column is `cns`, key is `n`).

This PR pushes the keystroke metadata onto the ADTs:

- **`Sort`** gains `def key: Char`, with each case object declaring its own letter (`Sort.Cns { val key = 'n' }`). `Sort.all` lists every case; `Sort.fromKey(c)` looks up by lowercased char.
- **`PhaseFilter`** gains `label: String` and `key = label.head` (filter keys really are first-letters; deriving from `label` avoids redundancy). Same `all` / `fromKey` helpers.

Three call-site collapses fall out:

- **`CompilerTop.inputLoop`**: 11-case keystroke ladder → single dispatch via `Sort.fromKey(c).foreach(sort.set)` (plus the same for `PhaseFilter`).
- **`Renderer.sortableColumn(padded, sort, activeSort)`**: new helper. The 16 `keyHeader(lpad(...), indexOf(...), ==)` call sites across `buildHeader` and `buildModuleHeader` collapse to one call each.
- **`renderFilterLegend`**: becomes a fold over `PhaseFilter.all`; `filterLegendEntry` takes a `PhaseFilter` (so the keystroke comes from the ADT, not `label.head` of a string).

Adding a new `Sort` is now **one line** in `Model.scala` plus one `sortableColumn(...)` call in the renderer. The input loop and filter legend update themselves.

## Test plan

- [x] `./mill flix.compile`
- [x] `./mill flix.run out/empty.flix`
- [x] Smoke-test the TUI with `--top` on a real build — verify every keystroke still selects the right sort/filter, every column header still underlines the right letter, and the filter legend still highlights the right word.

## Out of scope

This is the first of several improvements identified in a design review of the post-extraction `compilertop/` package. Notably **not** addressed here:

- `Layout.compute` still takes a `PhaseFilter` rather than booleans for column visibility.
- `appendNumericFields` still has 12 parameters.
- `buildHeader` and `buildModuleHeader` still have parallel structure (minus the per-column duplication this PR removes).

Each of those is a separate, narrower PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)