### PR TITLE
chore: reformat subfolder concurrency-and-parallelism (batch 15.1)

### DIFF
--- a/examples/concurrency-and-parallelism/using-channels-for-message-passing.flix
+++ b/examples/concurrency-and-parallelism/using-channels-for-message-passing.flix
@@ -1,11 +1,11 @@
 def sendMessage(s: Sender[String]): Unit \ Chan =
     Channel.send("Hello World!", s)
 
-def recvMessage(r: Receiver[String]): Unit \ {Chan, NonDet, IO} =
+def recvMessage(r: Receiver[String]): Unit \ { Chan, NonDet, IO } =
     let msg = Channel.recv(r);
     println(msg)
 
-def main(): Unit \ {Chan, NonDet, IO} = region rc {
+def main(): Unit \ { Chan, NonDet, IO } = region rc {
     let (s, r) = Channel.unbuffered();
     spawn sendMessage(s) @ rc;
     spawn recvMessage(r) @ rc

--- a/examples/concurrency-and-parallelism/using-par-yield-recursively.flix
+++ b/examples/concurrency-and-parallelism/using-par-yield-recursively.flix
@@ -1,5 +1,5 @@
 def parMap(f: a -> b, l: List[a]): List[b] = match l {
-    case Nil     => Nil
+    case Nil => Nil
     case x :: xs =>
         par (r <- f(x); rs <- parMap(f, xs))
             yield r :: rs

--- a/examples/concurrency-and-parallelism/using-par-yield.flix
+++ b/examples/concurrency-and-parallelism/using-par-yield.flix
@@ -1,5 +1,5 @@
 def parSum(): (Int32, Int32) =
-   par (x <- 1 + 2; y <- 3 + 4)
+    par (x <- 1 + 2; y <- 3 + 4)
         yield (x, y)
 
 def main(): Unit \ IO =

--- a/examples/concurrency-and-parallelism/using-select-with-default.flix
+++ b/examples/concurrency-and-parallelism/using-select-with-default.flix
@@ -1,13 +1,13 @@
 def sendMessage(s: Sender[String]): Unit \ Chan =
     Channel.send("Hello World", s)
 
-def recvMessage(rx: Receiver[String]): Unit \ {Chan, NonDet, IO} =
+def recvMessage(rx: Receiver[String]): Unit \ { Chan, NonDet, IO } =
     select {
         case m <- recv(rx) => println(m)
         case _             => println("No message was ready")
     }
 
-def main(): Unit \ {Chan, NonDet, IO} =
+def main(): Unit \ { Chan, NonDet, IO } =
     region rc {
         let (s, r) = Channel.buffered(1);
         spawn recvMessage(r) @ rc;

--- a/examples/concurrency-and-parallelism/using-select-with-timeout.flix
+++ b/examples/concurrency-and-parallelism/using-select-with-timeout.flix
@@ -1,17 +1,17 @@
 use Time.TimeUnit
 
-def sendMessage(s: Sender[String]): Unit \ {Chan, NonDet, IO} =
+def sendMessage(s: Sender[String]): Unit \ { Chan, NonDet, IO } =
     Channel.recv(Channel.timeout(5, TimeUnit.Milliseconds));
     Channel.send("Hello World", s)
 
-def recvMessage(c: Receiver[String]): String \ {Chan, NonDet, IO} =
+def recvMessage(c: Receiver[String]): String \ { Chan, NonDet, IO } =
     let t = Channel.timeout(1, TimeUnit.Milliseconds);
     select {
         case m <- recv(c) => m
         case _ <- recv(t) => "Timeout"
     }
 
-def main(): Unit \ {Chan, NonDet, IO} =
+def main(): Unit \ { Chan, NonDet, IO } =
     region rc {
         let (s, r) = Channel.buffered(1);
         spawn sendMessage(s) @ rc;

--- a/examples/concurrency-and-parallelism/using-select.flix
+++ b/examples/concurrency-and-parallelism/using-select.flix
@@ -10,7 +10,7 @@ def meow(tx: Sender[String], n: Int32): Unit \ Chan =
         case x => Channel.send("Meow!", tx); meow(tx, x - 1)
     }
 
-def main(): Unit \ {Chan, NonDet, IO} =
+def main(): Unit \ { Chan, NonDet, IO } =
     region rc {
         let (s1, r1) = Channel.buffered(10);
         let (s2, r2) = Channel.buffered(10);


### PR DESCRIPTION
As we discussed in https://github.com/flix/flix/pull/12725.

This PR includes the formatted source code of the subfolder `concurrency and parallelism`.