### PR TITLE
chore: changed SourceLocation of several effect errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -181,11 +181,13 @@ object TypeError {
     *
     * @param defEffSyms the symbol(s) the effect(s) in the function definition
     * @param usedEffSym the symbol of the effect causing the error
-    * @param loc    the location of the function explicitly declared as defEffSym.
+    * @param loc1    the location of the function explicitly declared as defEffSym.
     * @param loc2   the location where the other effect is used.
     */
-  case class EffectfulFunctionUsesOtherEffect(defEffSyms: List[EffSymOrRigidVar], usedEffSym: EffSymOrRigidVar, loc: SourceLocation, loc2: SourceLocation) extends TypeError {
+  case class EffectfulFunctionUsesOtherEffect(defEffSyms: List[EffSymOrRigidVar], usedEffSym: EffSymOrRigidVar, loc1: SourceLocation, loc2: SourceLocation) extends TypeError {
     def code: ErrorCode = ErrorCode.E6216
+
+    def loc: SourceLocation = loc2
 
     def summary: String = s"Unexpected effect '${usedEffSym.name}' in function declared as '${defEffSyms}'"
 
@@ -199,7 +201,7 @@ object TypeError {
       val defString = s"{${magenta(formatEffs(defEffSyms))}}"
       s""">> Unexpected effect '${magenta(usedEffSym.name)}' in function declared as '$defString'.
          |
-         |${highlight(loc, s"function declared as '$defString'", fmt)}
+         |${highlight(loc1, s"function declared as '$defString'", fmt)}
          |
          |${highlight(loc2, s"'${magenta(usedEffSym.name)}' used here", fmt)}
          |
@@ -215,11 +217,13 @@ object TypeError {
     * An error raised when an effect is used in a function that is explicitly declared Pure.
     *
     * @param effSym the symbol of the effect causing the error
-    * @param loc    the location of the function explicitly declared as {}.
+    * @param loc1    the location of the function explicitly declared as {}.
     * @param loc2   the location where the effect is used.
     */
-  case class ExplicitlyPureFunctionUsesEffect(effSym: EffSymOrRigidVar, loc: SourceLocation, loc2: SourceLocation) extends TypeError {
+  case class ExplicitlyPureFunctionUsesEffect(effSym: EffSymOrRigidVar, loc1: SourceLocation, loc2: SourceLocation) extends TypeError {
     def code: ErrorCode = ErrorCode.E6215
+
+    def loc: SourceLocation = loc2
 
     def summary: String = s"Unexpected effect '${effSym.name}' in {} function"
 
@@ -227,7 +231,7 @@ object TypeError {
       import fmt.*
       s""">> Unexpected effect '${magenta(effSym.name)}' in {} function.
          |
-         |${highlight(loc, "function declared {}", fmt)}
+         |${highlight(loc1, "function declared {}", fmt)}
          |
          |${highlight(loc2, s"'${magenta(effSym.name)}' used here", fmt)}
          |
@@ -242,11 +246,13 @@ object TypeError {
   /**
     * An error raised when IO is used in a function that is explicitly declared Pure.
     *
-    * @param loc  the location of the function explicitly declared as {}.
+    * @param loc1  the location of the function explicitly declared as {}.
     * @param loc2 the location where IO is used.
     */
-  case class ExplicitlyPureFunctionUsesIO(loc: SourceLocation, loc2: SourceLocation) extends TypeError {
+  case class ExplicitlyPureFunctionUsesIO(loc1: SourceLocation, loc2: SourceLocation) extends TypeError {
     def code: ErrorCode = ErrorCode.E6214
+
+    def loc: SourceLocation = loc2
 
     def summary: String = s"Unexpected effect 'IO' in {} function"
 
@@ -254,7 +260,7 @@ object TypeError {
       import fmt.*
       s""">> Unexpected effect '${magenta("IO")}' in {} function.
          |
-         |${highlight(loc, "function declared {}", fmt)}
+         |${highlight(loc1, "function declared {}", fmt)}
          |
          |${highlight(loc2, s"'${magenta("IO")}' used here", fmt)}
          |


### PR DESCRIPTION
This pull request refactors several error case classes in `TypeError.scala` to clarify the distinction between the location where a function is declared as pure or with specific effects, and the location where an unexpected effect is used. The changes improve code readability and make error messages more precise by renaming parameters and ensuring the correct locations are highlighted in error messages.

Specifically error locations are now reported at the place causing the error instead of where the fix would happen.

**Error handling improvements:**

* Renamed the `loc` parameter to `loc1` in the `EffectfulFunctionUsesOtherEffect`, `ExplicitlyPureFunctionUsesEffect`, and `ExplicitlyPureFunctionUsesIO` case classes to clarify that it refers to the location of the function declaration, and added a `loc` method that now returns the location where the effect is used (`loc2`). [[1]](diffhunk://#diff-484b9b0f48e55f941467325febb4a1bb7735153d002be2bcf601e5b07fb7591fL184-R191) [[2]](diffhunk://#diff-484b9b0f48e55f941467325febb4a1bb7735153d002be2bcf601e5b07fb7591fL218-R234) [[3]](diffhunk://#diff-484b9b0f48e55f941467325febb4a1bb7735153d002be2bcf601e5b07fb7591fL245-R263)
* Updated error message formatting in each case class to use `loc1` for highlighting the function declaration location, and `loc2` for where the effect is used, improving the accuracy of error reporting. [[1]](diffhunk://#diff-484b9b0f48e55f941467325febb4a1bb7735153d002be2bcf601e5b07fb7591fL202-R204) [[2]](diffhunk://#diff-484b9b0f48e55f941467325febb4a1bb7735153d002be2bcf601e5b07fb7591fL218-R234) [[3]](diffhunk://#diff-484b9b0f48e55f941467325febb4a1bb7735153d002be2bcf601e5b07fb7591fL245-R263)


## Screenshots


_Before:_

<img width="876" height="35" alt="image" src="https://github.com/user-attachments/assets/55787f06-37f2-4262-86c2-1eab2f1be28e" />

_After:_

<img width="876" height="35" alt="image" src="https://github.com/user-attachments/assets/2000d8ed-a864-4480-9f0f-b2668552d1d5" />
