### PR TITLE
chore: reformat subfolder effects and handlers (batch 15.3)

### DIFF
--- a/examples/effects-and-handlers/advanced/backtracking.flix
+++ b/examples/effects-and-handlers/advanced/backtracking.flix
@@ -13,20 +13,21 @@ eff Rewind {
 /// 3. not divisible by 2 (so not 0, 2, 4, 6, 8, ...)
 /// 4. not divisible by 3 (so not 0, 3, 6, 9, ...)
 /// And we will this by guessing and retrying
-def search(k: Int32): Int32 \ {Rewind, NonDet, IO} = {
+def search(k: Int32): Int32 \ { Rewind, NonDet, IO } = {
     let rnd = new Random();
     println("Beginning to search!");
     Rewind.save("start");
     let guess = rnd.nextInt(k);
     // 1. and 2. hold automatically
-    if (Int32.modulo(guess, 2) == 0) {println("retry for ${guess}"); Rewind.rewind("start"); ?unreachable}
+    if (Int32.modulo(guess, 2) == 0) { println("retry for ${guess}"); Rewind.rewind("start"); ?unreachable }
     // now 3. holds
-    else if (Int32.modulo(guess, 3) == 0) {println("retry for ${guess}"); Rewind.rewind("start"); ?unreachable}
+    else if (Int32.modulo(guess, 3) == 0) { println("retry for ${guess}"); Rewind.rewind("start"); ?unreachable }
     // now 4. holds and we can return
-    else guess
+    else
+        guess
 }
 
-pub def main(): Int32 \ {NonDet, IO} = region rc {
+pub def main(): Int32 \ { NonDet, IO } = region rc {
     let checkpoints = MutMap.empty(rc);
     run search(10) with handler Rewind {
         def save(label, k) = {
@@ -35,7 +36,7 @@ pub def main(): Int32 \ {NonDet, IO} = region rc {
         }
         def rewind(label, _k) = match MutMap.get(label, checkpoints) {
             case Some(k) => k()
-            case None => -1
+            case None    => -1
         }
     }
 }

--- a/examples/effects-and-handlers/advanced/nqueens.flix
+++ b/examples/effects-and-handlers/advanced/nqueens.flix
@@ -33,7 +33,7 @@ eff Searchable {
 /// position is not safe.
 ///
 def isSafePosition(pos: Int32, diagonal: Int32, sol: Placement): Bool = match sol {
-    case Nil     => true
+    case Nil => true
     case q :: qs =>
         let isSafe = pos != q and pos != q + diagonal and pos != q - diagonal;
         isSafe and isSafePosition(pos, diagonal + 1, qs)

--- a/examples/effects-and-handlers/console/readln-with.flix
+++ b/examples/effects-and-handlers/console/readln-with.flix
@@ -2,10 +2,11 @@ use Sys.Console
 
 /// Prompts for a number between 1 and 10, re-prompting on invalid input.
 def main(): Unit \ Console =
-    let n = Console.readlnWith("Enter a number (1-10): ", s ->
-        match Int32.fromString(s) {
+    let n = Console.readlnWith(
+        "Enter a number (1-10): ",
+        s -> match Int32.fromString(s) {
             case Some(i) if i >= 1 and i <= 10 => Ok(i)
-            case _ => Err("Please enter a number between 1 and 10.")
+            case _                             => Err("Please enter a number between 1 and 10.")
         }
     );
     Console.println("You entered: ${n}")

--- a/examples/effects-and-handlers/env/env-system-info.flix
+++ b/examples/effects-and-handlers/env/env-system-info.flix
@@ -3,10 +3,10 @@ use Sys.Env
 /// Reads system properties: OS name, architecture, version, and
 /// the number of available virtual processors.
 def main(): Unit \ { Env, IO } =
-    let name    = Env.getOsName();
-    let arch    = Env.getOsArch();
+    let name = Env.getOsName();
+    let arch = Env.getOsArch();
     let version = Env.getOsVersion();
-    let cpus    = Env.getVirtualProcessors();
+    let cpus = Env.getVirtualProcessors();
     println("OS:   ${name}");
     println("Arch: ${arch}");
     println("Ver:  ${version}");

--- a/examples/effects-and-handlers/fs/effect-hierarchy.flix
+++ b/examples/effects-and-handlers/fs/effect-hierarchy.flix
@@ -15,9 +15,9 @@ def main(): Unit \ { FileRead, FileTest, IO } =
 
 def safeRead(file: String): Unit \ { FileExists, ReadFile, IO } =
     match FileExists.exists(file) {
-        case Err(err)  => println("Error: ${err}")
+        case Err(err) => println("Error: ${err}")
         case Ok(false) => println("File does not exist")
-        case Ok(true)  =>
+        case Ok(true) =>
             match ReadFile.read(file) {
                 case Ok(content) => println(content)
                 case Err(err)    => println("Read error: ${err}")

--- a/examples/effects-and-handlers/fs/using-in-memory-fs.flix
+++ b/examples/effects-and-handlers/fs/using-in-memory-fs.flix
@@ -6,13 +6,13 @@ use Time.Clock
 def main(): Unit \ { Clock, IO } =
     run {
         let result = forM (
-            _       <- FileSystem.mkDirs("/data");
-            _       <- FileSystem.write(str = "Hello", "/data/hello.txt");
-            _       <- FileSystem.write(str = "World", "/data/world.txt");
+            _ <- FileSystem.mkDirs("/data");
+            _ <- FileSystem.write(str = "Hello", "/data/hello.txt");
+            _ <- FileSystem.write(str = "World", "/data/world.txt");
             entries <- FileSystem.list("/data");
             content <- FileSystem.read("/data/hello.txt");
-            _       <- FileSystem.delete("/data/hello.txt");
-            exists  <- FileSystem.exists("/data/hello.txt")
+            _ <- FileSystem.delete("/data/hello.txt");
+            exists <- FileSystem.exists("/data/hello.txt")
         ) yield (entries, content, exists);
         match result {
             case Err(err) => println("Error: ${err}")

--- a/examples/effects-and-handlers/http/post-with-json.flix
+++ b/examples/effects-and-handlers/http/post-with-json.flix
@@ -7,8 +7,8 @@ use Net.HttpResponse
 def main(): Unit \ { Http, IO } =
     let body = "{\"name\": \"Asterix\", \"age\": 35}";
     let req = HttpRequest.post("https://flix.dev/api/users", body)
-                |> HttpRequest.withContentType("application/json")
-                |> HttpRequest.withAccept("application/json");
+        |> HttpRequest.withContentType("application/json")
+        |> HttpRequest.withAccept("application/json");
     match Http.send(req) {
         case Ok(resp) =>
             println("Status: ${HttpResponse.status(resp)}");

--- a/examples/effects-and-handlers/http/using-http-build-request.flix
+++ b/examples/effects-and-handlers/http/using-http-build-request.flix
@@ -8,11 +8,11 @@ use Time.Duration.seconds
 /// a custom header, and a timeout before sending with `Http.send`.
 def main(): Unit \ { Http, IO } =
     let req = HttpRequest.get("https://flix.dev/api/search")
-                |> HttpRequest.withQueryParam("q", "flix programming language")
-                |> HttpRequest.withQueryParams(Map#{"page" => "1", "per_page" => "25", "sort" => "relevance"})
-                |> HttpRequest.withBearerToken("ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789")
-                |> HttpRequest.withHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
-                |> HttpRequest.withTimeout(seconds(5));
+        |> HttpRequest.withQueryParam("q", "flix programming language")
+        |> HttpRequest.withQueryParams(Map#{"page" => "1", "per_page" => "25", "sort" => "relevance"})
+        |> HttpRequest.withBearerToken("ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789")
+        |> HttpRequest.withHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+        |> HttpRequest.withTimeout(seconds(5));
     match Http.send(req) {
         case Ok(resp) =>
             println("Status: ${HttpResponse.status(resp)}");

--- a/examples/effects-and-handlers/process/process-exec-and-read-output.flix
+++ b/examples/effects-and-handlers/process/process-exec-and-read-output.flix
@@ -6,10 +6,10 @@ use Sys.Process
 def main(): Unit \ { Process, IO } = region rc {
     match Process.exec("java", "-version" :: Nil) {
         case Result.Err(err) => println("exec failed: ${err}")
-        case Result.Ok(ph)   =>
+        case Result.Ok(ph) =>
             match Process.stderr(ph) {
                 case Result.Err(err) => println("stderr failed: ${err}")
-                case Result.Ok(err)  =>
+                case Result.Ok(err) =>
                     let buf = Array.repeat(rc, 1024, (0i8: Int8));
                     match Readable.read(buf, err) {
                         case Result.Err(e) => println("read failed: ${e}")

--- a/examples/effects-and-handlers/process/process-wait-and-exit-value.flix
+++ b/examples/effects-and-handlers/process/process-wait-and-exit-value.flix
@@ -5,7 +5,7 @@ use Sys.Process
 def main(): Unit \ { Process, IO } =
     match Process.exec("java", "-version" :: Nil) {
         case Result.Err(err) => println("exec failed: ${err}")
-        case Result.Ok(ph)   =>
+        case Result.Ok(ph) =>
             match Process.waitFor(ph) {
                 case Result.Err(err) => println("waitFor failed: ${err}")
                 case Result.Ok(code) => println("Process exited with code: ${code}")

--- a/examples/effects-and-handlers/tcp/tcp-connect.flix
+++ b/examples/effects-and-handlers/tcp/tcp-connect.flix
@@ -8,7 +8,7 @@ use Net.TcpConnect
 def main(): Unit \ { Dns, TcpConnect, IO } = region rc {
     match Dns.lookup("tcpbin.com") {
         case Err(err) => println("DNS error: ${err}")
-        case Ok(ip)   =>
+        case Ok(ip) =>
             match TcpConnect.connect(ip, 4242i16) {
                 case Err(err) => println("Connect error: ${err}")
                 case Ok(socket) =>
@@ -20,7 +20,7 @@ def main(): Unit \ { Dns, TcpConnect, IO } = region rc {
                     let recvBuf = Array.repeat(rc, 1024, (0i8: Int8));
                     match Readable.read(recvBuf, socket) {
                         case Err(err) => println("Read error: ${err}")
-                        case Ok(n)    =>
+                        case Ok(n) =>
                             let bytes = Array.slice(rc, start = 0, end = n, recvBuf);
                             let reply = String.fromBytes(Array.toVector(bytes));
                             println("Echo: ${reply}")

--- a/examples/effects-and-handlers/tcp/tcp-send-and-receive.flix
+++ b/examples/effects-and-handlers/tcp/tcp-send-and-receive.flix
@@ -29,7 +29,7 @@ def main(): Unit \ { TcpBind, TcpConnect, TcpAccept, IO } = region rc {
                             let recvBuf = Array.repeat(rc, 1024, (0i8: Int8));
                             match Readable.read(recvBuf, serverSide) {
                                 case Err(err) => println("Read error: ${err}")
-                                case Ok(n)    =>
+                                case Ok(n) =>
                                     let bytes = Array.slice(rc, start = 0, end = n, recvBuf);
                                     let received = String.fromBytes(Array.toVector(bytes));
                                     println("Server received: ${received}")


### PR DESCRIPTION
As we discussed in PR https://github.com/flix/flix/pull/12725.

This PR formats all examples in subfolder `effects-and-handlers`.

Thanks :)