### PR TITLE
chore: reformat subfolder functional-style (batch 15.4)

### DIFF
--- a/examples/functional-style/algebraic-data-types-and-pattern-matching.flix
+++ b/examples/functional-style/algebraic-data-types-and-pattern-matching.flix
@@ -1,7 +1,7 @@
 /// An algebraic data type for shapes.
 enum Shape {
-    case Circle(Int32),          // circle radius
-    case Square(Int32),          // side length
+    case Circle(Int32) // circle radius
+    case Square(Int32) // side length
     case Rectangle(Int32, Int32) // height and width
 }
 

--- a/examples/functional-style/enums-and-parametric-polymorphism.flix
+++ b/examples/functional-style/enums-and-parametric-polymorphism.flix
@@ -1,6 +1,6 @@
 /// An algebraic data type for binary trees with leaves.
 enum Tree[a] {
-    case Leaf(a),
+    case Leaf(a)
     case Node(Tree[a], Tree[a])
 }
 

--- a/examples/functional-style/function-composition-pipelines-and-currying.flix
+++ b/examples/functional-style/function-composition-pipelines-and-currying.flix
@@ -5,8 +5,8 @@
 /// Constructs a list with ten elements and performs
 /// various operations on it in a pipeline.
 def main(): Unit \ IO =
-    List.range(0, 10) |>
-    List.map(x -> x * x) |>
-    List.take(5) |>
-    List.exists(x -> x == 1) |>
-    println
+    List.range(0, 10)
+        |> List.map(x -> x * x)
+        |> List.take(5)
+        |> List.exists(x -> x == 1)
+        |> println

--- a/examples/functional-style/lists-and-list-processing.flix
+++ b/examples/functional-style/lists-and-list-processing.flix
@@ -6,8 +6,8 @@ def l(): List[Int32] =
 
 /// We can use pattern matching to take a list apart:
 def length(l: List[a]): Int32 = match l {
-  case Nil     => 0
-  case _ :: xs => 1 + length(xs)
+    case Nil     => 0
+    case _ :: xs => 1 + length(xs)
 }
 
 /// The Flix library has extensive support for lists:


### PR DESCRIPTION
As we discussed in https://github.com/flix/flix/pull/12725 .

This PR formats the subfolder `functional-style`.