### PR TITLE
chore: reformat subfolder interoperability (batch 15.6)

### DIFF
--- a/examples/interoperability/files/writing-a-file-with-java.flix
+++ b/examples/interoperability/files/writing-a-file-with-java.flix
@@ -4,5 +4,5 @@ import java.io.FileWriter
 def main(): Unit \ IO =
     let lines = List#{"Foo", "Bar", "Baz"};
     let writer = new BufferedWriter(new FileWriter("foo.txt"));
-    lines |> List.forEach(line -> { writer.write(line); writer.newLine()});
+    lines |> List.forEach(line -> { writer.write(line); writer.newLine() });
     writer.close()

--- a/examples/interoperability/swing/swing-dialog.flix
+++ b/examples/interoperability/swing/swing-dialog.flix
@@ -32,7 +32,7 @@ def mkButton(content: String, onClick: ActionEvent -> Unit \ ef): JButton \ IO =
     button
 }
 
-def showDialog(title: { title = String }, content: { content = String }, frame: JFrame): Unit \ IO = {
+def showDialog(title: {title = String}, content: {content = String}, frame: JFrame): Unit \ IO = {
     JOptionPane.showConfirmDialog(frame, content#content, title#title, JOptionPane.YES_NO_CANCEL_OPTION);
     ()
 }


### PR DESCRIPTION
As we discussed in PR https://github.com/flix/flix/pull/12725.

This PR formats the subfolder `interoperability`.