### PR TITLE
chore: reformat subfolder modules (batch 15.7)

### DIFF
--- a/examples/modules/companion-module-effect.flix
+++ b/examples/modules/companion-module-effect.flix
@@ -11,5 +11,5 @@ def main(): Unit \ IO =
     run {
         StdOut.println(42)
     } with handler StdOut {
-        def printStr(s, k) = {println(s); k()}
+        def printStr(s, k) = { println(s); k() }
     }

--- a/examples/modules/companion-module-enum.flix
+++ b/examples/modules/companion-module-enum.flix
@@ -1,14 +1,14 @@
 enum Color {
-    case Red,
-    case Green,
+    case Red
+    case Green
     case Blue
 }
 
 mod Color {
     pub def isWarm(c: Color): Bool = match c {
-        case Red    => true
-        case Green  => false
-        case Blue   => false
+        case Red   => true
+        case Green => false
+        case Blue  => false
     }
 }
 

--- a/examples/modules/companion-module-struct.flix
+++ b/examples/modules/companion-module-struct.flix
@@ -1,6 +1,6 @@
 struct Node[t, r] {
     mut value: t,
-    mut next: Option[Node[t, r]]
+    mut next:  Option[Node[t, r]]
 }
 
 mod Node {
@@ -13,8 +13,8 @@ mod Node {
 
 def main(): Unit \ IO =
     region rc {
-        let n3 = new Node @ rc { value = 3, next = None };
-        let n2 = new Node @ rc { value = 2, next = Some(n3) };
-        let n1 = new Node @ rc { value = 1, next = Some(n2) };
+        let n3 = new Node @ rc {value = 3, next = None};
+        let n2 = new Node @ rc {value = 2, next = Some(n3)};
+        let n1 = new Node @ rc {value = 1, next = Some(n2)};
         println(Node.last(n1))
     }

--- a/examples/modules/use-from-a-module-locally.flix
+++ b/examples/modules/use-from-a-module-locally.flix
@@ -7,9 +7,9 @@ mod A {
 
     pub def isWarm(c: Color): Bool =
         match c {
-            case Color.Red    => true
-            case Color.Green  => false
-            case Color.Blue   => false
+            case Color.Red   => true
+            case Color.Green => false
+            case Color.Blue  => false
         }
 }
 

--- a/examples/modules/use-from-a-module.flix
+++ b/examples/modules/use-from-a-module.flix
@@ -7,9 +7,9 @@ mod A {
 
     pub def isWarm(c: Color): Bool =
         match c {
-            case Color.Red    => true
-            case Color.Green  => false
-            case Color.Blue   => false
+            case Color.Red   => true
+            case Color.Green => false
+            case Color.Blue  => false
         }
 }
 


### PR DESCRIPTION
As we discussed in PR https://github.com/flix/flix/pull/12725.

This PR formats the subfolder `modules`.