### PR TITLE
chore: reformat subfolder tail-recursion-and-termination (batch 15.10)

### DIFF
--- a/examples/tail-recursion-and-termination/direct-tail-recursion.flix
+++ b/examples/tail-recursion-and-termination/direct-tail-recursion.flix
@@ -6,7 +6,6 @@
 /// The `@Tailrec` annotation asks the compiler to verify that every
 /// self-recursive call is in tail position — here the recursive call
 /// `isPrefixOf(xs, ys)` is the last operation in its branch.
-
 @Terminates @Tailrec
 pub def isPrefixOf(l1: List[a], l2: List[a]): Bool with Eq[a] = match (l1, l2) {
     case (Nil, _)           => true

--- a/examples/tail-recursion-and-termination/tail-recursion-with-accumulator.flix
+++ b/examples/tail-recursion-and-termination/tail-recursion-with-accumulator.flix
@@ -5,7 +5,6 @@
 /// local defs are implicitly checked for termination as well.
 /// The `@Tailrec` annotation on the local def `loop` additionally
 /// verifies that every self-recursive call is in tail position.
-
 @Terminates
 pub def unzip(l: List[(a, b)]): (List[a], List[b]) =
     @Tailrec

--- a/examples/tail-recursion-and-termination/tail-recursion-with-reverse.flix
+++ b/examples/tail-recursion-and-termination/tail-recursion-with-reverse.flix
@@ -5,7 +5,6 @@
 /// local defs are implicitly checked for termination as well.
 /// The `@Tailrec` annotation on the local def `loop` additionally
 /// verifies that every self-recursive call is in tail position.
-
 @Terminates
 pub def map(f: a -> b \ ef, l: List[a]): List[b] \ ef =
     @Tailrec


### PR DESCRIPTION
As we discussed in PR https://github.com/flix/flix/pull/12725.

This PR formats the subfolder `tail-recursion-and-termination`.