### PR TITLE
chore: reformat subfolder Ast in Fixpoint3 (batch 14.1)

### DIFF
--- a/main/src/library/Fixpoint3/Ast/Datalog.flix
+++ b/main/src/library/Fixpoint3/Ast/Datalog.flix
@@ -57,7 +57,7 @@ pub mod Fixpoint3.Ast.Datalog {
                 let factSyms = facts |> Vector.map(predSymsOf) |> Monoid.fold;
                 let ruleSyms = rules |> Vector.map(predSymsOf) |> Monoid.fold;
                 factSyms ++ ruleSyms
-            case Datalog.Model(m)     => Map.keysOf(m) |> Set.toList |> List.map(predSymsOf) |> Monoid.fold
+            case Datalog.Model(m) => Map.keysOf(m) |> Set.toList |> List.map(predSymsOf) |> Monoid.fold
             case Datalog.Join(v1, v2) => predSymsOf(v1) ++ predSymsOf(v2)
             case Datalog.Provenance(rules, model) =>
                 let ruleSyms = rules |> Vector.map(predSymsOf) |> Monoid.fold;
@@ -271,12 +271,12 @@ pub mod Fixpoint3.Ast.Datalog {
                         case Some(l) => "${polarityPrefix(p)}${fixityPrefix(f)}${predSym}(${keyTerms |> Vector.join(", ")}; ${l})"
                     }
                 case BodyPredicate.Functional(boundVars, _, freeVars) => "<loop>(${boundVars}, ${freeVars})"
-                case BodyPredicate.Guard0(_)                          => "<clo>()"
-                case BodyPredicate.Guard1(_, v)                       => "<clo>(${v})"
-                case BodyPredicate.Guard2(_, v1, v2)                  => "<clo>(${v1}, ${v2})"
-                case BodyPredicate.Guard3(_, v1, v2, v3)              => "<clo>(${v1}, ${v2}, ${v3})"
-                case BodyPredicate.Guard4(_, v1, v2, v3, v4)          => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
-                case BodyPredicate.Guard5(_, v1, v2, v3, v4, v5)      => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
+                case BodyPredicate.Guard0(_) => "<clo>()"
+                case BodyPredicate.Guard1(_, v) => "<clo>(${v})"
+                case BodyPredicate.Guard2(_, v1, v2) => "<clo>(${v1}, ${v2})"
+                case BodyPredicate.Guard3(_, v1, v2, v3) => "<clo>(${v1}, ${v2}, ${v3})"
+                case BodyPredicate.Guard4(_, v1, v2, v3, v4) => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
+                case BodyPredicate.Guard5(_, v1, v2, v3, v4, v5) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
             }
     }
 

--- a/main/src/library/Fixpoint3/Ast/ExecutableRam.flix
+++ b/main/src/library/Fixpoint3/Ast/ExecutableRam.flix
@@ -115,16 +115,16 @@ pub mod Fixpoint3.Ast.ExecutableRam {
         pub def toString(stmt: RamStmt): String =
             let nl = String.lineSeparator();
             match stmt {
-                case RamStmt.Insert(op)             => ToString.toString(op)
+                case RamStmt.Insert(op) => ToString.toString(op)
                 case RamStmt.MergeInto(src, dst, _) => "Merge indexes[${src}] into indexes[${dst}]"
-                case RamStmt.Swap(lhs, rhs)         => "Swap indexes[${lhs}] and indexes[${rhs}]"
-                case RamStmt.Purge(ramSym)          => "Purge indexes[${ramSym}]"
-                case RamStmt.Seq(xs)                => Vector.join(";${nl}", xs)
+                case RamStmt.Swap(lhs, rhs) => "Swap indexes[${lhs}] and indexes[${rhs}]"
+                case RamStmt.Purge(ramSym) => "Purge indexes[${ramSym}]"
+                case RamStmt.Seq(xs) => Vector.join(";${nl}", xs)
                 case RamStmt.Until(test, body) =>
                     let tst = test |> Vector.join(" ∧ ");
                     "Until(${tst}) do${nl}${String.indent(4, "${body}")}end"
-                case RamStmt.Comment(comment)       => "/* ${comment} */"
-                case RamStmt.Par(xs)                => Vector.join("|${nl}", xs)
+                case RamStmt.Comment(comment) => "/* ${comment} */"
+                case RamStmt.Par(xs) => Vector.join("|${nl}", xs)
             }
     }
 
@@ -298,18 +298,18 @@ pub mod Fixpoint3.Ast.ExecutableRam {
 
     instance ToString[RamTerm] {
         pub def toString(term: RamTerm): String = match term {
-            case RamTerm.Lit(v, _)                                  => Debug.stringify(v)
+            case RamTerm.Lit(v, _) => Debug.stringify(v)
             case RamTerm.LoadFromTuple(tupleIndex, indexInTuple, _) => "x${tupleIndex}[${indexInTuple}]"
-            case RamTerm.LoadLatVar(i, _)                           => "LoadLatVar[${i}]"
+            case RamTerm.LoadLatVar(i, _) => "LoadLatVar[${i}]"
             case RamTerm.ProvMax(loads) =>
                 let loadsStr = Vector.joinWith(match (rv, i) -> "${rv}[${i}]", ", ", loads);
                 "max(${loadsStr})"
-            case RamTerm.Meet(_, lhs, rhs, _)                       => "(${lhs} ⊓ ${rhs})"
-            case RamTerm.App1(_, v, _)                              => "<clo>(${v})"
-            case RamTerm.App2(_, v1, v2, _)                         => "<clo>(${v1}, ${v2})"
-            case RamTerm.App3(_, v1, v2, v3, _)                     => "<clo>(${v1}, ${v2}, ${v3})"
-            case RamTerm.App4(_, v1, v2, v3, v4, _)                 => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
-            case RamTerm.App5(_, v1, v2, v3, v4, v5, _)             => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
+            case RamTerm.Meet(_, lhs, rhs, _) => "(${lhs} ⊓ ${rhs})"
+            case RamTerm.App1(_, v, _) => "<clo>(${v})"
+            case RamTerm.App2(_, v1, v2, _) => "<clo>(${v1}, ${v2})"
+            case RamTerm.App3(_, v1, v2, v3, _) => "<clo>(${v1}, ${v2}, ${v3})"
+            case RamTerm.App4(_, v1, v2, v3, v4, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
+            case RamTerm.App5(_, v1, v2, v3, v4, v5, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
         }
     }
 

--- a/main/src/library/Fixpoint3/Ast/Ram.flix
+++ b/main/src/library/Fixpoint3/Ast/Ram.flix
@@ -125,16 +125,16 @@ pub mod Fixpoint3.Ast.Ram {
         pub def toString(stmt: RamStmt): String =
             let nl = String.lineSeparator();
             match stmt {
-                case RamStmt.Insert(op)          => ToString.toString(op)
+                case RamStmt.Insert(op) => ToString.toString(op)
                 case RamStmt.MergeInto(src, dst) => "Merge ${src} into ${dst}"
-                case RamStmt.Swap(lhs, rhs)      => "Swap ${lhs} and ${rhs}"
-                case RamStmt.Purge(relSym)       => "Purge ${relSym}"
-                case RamStmt.Seq(xs)             => Vector.join(";${nl}", xs)
-                case RamStmt.Par(xs)             => Vector.join("|${nl}", xs)
+                case RamStmt.Swap(lhs, rhs) => "Swap ${lhs} and ${rhs}"
+                case RamStmt.Purge(relSym) => "Purge ${relSym}"
+                case RamStmt.Seq(xs) => Vector.join(";${nl}", xs)
+                case RamStmt.Par(xs) => Vector.join("|${nl}", xs)
                 case RamStmt.Until(test, body) =>
                     let tst = test |> Vector.join(" && ");
                     "until(${tst}) do${nl}${String.indent(4, "${body}")}end"
-                case RamStmt.Comment(comment)    => "/* ${comment} */"
+                case RamStmt.Comment(comment) => "/* ${comment} */"
             }
     }
 
@@ -291,16 +291,16 @@ pub mod Fixpoint3.Ast.Ram {
 
     instance ToString[RamTerm] {
         pub def toString(term: RamTerm): String = match term {
-            case RamTerm.Lit(v, _)                      => Debug.stringify(v)
+            case RamTerm.Lit(v, _) => Debug.stringify(v)
             case RamTerm.ProvMax(loads) =>
                 let loadsStr = Vector.joinWith(match (rv, i) -> "${rv}[${i}]", ", ", loads);
                 "max(${loadsStr})"
-            case RamTerm.RowLoad(var, index, _, _)      => "${var}[${index}]"
-            case RamTerm.Meet(_, lhs, rhs, _)           => "(${lhs} ⊓ ${rhs})"
-            case RamTerm.App1(_, v, _)                  => "<clo>(${v})"
-            case RamTerm.App2(_, v1, v2, _)             => "<clo>(${v1}, ${v2})"
-            case RamTerm.App3(_, v1, v2, v3, _)         => "<clo>(${v1}, ${v2}, ${v3})"
-            case RamTerm.App4(_, v1, v2, v3, v4, _)     => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
+            case RamTerm.RowLoad(var, index, _, _) => "${var}[${index}]"
+            case RamTerm.Meet(_, lhs, rhs, _) => "(${lhs} ⊓ ${rhs})"
+            case RamTerm.App1(_, v, _) => "<clo>(${v})"
+            case RamTerm.App2(_, v1, v2, _) => "<clo>(${v1}, ${v2})"
+            case RamTerm.App3(_, v1, v2, v3, _) => "<clo>(${v1}, ${v2}, ${v3})"
+            case RamTerm.App4(_, v1, v2, v3, v4, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
             case RamTerm.App5(_, v1, v2, v3, v4, v5, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
         }
     }


### PR DESCRIPTION
As we discussed in https://github.com/flix/flix/pull/12720. 

This PR formats only the subfolder `Ast` in `Fixpoint3`.