### PR TITLE
chore: format examples batch (15.12.1)

### DIFF
--- a/examples/unsorted/static-analysis/IDE.flix
+++ b/examples/unsorted/static-analysis/IDE.flix
@@ -47,19 +47,7 @@ mod IDE {
     /// Solves the given IDE instances.
     ///
     pub def runSolver(ide: IDE[p, n, d, f, l]): Vector[(n, d, l)]
-        with
-            LowerBound[f],
-            JoinLattice[f],
-            MeetLattice[f],
-            LowerBound[l],
-            UpperBound[l],
-            JoinLattice[l],
-            MeetLattice[l],
-            Order[n],
-            Order[d],
-            Order[p],
-            Order[f],
-            Order[l] =
+        with LowerBound[f], JoinLattice[f], MeetLattice[f], LowerBound[l], UpperBound[l], JoinLattice[l], MeetLattice[l], Order[n], Order[d], Order[p], Order[f], Order[l] =
         // Extract main.
         let main = ide#main;
 

--- a/examples/unsorted/static-analysis/IDE.flix
+++ b/examples/unsorted/static-analysis/IDE.flix
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 ///
 /// A fully polymorphic implementation of the IDE framework written in Flix.
 ///
@@ -30,28 +29,37 @@ mod IDE {
     /// - d is the type of analysis data elements.
     ///
     type alias IDE[p, n, d, f, l] = {
-        zero            = d,
-        main            = p,
-        cfg             = List[(n, n)],
-        startNodes      = List[(p, n)],
-        endNodes        = List[(p, n)],
-        callGraph       = List[(n, p)],
-        eshIntra        = (n, d) -> Vector[(d, f)],
-        eshCallStart    = (n, d, p) -> Vector[(d, f)],
-        eshEndReturn    = (p, d, n) -> Vector[(d, f)],
-        id              = f,
-        apply           = (f, l) -> l,
-        compose         = (f, f) -> f
+        zero         = d,
+        main         = p,
+        cfg          = List[(n, n)],
+        startNodes   = List[(p, n)],
+        endNodes     = List[(p, n)],
+        callGraph    = List[(n, p)],
+        eshIntra     = (n, d) -> Vector[(d, f)],
+        eshCallStart = (n, d, p) -> Vector[(d, f)],
+        eshEndReturn = (p, d, n) -> Vector[(d, f)],
+        id           = f,
+        apply        = (f, l) -> l,
+        compose      = (f, f) -> f
     }
 
     ///
     /// Solves the given IDE instances.
     ///
     pub def runSolver(ide: IDE[p, n, d, f, l]): Vector[(n, d, l)]
-        with LowerBound[f], JoinLattice[f], MeetLattice[f],
-             LowerBound[l], UpperBound[l], JoinLattice[l], MeetLattice[l],
-             Order[n], Order[d], Order[p], Order[f],  Order[l] =
-
+        with
+            LowerBound[f],
+            JoinLattice[f],
+            MeetLattice[f],
+            LowerBound[l],
+            UpperBound[l],
+            JoinLattice[l],
+            MeetLattice[l],
+            Order[n],
+            Order[d],
+            Order[p],
+            Order[f],
+            Order[l] =
         // Extract main.
         let main = ide#main;
 
@@ -81,7 +89,7 @@ mod IDE {
             JumpFn(d1, m, d3; compose(long, short)) :-
                 CFG(n, m),
                 JumpFn(d1, n, d2; long),
-                let (d3, short) = eshIntra1(n, d2).
+                let(d3, short) = eshIntra1(n, d2).
 
             // use summary
             JumpFn(d1, m, d3; compose(caller, summary)) :-
@@ -92,7 +100,7 @@ mod IDE {
             EshCallStart(call, d2, target, d3, f) :-
                 JumpFn(_d1, call, d2; nonbottom1),
                 CallGraph(call, target),
-                let (d3, f) = eshCallStart1(call, d2, target).
+                let(d3, f) = eshCallStart1(call, d2, target).
 
             JumpFn(d3, start, d3; ide#id) :-
                 EshCallStart(call, d2, target, d3, nonbottom2),
@@ -108,10 +116,10 @@ mod IDE {
                 EndNode(target, end),
                 EshCallStart(call, d4, target, d1, cs),
                 JumpFn(d1, end, d2; se),
-                let (d5, er) = eshEndReturn1(target, d2, call).
+                let(d5, er) = eshEndReturn1(target, d2, call).
 
             // Phase II line [13] from paper
-            ResultProc(proc, dp; apply(cs,v)) :-
+            ResultProc(proc, dp; apply(cs, v)) :-
                 Results(call, d; v),
                 EshCallStart(call, d, proc, dp, cs).
 
@@ -123,16 +131,13 @@ mod IDE {
                 ResultProc(proc, dp; vp),
                 InProc(proc, n),
                 JumpFn(dp, n, d; fn).
-
         };
-
 
         let f1 = inject ide#cfg, ide#callGraph, ide#startNodes, ide#endNodes into CFG/2, CallGraph/2, StartNode/2, EndNode/2;
 
         query p, f1 select (n, d, l) from Results(n, d; l)
 
 }
-
 
 ///
 /// We have now defined the IDE framework.
@@ -152,8 +157,8 @@ mod ConstantProp {
     ///            Bot
     ///
     pub enum Const with Eq, Order, ToString {
-        case Bot,
-        case Cst(Int32),
+        case Bot
+        case Cst(Int32)
         case Top
     }
 
@@ -188,10 +193,10 @@ mod ConstantProp {
     ///
     instance JoinLattice[Const] {
         pub def leastUpperBound(x: Const, y: Const): Const = match (x, y) {
-            case (Const.Bot, _)                    => y
-            case (_, Const.Bot)                    => x
+            case (Const.Bot, _)                 => y
+            case (_, Const.Bot)                 => x
             case (Const.Cst(n1), Const.Cst(n2)) => if (n1 == n2) Const.Cst(n1) else Const.Top
-            case _                                 => Const.Top
+            case _                              => Const.Top
         }
     }
 
@@ -238,9 +243,7 @@ mod ConstantProp {
     /// We can now define the micro functions.
     ///
     pub enum MicroFunction with Eq, Order, ToString {
-        case Bot,
-
-        // from paper: f = \l. a*l+b meet c; f(Top) = Top
+        case Bot // from paper: f = \l. a*l+b meet c; f(Top) = Top
         // paper is upside-down, so: f = \l. a*l+b join c; f(Bot) = Bot
         case NonBot(Int32, Int32, ConstantProp.Const)
     }
@@ -271,7 +274,7 @@ mod ConstantProp {
                 case (MicroFunction.NonBot(a1, b1, c1), MicroFunction.NonBot(a2, b2, c2)) =>
                     if (a1 == a2 and b1 == b2)
                         MicroFunction.NonBot(a1, b1, lub(c1, c2))
-                    else if ((a2-a1) != 0 and 0 == (b1 - b2) `Int32.remainder` (a2 - a1))
+                    else if ((a2 - a1) != 0 and 0 == (b1 - b2) `Int32.remainder` (a2 - a1))
                         // Divisible.
                         MicroFunction.NonBot(a1, b2, lub(Const.Cst(a1 * (b1 - b2) / (a2 - a1) + b1), lub(c1, c2)))
                     else
@@ -311,20 +314,20 @@ mod ConstantProp {
     /// Returns the result of applying the micro function `f` to the lattice element `l`.
     ///
     pub def apply(f: MicroFunction, l: ConstantProp.Const): ConstantProp.Const = match f {
-        case MicroFunction.Bot             => Const.Bot
+        case MicroFunction.Bot => Const.Bot
         case MicroFunction.NonBot(a, b, c) => match l {
             case Const.Bot => Const.Bot
-            case _         =>
-                JoinLattice.leastUpperBound(sum(mul(l, lift(a)), lift(b)),c)
+            case _ =>
+                JoinLattice.leastUpperBound(sum(mul(l, lift(a)), lift(b)), c)
         }
     }
 }
 
 pub enum IR with Eq {
-    case MainEntry(Vector[String]), // main entry point of program
-    case Nop,
-    case CallConst(String, Int32), // pass constant int as arg
-    case CallVar(String, String),  // pass variable as arg
+    case MainEntry(Vector[String]) // main entry point of program
+    case Nop
+    case CallConst(String, Int32) // pass constant int as arg
+    case CallVar(String, String) // pass variable as arg
     case Assign(String, Int32, String, Int32) // v1 := c1 * v2 + c2
 }
 
@@ -335,35 +338,38 @@ def main(): Unit \ IO =
     println("Running IDE");
 
     let cfg =
-        ("smain","n1") ::
-        ("n1","n2") ::
-        ("n2","n3") ::
-        ("n3","emain") ::
-
-        ("sp","n4") ::
-        ("n4","n5") ::
-        ("n4","n9") ::
-        ("n5","n6") ::
-        ("n6","n7") ::
-        ("n7","n8") ::
-        ("n8","n9") ::
-        ("n9","ep") :: Nil;
+        ("smain", "n1")
+            :: ("n1", "n2")
+            :: ("n2", "n3")
+            :: ("n3", "emain")
+            :: ("sp", "n4")
+            :: ("n4", "n5")
+            :: ("n4", "n9")
+            :: ("n5", "n6")
+            :: ("n6", "n7")
+            :: ("n7", "n8")
+            :: ("n8", "n9")
+            :: ("n9", "ep")
+            :: Nil;
 
     let callGraph =
-        ("n1","p") ::
-        ("n6","p") :: Nil;
+        ("n1", "p")
+            :: ("n6", "p")
+            :: Nil;
 
     let startNodes =
-        ("main","smain") ::
-        ("p","sp") :: Nil;
+        ("main", "smain")
+            :: ("p", "sp")
+            :: Nil;
 
     let endNodes =
-        ("main","emain") ::
-        ("p","ep") :: Nil;
+        ("main", "emain")
+            :: ("p", "ep")
+            :: Nil;
 
     def procedureParameters(p) = match p {
         case "p" => "a"
-        case _ => ?unreachable
+        case _   => ?unreachable
     };
 
     let globalVars = Set#{"x"};
@@ -371,32 +377,34 @@ def main(): Unit \ IO =
 
     def instruction(n) = match n {
         case "smain" => IR.MainEntry(Vector#{"x"})
-        case "n1" => IR.CallConst("p", 7)
-        case "n2" => IR.Nop
-        case "n3" => IR.Nop
+        case "n1"    => IR.CallConst("p", 7)
+        case "n2"    => IR.Nop
+        case "n3"    => IR.Nop
         case "emain" => IR.Nop
 
-        case "sp" => IR.Nop
-        case "n4" => IR.Nop
-        case "n5" => IR.Assign("a", 1, "a", -2)
-        case "n6" => IR.CallVar("p", "a")
-        case "n7" => IR.Nop
-        case "n8" => IR.Assign("a", 1, "a", 2)
-        case "n9" => IR.Assign("x", -2, "a", 5)
-        case "ep" => IR.Nop
+        case "sp"    => IR.Nop
+        case "n4"    => IR.Nop
+        case "n5"    => IR.Assign("a", 1, "a", -2)
+        case "n6"    => IR.CallVar("p", "a")
+        case "n7"    => IR.Nop
+        case "n8"    => IR.Assign("a", 1, "a", 2)
+        case "n9"    => IR.Assign("x", -2, "a", 5)
+        case "ep"    => IR.Nop
 
-        case _ => ?unreachable
+        case _       => ?unreachable
     };
 
     def eshIntra(n, d) = match instruction(n) {
         case IR.MainEntry(vars) =>
-            if (d == "zero") Vector.map(v -> (v, ConstantProp.MicroFunction.Bot), vars)
-            else Vector#{}
+            if (d == "zero")
+                Vector.map(v -> (v, ConstantProp.MicroFunction.Bot), vars)
+            else
+                Vector#{}
         case IR.Assign(v1, c1, v2, c2) =>
-          let kill = if (d == v1) Vector#{} else Vector#{(d, ConstantProp.id())};
-          let microfn = ConstantProp.MicroFunction.NonBot(c1, c2, ConstantProp.Const.Bot);
-          let gen = if (d == v2) Vector#{(v1, microfn)} else Vector#{};
-          kill ++ gen
+            let kill = if (d == v1) Vector#{} else Vector#{(d, ConstantProp.id())};
+            let microfn = ConstantProp.MicroFunction.NonBot(c1, c2, ConstantProp.Const.Bot);
+            let gen = if (d == v2) Vector#{(v1, microfn)} else Vector#{};
+            kill ++ gen
         case IR.CallConst(_, _) if isGlobalVar(d) => Vector#{}
         case IR.CallVar(_, _) if isGlobalVar(d) => Vector#{}
         case _ => Vector#{(d, ConstantProp.id())}
@@ -404,38 +412,44 @@ def main(): Unit \ IO =
 
     def eshCallStart(n, d, p) = match instruction(n) {
         case IR.CallConst(proc, arg) if (proc == p) =>
-          let parm = procedureParameters(proc);
-          if (d == "zero") Vector#{(parm,ConstantProp.MicroFunction.NonBot(0,arg,ConstantProp.Const.Bot))}
-          else if (d == parm) Vector#{}
-          else Vector#{(d, ConstantProp.id())}
+            let parm = procedureParameters(proc);
+            if (d == "zero")
+                Vector#{(parm, ConstantProp.MicroFunction.NonBot(0, arg, ConstantProp.Const.Bot))}
+            else if (d == parm)
+                Vector#{}
+            else
+                Vector#{(d, ConstantProp.id())}
         case IR.CallVar(proc, arg) if (proc == p) =>
-          let parm = procedureParameters(proc);
-          if (d == arg) Vector#{(parm,ConstantProp.id())}
-          else if (d == parm) Vector#{}
-          else Vector#{(d, ConstantProp.id())}
+            let parm = procedureParameters(proc);
+            if (d == arg)
+                Vector#{(parm, ConstantProp.id())}
+            else if (d == parm)
+                Vector#{}
+            else
+                Vector#{(d, ConstantProp.id())}
         case _ => Vector#{}
     };
 
     def eshEndReturn(p, d, n) = match instruction(n) {
-        case IR.CallConst(proc,_) if p == proc and isGlobalVar(d) => Vector#{(d, ConstantProp.id())}
-        case IR.CallVar(proc,_) if p == proc and isGlobalVar(d) => Vector#{(d, ConstantProp.id())}
-        case _ => Vector#{}
+        case IR.CallConst(proc, _) if p == proc and isGlobalVar(d) => Vector#{(d, ConstantProp.id())}
+        case IR.CallVar(proc, _) if p == proc and isGlobalVar(d)   => Vector#{(d, ConstantProp.id())}
+        case _                                                     => Vector#{}
     };
 
     let result = IDE.runSolver({
-        zero            = "zero",
-        main            = "main",
-        cfg             = cfg,
-        startNodes      = startNodes,
-        endNodes        = endNodes,
-        callGraph       = callGraph,
-        eshIntra        = eshIntra,
-        eshCallStart    = eshCallStart,
-        eshEndReturn    = eshEndReturn,
-        id              = ConstantProp.id(),
-        apply           = ConstantProp.apply,
-        compose         = ConstantProp.compose
-        });
+        zero         = "zero",
+        main         = "main",
+        cfg          = cfg,
+        startNodes   = startNodes,
+        endNodes     = endNodes,
+        callGraph    = callGraph,
+        eshIntra     = eshIntra,
+        eshCallStart = eshCallStart,
+        eshEndReturn = eshEndReturn,
+        id           = ConstantProp.id(),
+        apply        = ConstantProp.apply,
+        compose      = ConstantProp.compose
+    });
 
     println(result)
 

--- a/examples/unsorted/static-analysis/IFDS.flix
+++ b/examples/unsorted/static-analysis/IFDS.flix
@@ -8,15 +8,15 @@ mod IFDS {
     /// - d is the type of analysis data elements.
     ///
     type alias IFDS[p, n, d] = {
-        zero            = d,
-        main            = p,
-        cfg             = List[(n, n)],
-        startNodes      = List[(p, n)],
-        endNodes        = List[(p, n)],
-        callGraph       = List[(n, p)],
-        eshIntra        = (n, d) -> Vector[d],
-        eshCallStart    = (n, d, p) -> Vector[d],
-        eshEndReturn    = (p, d, n) -> Vector[d]
+        zero         = d,
+        main         = p,
+        cfg          = List[(n, n)],
+        startNodes   = List[(p, n)],
+        endNodes     = List[(p, n)],
+        callGraph    = List[(n, p)],
+        eshIntra     = (n, d) -> Vector[d],
+        eshCallStart = (n, d, p) -> Vector[d],
+        eshEndReturn = (p, d, n) -> Vector[d]
     }
 
     ///
@@ -24,7 +24,6 @@ mod IFDS {
     ///
     pub def runSolver(ifds: IFDS[p, n, d]): Vector[(n, d)]
         with Order[n], Order[d], Order[p] =
-
         // Extract main.
         let main = ifds#main;
 
@@ -79,9 +78,8 @@ mod IFDS {
                 PathEdge(d1, end, d2),
                 let d5 = eshEndReturn1(target, d2, call).
 
-            Results(n, d2) :- PathEdge(_,n,d2).
+            Results(n, d2) :- PathEdge(_, n, d2).
         };
-
 
         let f1 = inject ifds#cfg, ifds#callGraph, ifds#startNodes, ifds#endNodes into CFG/2, CallGraph/2, StartNode/2, EndNode/2;
 
@@ -90,10 +88,10 @@ mod IFDS {
 }
 
 pub enum IR with Eq {
-    case MainEntry(Vector[String]), // main entry point of program
-    case Nop,
-    case Call(String, String), // call a procedure, pass variable as argument
-    case Read(String), // read input into a variable
+    case MainEntry(Vector[String]) // main entry point of program
+    case Nop
+    case Call(String, String) // call a procedure, pass variable as argument
+    case Read(String) // read input into a variable
     case Assign(String, String, String) // v1 := v2 - v3
 }
 
@@ -104,35 +102,38 @@ def main(): Unit \ IO =
     println("Running IFDS");
 
     let cfg =
-        ("smain","n1") ::
-        ("n1","n2") ::
-        ("n2","n3") ::
-        ("n3","emain") ::
-
-        ("sp","n4") ::
-        ("n4","n5") ::
-        ("n4","ep") ::
-        ("n5","n6") ::
-        ("n6","n7") ::
-        ("n7","n8") ::
-        ("n8","n9") ::
-        ("n9","ep") :: Nil;
+        ("smain", "n1")
+            :: ("n1", "n2")
+            :: ("n2", "n3")
+            :: ("n3", "emain")
+            :: ("sp", "n4")
+            :: ("n4", "n5")
+            :: ("n4", "ep")
+            :: ("n5", "n6")
+            :: ("n6", "n7")
+            :: ("n7", "n8")
+            :: ("n8", "n9")
+            :: ("n9", "ep")
+            :: Nil;
 
     let callGraph =
-        ("n2","p") ::
-        ("n7","p") :: Nil;
+        ("n2", "p")
+            :: ("n7", "p")
+            :: Nil;
 
     let startNodes =
-        ("main","smain") ::
-        ("p","sp") :: Nil;
+        ("main", "smain")
+            :: ("p", "sp")
+            :: Nil;
 
     let endNodes =
-        ("main","emain") ::
-        ("p","ep") :: Nil;
+        ("main", "emain")
+            :: ("p", "ep")
+            :: Nil;
 
     def procedureParameters(p) = match p {
         case "p" => "a"
-        case _ => ?unreachable
+        case _   => ?unreachable
     };
 
     let globalVars = Set#{"g"};
@@ -142,27 +143,29 @@ def main(): Unit \ IO =
 
     def instruction(n) = match n {
         case "smain" => IR.MainEntry(Vector#{"x"})
-        case "n1" => IR.Read("x")
-        case "n2" => IR.Call("p", "x")
-        case "n3" => IR.Nop
+        case "n1"    => IR.Read("x")
+        case "n2"    => IR.Call("p", "x")
+        case "n3"    => IR.Nop
         case "emain" => IR.Nop
 
-        case "sp" => IR.Nop
-        case "n4" => IR.Nop
-        case "n5" => IR.Read("g")
-        case "n6" => IR.Assign("a", "a", "g")
-        case "n7" => IR.Call("p", "a")
-        case "n8" => IR.Nop
-        case "n9" => IR.Nop
-        case "ep" => IR.Nop
+        case "sp"    => IR.Nop
+        case "n4"    => IR.Nop
+        case "n5"    => IR.Read("g")
+        case "n6"    => IR.Assign("a", "a", "g")
+        case "n7"    => IR.Call("p", "a")
+        case "n8"    => IR.Nop
+        case "n9"    => IR.Nop
+        case "ep"    => IR.Nop
 
-        case _ => ?unreachable
+        case _       => ?unreachable
     };
 
     def eshIntra(n, d) = match instruction(n) {
         case IR.MainEntry(vars) =>
-            if (d == "zero") vars ++ Foldable.toVector(globalVars)
-            else Vector#{}
+            if (d == "zero")
+                vars ++ Foldable.toVector(globalVars)
+            else
+                Vector#{}
         case IR.Nop => Vector#{d}
         case IR.Call(target, arg) =>
             if (isGlobalVar(d)) Vector#{} else Vector#{d}
@@ -176,30 +179,33 @@ def main(): Unit \ IO =
 
     def eshCallStart(n, d, p) = match instruction(n) {
         case IR.Call(proc, arg) if (proc == p) =>
-          let parm = procedureParameters(proc);
-          if (d == arg) Vector#{parm}
-          else if (d == parm) Vector#{}
-          else Vector#{d}
+            let parm = procedureParameters(proc);
+            if (d == arg)
+                Vector#{parm}
+            else if (d == parm)
+                Vector#{}
+            else
+                Vector#{d}
         case _ => Vector#{}
     };
 
     def eshEndReturn(p, d, n) = match instruction(n) {
-        case IR.Call(proc,_) if p == proc and isGlobalVar(d) =>
-          Vector#{d}
+        case IR.Call(proc, _) if p == proc and isGlobalVar(d) =>
+            Vector#{d}
         case _ => Vector#{}
     };
 
     let result = IFDS.runSolver({
-        zero            = "zero",
-        main            = "main",
-        cfg             = cfg,
-        startNodes      = startNodes,
-        endNodes        = endNodes,
-        callGraph       = callGraph,
-        eshIntra        = eshIntra,
-        eshCallStart    = eshCallStart,
-        eshEndReturn    = eshEndReturn
-        });
+        zero         = "zero",
+        main         = "main",
+        cfg          = cfg,
+        startNodes   = startNodes,
+        endNodes     = endNodes,
+        callGraph    = callGraph,
+        eshIntra     = eshIntra,
+        eshCallStart = eshCallStart,
+        eshEndReturn = eshEndReturn
+    });
 
     println(result)
 


### PR DESCRIPTION
As discussed in PR https://github.com/flix/flix/pull/12749.

This PR formats `IDE` and `IDFS` due to a bug within let matches. 