### PR TITLE
chore: reformat whole stdlib with the most recent formatter version

### DIFF
--- a/main/src/library/BPlusTree.flix
+++ b/main/src/library/BPlusTree.flix
@@ -748,7 +748,7 @@ pub mod BPlusTree {
                         checkRemaining(Iterator.next(i1), Iterator.next(i2))
                 }
                 case (Some(_), None) => false
-                case (None, _)       => true
+                case (None, _) => true
             };
             checkRemaining(Iterator.next(i1), Iterator.next(i2))
         }

--- a/main/src/library/BPlusTree/Node.flix
+++ b/main/src/library/BPlusTree/Node.flix
@@ -107,7 +107,7 @@ mod BPlusTree.Node {
                 sameElementsFromLeaf(j1 + 1, m1, j2 + 1, m2)
             else
                 false
-        case _            => false
+        case _ => false
     }
 
     ///

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -870,7 +870,7 @@ pub mod Chain {
     pub def compare(c1: Chain[a], c2: Chain[a]): Comparison with Order[a] =
         def loop(cc1, cc2) = match (cc1, cc2) {
             case (SomeLeft(_, _), NoneLeft) => Comparison.GreaterThan
-            case (NoneLeft, NoneLeft)       => Comparison.EqualTo
+            case (NoneLeft, NoneLeft) => Comparison.EqualTo
             case (NoneLeft, SomeLeft(_, _)) => Comparison.LessThan
             case (SomeLeft(l, ls), SomeLeft(r, rs)) =>
                 match (l <=> r) {

--- a/main/src/library/Debug.flix
+++ b/main/src/library/Debug.flix
@@ -73,14 +73,14 @@ pub mod Debug {
     pub def stringify(x: a): String = unsafe IO {
         use Reflect.JvmValue;
         match Reflect.reflectValue(x) {
-            case JvmValue.JvmBool(b)    => if (b) "true" else "false"
-            case JvmValue.JvmChar(c)    => "'" + escape("${(c: Char)}") + "'"
+            case JvmValue.JvmBool(b) => if (b) "true" else "false"
+            case JvmValue.JvmChar(c) => "'" + escape("${(c: Char)}") + "'"
             case JvmValue.JvmFloat32(y) => Float.toString(y) + "f32"
             case JvmValue.JvmFloat64(y) => Double.toString(y)
-            case JvmValue.JvmInt8(y)    => Byte.toString(y) + "i8"
-            case JvmValue.JvmInt16(y)   => Short.toString(y) + "i16"
-            case JvmValue.JvmInt32(y)   => Integer.toString(y)
-            case JvmValue.JvmInt64(y)   => Long.toString(y) + "i64"
+            case JvmValue.JvmInt8(y) => Byte.toString(y) + "i8"
+            case JvmValue.JvmInt16(y) => Short.toString(y) + "i16"
+            case JvmValue.JvmInt32(y) => Integer.toString(y)
+            case JvmValue.JvmInt64(y) => Long.toString(y) + "i64"
             case JvmValue.JvmObject(obj) =>
                 if (Objects.isNull(obj)) {
                     "null"

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -44,12 +44,12 @@ pub mod DelayList {
         /// Compares `l1` and `l2` lexicographically.
         ///
         pub def compare(l1: DelayList[a], l2: DelayList[a]): Comparison = match (l1, l2) {
-            case (DelayList.ENil, DelayList.ENil)           => Comparison.EqualTo
-            case (_, DelayList.ENil)                        => Comparison.GreaterThan
-            case (DelayList.ENil, _)                        => Comparison.LessThan
+            case (DelayList.ENil, DelayList.ENil) => Comparison.EqualTo
+            case (_, DelayList.ENil) => Comparison.GreaterThan
+            case (DelayList.ENil, _) => Comparison.LessThan
             case (DelayList.LList(xs), DelayList.LList(ys)) => (force xs) <=> (force ys)
-            case (_, DelayList.LList(ys))                   => l1 <=> (force ys)
-            case (DelayList.LList(xs), _)                   => (force xs) <=> l2
+            case (_, DelayList.LList(ys)) => l1 <=> (force ys)
+            case (DelayList.LList(xs), _) => (force xs) <=> l2
             case (DelayList.ECons(x, xs), DelayList.ECons(y, ys)) =>
                 let cmp = x <=> y;
                 if (cmp == Comparison.EqualTo) xs <=> ys else cmp
@@ -492,7 +492,7 @@ pub mod DelayList {
     ///
     def mapWithIndexE(f: (Int32, a) -> b \ ef, l: DelayList[a]): DelayList[b] \ ef =
         def loop(ll, i, k) = match ll {
-            case ENil      => k(ENil)
+            case ENil => k(ENil)
             case ECons(x, xs) =>
                 let x1 = f(i, x);
                 loop(xs, i + 1, ks -> k(ECons(x1, ks)))
@@ -538,7 +538,7 @@ pub mod DelayList {
     ///
     def flatMapE(f: a -> DelayList[b] \ ef, l: DelayList[a]): DelayList[b] \ ef =
         def loop(ll, k) = match ll {
-            case ENil      => k(ENil)
+            case ENil => k(ENil)
             case ECons(x, xs) =>
                 let xs1 = f(x);
                 loop(xs, ks -> k(append(xs1, ks)))
@@ -761,7 +761,7 @@ pub mod DelayList {
     @Lazy
     def filterMapL(f: a -> Option[b], l: DelayList[a]): DelayList[b] =
         def loop(ll) = match ll {
-            case ENil      => ENil
+            case ENil => ENil
             case ECons(x, xs) =>
                 match f(x) {
                     case None    => loop(xs)
@@ -786,7 +786,7 @@ pub mod DelayList {
     ///
     def filterMapE(f: a -> Option[b] \ ef, l: DelayList[a]): DelayList[b] \ ef =
         def loop(ll, k) = match ll {
-            case ENil      => k(ENil)
+            case ENil => k(ENil)
             case ECons(x, xs) => match f(x) {
                 case None    => loop(xs, k)
                 case Some(v) => loop(xs, ks -> k(ECons(v, ks)))
@@ -837,7 +837,7 @@ pub mod DelayList {
     ///
     @Experimental
     pub def findMap(f: a -> Option[b] \ ef, l: DelayList[a]): Option[b] \ ef = match l {
-        case ENil      => None
+        case ENil => None
         case ECons(x, xs) => match f(x) {
             case None    => findMap(f, xs)
             case Some(v) => Some(v)
@@ -889,7 +889,7 @@ pub mod DelayList {
     @Experimental
     pub def partition(f: a -> Bool \ ef, l: DelayList[a]): (DelayList[a], DelayList[a]) \ ef =
         def loop(ll, k) = match ll {
-            case ENil      => k((ENil, ENil))
+            case ENil => k((ENil, ENil))
             case ECons(x, xs) =>
                 if (f(x))
                     loop(xs, match (ks, ls) -> k((ECons(x, ks), ls)))
@@ -929,7 +929,7 @@ pub mod DelayList {
     ///
     @Lazy
     def spanL(f: a -> Bool, l: DelayList[a]): (DelayList[a], DelayList[a]) = match l {
-        case ENil      => (ENil, ENil)
+        case ENil => (ENil, ENil)
         case ECons(x, xs) =>
             if (f(x))
                 let t = lazy spanL(f, xs);
@@ -953,7 +953,7 @@ pub mod DelayList {
     ///
     def spanE(f: a -> Bool \ ef, l: DelayList[a]): (DelayList[a], DelayList[a]) \ ef =
         def loop(ll, k) = match ll {
-            case ENil      => k((ENil, ENil))
+            case ENil => k((ENil, ENil))
             case ECons(x, xs) =>
                 if (f(x))
                     loop(xs, match (ks, ls) -> k((ECons(x, ks), ls)))

--- a/main/src/library/Fs/FsLayer.flix
+++ b/main/src/library/Fs/FsLayer.flix
@@ -848,7 +848,7 @@ mod Fs.FsLayer {
                         else
                             Err(IoError(ErrorKind.Conflict, "Conflict on '${file}': expected mtime ${oldTime}, found ${curTime}"))
                     case Err(IoError(ErrorKind.NotFound, _)) => Ok(())
-                    case Err(e)                              => Err(e)
+                    case Err(e) => Err(e)
                 }
         }
 
@@ -884,7 +884,7 @@ mod Fs.FsLayer {
                 else
                     Err(IoError(ErrorKind.ChecksumMismatch, "Checksum mismatch for '${file}': expected ${String.trim(expected)}, got ${actual}"))
             case Err(IoError(ErrorKind.NotFound, _)) => Ok(())
-            case Err(e)                              => Err(e)
+            case Err(e) => Err(e)
         }
 
     ///
@@ -1013,7 +1013,7 @@ mod Fs.FsLayer {
     ): Result[IoError, a] \ ef1 + ef2 =
         match doSize(file) {
             case Err(IoError(ErrorKind.NotFound, _)) => doAction()
-            case Err(e)                              => Err(e)
+            case Err(e) => Err(e)
             case Ok(sz) =>
                 if (toBytes(sz) < toBytes(maxSize))
                     doAction()

--- a/main/src/library/Fs/MemoryOverlay.flix
+++ b/main/src/library/Fs/MemoryOverlay.flix
@@ -163,7 +163,7 @@ mod Fs.MemoryOverlay {
         use Fs.Size.bytes;
         let norm = normalize(path);
         match Map.get(norm, o->files) {
-            case Some(OverlayEntry.TextEntry(s))   => Some(Ok(Fs.FsLayer.estimateStringBytes(s)))
+            case Some(OverlayEntry.TextEntry(s)) => Some(Ok(Fs.FsLayer.estimateStringBytes(s)))
             case Some(OverlayEntry.BinaryEntry(b)) => Some(Ok(bytes(Int32.toInt64(Vector.length(b)))))
             case None =>
                 if (isWhiteout(path, o))
@@ -176,7 +176,7 @@ mod Fs.MemoryOverlay {
     pub def tryRead(path: String, o: Fs.MemoryOverlay[r]): Option[Result[IoError, String]] \ r =
         let norm = normalize(path);
         match Map.get(norm, o->files) {
-            case Some(OverlayEntry.TextEntry(s))   => Some(Ok(s))
+            case Some(OverlayEntry.TextEntry(s)) => Some(Ok(s))
             case Some(OverlayEntry.BinaryEntry(b)) => Some(Ok(String.fromBytes(b)))
             case None =>
                 if (isWhiteout(path, o))
@@ -198,7 +198,7 @@ mod Fs.MemoryOverlay {
         let norm = normalize(path);
         match Map.get(norm, o->files) {
             case Some(OverlayEntry.BinaryEntry(b)) => Some(Ok(b))
-            case Some(OverlayEntry.TextEntry(s))   => Some(Ok(String.toBytes(s)))
+            case Some(OverlayEntry.TextEntry(s)) => Some(Ok(String.toBytes(s)))
             case None =>
                 if (isWhiteout(path, o))
                     Some(notFound(path))

--- a/main/src/library/GetOpt.flix
+++ b/main/src/library/GetOpt.flix
@@ -235,7 +235,7 @@ pub mod GetOpt {
                 case (_, _, rest)                                   => (OptionKind.UnreqOpt("--${xstr}"), rest)
             }
             case Err(GetOptionFailure.Ambiguous(options)) => (errAmbig(options, optStr), tokens)
-            case Err(GetOptionFailure.NotFound)           => (OptionKind.UnreqOpt("--${xstr}"), tokens)
+            case Err(GetOptionFailure.NotFound) => (OptionKind.UnreqOpt("--${xstr}"), tokens)
         }
 
     /// Returns the "left view" of String `s`.
@@ -266,9 +266,9 @@ pub mod GetOpt {
                 case (ArgDescr.OptArg(f, _), "", rest)      => (decodeArg(f(None), optStr), rest)
                 case (ArgDescr.OptArg(f, _), str, rest)     => (decodeArg(f(Some(str)), optStr), rest)
             }
-            case Err(GetOptionFailure.Ambiguous(options))     => (errAmbig(options, optStr), tokens)
+            case Err(GetOptionFailure.Ambiguous(options)) => (errAmbig(options, optStr), tokens)
             case Err(GetOptionFailure.NotFound) if xstr == "" => (OptionKind.UnreqOpt(optStr), tokens)
-            case Err(GetOptionFailure.NotFound)               => (OptionKind.UnreqOpt(optStr), "-${xstr}" :: tokens)
+            case Err(GetOptionFailure.NotFound) => (OptionKind.UnreqOpt(optStr), "-${xstr}" :: tokens)
         }
 
     ///

--- a/main/src/library/Graph.flix
+++ b/main/src/library/Graph.flix
@@ -29,8 +29,8 @@ pub mod Graph {
     pub def closure(g: m[(t, t)]): Set[(t, t)] \ Foldable.Aef[m] with Foldable[m], Order[t] = {
         let edges = inject g into Edge/2;
         let res = query edges, nodes(), reachability()
-                  select (src, dst)
-                  from Reachable(src, dst);
+            select (src, dst)
+            from Reachable(src, dst);
         Vector.toSet(res)
     }
 
@@ -41,8 +41,8 @@ pub mod Graph {
     pub def reachableFrom(src: t, g: m[(t, t)]): Set[t] \ Foldable.Aef[m] with Foldable[m], Order[t] = {
         let edges = inject g into Edge/2;
         let res = query edges, reachabilityFromSrc(src)
-                  select dst
-                  from Reachable(dst);
+            select dst
+            from Reachable(dst);
         Vector.toSet(res)
     }
 
@@ -58,8 +58,8 @@ pub mod Graph {
             UnReachable(x) :- Node(x), not Reachable(x).
         };
         let res = query edges, nodes(), reachabilityFromSrc(src), unreachablility
-                  select dst
-                  from UnReachable(dst);
+            select dst
+            from UnReachable(dst);
         Vector.toSet(res)
     }
 
@@ -89,8 +89,8 @@ pub mod Graph {
             Components(s) :- fix Connected(n; s), if (Some(n) == Set.minimum(s)).
         };
         let res = query edges, nodes(), reachability(), connected, components
-                  select x
-                  from Components(x);
+            select x
+            from Components(x);
         Vector.toSet(res)
     }
 
@@ -104,8 +104,8 @@ pub mod Graph {
             RevEdge(y, x) :- Edge(x, y).
         };
         let res = query edges, rev
-                  select (x, y)
-                  from RevEdge(x, y);
+            select (x, y)
+            from RevEdge(x, y);
         Vector.toSet(res)
     }
 
@@ -121,8 +121,8 @@ pub mod Graph {
             InvEdge(x, y) :- Node(x), Node(y), not Edge(x, y), if (x != y).
         };
         let res = query nodes(), edges, inverse
-                  select (x, y)
-                  from InvEdge(x, y);
+            select (x, y)
+            from InvEdge(x, y);
         Vector.toSet(res)
     }
 
@@ -139,9 +139,9 @@ pub mod Graph {
             Reachable(n1, n2) :- Reachable(n1, m), Edge(m, n2).
         };
         let res = query edges, reachability
-                  select ()
-                  from Reachable(x, y)
-                  where x == y;
+            select ()
+            from Reachable(x, y)
+            where x == y;
         Vector.length(res) > 0
     }
 
@@ -159,11 +159,11 @@ pub mod Graph {
             Node(x) :- Edge(x, _, _).
             Node(x) :- Edge(_, _, x).
             // Collect all nodes.
-            Nodes(;Set#{x}) :- Node(x).
+            Nodes(; Set#{x}) :- Node(x).
             // Compute the number of nodes.
-            NodeCount(Set.size(ns)) :- fix Nodes(;ns).
+            NodeCount(Set.size(ns)) :- fix Nodes(; ns).
             // Compute the rank (the index in a sorted order) each node has.
-            NodeRank(x, rank(x, ns)) :- Node(x), fix Nodes(;ns).
+            NodeRank(x, rank(x, ns)) :- Node(x), fix Nodes(; ns).
             // `Dist(x, y, k; w)` says that `x` can reach `y` with a path of
             // length `w` using only intermediate nodes of rank less than
             // `k`. The `k` parameter is to control the number of iterations.
@@ -172,11 +172,14 @@ pub mod Graph {
             Dist(x, y, 0; Down.Down(w)) :- Edge(x, w, y).
             // If there exists a path of length `w` without using node `k+1`
             // then that path is also valid using node `k+1`.
-            Dist(x, y, k+1; w) :- Dist(x, y, k; w), NodeCount(c), if (k < c).
+            Dist(x, y, k + 1; w) :- Dist(x, y, k; w), NodeCount(c), if (k < c).
             // Combine paths if they use intermediate nodes of the correct
             // rank (also making sure `k` doesn't increase forever).
-            Dist(x, y, k+1; w1 + w2) :- Dist(x, kth, k; w1), Dist(kth, y, k; w2),
-                NodeRank(kth, k), NodeCount(c), if (k < c).
+            Dist(x, y, k + 1; w1 + w2) :- Dist(x, kth, k; w1),
+                Dist(kth, y, k; w2),
+                NodeRank(kth, k),
+                NodeCount(c),
+                if (k < c).
             // If `x` can go to `x` with a negative distances, then it can be
             // repeated.
             NegCycle() :- fix Dist(x, x, _; w), if (destructDown(w) < 0).
@@ -186,13 +189,13 @@ pub mod Graph {
         };
         let sol = solve edges, negCycle, mapping;
         let cycle = query sol
-                    select ()
-                    from NegCycle();
+            select ()
+            from NegCycle();
         if (Vector.isEmpty(cycle)) {
             // No negative cycle.
             let res = query sol
-                      select (p, d)
-                      from Mapping(p, d);
+                select (p, d)
+                from Mapping(p, d);
             Some(Vector.toMap(res))
         } else {
             // Negative cycle.
@@ -215,14 +218,14 @@ pub mod Graph {
             // Add distances from the edges.
             Dist(x, y; Down.Down(d)) :- Edge(x, d, y).
             // Add transitive distances.
-            Dist(x, y; d1 + Down.Down(d2)) :- Dist(x, z; d1) , Edge(z, d2, y).
+            Dist(x, y; d1 + Down.Down(d2)) :- Dist(x, z; d1), Edge(z, d2, y).
         };
         let mapping = #{
             Mapping((x, y), destructDown(d)) :- fix Dist(x, y; d).
         };
         let res = query edges, dists, mapping
-                  select (p, d)
-                  from Mapping(p, d);
+            select (p, d)
+            from Mapping(p, d);
         res |> Vector.toMap
     }
 
@@ -244,7 +247,7 @@ pub mod Graph {
     /// Returns the shortest distance from `src` to `dst` in the weighted
     /// directed graph `g`.
     ///
-    pub def distance(src: { src = t }, dst: { dst = t }, g: m[(t, Int32, t)]): Option[Int32] \ Foldable.Aef[m] with Foldable[m], Order[t] =
+    pub def distance(src: {src = t}, dst: {dst = t}, g: m[(t, Int32, t)]): Option[Int32] \ Foldable.Aef[m] with Foldable[m], Order[t] =
         distancesFrom(src#src, g) |> Map.get(dst#dst)
 
     ///
@@ -253,7 +256,7 @@ pub mod Graph {
     ///
     pub def toUndirected(g: m[(t, t)]): Set[(t, t)] \ Foldable.Aef[m] with Foldable[m], Order[t] = {
         g |> Foldable.toSet
-          |> Set.flatMap(match (a, b) -> Set#{(a, b), (b, a)})
+            |> Set.flatMap(match (a, b) -> Set#{(a, b), (b, a)})
     }
 
     ///
@@ -262,7 +265,7 @@ pub mod Graph {
     ///
     pub def toUndirectedLabeled(g: m[(t, Int32, t)]): Set[(t, Int32, t)] \ Foldable.Aef[m] with Foldable[m], Order[t] = {
         g |> Foldable.toSet
-          |> Set.flatMap(match (a, w, b) -> Set#{(a, w, b), (b, w, a)})
+            |> Set.flatMap(match (a, w, b) -> Set#{(a, w, b), (b, w, a)})
     }
 
     ///
@@ -275,13 +278,14 @@ pub mod Graph {
         let edges = inject g into Edge/3;
         let nodes = #{
             Dist(src; Down.Down(0)) :- if (limit >= 0).
-            Dist(y; d + Down.Down(w)) :- Dist(x; d), Edge(x, w, y),
-                                    if (destructDown(d) + w <= limit).
+            Dist(y; d + Down.Down(w)) :- Dist(x; d),
+                Edge(x, w, y),
+                if (destructDown(d) + w <= limit).
             Node(x) :- fix Dist(x; _).
         };
         let res = query edges, nodes
-                  select x
-                  from Node(x);
+            select x
+            from Node(x);
         Vector.toSet(res)
     }
 
@@ -293,13 +297,14 @@ pub mod Graph {
         let edges = inject g into Edge/2;
         let nodes = #{
             Dist(src; Down.Down(0)) :- if (limit >= 0).
-            Dist(y; d + Down.Down(1)) :- Dist(x; d), Edge(x, y),
-                                    if (destructDown(d) + 1 <= limit).
+            Dist(y; d + Down.Down(1)) :- Dist(x; d),
+                Edge(x, y),
+                if (destructDown(d) + 1 <= limit).
             Node(x) :- fix Dist(x; _).
         };
         let res = query edges, nodes
-                  select x
-                  from Node(x);
+            select x
+            from Node(x);
         Vector.toSet(res)
     }
 
@@ -325,15 +330,17 @@ pub mod Graph {
 
             // Find a consistent index for each node, not necessarily unique.
             Index(x; 0) :- Node(x), not EdgeSecond(x), EdgeFirst(x).
-            Index(x; i+1) :- Before(y, x), not Before(x, y),
-                               After(x, y), Index(y; i).
+            Index(x; i + 1) :- Before(y, x),
+                not Before(x, y),
+                After(x, y),
+                Index(y; i).
         };
         let res = query edges, nodes(), topSort select (x, i) from Index(x; i);
         let ml = MutList.empty(rc);
         // Extract nodes in fixed order.
-        res |>
-            Vector.sortBy(match (x, i) -> (i, x)) |>
-            Vector.forEach(match (x, _) -> MutList.push(x, ml));
+        res
+            |> Vector.sortBy(match (x, i) -> (i, x))
+            |> Vector.forEach(match (x, _) -> MutList.push(x, ml));
         MutList.toList(ml)
     }
 
@@ -354,8 +361,8 @@ pub mod Graph {
                 fix TouchSet(n; s).
         };
         let res = query edges, in, nodes()
-                  select (n, d)
-                  from Degree(n, d);
+            select (n, d)
+            from Degree(n, d);
         Vector.toMap(res)
     }
 
@@ -370,26 +377,26 @@ pub mod Graph {
             Dist(y; n + Down.Down(1)) :- Dist(x; n), Edge(x, y).
 
             // Find the max frontier.
-            Frontiers(;Set#{destructDown(n)}) :- fix Dist(_; n).
-            MaxFrontier(Set.maximum(s) |> Option.getWithDefault(0)) :- fix Frontiers(;s).
+            Frontiers(; Set#{destructDown(n)}) :- fix Dist(_; n).
+            MaxFrontier(Set.maximum(s) |> Option.getWithDefault(0)) :- fix Frontiers(; s).
 
             // Initialize all frontiers (with non-bot element).
             Frontier(0; Some(Set#{})) :- MaxFrontier(m), if (m > 0).
-            Frontier(n+1; Some(Set#{})) :- Frontier(n; _), MaxFrontier(m), if (n < m).
+            Frontier(n + 1; Some(Set#{})) :- Frontier(n; _), MaxFrontier(m), if (n < m).
 
             // Collect the frontiers.
             Frontier(destructDown(n); Some(Set#{x})) :- fix Dist(x; n).
         };
         let res = query edges, frontiers
-                  select (n, s)
-                  from Frontier(n; s);
+            select (n, s)
+            from Frontier(n; s);
         let unwrapOption = match (n, s) -> match s {
             case Some(v) => Some((n, v))
-            case None => None
+            case None    => None
         };
-        res |>
-            Vector.filterMap(unwrapOption) |>
-            Vector.toMap
+        res
+            |> Vector.filterMap(unwrapOption)
+            |> Vector.toMap
     }
 
     ///
@@ -404,22 +411,30 @@ pub mod Graph {
         let edges = inject g into Edge/2;
         def unpack(opt) = match opt {
             case Some(v) => v
-            case None => unreachable!()
+            case None    => unreachable!()
         };
         let cuts = #{
             CutPoint(x, Set.maximum(cut) |> unpack, y) :-
-                fix CutPointSet(x, y; cut), if (not Set.isEmpty(cut)).
-            CutPointSet(x, y; Set#{cut}) :- Reachable(x, y), Node(cut),
-                                            not Circumvent(x, cut, y),
-                                            if (x != cut), if (y != cut), if (x != y).
-            Circumvent(x, cut, y) :- Node(cut), Edge(x, y),
-                                     if (x != cut), if (y != cut).
-            Circumvent(x, cut, y) :- Circumvent(x, cut, z), Edge(z, y),
-                                     Node(cut), if (y != cut).
+                fix CutPointSet(x, y; cut),
+                if (not Set.isEmpty(cut)).
+            CutPointSet(x, y; Set#{cut}) :- Reachable(x, y),
+                Node(cut),
+                not Circumvent(x, cut, y),
+                if (x != cut),
+                if (y != cut),
+                if (x != y).
+            Circumvent(x, cut, y) :- Node(cut),
+                Edge(x, y),
+                if (x != cut),
+                if (y != cut).
+            Circumvent(x, cut, y) :- Circumvent(x, cut, z),
+                Edge(z, y),
+                Node(cut),
+                if (y != cut).
         };
         let res = query edges, nodes(), reachability(), cuts
-                  select (x, cut, y)
-                  from CutPoint(x, cut, y);
+            select (x, cut, y)
+            from CutPoint(x, cut, y);
         Vector.toSet(res)
     }
 
@@ -439,8 +454,8 @@ pub mod Graph {
                 fix InSet(n; s).
         };
         let res = query edges, in, nodes()
-                  select (n, d)
-                  from InDegree(n, d);
+            select (n, d)
+            from InDegree(n, d);
         Vector.toMap(res)
     }
 
@@ -460,8 +475,8 @@ pub mod Graph {
                 fix OutSet(n; s).
         };
         let res = query edges, out, nodes()
-                  select (n, d)
-                  from OutDegree(n, d);
+            select (n, d)
+            from OutDegree(n, d);
         Vector.toMap(res)
     }
 
@@ -473,7 +488,8 @@ pub mod Graph {
     pub def toGraphviz(g: m[(t, t)]): String \ Foldable.Aef[m] with Foldable[m], Order[t], ToString[t] =
         "digraph {" + String.lineSeparator()
             + Foldable.joinWith(match (x, y) -> "  ${graphvizId(x)} -> ${graphvizId(y)}" + String.lineSeparator(), "", g)
-            + "}" + String.lineSeparator()
+            + "}"
+            + String.lineSeparator()
 
     ///
     /// Returns a Graphviz (DOT) string of the directed graph `g`.
@@ -483,13 +499,12 @@ pub mod Graph {
     pub def toGraphvizLabeled(g: m[(t, l, t)]): String \ Foldable.Aef[m] with Foldable[m], ToString[t], ToString[l] =
         "digraph {" + String.lineSeparator()
             + Foldable.joinWith(match (x, w, y) -> "  ${graphvizId(x)} -> ${graphvizId(y)} [label = ${w}]" + String.lineSeparator(), "", g)
-            + "}" + String.lineSeparator()
-
+            + "}"
+            + String.lineSeparator()
 
     // -------------------------------------------------------------------------
     // Private Functions -------------------------------------------------------
     // -------------------------------------------------------------------------
-
 
     ///
     /// Wraps `toString(id)` with double quotes and escapes any existing quotes

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -61,7 +61,7 @@ pub mod List {
         @Terminates @Tailrec
         pub def compare(l1: List[a], l2: List[a]): Comparison = match (l1, l2) {
             case (_ :: _, Nil) => Comparison.GreaterThan
-            case (Nil, Nil)    => Comparison.EqualTo
+            case (Nil, Nil) => Comparison.EqualTo
             case (Nil, _ :: _) => Comparison.LessThan
             case (z :: zs, w :: ws) =>
                 let cmp = z <=> w;

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -668,7 +668,7 @@ pub mod Nec {
     ///
     pub def zipWith(f: (a, b) -> c \ ef, c1: Nec[a], c2: Nec[b]): Nec[c] \ ef =
         def loop(nec1: Nec[a], nec2: Nec[b], k: Nec[c] -> Nec[c] \ ef) = match (viewLeft(nec1), viewLeft(nec2)) {
-            case (ViewLeft.OneLeft(x), ViewLeft.OneLeft(y))     => { let a = f(x, y); k(singleton(a)) }
+            case (ViewLeft.OneLeft(x), ViewLeft.OneLeft(y)) => { let a = f(x, y); k(singleton(a)) }
             case (ViewLeft.OneLeft(x), ViewLeft.SomeLeft(y, _)) => { let a = f(x, y); k(singleton(a)) }
             case (ViewLeft.SomeLeft(x, _), ViewLeft.OneLeft(y)) => { let a = f(x, y); k(singleton(a)) }
             case (ViewLeft.SomeLeft(x, rs), ViewLeft.SomeLeft(y, qs)) => {

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -174,7 +174,7 @@ pub mod RedBlackTree {
                 case Comparison.EqualTo     => Node(c, a, k, v, b)
                 case Comparison.GreaterThan => balance(Node(c, a, k1, v1, loop(b)))
             }
-            case _    => unreachable!()
+            case _ => unreachable!()
         };
         blacken(loop(t))
 
@@ -191,7 +191,7 @@ pub mod RedBlackTree {
                 case Comparison.EqualTo     => Node(c, a, k, f(k, v, v1), b)
                 case Comparison.GreaterThan => balance(Node(c, a, k1, v1, loop(b)))
             }
-            case _    => unreachable!()
+            case _ => unreachable!()
         };
         blacken(loop(t))
 
@@ -204,14 +204,14 @@ pub mod RedBlackTree {
         def loop(tt) = match tt {
             case Leaf => Leaf
             case Node(c, a, k1, v1, b) => match k <=> k1 {
-                case Comparison.LessThan    => balance(Node(c, loop(a), k1, v1, b))
+                case Comparison.LessThan => balance(Node(c, loop(a), k1, v1, b))
                 case Comparison.EqualTo => match f(k1, v1) {
                     case None    => tt
                     case Some(v) => Node(c, a, k, v, b)
                 }
                 case Comparison.GreaterThan => balance(Node(c, a, k1, v1, loop(b)))
             }
-            case _    => unreachable!()
+            case _ => unreachable!()
         };
         blacken(loop(t))
 
@@ -222,7 +222,7 @@ pub mod RedBlackTree {
     ///
     pub def remove(k: k, t: RedBlackTree[k, v]): RedBlackTree[k, v] with Order[k] =
         def loop(tt) = match tt {
-            case Node(Color.Red, Leaf, k1, _, Leaf)   => if ((k <=> k1) == Comparison.EqualTo) Leaf else tt
+            case Node(Color.Red, Leaf, k1, _, Leaf) => if ((k <=> k1) == Comparison.EqualTo) Leaf else tt
             case Node(Color.Black, Leaf, k1, _, Leaf) => if ((k <=> k1) == Comparison.EqualTo) DoubleBlackLeaf else tt
             case Node(Color.Black, Node(Color.Red, Leaf, k1, v1, Leaf), k2, v2, Leaf) =>
                 match k <=> k2 {
@@ -232,13 +232,13 @@ pub mod RedBlackTree {
                 }
             case Node(c, a, k1, v1, b) =>
                 match k <=> k1 {
-                    case Comparison.LessThan    => rotate(Node(c, loop(a), k1, v1, b))
+                    case Comparison.LessThan => rotate(Node(c, loop(a), k1, v1, b))
                     case Comparison.EqualTo =>
                         let (k2, v2, e) = minDelete(b);
                         rotate(Node(c, a, k2, v2, e))
                     case Comparison.GreaterThan => rotate(Node(c, a, k1, v1, loop(b)))
                 }
-            case _                                    => tt
+            case _ => tt
         };
         redden(loop(t))
 
@@ -272,7 +272,7 @@ pub mod RedBlackTree {
     /// Optionally returns the first key-value pair in `t` that satisfies the predicate `f` when searching from left to right.
     ///
     pub def findLeft(f: (k, v) -> Bool \ ef, t: RedBlackTree[k, v]): Option[(k, v)] \ ef = match t {
-        case Leaf            => None
+        case Leaf => None
         case DoubleBlackLeaf => None
         case Node(_, a, k, v, b) => match findLeft(f, a) {
             case Some((ka, va)) => Some((ka, va))
@@ -288,7 +288,7 @@ pub mod RedBlackTree {
     /// Optionally returns the first key-value pair in `t` that satisfies the predicate `f` when searching from right to left.
     ///
     pub def findRight(f: (k, v) -> Bool \ ef, t: RedBlackTree[k, v]): Option[(k, v)] \ ef = match t {
-        case Leaf            => None
+        case Leaf => None
         case DoubleBlackLeaf => None
         case Node(_, a, k, v, b) => match findRight(f, b) {
             case Some((kb, vb)) => Some((kb, vb))
@@ -633,7 +633,7 @@ pub mod RedBlackTree {
         case Node(Color.Black, Node(Color.Black, a, k1, v1, b), k2, v2, Node(Color.Black, c, k3, v3, d)) =>
             Node(Color.Red, Node(Color.Black, a, k1, v1, b), k2, v2, Node(Color.Black, c, k3, v3, d))
         case DoubleBlackLeaf => Leaf
-        case _               => t
+        case _ => t
     }
 
     ///
@@ -641,14 +641,14 @@ pub mod RedBlackTree {
     ///
     def minDelete(t: RedBlackTree[k, v]): (k, v, RedBlackTree[k, v]) =
         def loop(tt) = match tt {
-            case Node(Color.Red, Leaf, k1, v1, Leaf)   => (k1, v1, Leaf)
+            case Node(Color.Red, Leaf, k1, v1, Leaf) => (k1, v1, Leaf)
             case Node(Color.Black, Leaf, k1, v1, Leaf) => (k1, v1, DoubleBlackLeaf)
             case Node(Color.Black, Leaf, k1, v1, Node(Color.Red, Leaf, k2, v2, Leaf)) =>
                 (k1, v1, Node(Color.Black, Leaf, k2, v2, Leaf))
             case Node(c, a, k1, v1, b) =>
                 let (k, v, child) = loop(a);
                 (k, v, rotate(Node(c, child, k1, v1, b)))
-            case _                                     => unreachable!()
+            case _ => unreachable!()
         };
         loop(t)
 
@@ -738,7 +738,7 @@ pub mod RedBlackTree {
                 parSeqMapWithKey(f, st)
             else
                 match st {
-                    case Leaf            => Leaf
+                    case Leaf => Leaf
                     case DoubleBlackLeaf => DoubleBlackLeaf
                     case Node(c, a, k, v, b) =>
                         par (
@@ -763,7 +763,7 @@ pub mod RedBlackTree {
     def parSeqMapWithKey(f: (k, v1) -> v2, t: RedBlackTree[k, v1]): RedBlackTree[k, v2] = match t {
         // Note that while this is identical to `seqMapWithKey` it must still be its own function
         // because the parallel path must not be reuse the seq. path.
-        case Leaf            => Leaf
+        case Leaf => Leaf
         case DoubleBlackLeaf => DoubleBlackLeaf
         case Node(c, a, k, v, b) =>
             let a1 = seqMapWithKey(f, a);
@@ -776,7 +776,7 @@ pub mod RedBlackTree {
     /// Sequentially maps `f` over the tree `t`.
     ///
     def seqMapWithKey(f: (k, v1) -> v2 \ ef, t: RedBlackTree[k, v1]): RedBlackTree[k, v2] \ ef = match t {
-        case Leaf            => Leaf
+        case Leaf => Leaf
         case DoubleBlackLeaf => DoubleBlackLeaf
         case Node(c, a, k, v, b) =>
             let a1 = seqMapWithKey(f, a);
@@ -800,7 +800,7 @@ pub mod RedBlackTree {
                 seqCount(f, st)
             else
                 match st {
-                    case Leaf            => 0
+                    case Leaf => 0
                     case DoubleBlackLeaf => 0
                     case Node(_, a, k, v, b) =>
                         par (
@@ -821,7 +821,7 @@ pub mod RedBlackTree {
     /// that satisfy the predicate `f`.
     ///
     def seqCount(f: (k, v) -> Bool, t: RedBlackTree[k, v]): Int32 = match t {
-        case Leaf            => 0
+        case Leaf => 0
         case DoubleBlackLeaf => 0
         case Node(_, a, k, v, b) =>
             let a1 = seqCount(f, a);
@@ -847,7 +847,7 @@ pub mod RedBlackTree {
     /// according to the function `f`.
     ///
     pub def sumWith(f: (k, v) -> Int32 \ ef, t: RedBlackTree[k, v]): Int32 \ ef = match t {
-        case Leaf            => 0
+        case Leaf => 0
         case DoubleBlackLeaf => 0
         case Node(_, a, k, v, b) =>
             let x = sumWith(f, a);
@@ -871,7 +871,7 @@ pub mod RedBlackTree {
                 seqSumWith(f, st)
             else
                 match st {
-                    case Leaf            => 0
+                    case Leaf => 0
                     case DoubleBlackLeaf => 0
                     case Node(_, a, k, v, b) =>
                         par (
@@ -895,7 +895,7 @@ pub mod RedBlackTree {
     /// megamorphic calls -- we use a copy here.
     ///
     def seqSumWith(f: (k, v) -> Int32, t: RedBlackTree[k, v]): Int32 = match t {
-        case Leaf            => 0
+        case Leaf => 0
         case DoubleBlackLeaf => 0
         case Node(_, a, k, v, b) =>
             let x = seqSumWith(f, a);
@@ -973,7 +973,7 @@ pub mod RedBlackTree {
                 seqLimitBy(cmp, st)
             else
                 match st {
-                    case Leaf            => None
+                    case Leaf => None
                     case DoubleBlackLeaf => None
                     case Node(_, a, k, v, b) =>
                         par (
@@ -983,7 +983,7 @@ pub mod RedBlackTree {
                             l <- visitSubtree((n - 2) / 2, a);
                             r <- visitSubtree((n - 2) / 2, b)
                         ) yield match (l, r) {
-                            case (None, None)           => Some((k, v))
+                            case (None, None) => Some((k, v))
                             case (None, Some((kr, vr))) => Some(cmp(k, v, kr, vr))
                             case (Some((kl, vl)), None) => Some(cmp(kl, vl, k, v))
                             case (Some((kl, vl)), Some((kr, vr))) =>

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -213,8 +213,10 @@ pub mod Reducible {
         pub def dropWhile(f: a -> Bool \ ef, t: t[a]): List[a] \ ef =
             def step(acc, a) = {
                 let (c, xs) = acc;
-                if (c and f(a)) (true, xs)
-                else            (false, a :: xs)
+                if (c and f(a))
+                    (true, xs)
+                else
+                    (false, a :: xs)
             };
             Reducible.foldLeft(step, (true, Nil), t) |> snd |> List.reverse
 
@@ -224,8 +226,10 @@ pub mod Reducible {
         pub def takeWhile(f: a -> Bool \ ef, t: t[a]): List[a] \ ef =
             def step(acc, a) = {
                 let (c, xs) = acc;
-                if (c and f(a)) (true, a :: xs)
-                else            (false, xs)
+                if (c and f(a))
+                    (true, a :: xs)
+                else
+                    (false, xs)
             };
             Reducible.foldLeft(step, (true, Nil), t) |> snd |> List.reverse
 

--- a/main/src/library/RichString.flix
+++ b/main/src/library/RichString.flix
@@ -311,7 +311,7 @@ pub mod RichString {
     pub def joinWith(f: a -> RichString \ ef, sep: RichString, xs: t[a]): RichString \ (ef + Foldable.Aef[t]) with Foldable[t] =
         let l = Foldable.toList(xs);
         match l {
-            case Nil      => empty()
+            case Nil => empty()
             case x :: Nil => f(x)
             case x :: rest =>
                 List.foldLeft((acc, elem) -> acc + sep + f(elem), f(x), rest)

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -185,7 +185,6 @@ pub mod String {
                 Err(unsafe IO { e.getMessage() })
         }
 
-
     ///
     /// Compile the regular expression `regex` into a Regex with the supplied flags.
     ///
@@ -202,7 +201,6 @@ pub mod String {
             case e: PatternSyntaxException =>
                 Err(unsafe IO { e.getMessage() })
         }
-
 
     ///
     /// Build a string of length `len` by applying `f` to the successive indices.
@@ -254,7 +252,7 @@ pub mod String {
     /// each pair of strings.
     ///
     pub def intercalateChar(sep: Char, xs: List[String]): String = match xs {
-        case Nil     => ""
+        case Nil => ""
         case x :: rs => region rc {
             let sb = StringBuilder.empty(rc);
             StringBuilder.appendString(x, sb);
@@ -281,7 +279,7 @@ pub mod String {
     ///
     /// Returns the reverse of `s`.
     ///
-    pub def reverse(s: String) : String =
+    pub def reverse(s: String): String =
         let start = length(s) - 1;
         init(i -> charAt(start - i, s), start + 1)
 
@@ -322,7 +320,7 @@ pub mod String {
         let len = length(s);
         let n1 = n `Int32.remainder` len;
         let start = len - n1;
-        let f = i -> { let i1 = start + i; charAt(i1 `Int32.remainder` len, s)};
+        let f = i -> { let i1 = start + i; charAt(i1 `Int32.remainder` len, s) };
         init(f, len)
 
     ///
@@ -373,7 +371,7 @@ pub mod String {
     ///
     pub def sliceLeft(end: {end = Int32}, s: String): String = match length(s) {
         case len if end#end > len => ""
-        case _   if end#end < 0   => ""
+        case _ if end#end < 0     => ""
         case _                    => slice(start = 0, end, s)
     }
 
@@ -384,7 +382,7 @@ pub mod String {
     ///
     pub def sliceRight(start: {start = Int32}, s: String): String = match length(s) {
         case len if start#start >= len => ""
-        case _   if start#start < 0    => ""
+        case _ if start#start < 0      => ""
         case len                       => slice(start, end = len, s)
     }
 
@@ -449,11 +447,10 @@ pub mod String {
     ///
     pub def indicesOf(substr: {substr = String}, s: String): Vector[Int32] =
         let sublen = length(substr#substr);
-        let step = ix ->
-            match indexOfLeftWithOffset({substr = substr#substr}, {offset = ix}, s) {
-                case None => None
-                case Some(ix2) => Some((ix2, ix2 + sublen))
-            };
+        let step = ix -> match indexOfLeftWithOffset({substr = substr#substr}, {offset = ix}, s) {
+            case None      => None
+            case Some(ix2) => Some((ix2, ix2 + sublen))
+        };
         List.unfold(step, 0) |> List.toVector
 
     ///
@@ -563,7 +560,7 @@ pub mod String {
     pub def dropWhileRight(f: Char -> Bool, s: String): String =
         match findIndexOfRight(x -> not (f(x)), s) {
             case None    => ""
-            case Some(i) => sliceLeft(end = i + 1, s)     // must include i
+            case Some(i) => sliceLeft(end = i + 1, s) // must include i
         }
 
     ///
@@ -589,11 +586,10 @@ pub mod String {
     ///
     pub def splitAt(n: Int32, s: String): (String, String) =
         match length(s) {
-            case _   if n <= 0  => ("", s)
+            case _ if n <= 0    => ("", s)
             case len if n > len => (s, "")
             case _              => (sliceLeft(end = n, s), sliceRight(start = n, s))
         }
-
 
     ///
     /// Applies `f` to a start value `x` and all elements in `s` going from left to right.
@@ -662,7 +658,7 @@ pub mod String {
         def loop(a) = {
             let a1 = f(a);
             match a1 {
-                case None           => StringBuilder.toString(sb)
+                case None => StringBuilder.toString(sb)
                 case Some((c, st1)) => {
                     StringBuilder.append(c, sb);
                     loop(st1)
@@ -684,7 +680,7 @@ pub mod String {
         let sb = StringBuilder.empty(rc);
         def loop() = {
             match f() {
-                case None    => StringBuilder.toString(sb)
+                case None => StringBuilder.toString(sb)
                 case Some(c) => {
                     StringBuilder.append(c, sb);
                     loop()
@@ -699,12 +695,12 @@ pub mod String {
     ///
     /// This is a version of `unfold` where `f` generates substrings rather than chars.
     ///
-    pub def unfoldString(f: b -> Option[(String, b)] \ ef, x: b) : String \ ef = region rc {
+    pub def unfoldString(f: b -> Option[(String, b)] \ ef, x: b): String \ ef = region rc {
         let sb = StringBuilder.empty(rc);
         def loop(a) = {
             let a1 = f(a);
             match a1 {
-                case None             => StringBuilder.toString(sb)
+                case None => StringBuilder.toString(sb)
                 case Some(((s, st1))) => {
                     StringBuilder.appendString(s, sb);
                     loop(st1)
@@ -726,7 +722,7 @@ pub mod String {
         let sb = StringBuilder.empty(rc);
         def loop() = {
             match f() {
-                case None    => StringBuilder.toString(sb)
+                case None => StringBuilder.toString(sb)
                 case Some(s) => {
                     StringBuilder.appendString(s, sb);
                     loop()
@@ -747,7 +743,7 @@ pub mod String {
         let sb = StringBuilder.empty(rc);
         def loop(c) = {
             match f(c) {
-                case None     => StringBuilder.toString(sb)
+                case None => StringBuilder.toString(sb)
                 case Some(c1) => {
                     StringBuilder.append(c1, sb);
                     loop(c1)
@@ -902,10 +898,10 @@ pub mod String {
         let f = ix ->
             if (ix >= i and ix < i + n) {
                 let offset = ix - i;
-                if (offset < 0 or offset >= sublen) charAt(ix,s) else charAt(offset, sub)
-            } else charAt(ix, s);
+                if (offset < 0 or offset >= sublen) charAt(ix, s) else charAt(offset, sub)
+            } else
+                charAt(ix, s);
         init(f, length(s))
-
 
     ///
     /// Indent every line in string `s` by `n` spaces. `n` must be greater than `0`.
@@ -1010,7 +1006,7 @@ pub mod String {
     /// single space character.
     ///
     pub def unwords(l: List[String]): String = match l {
-        case Nil     => ""
+        case Nil => ""
         case x :: xs => region rc {
             let sb = StringBuilder.empty(rc);
             StringBuilder.appendString(x, sb);
@@ -1094,23 +1090,23 @@ pub mod String {
     /// Returns the empty string if `s1` and `s2` do not share a common suffix.
     ///
     pub def commonSuffix(s1: String, s2: String): String =
-            def loop(i, j, acc) = {
-                if (i < 0)
-                    s1
-                else if (j < 0)
-                    s2
-                else {
-                    let c1 = charAt(i, s1);
-                    let c2 = charAt(j, s2);
-                    if (c1 != c2)
-                        takeRight(acc, s1)
-                    else
-                        loop(i - 1, j - 1, acc + 1)
-                }
-            };
-            let start1 = length(s1) - 1;
-            let start2 = length(s2) - 1;
-            loop(start1, start2, 0)
+        def loop(i, j, acc) = {
+            if (i < 0)
+                s1
+            else if (j < 0)
+                s2
+            else {
+                let c1 = charAt(i, s1);
+                let c2 = charAt(j, s2);
+                if (c1 != c2)
+                    takeRight(acc, s1)
+                else
+                    loop(i - 1, j - 1, acc + 1)
+            }
+        };
+        let start1 = length(s1) - 1;
+        let start2 = length(s2) - 1;
+        loop(start1, start2, 0)
 
     ///
     /// Abbreviate the string `s` if it exceeds the width `w`.
@@ -1123,8 +1119,8 @@ pub mod String {
     pub def abbreviateLeft(w: Int32, s: String): String =
         match length(s) {
             case len if len < w => s
-            case _   if w < 3   => ""
-            case len            => {
+            case _ if w < 3 => ""
+            case len => {
                 let start = len - w + 3;
                 "..." + slice(start = start, end = len, s)
             }
@@ -1141,7 +1137,7 @@ pub mod String {
     pub def abbreviateRight(w: Int32, s: String): String =
         match length(s) {
             case len if len < w => s
-            case _   if w < 3   => ""
+            case _ if w < 3     => ""
             case _              => slice(start = 0, end = w - 3, s) + "..."
         }
 
@@ -1157,17 +1153,25 @@ pub mod String {
         let v0 = Array.repeat(rc, n + 1, 0);
         let v1 = Array.repeat(rc, n + 1, 0);
         forIndex(0, n, i -> Array.put(i, i, v0));
-        forIndex(0, m - 1, i -> {
-            Array.put(i + 1, 0, v1);
-            forIndex(0, n - 1, j -> {
-                let substitutionCost = if (charAt(i, s) == charAt(j, t)) 0 else 1;
-                let a = Array.get(j, v1) + 1;
-                let b = Array.get(j + 1, v0) + 1;
-                let c = Array.get(j, v0) + substitutionCost;
-                Array.put(Int32.min(a, Int32.min(b, c)), j + 1, v1)
-            });
-            arraySwap(v0, v1)
-        });
+        forIndex(
+            0,
+            m - 1,
+            i -> {
+                Array.put(i + 1, 0, v1);
+                forIndex(
+                    0,
+                    n - 1,
+                    j -> {
+                        let substitutionCost = if (charAt(i, s) == charAt(j, t)) 0 else 1;
+                        let a = Array.get(j, v1) + 1;
+                        let b = Array.get(j + 1, v0) + 1;
+                        let c = Array.get(j, v0) + substitutionCost;
+                        Array.put(Int32.min(a, Int32.min(b, c)), j + 1, v1)
+                    }
+                );
+                arraySwap(v0, v1)
+            }
+        );
         Array.get(n, v0)
     }
 
@@ -1182,8 +1186,8 @@ pub mod String {
     ///
     /// Helper function for `levenshteinDistance`.
     ///
-    def arraySwap(a: Array[Int32, r1], b : Array[Int32, r2]): Unit \ { r2, r1 } =
-        forIndex(0, Array.length(a) - 1, {i -> Array.put(Array.get(i, b), i, a) })
+    def arraySwap(a: Array[Int32, r1], b: Array[Int32, r2]): Unit \ { r2, r1 } =
+        forIndex(0, Array.length(a) - 1, { i -> Array.put(Array.get(i, b), i, a) })
 
     ///
     /// Returns an array where the element at index `i` is `(x, y)` where
@@ -1384,7 +1388,8 @@ pub mod String {
     /// If a line contains a single word that exceeds the length of `w`, the word will be broken.
     ///
     pub def wrap(w: Int32, s: String): String =
-        if (w <= 0) ""
+        if (w <= 0)
+            ""
         else {
             let lines = List.flatMap(l -> wrapLine(w, l), lines(s));
             intercalate(lineSeparator(), lines)
@@ -1403,7 +1408,7 @@ pub mod String {
             let endOpt = Regex.indexOfLastWithBounds(regex"(?<!\\s)\\s", {start = 0}, {end = w}, s);
             let end = match endOpt {
                 case Some(end) => end
-                case None => w
+                case None      => w
             };
             sliceLeft({end = end}, s) :: wrapLine(w, trimLeft(sliceRight({start = end}, s)))
         }

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -479,14 +479,16 @@ pub mod Vector {
             MutList.push(Vector.get(0, v), l);
             discard {
                 (Vector.get(0, v), v)
-                    ||> Vector.foldLeft(head -> cur -> {
+                    ||> Vector.foldLeft(
+                        head -> cur -> {
                             if (f(head, cur)) {
                                 head
                             } else {
                                 MutList.push(cur, l);
                                 cur
                             }
-                        })
+                        }
+                    )
             };
             MutList.toVector(l)
         }
@@ -973,7 +975,8 @@ pub mod Vector {
         let len = sumLengths(vs);
         let pos = Ref.fresh(rc, 0);
         let arr = Array.empty(rc, len);
-        forEach(v -> {
+        forEach(
+            v -> {
                 let i = Ref.get(pos);
                 Ref.put(i + length(v), pos);
                 arrayUpdateSeqV(i, v, arr)
@@ -1256,7 +1259,8 @@ pub mod Vector {
         let len = length(v);
         let arr = Array.empty(rc, len);
         let brr = Array.empty(rc, len);
-        forEachWithIndex((i, x) -> {
+        forEachWithIndex(
+            (i, x) -> {
                 let (l, r) = x;
                 Array.put(l, i, arr);
                 Array.put(r, i, brr)
@@ -1306,7 +1310,8 @@ pub mod Vector {
     /// Collects the successful results of applying the partial function `f` to every element in `v`.
     ///
     pub def filterMap(f: a -> Option[b] \ ef, v: Vector[a]): Vector[b] \ ef =
-        foldRight((x, xs) -> match f(x) {
+        foldRight(
+            (x, xs) -> match f(x) {
                 case None    => xs
                 case Some(b) => b :: xs
             },


### PR DESCRIPTION
This PR is the finishing touch of formatting the standard library. 

What does this PR try to solve? 
- We still have unformatted files for example `Graph.flix`.
- Due to changes in formatting logic ranging over the course of multiple batches might have caused unintentional formatting styles to be out of sync due to the usage of different formatter versions.

What are the out of sync formatting issues?
- One batch used option 1 from the discussion on Zulip of how function arguments must be formatted. (e.g `Vector.flix`)
- The logic change in regards to aligning `=>` in cases.

What is the outcome, running the current flixfmt version against the standard library must yield no changes at all anymore. Additionally, all files now have the same formatting style regardless of their corresponding batch.

Finally, it makes the following PR obsolete (https://github.com/flix/flix/pull/12692).
Hope it is fine to create a new PR, I'll just close it. Of course I'm more than happy to move these changes to the other PR. This was just the simplest way.