### PR TITLE
chore: reformat all `examples` again with newest formatter version

### DIFF
--- a/examples/datalog/connect-graph.flix
+++ b/examples/datalog/connect-graph.flix
@@ -85,10 +85,10 @@ def main(): Unit \ IO =
             :: "              └─┘    "
             :: Nil;
 
-        println(graphString |> String.intercalate(String.lineSeparator()));
-        println("The graph above has the components below with edges between them");
+    println(graphString |> String.intercalate(String.lineSeparator()));
+    println("The graph above has the components below with edges between them");
 
-        def pad(s) = ToString.toString(s) |> String.padLeft(15, ' ');
-        result
-            |> Vector.map(match (c1, c2) -> "${pad(c1)} <--> ${c2}")
-            |> Vector.forEach(println)
+    def pad(s) = ToString.toString(s) |> String.padLeft(15, ' ');
+    result
+        |> Vector.map(match (c1, c2) -> "${pad(c1)} <--> ${c2}")
+        |> Vector.forEach(println)

--- a/examples/datalog/railroad-network.flix
+++ b/examples/datalog/railroad-network.flix
@@ -61,23 +61,23 @@ def exampleGraph(): Set[(String, String)] =
             :: "       │ dalte ├───┤quater │                   "
             :: "       └───────┘   └───────┘                   "
             :: Nil;
-        // The graph as a set of links.
-        Set#{
-            ("semel", "bis"),
-            ("semel", "quincy"),
-            ("semel", "clote"),
-            ("bis", "ter"),
-            ("ter", "olfe"),
-            ("ter", "quincy"),
-            ("ter", "icsi"),
-            ("icsi", "mamuk"),
-            ("mamuk", "quincy"),
-            ("mamuk", "clote"),
-            ("mamuk", "quater"),
-            ("mamuk", "dalte"),
-            ("clote", "quincy"),
-            ("dalte", "quater")
-        }
+    // The graph as a set of links.
+    Set#{
+        ("semel", "bis"),
+        ("semel", "quincy"),
+        ("semel", "clote"),
+        ("bis", "ter"),
+        ("ter", "olfe"),
+        ("ter", "quincy"),
+        ("ter", "icsi"),
+        ("icsi", "mamuk"),
+        ("mamuk", "quincy"),
+        ("mamuk", "clote"),
+        ("mamuk", "quater"),
+        ("mamuk", "dalte"),
+        ("clote", "quincy"),
+        ("dalte", "quater")
+    }
 
 ///
 /// Test which of the stations are safely and unsafely connected from `bis`.

--- a/examples/datalog/single-source-shortest-paths.flix
+++ b/examples/datalog/single-source-shortest-paths.flix
@@ -350,7 +350,7 @@ mod ShortestPath {
                         case 10 =>
                             let shortestPathFound =
                                 v == Vector#{0, 1, 2, 3, 10} or v == Vector#{0, 1, 2, 6, 10} or v == Vector#{0, 4, 5, 6, 10} or v == Vector#{0, 7, 5, 6, 10} or v == Vector#{0, 7, 8, 6, 10} or v == Vector#{0, 7, 8, 9, 10};
-                                shortestPathFound
+                            shortestPathFound
                         case _ => unreachable!()
                     }
                 )


### PR DESCRIPTION
This PR is similar to the PR https://github.com/flix/flix/pull/12755.

The only difference it concerns the reformatting of all `examples` with the most recent version of the formatter. All changes here are due to a fixed bug in the `let` formatting logic, which was applied after the datalog batch. 

One exception: `train-schedule.flix` is still unformatted due to the usage within a paper. 