### PR TITLE
feat: inlay-hint double vision fix

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -70,7 +70,9 @@ object InlayHintProvider {
       }
       mkHintsFromEffects(positionToEffectsMap) ::: getInlayHintsFromErrors(errors) ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
     } else {
-      List.empty[InlayHint] ::: getInlayHintsFromErrors(errors) ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
+      val hints = List.empty[InlayHint] ::: getInlayHintsFromErrors(errors) ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
+      // Remove duplicate inlay hints
+      hints.distinct
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -81,10 +81,16 @@ object InlayHintProvider {
     errors.foldLeft(List(): List[InlayHint]) {
       case (acc, TypeError.ExplicitlyPureFunctionUsesIO(loc, _)) =>
         val hint = mkIOHint(Position.from(loc.start), "IO", "IO", Range.from(loc))
+        // If an inlay hint is already in the accumulator, don't add it. Duplicate hints occur because
+        // error location is different if there are more than one occurrence of this error,
+        // but the fix will remain the same.
         if (acc.contains(hint)) acc else hint :: acc
 
       case (acc, TypeError.ImplicitlyPureFunctionUsesIO(loc, _)) =>
         val hint = mkIOHint(Position.from(loc.end), " \\ IO ", " \\ IO ", Range.from(loc))
+        // If an inlay hint is already in the accumulator, don't add it. Duplicate hints occur because
+        // error location is different if there are more than one occurrence of this error,
+        // but the fix will remain the same.
         if (acc.contains(hint)) acc else hint :: acc
 
       case (acc, _) => acc

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -68,11 +68,9 @@ object InlayHintProvider {
           val position = Position(loc.endLine, loc.source.getLine(loc.endLine).length + 2)
           acc.updated(position, acc.getOrElse(position, Set.empty[Symbol.EffSym]) + eff)
       }
-      mkHintsFromEffects(positionToEffectsMap) ::: getInlayHintsFromErrors(errors) ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
+      mkHintsFromEffects(positionToEffectsMap) ::: getInlayHintsFromErrors(errors).distinct ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
     } else {
-      val hints = List.empty[InlayHint] ::: getInlayHintsFromErrors(errors) ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
-      // Remove duplicate inlay hints
-      hints.distinct
+      List.empty[InlayHint] ::: getInlayHintsFromErrors(errors).distinct ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -38,7 +38,7 @@ object InlayHintProvider {
 
   /**
     * Returns a list of inlay hints for the given URI and range.
-    *effectErrorsHints
+    *
     * @param uri   The URI of the file.
     * @param range The range within the file to get inlay hints for.
     * @param root  The root of the typed AST.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -38,7 +38,7 @@ object InlayHintProvider {
 
   /**
     * Returns a list of inlay hints for the given URI and range.
-    *
+    *effectErrorsHints
     * @param uri   The URI of the file.
     * @param range The range within the file to get inlay hints for.
     * @param root  The root of the typed AST.
@@ -68,20 +68,25 @@ object InlayHintProvider {
           val position = Position(loc.endLine, loc.source.getLine(loc.endLine).length + 2)
           acc.updated(position, acc.getOrElse(position, Set.empty[Symbol.EffSym]) + eff)
       }
-      mkHintsFromEffects(positionToEffectsMap) ::: getInlayHintsFromErrors(errors).distinct ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
+      mkHintsFromEffects(positionToEffectsMap) ::: getInlayHintsFromErrors(errors) ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
     } else {
-      List.empty[InlayHint] ::: getInlayHintsFromErrors(errors).distinct ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
+      List.empty[InlayHint] ::: getInlayHintsFromErrors(errors) ::: getDecreasingParamHints(uri) ::: getTailRecursionHints(uri)
     }
   }
 
   /**
     * Returns a list of inlay hints from a given list of CompilationMessage(s),
-    * specifically containing explicitly and implicitly pure functions using IO, errors.
     */
   private def getInlayHintsFromErrors(errors: List[CompilationMessage]): List[InlayHint] = {
     errors.foldLeft(List(): List[InlayHint]) {
-      case (acc, TypeError.ExplicitlyPureFunctionUsesIO(loc, _)) => mkIOHint(Position.from(loc.start), "IO", "IO", Range.from(loc)) :: acc
-      case (acc, TypeError.ImplicitlyPureFunctionUsesIO(loc, _)) => mkIOHint(Position.from(loc.end), " \\ IO ", " \\ IO ", Range.from(loc)) :: acc
+      case (acc, TypeError.ExplicitlyPureFunctionUsesIO(loc, _)) =>
+        val hint = mkIOHint(Position.from(loc.start), "IO", "IO", Range.from(loc))
+        if (acc.contains(hint)) acc else hint :: acc
+
+      case (acc, TypeError.ImplicitlyPureFunctionUsesIO(loc, _)) =>
+        val hint = mkIOHint(Position.from(loc.end), " \\ IO ", " \\ IO ", Range.from(loc))
+        if (acc.contains(hint)) acc else hint :: acc
+
       case (acc, _) => acc
     }
   }


### PR DESCRIPTION
This pull request improves the inlay hint generation in the `InlayHintProvider` by ensuring that duplicate effect-related inlay hints, for specifically ExplicitlyPureFunctionUsesIO and ImplicitlyPureFunctionUsesIO, are removed from the final result. This change helps prevent duplicate hints in those cases from being displayed to the user.

Improvements to inlay hint generation:

* Deduplicates inlay hints for ExplicitlyPureFunctionUsesIO and ImplicitlyPureFunctionUsesIO by checking that they are not already added to the list of inlay hints at generation.

This small PR aims to resolve #12363.
