### PR TITLE
feat: add rnd column to compiler-top

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/FlixEvent.scala
+++ b/main/src/ca/uwaterloo/flix/api/FlixEvent.scala
@@ -61,6 +61,19 @@ object FlixEvent {
   case class NewConstraintsDef(sym: Symbol.DefnSym, tconstrs: List[TypeConstraint]) extends FlixEvent
 
   /**
+    * An event that is fired after each completed round of the Optimizer fixed-point loop.
+    * `round` is the 0-based iteration index; `delta` is the set of defs whose bodies were
+    * actually modified during the round (i.e. the workset returned by `Inliner.run`, not
+    * the set of defs that will be re-analyzed next round — those happen to coincide because
+    * the inliner marks `sym0` changed at every transformation site inside `sym0`'s body).
+    *
+    * Used by the profiler to record the last round at which each def mutated, surfacing
+    * defs that are still churning at the end of the fixed point versus those that
+    * converged early.
+    */
+  case class OptimizerRoundCompleted(round: Int, delta: Set[Symbol.DefnSym]) extends FlixEvent
+
+  /**
    * An event that is fired when a new system of Boolean equation is about to be solved.
    */
   case class SolveEffEquations(econstrs: List[Equation]) extends FlixEvent

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Optimizer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Optimizer.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.language.phase.optimizer
 
-import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
+import ca.uwaterloo.flix.api.{CompilerConstants, Flix, FlixEvent}
 import ca.uwaterloo.flix.language.ast.MonoAst
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugMonoAst
 
@@ -27,12 +27,13 @@ object Optimizer {
   def run(root: MonoAst.Root)(implicit flix: Flix): MonoAst.Root = flix.phase("Optimizer") {
     var currentRoot = root
     var currentDelta = currentRoot.defs.keys.toSet
-    for (_ <- 0 until CompilerConstants.MaxOptimizerRounds) {
+    for (round <- 0 until CompilerConstants.MaxOptimizerRounds) {
       if (currentDelta.nonEmpty) {
         val afterOccurrenceAnalyzer = OccurrenceAnalyzer.run(currentRoot, currentDelta)
         val (newRoot, newDelta) = Inliner.run(afterOccurrenceAnalyzer)
         currentRoot = newRoot
         currentDelta = newDelta
+        flix.emitEvent(FlixEvent.OptimizerRoundCompleted(round, newDelta))
       }
     }
     currentRoot

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -71,6 +71,7 @@ object Aggregation {
     case Sort.Mono  => sumPhaseCounts(s.byPhaseCount, MonoCountPhases).toDouble
     case Sort.Opt   => sumPhaseCounts(s.byPhaseCount, OptCountPhases).toDouble
     case Sort.Inl   => s.inlined.toDouble
+    case Sort.LastChange => s.lastChangedRound.toDouble
     case Sort.Cls   => sumPhaseCounts(s.byPhaseCount, ClsCountPhases).toDouble
     case Sort.Size  => s.classBytes.toDouble
     case Sort.Alloc => s.allocBytes.toDouble
@@ -86,6 +87,7 @@ object Aggregation {
     case Sort.Mono  => sumPhaseCounts(m.byPhaseCount, MonoCountPhases).toDouble
     case Sort.Opt   => sumPhaseCounts(m.byPhaseCount, OptCountPhases).toDouble
     case Sort.Inl   => m.totalInlined.toDouble
+    case Sort.LastChange => m.maxLastChangedRound.toDouble
     case Sort.Cls   => sumPhaseCounts(m.byPhaseCount, ClsCountPhases).toDouble
     case Sort.Size  => m.totalClassBytes.toDouble
     case Sort.Alloc => m.totalAllocBytes.toDouble
@@ -125,7 +127,11 @@ object Aggregation {
       val totalInlined = defs.iterator.map(_.inlined).sum
       val totalClassBytes = defs.iterator.map(_.classBytes).sum
       val totalAllocBytes = defs.iterator.map(_.allocBytes).sum
-      ModuleStats(mod, totalNanos, totalCallCount, totalLocLines, byPhase, byPhaseCount, byPhaseAlloc, totalCns, totalTvars, totalEvars, totalInlined, totalClassBytes, totalAllocBytes)
+      // `-1` is the per-def "never observed" sentinel; the module rollup
+      // preserves that sentinel only when *every* def in the module
+      // converged outside the optimizer, since `max` of all-(-1)s is `-1`.
+      val maxLastChangedRound = defs.iterator.map(_.lastChangedRound).maxOption.getOrElse(-1)
+      ModuleStats(mod, totalNanos, totalCallCount, totalLocLines, byPhase, byPhaseCount, byPhaseAlloc, totalCns, totalTvars, totalEvars, totalInlined, totalClassBytes, totalAllocBytes, maxLastChangedRound)
     }.toVector.sortBy(m => -moduleSortKey(m, srt))
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
@@ -48,8 +48,8 @@ object Layout {
 
   /** Width contribution of the optional LOC column (separator + width). */
   private val LocColWidth: Int = 1 + 4
-  /** Width contribution of the optional mono / opt / inl / cls / size per-phase count columns (4 × 4-char + 1 × 5-char, with separators). */
-  private val CountsColWidth: Int = 4 * (1 + 4) + (1 + 5)
+  /** Width contribution of the optional mono / opt / inl / rnd / cls / size per-phase count columns (5 × 4-char + 1 × 5-char, with separators). */
+  private val CountsColWidth: Int = 5 * (1 + 4) + (1 + 5)
   /** Width contribution of the optional cns column (separator + 5-char numeric field). */
   private val CnsColWidth: Int = 1 + 5
   /** Width contribution of the optional tvars column (separator + 4-char numeric field). */
@@ -67,7 +67,7 @@ object Layout {
   /**
     * Picks a [[Layout]] for the given terminal width by trying tiers in
     * descending feature order. The caller gates the optional count-style
-    * columns by passing `showCounts` (mono / opt / inl / cls / size) and
+    * columns by passing `showCounts` (mono / opt / inl / rnd / cls / size) and
     * `showCns` (cns / tv / ev) — Layout itself doesn't know which UI mode
     * they correspond to. When a flag is false the column is hidden and the
     * reclaimed width expands the sym / location text columns instead.

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -87,6 +87,8 @@ object Model {
     case object Opt     extends Sort { val key = 'o' }
     /** Most times inlined at a call site first — surfaces small leaf defs that get duplicated everywhere. */
     case object Inl     extends Sort { val key = 'i' }
+    /** Highest last-changed Optimizer round first — surfaces defs that are still mutating at the end of the fixed point. Distinct from [[Opt]], which counts re-visits and conflates "revisited but stable" with "revisited and still changing". Defs never observed to change (lastChangedRound = -1) sink to the bottom. */
+    case object LastChange extends Sort { val key = 'r' }
     /** Most class files emitted first — surfaces JVM fan-out from polymorphism / closures. */
     case object Cls     extends Sort { val key = 'c' }
     /** Largest total `.class` byte size first — surfaces defs whose bodies compile to bulky bytecode. */
@@ -101,7 +103,7 @@ object Model {
     case object Evars   extends Sort { val key = 'e' }
 
     /** All sort values. */
-    val all: List[Sort] = List(Time, Hotness, Mono, Opt, Inl, Cls, Size, Alloc, Cns, Tvars, Evars)
+    val all: List[Sort] = List(Time, Hotness, Mono, Opt, Inl, LastChange, Cls, Size, Alloc, Cns, Tvars, Evars)
 
     /** The sort whose `key` matches `c` (case-insensitive), or `None`. */
     def fromKey(c: Char): Option[Sort] = all.find(_.key == c.toLower)
@@ -130,8 +132,9 @@ object Model {
     * @param totalInlined   summed inliner call-site inline counts across the module's defs.
     * @param totalClassBytes summed bytecode byte size of emitted `.class` files across the module's defs.
     * @param totalAllocBytes summed compiler-side heap allocation bytes across the module's defs.
+    * @param maxLastChangedRound max across the module's defs of [[Profiler.DefnStats.lastChangedRound]]. `-1` when no def in the module entered the optimizer. The module ranks by its slowest-to-converge def, mirroring the def-level sort.
     */
-  final case class ModuleStats(module: String, totalNanos: Long, totalCallCount: Long, totalLocLines: Int, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], totalCns: Long, totalTvars: Long, totalEvars: Long, totalInlined: Long, totalClassBytes: Long, totalAllocBytes: Long) {
+  final case class ModuleStats(module: String, totalNanos: Long, totalCallCount: Long, totalLocLines: Int, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], totalCns: Long, totalTvars: Long, totalEvars: Long, totalInlined: Long, totalClassBytes: Long, totalAllocBytes: Long, maxLastChangedRound: Int) {
     /** Returns the phase that consumed the most time in this module, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
@@ -93,9 +93,10 @@ object Profiler {
     * @param inlined      number of times this def was inlined at a call site by the inliner across all optimizer rounds.
     * @param classBytes   total bytes of generated `.class` files attributed to this def (function class + any closure classes).
     * @param allocBytes   total compiler-side heap allocation (Hotspot per-thread allocated bytes) summed across `track` calls for this sym. 0 when the JVM doesn't support [[com.sun.management.ThreadMXBean.getThreadAllocatedBytes]].
+    * @param lastChangedRound 0-based index of the last Optimizer round during which the inliner modified this def's body, or `-1` if the def was never observed to change (e.g. converged before the first round, or never entered the optimizer). Defs with high values are still churning at the end of the fixed point.
     * @param loc          the source location of the def's body, used to compute LOC.
     */
-  final case class DefnStats(sym: Symbol.DefnSym, isActive: Boolean, callCount: Int, totalNanos: Long, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], cns: Long, tvars: Long, evars: Long, inlined: Long, classBytes: Long, allocBytes: Long, loc: SourceLocation) {
+  final case class DefnStats(sym: Symbol.DefnSym, isActive: Boolean, callCount: Int, totalNanos: Long, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], cns: Long, tvars: Long, evars: Long, inlined: Long, classBytes: Long, allocBytes: Long, lastChangedRound: Int, loc: SourceLocation) {
     /** Returns the phase that consumed the most time, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
@@ -116,9 +117,10 @@ object Profiler {
     * @param inlined       accumulator: number of times this def was inlined at a call site by the inliner.
     * @param classBytes    accumulator: summed `.class` byte length of every class emitted for this def.
     * @param allocBytes    accumulator: summed Hotspot per-thread allocation deltas across `track` calls for this sym. Captures compiler-side heap pressure, independent of wall time.
+    * @param lastChangedRound max-of: 0-based Optimizer round index at which this def's body was last modified by the inliner. Initialized to `-1` so defs that never enter the optimizer (or that converge before the first round) stay distinguishable from "changed in round 0". Updated via `updateAndGet(max)` on every `OptimizerRoundCompleted` event whose `delta` contains this sym.
     * @param loc           set on first `track` call; carries the def-body span so we can show LOC.
     */
-  private final case class Counters(inProgress: AtomicInteger, callCount: AtomicInteger, totalNanos: AtomicLong, perPhaseNanos: ConcurrentHashMap[String, AtomicLong], perPhaseCount: ConcurrentHashMap[String, AtomicLong], perPhaseAlloc: ConcurrentHashMap[String, AtomicLong], constraints: AtomicLong, tvars: AtomicLong, evars: AtomicLong, inlined: AtomicLong, classBytes: AtomicLong, allocBytes: AtomicLong, loc: AtomicReference[SourceLocation])
+  private final case class Counters(inProgress: AtomicInteger, callCount: AtomicInteger, totalNanos: AtomicLong, perPhaseNanos: ConcurrentHashMap[String, AtomicLong], perPhaseCount: ConcurrentHashMap[String, AtomicLong], perPhaseAlloc: ConcurrentHashMap[String, AtomicLong], constraints: AtomicLong, tvars: AtomicLong, evars: AtomicLong, inlined: AtomicLong, classBytes: AtomicLong, allocBytes: AtomicLong, lastChangedRound: AtomicInteger, loc: AtomicReference[SourceLocation])
 
   /**
     * Composite map key for per-`DefnSym` accumulators.
@@ -211,9 +213,12 @@ final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
 
   /**
     * Subscribes the profiler to compiler events emitted via `Flix.emitEvent`.
-    * Today only [[FlixEvent.NewConstraintsDef]] is consumed — Typer fires it
-    * once per def with the post-generation constraint list, which gives us
-    * a clean per-def `cns` reading without instrumenting any inner loops.
+    * Each handler latches its reading onto the per-source-sym [[Counters]] via
+    * [[countersFor]]:
+    *   - [[FlixEvent.NewConstraintsDef]]   set `cns` / `tvars` / `evars` (replaces, not adds).
+    *   - [[FlixEvent.InlinedDef]]          increments `inlined`.
+    *   - [[FlixEvent.EmittedClass]]        adds to `classBytes`.
+    *   - [[FlixEvent.OptimizerRoundCompleted]] updates `lastChangedRound` via `max`.
     */
   override def notify(e: FlixEvent): Unit = e match {
     case FlixEvent.NewConstraintsDef(sym, tconstrs) =>
@@ -230,6 +235,17 @@ final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
       countersFor(sym).inlined.incrementAndGet()
     case FlixEvent.EmittedClass(sym, bytes) =>
       countersFor(sym).classBytes.addAndGet(bytes.toLong)
+    case FlixEvent.OptimizerRoundCompleted(round, delta) =>
+      // `updateAndGet(max)` rather than `set`: events are emitted sequentially
+      // from Optimizer.run so `round` is monotonic here, but using max keeps
+      // us correct under any reordering and against future parallel optimizer
+      // rounds. Delta syms are monomorphic specializations; `countersFor`
+      // strips the fresh id via `sourceOf` so the round attribution rolls up
+      // to the source sym, matching the `inlined` / `classBytes` convention.
+      delta.foreach { sym =>
+        val c = countersFor(sym)
+        c.lastChangedRound.updateAndGet(prev => math.max(prev, round))
+      }
     case _ => ()
   }
 
@@ -289,7 +305,7 @@ final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
       val loc = Option(c.loc.get()).getOrElse(key.loc)
       Profiler.DefnStats(key.sym, isActive = c.inProgress.get() > 0,
         c.callCount.get(), c.totalNanos.get(), byPhase, byPhaseCount, byPhaseAlloc,
-        c.constraints.get(), c.tvars.get(), c.evars.get(), c.inlined.get(), c.classBytes.get(), c.allocBytes.get(), loc)
+        c.constraints.get(), c.tvars.get(), c.evars.get(), c.inlined.get(), c.classBytes.get(), c.allocBytes.get(), c.lastChangedRound.get(), loc)
     }.toVector
   }
 
@@ -311,6 +327,7 @@ final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
       inlined = new AtomicLong(0L),
       classBytes = new AtomicLong(0L),
       allocBytes = new AtomicLong(0L),
+      lastChangedRound = new AtomicInteger(-1),
       loc = new AtomicReference[SourceLocation](null)
     ))
 

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -98,6 +98,7 @@ object Renderer {
   private final case class RowCells(locLines: Int,
                                     byPhaseCount: Map[String, Long],
                                     inlined: Long,
+                                    lastChangedRound: Int,
                                     classBytes: Long,
                                     cns: Long,
                                     tvars: Long,
@@ -130,19 +131,20 @@ object Renderer {
     val cells: RowCells = {
       val pctWall = 100.0 * s.totalNanos / safeElapsed
       RowCells(
-        locLines      = locLines,
-        byPhaseCount  = s.byPhaseCount,
-        inlined       = s.inlined,
-        classBytes    = s.classBytes,
-        cns           = s.cns,
-        tvars         = s.tvars,
-        evars         = s.evars,
-        dominantPhase = s.dominantPhase.getOrElse("?"),
-        allocBytes    = s.allocBytes,
-        nanos         = s.totalNanos,
-        pctCpu        = pctWall / parallelism,
-        pctWall       = pctWall,
-        aggregate     = false,
+        locLines         = locLines,
+        byPhaseCount     = s.byPhaseCount,
+        inlined          = s.inlined,
+        lastChangedRound = s.lastChangedRound,
+        classBytes       = s.classBytes,
+        cns              = s.cns,
+        tvars            = s.tvars,
+        evars            = s.evars,
+        dominantPhase    = s.dominantPhase.getOrElse("?"),
+        allocBytes       = s.allocBytes,
+        nanos            = s.totalNanos,
+        pctCpu           = pctWall / parallelism,
+        pctWall          = pctWall,
+        aggregate        = false,
       )
     }
 
@@ -166,19 +168,20 @@ object Renderer {
     val cells: RowCells = {
       val pctWall = 100.0 * m.totalNanos / safeElapsed
       RowCells(
-        locLines      = m.totalLocLines,
-        byPhaseCount  = m.byPhaseCount,
-        inlined       = m.totalInlined,
-        classBytes    = m.totalClassBytes,
-        cns           = m.totalCns,
-        tvars         = m.totalTvars,
-        evars         = m.totalEvars,
-        dominantPhase = m.dominantPhase.getOrElse("?"),
-        allocBytes    = m.totalAllocBytes,
-        nanos         = m.totalNanos,
-        pctCpu        = pctWall / parallelism,
-        pctWall       = pctWall,
-        aggregate     = true,
+        locLines         = m.totalLocLines,
+        byPhaseCount     = m.byPhaseCount,
+        inlined          = m.totalInlined,
+        lastChangedRound = m.maxLastChangedRound,
+        classBytes       = m.totalClassBytes,
+        cns              = m.totalCns,
+        tvars            = m.totalTvars,
+        evars            = m.totalEvars,
+        dominantPhase    = m.dominantPhase.getOrElse("?"),
+        allocBytes       = m.totalAllocBytes,
+        nanos            = m.totalNanos,
+        pctCpu           = pctWall / parallelism,
+        pctWall          = pctWall,
+        aggregate        = true,
       )
     }
 
@@ -380,6 +383,7 @@ final class Renderer {
       sb.append(' '); sb.append(sortableColumn(lpad("mono", 4), Sort.Mono, activeSort))
       sb.append(' '); sb.append(sortableColumn(lpad("opt",  4), Sort.Opt,  activeSort))
       sb.append(' '); sb.append(sortableColumn(lpad("inl",  4), Sort.Inl,  activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("rnd",  4), Sort.LastChange, activeSort))
       sb.append(' '); sb.append(sortableColumn(lpad("cls",  4), Sort.Cls,  activeSort))
       sb.append(' '); sb.append(sortableColumn(lpad("size", 5), Sort.Size, activeSort))
     }
@@ -453,9 +457,14 @@ final class Renderer {
       val mono = sumPhaseCounts(cells.byPhaseCount, MonoCountPhases)
       val opt  = sumPhaseCounts(cells.byPhaseCount, OptCountPhases)
       val cls  = sumPhaseCounts(cells.byPhaseCount, ClsCountPhases)
+      // `-1` is the "never observed" sentinel from Profiler — render as `-`
+      // rather than a number so it visually sinks alongside other unscored
+      // cells. Rounds are 0..MaxOptimizerRounds-1, single-digit in practice.
+      val lcrStr = if (cells.lastChangedRound < 0) "-" else cells.lastChangedRound.toString
       sb.append(' '); sb.append(lpad(mono.toString, 4))
       sb.append(' '); sb.append(lpad(opt.toString, 4))
       sb.append(' '); sb.append(lpad(cells.inlined.toString, 4))
+      sb.append(' '); sb.append(lpad(lcrStr, 4))
       sb.append(' '); sb.append(lpad(cls.toString, 4))
       sb.append(' '); sb.append(lpad(formatBytes(cells.classBytes), 5))
     }


### PR DESCRIPTION
## Summary

- New `rnd` column in compiler-top shows the 0-based Optimizer round in which each def's body last changed; `-` means never observed to change (never entered the optimizer or converged before round 0).
- Sortable via key `r`. At module scope the column is the max across the module's defs.
- Distinguishes "still churning at the end of the fixed point" from "merely re-visited but stable" — the existing `opt` column conflates the two.

## Plumbing

- `Optimizer.run` now emits `FlixEvent.OptimizerRoundCompleted(round, delta)` at the end of each fixed-point iteration.
- `Profiler` subscribes and updates each sym's `lastChangedRound` via `updateAndGet(max)` so attribution is robust to event reordering and would survive future parallel rounds.
- `Counters` initializes the new field to `-1`; `DefnStats` / `ModuleStats` and the renderer thread the value through; `Layout` widens `CountsColWidth` to accommodate the extra 4-char column.

## Test plan

- [ ] `./mill flix.compile` succeeds.
- [ ] Standard library compiles (`./mill flix.run out/empty.flix`).
- [ ] Run a Flix file with `--top` in backend filter (`b`); verify the `rnd` column renders, mostly small single-digit values, with `-` for defs that didn't enter the optimizer.
- [ ] Press `r` to sort by `rnd`; verify hot churners surface at the top.
- [ ] Module table shows the per-module max correctly (modules containing a `-1`-only set of defs render `-`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)