### PR TITLE
refactor: cosmetic tweaks to compiler-top TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.tools.compilertop
 
-import ca.uwaterloo.flix.tools.compilertop.Formatting.locLineCount
+import ca.uwaterloo.flix.tools.compilertop.Formatting.lineCount
 import ca.uwaterloo.flix.tools.compilertop.Model.*
 import ca.uwaterloo.flix.tools.compilertop.Profiler.DefnStats
 
@@ -67,7 +67,7 @@ object Aggregation {
     */
   def defSortKey(s: DefnStats, srt: Sort): Double = srt match {
     case Sort.Time    => s.totalNanos.toDouble
-    case Sort.Hotness => Formatting.hotnessMsPerLine(s.totalNanos, locLineCount(s.loc))
+    case Sort.Hotness => Formatting.hotnessMsPerLine(s.totalNanos, lineCount(s.loc))
     case Sort.Mono  => sumPhaseCounts(s.byPhaseCount, MonoCountPhases).toDouble
     case Sort.Opt   => sumPhaseCounts(s.byPhaseCount, OptCountPhases).toDouble
     case Sort.Inl   => s.inlined.toDouble
@@ -82,7 +82,7 @@ object Aggregation {
   /** Module-level analogue of [[defSortKey]], applied after summing across each module's defs. */
   def moduleSortKey(m: ModuleStats, srt: Sort): Double = srt match {
     case Sort.Time    => m.totalNanos.toDouble
-    case Sort.Hotness => Formatting.hotnessMsPerLine(m.totalNanos, m.totalLocLines)
+    case Sort.Hotness => Formatting.hotnessMsPerLine(m.totalNanos, m.totalLines)
     case Sort.Mono  => sumPhaseCounts(m.byPhaseCount, MonoCountPhases).toDouble
     case Sort.Opt   => sumPhaseCounts(m.byPhaseCount, OptCountPhases).toDouble
     case Sort.Inl   => m.totalInlined.toDouble
@@ -103,7 +103,7 @@ object Aggregation {
     groups.iterator.map { case (mod, defs) =>
       val totalNanos = defs.iterator.map(_.totalNanos).sum
       val totalCallCount = defs.iterator.map(_.callCount.toLong).sum
-      val totalLocLines = defs.iterator.map(s => locLineCount(s.loc)).sum
+      val totalLines = defs.iterator.map(s => lineCount(s.loc)).sum
       val byPhase = defs.foldLeft(Map.empty[String, Long]) { (acc, d) =>
         d.byPhase.foldLeft(acc) { case (m, (phase, n)) =>
           m.updated(phase, m.getOrElse(phase, 0L) + n)
@@ -125,7 +125,7 @@ object Aggregation {
       val totalInlined = defs.iterator.map(_.inlined).sum
       val totalClassBytes = defs.iterator.map(_.classBytes).sum
       val totalAllocBytes = defs.iterator.map(_.allocBytes).sum
-      ModuleStats(mod, totalNanos, totalCallCount, totalLocLines, byPhase, byPhaseCount, byPhaseAlloc, totalCns, totalTvars, totalEvars, totalInlined, totalClassBytes, totalAllocBytes)
+      ModuleStats(mod, totalNanos, totalCallCount, totalLines, byPhase, byPhaseCount, byPhaseAlloc, totalCns, totalTvars, totalEvars, totalInlined, totalClassBytes, totalAllocBytes)
     }.toVector.sortBy(m => -moduleSortKey(m, srt))
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Formatting.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Formatting.scala
@@ -34,14 +34,14 @@ object Formatting {
   }
 
   /**
-    * Returns ms-per-source-line for the given `nanos / locLines` pair, or 0
-    * when `locLines <= 0` (synthetic defs with no real source span — the
+    * Returns ms-per-source-line for the given `nanos / lines` pair, or 0
+    * when `lines <= 0` (synthetic defs with no real source span — the
     * denominator would be meaningless). Single source of truth for the
     * "hotness" metric used by both the hotness sort key and the threshold-
     * based row coloring.
     */
-  def hotnessMsPerLine(nanos: Long, locLines: Int): Double =
-    if (locLines <= 0) 0.0 else (nanos / 1_000_000L).toDouble / locLines
+  def hotnessMsPerLine(nanos: Long, lines: Int): Double =
+    if (lines <= 0) 0.0 else (nanos / 1_000_000L).toDouble / lines
 
   // -- Formatting helpers -------------------------------------------------
 
@@ -50,7 +50,7 @@ object Formatting {
     if (!loc.isReal) "?" else s"${loc.source.name}:${loc.startLine}"
 
   /** Returns the inclusive line span of `loc`, or 0 if synthetic. */
-  def locLineCount(loc: SourceLocation): Int =
+  def lineCount(loc: SourceLocation): Int =
     if (!loc.isReal) 0 else (loc.endLine - loc.startLine + 1).max(0)
 
   /** Formats a nanosecond duration as `Nms` or `N.Ns` (≥10s). */

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
@@ -17,20 +17,20 @@ package ca.uwaterloo.flix.tools.compilertop
 
 /**
   * Column layout for the per-frame table render. Computed from the current
-  * terminal width: when the terminal is narrow, the optional LOC / counts
+  * terminal width: when the terminal is narrow, the optional lines / counts
   * / cns / phase columns are dropped in that order (lowest-signal first).
   * When the terminal is wide, the surplus is distributed between the
   * DefnSym and location columns proportionally to their default widths.
   *
   * @param symWidth    width of the DefnSym column.
   * @param locWidth    width of the location column.
-  * @param showLOC     whether to render the LOC column.
+  * @param showLines   whether to render the lines column.
   * @param showCounts  whether to render the mono / opt / cls per-phase count columns.
   * @param showCns     whether to render the cns / tv / ev columns.
   * @param showPhase   whether to render the dominant-phase column.
   * @param totalWidth  total rendered width of the row, less leading/trailing pad.
   */
-final case class Layout(symWidth: Int, locWidth: Int, showLOC: Boolean, showCounts: Boolean, showCns: Boolean, showPhase: Boolean, totalWidth: Int)
+final case class Layout(symWidth: Int, locWidth: Int, showLines: Boolean, showCounts: Boolean, showCns: Boolean, showPhase: Boolean, totalWidth: Int)
 
 object Layout {
 
@@ -46,8 +46,8 @@ object Layout {
   /** Fixed-width contribution of `alloc + time + %cpu + %wall` columns and their separators. */
   private val FixedTailWidth: Int = 5 + 1 + 9 + 1 + 6 + 1 + 6 // alloc(5) + time(9) + %cpu(6) + %wall(6) with three separators between
 
-  /** Width contribution of the optional LOC column (separator + width). */
-  private val LocColWidth: Int = 1 + 4
+  /** Width contribution of the optional lines column (separator + width). */
+  private val LinesColWidth: Int = 1 + 5
   /** Width contribution of the optional mono / opt / inl / cls / size per-phase count columns (4 × 4-char + 1 × 5-char, with separators). */
   private val CountsColWidth: Int = 4 * (1 + 4) + (1 + 5)
   /** Width contribution of the optional cns column (separator + 5-char numeric field). */
@@ -89,49 +89,49 @@ object Layout {
 
     /**
       * Returns a [[Layout]] for `tierFixed` chars of non-text columns
-      * (LOC / counts / phase / tail) plus a sym + loc text section that
+      * (lines / counts / phase / tail) plus a sym + loc text section that
       * expands to fill any surplus over [[DefaultSymWidth]] /
       * [[DefaultLocWidth]]. The resulting `totalWidth` equals `cols`
       * exactly, so the divider and rows fill the terminal regardless of
       * which tier we landed in.
       */
-    def fillTier(tierFixed: Int, showLOC: Boolean, showCountsOut: Boolean, showCnsOut: Boolean, showPhase: Boolean): Layout = {
+    def fillTier(tierFixed: Int, showLines: Boolean, showCountsOut: Boolean, showCnsOut: Boolean, showPhase: Boolean): Layout = {
       val baseText = textWidth(DefaultSymWidth, DefaultLocWidth)
       val extra = (cols - (baseText + tierFixed)).max(0)
       val extraSym = extra * 46 / 100
       val extraLoc = extra - extraSym
       val symW = DefaultSymWidth + extraSym
       val locW = DefaultLocWidth + extraLoc
-      Layout(symW, locW, showLOC = showLOC, showCounts = showCountsOut, showCns = showCnsOut, showPhase = showPhase,
+      Layout(symW, locW, showLines = showLines, showCounts = showCountsOut, showCns = showCnsOut, showPhase = showPhase,
         totalWidth = textWidth(symW, locW) + tierFixed)
     }
 
     // Try tiers in descending feature order. Each tier expands sym/loc
     // into whatever width is left over after its fixed columns.
-    val full = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + extraColsW + PhaseColWidth + tail
+    val full = textWidth(DefaultSymWidth, DefaultLocWidth) + LinesColWidth + extraColsW + PhaseColWidth + tail
     if (cols >= full)
-      return fillTier(LocColWidth + extraColsW + PhaseColWidth + tail, showLOC = true, showCountsOut = showCounts, showCnsOut = showCns, showPhase = true)
+      return fillTier(LinesColWidth + extraColsW + PhaseColWidth + tail, showLines = true, showCountsOut = showCounts, showCnsOut = showCns, showPhase = true)
 
     // Tier: drop phase.
-    val noPhase = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + extraColsW + tail
+    val noPhase = textWidth(DefaultSymWidth, DefaultLocWidth) + LinesColWidth + extraColsW + tail
     if (cols >= noPhase)
-      return fillTier(LocColWidth + extraColsW + tail, showLOC = true, showCountsOut = showCounts, showCnsOut = showCns, showPhase = false)
+      return fillTier(LinesColWidth + extraColsW + tail, showLines = true, showCountsOut = showCounts, showCnsOut = showCns, showPhase = false)
 
     // Tier: drop phase + the optional counts (mono/opt/inl/cls/size or cns/tv/ev).
-    val noPhaseNoExtras = textWidth(DefaultSymWidth, DefaultLocWidth) + LocColWidth + tail
+    val noPhaseNoExtras = textWidth(DefaultSymWidth, DefaultLocWidth) + LinesColWidth + tail
     if (cols >= noPhaseNoExtras)
-      return fillTier(LocColWidth + tail, showLOC = true, showCountsOut = false, showCnsOut = false, showPhase = false)
+      return fillTier(LinesColWidth + tail, showLines = true, showCountsOut = false, showCnsOut = false, showPhase = false)
 
-    // Tier: drop phase + extras + LOC.
+    // Tier: drop phase + extras + lines.
     val noOptional = textWidth(DefaultSymWidth, DefaultLocWidth) + tail
     if (cols >= noOptional)
-      return fillTier(tail, showLOC = false, showCountsOut = false, showCnsOut = false, showPhase = false)
+      return fillTier(tail, showLines = false, showCountsOut = false, showCnsOut = false, showPhase = false)
 
     // Even minimum tier doesn't fit; shrink sym/locWidth to floors.
     val available = (cols - tail).max(MinSymWidth + 1 + MinLocWidth)
     val symW = MinSymWidth.max(available * 46 / 100)
     val locW = MinLocWidth.max(available - 1 - symW)
-    Layout(symW, locW, showLOC = false, showCounts = false, showCns = false, showPhase = false,
+    Layout(symW, locW, showLines = false, showCounts = false, showCns = false, showPhase = false,
       textWidth(symW, locW) + tail)
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -136,7 +136,7 @@ object Model {
     * @param module         dot-joined namespace (or `(root)` when empty).
     * @param totalNanos     summed wall-clock time across the module's defs.
     * @param totalCallCount summed `track` call counts across the module's defs.
-    * @param totalLocLines  summed source-line counts across the module's defs.
+    * @param totalLines     summed source-line counts across the module's defs.
     * @param byPhase        phase → summed nanoseconds across the module's defs.
     * @param byPhaseCount   phase → summed track-call counts across the module's defs.
     * @param byPhaseAlloc   phase → summed compiler-side allocation bytes across the module's defs. Lets the frontend/backend filter re-project module allocation the same way it re-projects module time.
@@ -147,7 +147,7 @@ object Model {
     * @param totalClassBytes summed bytecode byte size of emitted `.class` files across the module's defs.
     * @param totalAllocBytes summed compiler-side heap allocation bytes across the module's defs.
     */
-  final case class ModuleStats(module: String, totalNanos: Long, totalCallCount: Long, totalLocLines: Int, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], totalCns: Long, totalTvars: Long, totalEvars: Long, totalInlined: Long, totalClassBytes: Long, totalAllocBytes: Long) {
+  final case class ModuleStats(module: String, totalNanos: Long, totalCallCount: Long, totalLines: Int, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], totalCns: Long, totalTvars: Long, totalEvars: Long, totalInlined: Long, totalClassBytes: Long, totalAllocBytes: Long) {
     /** Returns the phase that consumed the most time in this module, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -97,7 +97,7 @@ object Renderer {
     *                  warning colors, since aggregating across defs almost
     *                  always trips the thresholds. False for def rows.
     */
-  private final case class RowCells(locLines: Int,
+  private final case class RowCells(lines: Int,
                                     byPhaseCount: Map[String, Long],
                                     inlined: Long,
                                     classBytes: Long,
@@ -126,13 +126,13 @@ object Renderer {
 
   /** Def-table row: hotness-colored sym, active marker, location column. */
   private final case class DefnRow(s: DefnStats, safeElapsed: Double, parallelism: Int) extends Row {
-    private val locLines = locLineCount(s.loc)
+    private val lines = lineCount(s.loc)
 
     /** Numeric cells for this def, with `aggregate = false` so warning colors apply. */
     val cells: RowCells = {
       val pctWall = 100.0 * s.totalNanos / safeElapsed
       RowCells(
-        locLines      = locLines,
+        lines         = lines,
         byPhaseCount  = s.byPhaseCount,
         inlined       = s.inlined,
         classBytes    = s.classBytes,
@@ -154,7 +154,7 @@ object Renderer {
       val nameText = truncate(s.sym.name, nameMax)
       val locField = rpad(truncate(formatLocation(s.loc), layout.locWidth), layout.locWidth)
       val marker   = if (s.isActive) yellow("*") else " "
-      sb.append(styleSym(nameText, s.totalNanos, locLines))
+      sb.append(styleSym(nameText, s.totalNanos, lines))
       sb.append(marker)
       sb.append(" " * (nameMax - nameText.length))
       sb.append(' ')
@@ -168,7 +168,7 @@ object Renderer {
     val cells: RowCells = {
       val pctWall = 100.0 * m.totalNanos / safeElapsed
       RowCells(
-        locLines      = m.totalLocLines,
+        lines         = m.totalLines,
         byPhaseCount  = m.byPhaseCount,
         inlined       = m.totalInlined,
         classBytes    = m.totalClassBytes,
@@ -240,7 +240,7 @@ final class Renderer {
     val modRows: Vector[Row] = state.modules.map(m => ModuleRow(m, safeElapsed, state.parallelism))
 
     // Def table: header, then rows or a centered placeholder if empty.
-    renderHeaderRow(sb, rpad("Def (hot)", state.layout.symWidth), withLocation = true, state.layout, state.activeSort)
+    renderHeaderRow(sb, rpad("def (hot)", state.layout.symWidth), withLocation = true, state.layout, state.activeSort)
     if (defRows.isEmpty) renderEmptyPlaceholder(sb, "(no timings yet)", state.layout)
     else renderTable(sb, defRows, state.layout)
 
@@ -248,7 +248,7 @@ final class Renderer {
     if (modRows.nonEmpty) {
       val modWidth = state.layout.symWidth + 1 + state.layout.locWidth
       sb.append('\n')
-      renderHeaderRow(sb, rpad("Module (hot)", modWidth), withLocation = false, state.layout, state.activeSort)
+      renderHeaderRow(sb, rpad("module (hot)", modWidth), withLocation = false, state.layout, state.activeSort)
       renderTable(sb, modRows, state.layout)
     }
   }
@@ -345,6 +345,9 @@ final class Renderer {
     sb.append(styleHeap(heapUsedField, heapRatio))
     sb.append(dim(" / "))
     sb.append(heapMaxField)
+    // Align under the `[all|frontend|backend]` legend on the dashboard line above.
+    sb.append("     ")
+    sb.append(color("? for help", Gray))
     sb.append('\n')
   }
 
@@ -371,8 +374,8 @@ final class Renderer {
     * "(h̲ot)" annotation marks the hotness sort key. The active column is
     * rendered bold yellow; the rest bold cyan.
     *
-    * Two callers — `Def (hot)` + a `"location"` column for the def table,
-    * `Module (hot)` (single wide column, no location) for the module table.
+    * Two callers — `def (hot)` + a `"location"` column for the def table,
+    * `module (hot)` (single wide column, no location) for the module table.
     */
   private def buildHeader(leading: String, withLocation: Boolean, layout: Layout, activeSort: Sort): String = {
     val sb = new StringBuilder
@@ -383,8 +386,8 @@ final class Renderer {
       sb.append(' ')
       sb.append(plainHeader(rpad("location", layout.locWidth)))
     }
-    if (layout.showLOC) {
-      sb.append(' '); sb.append(plainHeader(lpad("LOC", 4)))
+    if (layout.showLines) {
+      sb.append(' '); sb.append(plainHeader(lpad("lines", 5)))
     }
     if (layout.showCounts) {
       sb.append(' '); sb.append(sortableColumn(lpad("mono", 4), Sort.Mono, activeSort))
@@ -457,10 +460,10 @@ final class Renderer {
     // The three groups mirror how Layout / the table renderer gate columns:
     // common columns are always shown; frontend columns only appear under
     // the `frontend` filter; backend columns only under the `backend` filter.
-    sb.append("  "); sb.append(bold(cyan("Common Cols"))); sb.append('\n')
-    appendHelpCol(sb, "Def",      "fully qualified def name; color = hotness (ms/source-line); '*' marks the def currently compiling")
+    sb.append("  "); sb.append(bold(cyan("Common columns"))); sb.append('\n')
+    appendHelpCol(sb, "def",      "fully qualified def name; color = hotness (ms/source-line); '*' marks the def currently compiling")
     appendHelpCol(sb, "location", "source file:line of the def")
-    appendHelpCol(sb, "LOC",      "source-line span of the def body")
+    appendHelpCol(sb, "lines",    "source-line span of the def body")
     appendHelpCol(sb, "phase",    "phase that consumed the most time for this def")
     appendHelpCol(sb, "alloc",    "compiler-side heap bytes allocated processing this def")
     appendHelpCol(sb, "time",     "wall-clock time spent on this def")
@@ -468,17 +471,16 @@ final class Renderer {
     appendHelpCol(sb, "%wall",    "time / elapsed — upper bound on wall-clock savings if removed")
     sb.append('\n')
 
-    sb.append("  "); sb.append(bold(cyan("Frontend Cols"))); sb.append('\n')
+    sb.append("  "); sb.append(bold(cyan("Frontend columns"))); sb.append('\n')
     appendHelpCol(sb, "cns",      "type constraints (Typer)")
     appendHelpCol(sb, "tv",       "type variables (Kind.Star)")
     appendHelpCol(sb, "ev",       "effect variables (Kind.Eff)")
     sb.append('\n')
 
-    sb.append("  "); sb.append(bold(cyan("Backend Cols"))); sb.append('\n')
+    sb.append("  "); sb.append(bold(cyan("Backend columns"))); sb.append('\n')
     appendHelpCol(sb, "mono",     "monomorphic instances created (Monomorpher)")
     appendHelpCol(sb, "opt",      "optimizer fixed-point re-visits (Optimizer + LambdaDrop)")
     appendHelpCol(sb, "inl",      "times inlined at a call site")
-    appendHelpCol(sb, "rnd",      "last Optimizer round in which the def changed; '-' if never observed")
     appendHelpCol(sb, "cls",      ".class files emitted (CodeGen)")
     appendHelpCol(sb, "size",     "total bytecode size of emitted .class files")
   }
@@ -505,10 +507,10 @@ final class Renderer {
     * plain in both tables.
     */
   private def appendNumericFields(sb: StringBuilder, cells: RowCells, layout: Layout): Unit = {
-    if (layout.showLOC) {
+    if (layout.showLines) {
       sb.append(' ')
-      val locStr = if (cells.locLines > 0) cells.locLines.toString else "-"
-      sb.append(lpad(locStr, 4))
+      val linesStr = if (cells.lines > 0) cells.lines.toString else "-"
+      sb.append(lpad(linesStr, 5))
     }
     if (layout.showCounts) {
       val mono = sumPhaseCounts(cells.byPhaseCount, MonoCountPhases)

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
@@ -55,12 +55,12 @@ object Styling {
   /**
     * Colors the sym name based on its hotness (ms-per-source-line) — surfaces
     * small defs that consume time disproportionate to their body size. Defs
-    * with no real source span (`locLines <= 0`) are left unstyled because the
+    * with no real source span (`lines <= 0`) are left unstyled because the
     * denominator is meaningless; [[hotnessMsPerLine]] returns 0 for them so
     * they fall below the yellow threshold and pass through unchanged.
     */
-  def styleSym(name: String, nanos: Long, locLines: Int): String = {
-    val msPerLine = Formatting.hotnessMsPerLine(nanos, locLines)
+  def styleSym(name: String, nanos: Long, lines: Int): String = {
+    val msPerLine = Formatting.hotnessMsPerLine(nanos, lines)
     if (msPerLine >= HotnessRedThresholdMsPerLine) bold(red(name))
     else if (msPerLine >= HotnessYellowThresholdMsPerLine) yellow(name)
     else name


### PR DESCRIPTION
## Summary

Small UI-only changes to the compiler-top TUI:

- Adds a gray **"? for help"** hint on the stats line, positioned under the `[all|frontend|backend]` legend.
- Renames the help-view section headers `Cols` → `columns`.
- Lowercases the `Def (hot)` / `Module (hot)` table headers and the `Def` help-row label to match the other column names.
- Renames the `LOC` column to `lines` (widened 4 → 5 to fit), along with the matching internal identifiers (`locLineCount` → `lineCount`, `totalLocLines` → `totalLines`, `LocColWidth` → `LinesColWidth`, `showLOC` → `showLines`, `locLines` fields/params → `lines`). `SourceLocation`-named identifiers (`loc`, `locWidth`, `formatLocation`, …) are unaffected.
- Drops the stale `rnd` entry from the backend-columns help section — that column no longer exists.

## Test plan

- [x] `./mill flix.compile` succeeds.
- [x] Manual: launch the TUI and confirm the tip renders in gray, the renamed columns and help section all read as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)