### PR TITLE
feat: add dep column to compiler-top (probably not actionable)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/FlixEvent.scala
+++ b/main/src/ca/uwaterloo/flix/api/FlixEvent.scala
@@ -56,6 +56,20 @@ object FlixEvent {
   case class InlinedDef(sym: Symbol.DefnSym) extends FlixEvent
 
   /**
+    * An event that is fired once at the end of the Monomorpher's specialization loop, carrying a
+    * map from each source [[Symbol.DefnSym]] to the max BFS wave-depth at which any specialization
+    * of it was processed.
+    *
+    *   - Non-parametric defs sit at depth `0` (the seed wave that opens the loop).
+    *   - A specialization enqueued from a wave-`N` def is processed at wave `N + 1`.
+    *
+    * Captures the *depth* of the specialization fan-out — orthogonal to the breadth surfaced by
+    * the existing `mono` column, which counts instantiations regardless of how deep into the
+    * generic-call chain they were triggered.
+    */
+  case class MonomorphizationDepth(depthBySourceSym: Map[Symbol.DefnSym, Int]) extends FlixEvent
+
+  /**
     * An event that is fired when new type constraints are collected for the given def symbol `sym`.
     */
   case class NewConstraintsDef(sym: Symbol.DefnSym, tconstrs: List[TypeConstraint]) extends FlixEvent

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -16,7 +16,7 @@
 
 package ca.uwaterloo.flix.language.phase.monomorph
 
-import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.api.{Flix, FlixEvent}
 import ca.uwaterloo.flix.language.ast.TypedAst.{Binder, Expr, Instance, StructField}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{CaseSymUse, DefSymUse, LocalDefSymUse}
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
@@ -321,6 +321,15 @@ object Specialization {
     implicit val is: Map[(Symbol.TraitSym, TypeConstructor), Instance] = mkInstanceMap(root.instances)
     implicit val ctx: Context = new Context()
 
+    // Tracks the max BFS wave-depth at which each source `DefnSym` has been processed.
+    // Wave 0 is the seed pass over non-parametric defs; each subsequent iteration of the
+    // queue-drain loop increments the wave. Reported to subscribers via
+    // `FlixEvent.MonomorphizationDepth` after the loop completes.
+    val depthBySourceSym = new java.util.concurrent.ConcurrentHashMap[Symbol.DefnSym, Integer]()
+    def recordDepth(sym: Symbol.DefnSym, wave: Int): Unit = {
+      depthBySourceSym.merge(sym, wave, (a, b) => if (a >= b) a else b)
+    }
+
     // Collect all non-parametric function definitions.
     val nonParametricDefns = root.defs.filter {
       case (_, defn) => defn.spec.tparams.isEmpty
@@ -331,6 +340,7 @@ object Specialization {
     // This will enqueue additional functions for specialization.
     ParOps.parMap(nonParametricDefns) {
       case (sym, defn) => flix.profile(defn.sym, defn.loc) {
+        recordDepth(defn.sym, 0)
         // We use an empty substitution because the defs are non-parametric.
         // It's important that non-parametric functions keep their symbol to not
         // invalidate the set of entryPoints functions.
@@ -342,17 +352,28 @@ object Specialization {
 
     // Perform function specialization until the queue is empty.
     // Perform specialization in parallel along the frontier, i.e. each frontier is done in parallel.
+    var wave = 0
     while (ctx.nonEmptySpecializationQueue) {
+      wave += 1
       // Extract a function from the queue and specializes it w.r.t. its substitution.
       val queue = ctx.dequeueAllSpecializations
       ParOps.parMap(queue) {
         case (freshSym, defn, subst) => flix.profile(defn.sym, defn.loc) {
+          recordDepth(defn.sym, wave)
           val specializedDefn = specializeDef(freshSym, defn, subst)
           val loweredDefn = Lowering.lowerDef(specializedDefn)
           ctx.addSpecializedDef(freshSym, loweredDefn)
         }
       }
     }
+
+    // Hand the final per-source-sym depth map to the profiler. Converted from the Java
+    // ConcurrentHashMap[DefnSym, Integer] into the Scala Map[DefnSym, Int] the event expects.
+    val depthSnapshot: Map[Symbol.DefnSym, Int] = {
+      import scala.jdk.CollectionConverters.*
+      depthBySourceSym.asScala.iterator.map { case (s, d) => s -> d.intValue() }.toMap
+    }
+    flix.emitEvent(FlixEvent.MonomorphizationDepth(depthSnapshot))
 
     val effects = ParOps.parMapValues(root.effects) {
       case TypedAst.Effect(doc, ann, mod, sym, targs, ops0, loc) =>

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -69,6 +69,7 @@ object Aggregation {
     case Sort.Time    => s.totalNanos.toDouble
     case Sort.Hotness => Formatting.hotnessMsPerLine(s.totalNanos, lineCount(s.loc))
     case Sort.Mono  => sumPhaseCounts(s.byPhaseCount, MonoCountPhases).toDouble
+    case Sort.Depth => if (s.maxDepth < 0) Double.NegativeInfinity else s.maxDepth.toDouble
     case Sort.Opt   => sumPhaseCounts(s.byPhaseCount, OptCountPhases).toDouble
     case Sort.Inl   => s.inlined.toDouble
     case Sort.Cls   => sumPhaseCounts(s.byPhaseCount, ClsCountPhases).toDouble
@@ -84,6 +85,7 @@ object Aggregation {
     case Sort.Time    => m.totalNanos.toDouble
     case Sort.Hotness => Formatting.hotnessMsPerLine(m.totalNanos, m.totalLines)
     case Sort.Mono  => sumPhaseCounts(m.byPhaseCount, MonoCountPhases).toDouble
+    case Sort.Depth => if (m.maxDepth < 0) Double.NegativeInfinity else m.maxDepth.toDouble
     case Sort.Opt   => sumPhaseCounts(m.byPhaseCount, OptCountPhases).toDouble
     case Sort.Inl   => m.totalInlined.toDouble
     case Sort.Cls   => sumPhaseCounts(m.byPhaseCount, ClsCountPhases).toDouble
@@ -125,7 +127,11 @@ object Aggregation {
       val totalInlined = defs.iterator.map(_.inlined).sum
       val totalClassBytes = defs.iterator.map(_.classBytes).sum
       val totalAllocBytes = defs.iterator.map(_.allocBytes).sum
-      ModuleStats(mod, totalNanos, totalCallCount, totalLines, byPhase, byPhaseCount, byPhaseAlloc, totalCns, totalTvars, totalEvars, totalInlined, totalClassBytes, totalAllocBytes)
+      // `max` of all-(-1)s is `-1`, propagating the per-def "never observed"
+      // sentinel up. Otherwise the module shows the deepest BFS wave any of
+      // its defs sits at.
+      val maxDepth = defs.iterator.map(_.maxDepth).maxOption.getOrElse(-1)
+      ModuleStats(mod, totalNanos, totalCallCount, totalLines, byPhase, byPhaseCount, byPhaseAlloc, totalCns, totalTvars, totalEvars, totalInlined, totalClassBytes, totalAllocBytes, maxDepth)
     }.toVector.sortBy(m => -moduleSortKey(m, srt))
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
@@ -48,8 +48,8 @@ object Layout {
 
   /** Width contribution of the optional lines column (separator + width). */
   private val LinesColWidth: Int = 1 + 5
-  /** Width contribution of the optional mono / opt / inl / cls / size per-phase count columns (4 × 4-char + 1 × 5-char, with separators). */
-  private val CountsColWidth: Int = 4 * (1 + 4) + (1 + 5)
+  /** Width contribution of the optional mono / dep / opt / inl / cls / size per-phase count columns (5 × 4-char + 1 × 5-char, with separators). */
+  private val CountsColWidth: Int = 5 * (1 + 4) + (1 + 5)
   /** Width contribution of the optional cns column (separator + 5-char numeric field). */
   private val CnsColWidth: Int = 1 + 5
   /** Width contribution of the optional tvars column (separator + 4-char numeric field). */
@@ -67,7 +67,7 @@ object Layout {
   /**
     * Picks a [[Layout]] for the given terminal width by trying tiers in
     * descending feature order. The caller gates the optional count-style
-    * columns by passing `showCounts` (mono / opt / inl / cls / size) and
+    * columns by passing `showCounts` (mono / dep / opt / inl / cls / size) and
     * `showCns` (cns / tv / ev) — Layout itself doesn't know which UI mode
     * they correspond to. When a flag is false the column is hidden and the
     * reclaimed width expands the sym / location text columns instead.
@@ -117,7 +117,7 @@ object Layout {
     if (cols >= noPhase)
       return fillTier(LinesColWidth + extraColsW + tail, showLines = true, showCountsOut = showCounts, showCnsOut = showCns, showPhase = false)
 
-    // Tier: drop phase + the optional counts (mono/opt/inl/cls/size or cns/tv/ev).
+    // Tier: drop phase + the optional counts (mono/dep/opt/inl/cls/size or cns/tv/ev).
     val noPhaseNoExtras = textWidth(DefaultSymWidth, DefaultLocWidth) + LinesColWidth + tail
     if (cols >= noPhaseNoExtras)
       return fillTier(LinesColWidth + tail, showLines = true, showCountsOut = false, showCnsOut = false, showPhase = false)

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -99,6 +99,8 @@ object Model {
     case object Hotness extends Sort { val key = 'h' }
     /** Most monomorphic instances first — surfaces generic-explosion hotspots. */
     case object Mono    extends Sort { val key = 'm' }
+    /** Deepest Monomorpher BFS wave first — surfaces source syms whose specializations sit deep inside a chain of generic calls. Orthogonal to [[Mono]] (which counts breadth of instantiations regardless of depth): a small generic combinator can have low `mono` and high `dep` if it is reached only through a long generic-call chain. `-1` for defs that never reached the Monomorpher; those sink to the bottom. */
+    case object Depth   extends Sort { val key = 'd' }
     /** Most optimizer fixed-point re-visits first — surfaces inliner / occurrence-analyzer thrashing. */
     case object Opt     extends Sort { val key = 'o' }
     /** Most times inlined at a call site first — surfaces small leaf defs that get duplicated everywhere. */
@@ -117,7 +119,7 @@ object Model {
     case object Evars   extends Sort { val key = 'e' }
 
     /** All sort values. */
-    val all: List[Sort] = List(Time, Hotness, Mono, Opt, Inl, Cls, Size, Alloc, Cns, Tvars, Evars)
+    val all: List[Sort] = List(Time, Hotness, Mono, Depth, Opt, Inl, Cls, Size, Alloc, Cns, Tvars, Evars)
 
     /** The sort whose `key` matches `c` (case-insensitive), or `None`. */
     def fromKey(c: Char): Option[Sort] = all.find(_.key == c.toLower)
@@ -146,8 +148,9 @@ object Model {
     * @param totalInlined   summed inliner call-site inline counts across the module's defs.
     * @param totalClassBytes summed bytecode byte size of emitted `.class` files across the module's defs.
     * @param totalAllocBytes summed compiler-side heap allocation bytes across the module's defs.
+    * @param maxDepth       max across the module's defs of [[Profiler.DefnStats.maxDepth]] — the deepest Monomorpher BFS wave any def in the module sits at. `-1` when no def in the module reached the Monomorpher. Module ranks by its deepest-chain def, mirroring the def-level sort.
     */
-  final case class ModuleStats(module: String, totalNanos: Long, totalCallCount: Long, totalLines: Int, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], totalCns: Long, totalTvars: Long, totalEvars: Long, totalInlined: Long, totalClassBytes: Long, totalAllocBytes: Long) {
+  final case class ModuleStats(module: String, totalNanos: Long, totalCallCount: Long, totalLines: Int, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], totalCns: Long, totalTvars: Long, totalEvars: Long, totalInlined: Long, totalClassBytes: Long, totalAllocBytes: Long, maxDepth: Int) {
     /** Returns the phase that consumed the most time in this module, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
@@ -93,9 +93,10 @@ object Profiler {
     * @param inlined      number of times this def was inlined at a call site by the inliner across all optimizer rounds.
     * @param classBytes   total bytes of generated `.class` files attributed to this def (function class + any closure classes).
     * @param allocBytes   total compiler-side heap allocation (Hotspot per-thread allocated bytes) summed across `track` calls for this sym. 0 when the JVM doesn't support [[com.sun.management.ThreadMXBean.getThreadAllocatedBytes]].
+    * @param maxDepth     max BFS wave-depth in the Monomorpher at which any specialization of this source sym was processed. Wave 0 = non-parametric seed; subsequent waves are queue-drain iterations. `-1` if the def never reached the Monomorpher (e.g. removed earlier, or compiled with a different pipeline).
     * @param loc          the source location of the def's body, used to compute LOC.
     */
-  final case class DefnStats(sym: Symbol.DefnSym, isActive: Boolean, callCount: Int, totalNanos: Long, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], cns: Long, tvars: Long, evars: Long, inlined: Long, classBytes: Long, allocBytes: Long, loc: SourceLocation) {
+  final case class DefnStats(sym: Symbol.DefnSym, isActive: Boolean, callCount: Int, totalNanos: Long, byPhase: Map[String, Long], byPhaseCount: Map[String, Long], byPhaseAlloc: Map[String, Long], cns: Long, tvars: Long, evars: Long, inlined: Long, classBytes: Long, allocBytes: Long, maxDepth: Int, loc: SourceLocation) {
     /** Returns the phase that consumed the most time, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
@@ -116,9 +117,10 @@ object Profiler {
     * @param inlined       accumulator: number of times this def was inlined at a call site by the inliner.
     * @param classBytes    accumulator: summed `.class` byte length of every class emitted for this def.
     * @param allocBytes    accumulator: summed Hotspot per-thread allocation deltas across `track` calls for this sym. Captures compiler-side heap pressure, independent of wall time.
+    * @param maxDepth      max BFS wave-depth in the Monomorpher at which any specialization of this source sym was processed. Set from `FlixEvent.MonomorphizationDepth` via `updateAndGet(max)` so a future re-emission can only raise it. Initialized to `-1` so defs that never enter the Monomorpher stay distinguishable from "depth 0 (non-parametric seed)".
     * @param loc           set on first `track` call; carries the def-body span so we can show LOC.
     */
-  private final case class Counters(inProgress: AtomicInteger, callCount: AtomicInteger, totalNanos: AtomicLong, perPhaseNanos: ConcurrentHashMap[String, AtomicLong], perPhaseCount: ConcurrentHashMap[String, AtomicLong], perPhaseAlloc: ConcurrentHashMap[String, AtomicLong], constraints: AtomicLong, tvars: AtomicLong, evars: AtomicLong, inlined: AtomicLong, classBytes: AtomicLong, allocBytes: AtomicLong, loc: AtomicReference[SourceLocation])
+  private final case class Counters(inProgress: AtomicInteger, callCount: AtomicInteger, totalNanos: AtomicLong, perPhaseNanos: ConcurrentHashMap[String, AtomicLong], perPhaseCount: ConcurrentHashMap[String, AtomicLong], perPhaseAlloc: ConcurrentHashMap[String, AtomicLong], constraints: AtomicLong, tvars: AtomicLong, evars: AtomicLong, inlined: AtomicLong, classBytes: AtomicLong, allocBytes: AtomicLong, maxDepth: AtomicInteger, loc: AtomicReference[SourceLocation])
 
   /**
     * Composite map key for per-`DefnSym` accumulators.
@@ -210,10 +212,13 @@ final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
     }
 
   /**
-    * Subscribes the profiler to compiler events emitted via `Flix.emitEvent`.
-    * Today only [[FlixEvent.NewConstraintsDef]] is consumed — Typer fires it
-    * once per def with the post-generation constraint list, which gives us
-    * a clean per-def `cns` reading without instrumenting any inner loops.
+    * Subscribes the profiler to compiler events emitted via `Flix.emitEvent`. Each handler
+    * latches its reading onto the per-source-sym [[Counters]] via [[countersFor]]:
+    *
+    *   - [[FlixEvent.NewConstraintsDef]]      set `cns` / `tvars` / `evars` (replaces, not adds).
+    *   - [[FlixEvent.InlinedDef]]             increment `inlined`.
+    *   - [[FlixEvent.EmittedClass]]           add to `classBytes`.
+    *   - [[FlixEvent.MonomorphizationDepth]]  raise `maxDepth` to the per-sym entry via `max`.
     */
   override def notify(e: FlixEvent): Unit = e match {
     case FlixEvent.NewConstraintsDef(sym, tconstrs) =>
@@ -230,6 +235,14 @@ final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
       countersFor(sym).inlined.incrementAndGet()
     case FlixEvent.EmittedClass(sym, bytes) =>
       countersFor(sym).classBytes.addAndGet(bytes.toLong)
+    case FlixEvent.MonomorphizationDepth(depthBySourceSym) =>
+      // `updateAndGet(max)`: the Monomorpher emits this once per compile but using max keeps
+      // attribution correct under incremental rebuilds (where a fresh compile follows a partial
+      // earlier one) and never accidentally lowers a previously-recorded depth.
+      depthBySourceSym.foreach { case (sym, d) =>
+        val c = countersFor(sym)
+        c.maxDepth.updateAndGet(prev => math.max(prev, d))
+      }
     case _ => ()
   }
 
@@ -289,7 +302,8 @@ final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
       val loc = Option(c.loc.get()).getOrElse(key.loc)
       Profiler.DefnStats(key.sym, isActive = c.inProgress.get() > 0,
         c.callCount.get(), c.totalNanos.get(), byPhase, byPhaseCount, byPhaseAlloc,
-        c.constraints.get(), c.tvars.get(), c.evars.get(), c.inlined.get(), c.classBytes.get(), c.allocBytes.get(), loc)
+        c.constraints.get(), c.tvars.get(), c.evars.get(), c.inlined.get(), c.classBytes.get(), c.allocBytes.get(),
+        c.maxDepth.get(), loc)
     }.toVector
   }
 
@@ -311,6 +325,7 @@ final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
       inlined = new AtomicLong(0L),
       classBytes = new AtomicLong(0L),
       allocBytes = new AtomicLong(0L),
+      maxDepth = new AtomicInteger(-1),
       loc = new AtomicReference[SourceLocation](null)
     ))
 

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -106,6 +106,7 @@ object Renderer {
                                     evars: Long,
                                     dominantPhase: String,
                                     allocBytes: Long,
+                                    maxDepth: Int,
                                     nanos: Long,
                                     pctCpu: Double,
                                     pctWall: Double,
@@ -141,6 +142,7 @@ object Renderer {
         evars         = s.evars,
         dominantPhase = s.dominantPhase.getOrElse("?"),
         allocBytes    = s.allocBytes,
+        maxDepth      = s.maxDepth,
         nanos         = s.totalNanos,
         pctCpu        = pctWall / parallelism,
         pctWall       = pctWall,
@@ -177,6 +179,7 @@ object Renderer {
         evars         = m.totalEvars,
         dominantPhase = m.dominantPhase.getOrElse("?"),
         allocBytes    = m.totalAllocBytes,
+        maxDepth      = m.maxDepth,
         nanos         = m.totalNanos,
         pctCpu        = pctWall / parallelism,
         pctWall       = pctWall,
@@ -403,11 +406,12 @@ final class Renderer {
       sb.append(' '); sb.append(plainHeader(lpad("lines", 5)))
     }
     if (layout.showCounts) {
-      sb.append(' '); sb.append(sortableColumn(lpad("mono", 4), Sort.Mono, activeSort))
-      sb.append(' '); sb.append(sortableColumn(lpad("opt",  4), Sort.Opt,  activeSort))
-      sb.append(' '); sb.append(sortableColumn(lpad("inl",  4), Sort.Inl,  activeSort))
-      sb.append(' '); sb.append(sortableColumn(lpad("cls",  4), Sort.Cls,  activeSort))
-      sb.append(' '); sb.append(sortableColumn(lpad("size", 5), Sort.Size, activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("mono", 4), Sort.Mono,  activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("dep",  4), Sort.Depth, activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("opt",  4), Sort.Opt,   activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("inl",  4), Sort.Inl,   activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("cls",  4), Sort.Cls,   activeSort))
+      sb.append(' '); sb.append(sortableColumn(lpad("size", 5), Sort.Size,  activeSort))
     }
     if (layout.showCns) {
       sb.append(' '); sb.append(sortableColumn(lpad("cns", 5), Sort.Cns,   activeSort))
@@ -492,6 +496,7 @@ final class Renderer {
 
     sb.append("  "); sb.append(bold(cyan("Backend columns"))); sb.append('\n')
     appendHelpCol(sb, "mono",     "the number of monomorphic copies created during monomorphization")
+    appendHelpCol(sb, "dep",      "the maximum Monomorpher BFS wave-depth at which any specialization of this source sym was processed (0 = non-parametric seed)")
     appendHelpCol(sb, "opt",      "the number of optimizer fixed-point re-visits across Optimizer and LambdaDrop")
     appendHelpCol(sb, "inl",      "the number of times the def was inlined at a call site")
     appendHelpCol(sb, "cls",      "the number of .class files emitted for the def")
@@ -529,7 +534,11 @@ final class Renderer {
       val mono = sumPhaseCounts(cells.byPhaseCount, MonoCountPhases)
       val opt  = sumPhaseCounts(cells.byPhaseCount, OptCountPhases)
       val cls  = sumPhaseCounts(cells.byPhaseCount, ClsCountPhases)
+      // `-1` is the Profiler "never observed" sentinel — render as `-` so
+      // defs that didn't reach the Monomorpher don't render as `-1`.
+      val depStr = if (cells.maxDepth < 0) "-" else cells.maxDepth.toString
       sb.append(' '); sb.append(lpad(mono.toString, 4))
+      sb.append(' '); sb.append(lpad(depStr, 4))
       sb.append(' '); sb.append(lpad(opt.toString, 4))
       sb.append(' '); sb.append(lpad(cells.inlined.toString, 4))
       sb.append(' '); sb.append(lpad(cls.toString, 4))


### PR DESCRIPTION
## TL;DR — read before reviewing

**This PR implements the column cleanly and the metric does what it's supposed to, but I don't think the column is actually useful and would lean toward not merging.** The implementation is here as a record of the attempt and so the underlying `MonomorphizationDepth` event can stay around as a reusable hook. See "Why this is probably not worth merging" below.

## What the column shows

`dep` is the per-source-sym maximum Monomorpher BFS wave-depth at which any specialization of that sym was processed:

- Non-parametric defs sit at depth 0 (the seed pass).
- A specialization enqueued while processing a wave-N def is dequeued and processed at wave N+1.
- The max across all specializations of a source sym is what the column shows.

Sortable via key `d`. `-` for defs that never reached the Monomorpher. Module rollup is the max across the module's defs.

## What the column actually surfaces

On stdlib compilation, the top of `dep` is a different set of defs than top of `time` / `size` / `cls`:

| def | dep | mono | size | time |
|-----|-----|------|------|------|
| `Array.copyOfRange` | 14 | 88 | 0B | 96ms |
| `Array.forEachWithIndex` | 14 | 17 | 0B | 8ms |
| `Array.length` | 13 | 100 | 0B | 7ms |
| `Array.updateSequence` | 13 | 9 | 11KB | 28ms |
| `Array.slice` | 13 | 13 | 8KB | 6ms |
| `Reflect.reflectType` | 13 | 104 | 0B | 3ms |

These defs are small (mostly 2-14 lines), fast, and most produce zero bytecode — they get fully inlined away. By every existing magnitude column they sit at the bottom of the table. By `dep` they top it. `dep` and `mono` dissociate as predicted (e.g. `updateSequence` at dep=13 / mono=9 is "deep but narrow").

So the **orthogonality test passes** — `dep` ranks completely different defs than `time` / `size` / `cls` / `inl`.

## Why this is probably not worth merging

The orthogonality is real but the result is **unsurprising in a way that defeats actionability**. `Array.length` at depth 13 is what you'd predict a priori: it's a primitive every generic-over-arrays eventually bottoms out at. `Reflect.reflectType` at depth 13 with 104 instantiations is what type-reflection structurally implies. The column **confirms an a priori truth about stdlib's call graph rather than surfacing a hidden surprise**.

More importantly, the per-def max depth is a **leaf-of-chain property**. It describes where the def *sits* in the specialization graph, not anything the def itself controls or could be fixed at. Whatever's at depth 12, 11, ..., 1, 0 is where the chain is being assembled; the leaf is innocent. So even though `dep` ranks different defs than `time`, the rank doesn't point at an action target.

Compare to `alloc` (the one metric we've kept from this exploration): a def with high `alloc` is the place where allocation is happening — you can profile its body and fix it. A def with high `dep` is the bottom of a chain — you'd have to investigate **the chain itself**, which isn't in the column.

This refines a meta-rule I'd been operating with. "Physically separate resource (alloc) or structural source property (depth)" was the bar I'd set for which columns are worth adding. That bar isn't strong enough — depth passes it and still doesn't yield action. **The action target has to be the def itself**, not a property of where it sits in some graph.

## What might earn the data its keep

The underlying `MonomorphizationDepth` event captures the specialization-graph structure in a form three different downstream uses could each consume:

- **Per-root max depth.** Flip the perspective — which non-parametric (depth-0) defs *generate* the longest chains. That puts the column on the action target (a root the user can audit) rather than the chain endpoint.
- **`dep × mono` joint signal.** High dep × low mono = "deep narrow chain to me" — narrow usage but deep specialization implies the chain exists *for this one thing*. Worth investigating. High dep × high mono = expected, ignore.
- **Cross-run regression detection.** If `length` jumps from depth 13 to depth 20 between two compiles, something changed upstream. Same shape as the cross-run idea logged under Idea 1's "If revisited" in `COMPILERTOP_IDEAS.md`.

## Plumbing

- `FlixEvent.MonomorphizationDepth(depthBySourceSym: Map[DefnSym, Int])`, emitted once at end of `Specialization.run`.
- `Specialization.run` tracks `depthBySourceSym` via a `ConcurrentHashMap[DefnSym, Integer]`, recording wave 0 for the non-parametric seed pass and incrementing `wave` on each queue-drain iteration. `merge` with a max BiFunction keeps the deepest observation.
- `Profiler.Counters` gains `maxDepth: AtomicInteger` (init `-1`); handler uses `updateAndGet(max)` so a future incremental rebuild can only raise it. Threaded through `DefnStats` and `snapshot()`.
- `Sort.Depth` (key `d`), inserted in `Sort.all` between `Mono` and `Opt`. `Aggregation` sort/rollup with `Double.NegativeInfinity` for unobserved.
- `ModuleStats.maxDepth` rolled up via `maxOption.getOrElse(-1)`.
- `Layout.CountsColWidth` bumped from `4 × (1+4) + (1+5)` to `5 × (1+4) + (1+5)`.
- `Renderer`: `dep` sortable header between `mono` and `opt`; cell renders integer or `-`; help-view row in the Backend columns section.

## Test plan

- [ ] `./mill flix.compile` succeeds.
- [ ] Standard library compiles (`./mill flix.run out/empty.flix`).
- [ ] Run with `--top`, press `b` to enter backend filter, verify the `dep` column renders integer values for hot defs and `-` for unobserved.
- [ ] Press `d` to sort; verify the top is dominated by Array primitives / reflection helpers (small lines, often size=0B from full inlining).
- [ ] Press `?`; verify the `dep` row appears in the Backend columns section.
- [ ] Module table under backend filter shows aggregated `dep` (max across the module's defs).

## Recommendation

Read this PR for the implementation pattern (clean event + counter + column, mirroring what landed in #12773's PR sequence). Don't merge unless you disagree with the actionability critique. The `COMPILERTOP_IDEAS.md` update in master adds an Idea 4 "Reverted (orthogonal but not actionable)" entry that documents this verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)