### PR TITLE
refactor: merge def and location columns in compiler-top TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Formatting.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Formatting.scala
@@ -91,6 +91,15 @@ object Formatting {
   def truncate(s: String, width: Int): String =
     if (s.length <= width) s else s.take(width - 1) + "…"
 
+  /**
+    * Returns `s` truncated to `width` characters, with a *leading* ellipsis
+    * when shortened. Mirror of [[truncate]] for fields where the tail carries
+    * the signal — e.g. a source location like `…flix:128` reads better than
+    * `Foo.fl…` when the budget can't fit the whole `Foo.flix:128`.
+    */
+  def truncateFront(s: String, width: Int): String =
+    if (s.length <= width) s else "…" + s.takeRight(width - 1)
+
   /** Left-pads `s` with spaces to width `w`. */
   def lpad(s: String, w: Int): String =
     if (s.length >= w) s else " " * (w - s.length) + s

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
@@ -19,29 +19,32 @@ package ca.uwaterloo.flix.tools.compilertop
   * Column layout for the per-frame table render. Computed from the current
   * terminal width: when the terminal is narrow, the optional lines / counts
   * / cns / phase columns are dropped in that order (lowest-signal first).
-  * When the terminal is wide, the surplus is distributed between the
-  * DefnSym and location columns proportionally to their default widths.
+  * When the terminal is wide, the surplus expands the merged name column
+  * directly. The name column holds the def name + its source location in
+  * parens on def rows, and the module name on module rows.
   *
-  * @param symWidth    width of the DefnSym column.
-  * @param locWidth    width of the location column.
+  * @param nameWidth   width of the merged name column (def + `(file:line)` on def rows, module name on module rows).
   * @param showLines   whether to render the lines column.
   * @param showCounts  whether to render the mono / opt / cls per-phase count columns.
   * @param showCns     whether to render the cns / tv / ev columns.
   * @param showPhase   whether to render the dominant-phase column.
   * @param totalWidth  total rendered width of the row, less leading/trailing pad.
   */
-final case class Layout(symWidth: Int, locWidth: Int, showLines: Boolean, showCounts: Boolean, showCns: Boolean, showPhase: Boolean, totalWidth: Int)
+final case class Layout(nameWidth: Int, showLines: Boolean, showCounts: Boolean, showCns: Boolean, showPhase: Boolean, totalWidth: Int)
 
 object Layout {
 
-  /** Default width of the DefnSym column when the terminal is wide enough. */
-  private val DefaultSymWidth: Int = 24
-  /** Default width of the location column when the terminal is wide enough. */
-  private val DefaultLocWidth: Int = 28
-  /** Floor on the DefnSym column width when the terminal is narrow. */
-  private val MinSymWidth: Int = 16
-  /** Floor on the location column width when the terminal is narrow. */
-  private val MinLocWidth: Int = 20
+  /**
+    * Default width of the merged name column. Sized to comfortably fit the
+    * common case of `Module.def (File.flix:NNN)` without truncation; longer
+    * names trim the location from the front first, then the sym from the
+    * back. Smaller than the previous `sym (24) + 1 + loc (28) = 53` budget
+    * because most defs use a fraction of that — the freed width lets
+    * optional columns (phase / counts / lines) survive at narrower terminals.
+    */
+  private val DefaultNameWidth: Int = 44
+  /** Floor on the merged name column width when the terminal is narrow. */
+  private val MinNameWidth: Int = 30
 
   /** Fixed-width contribution of `alloc + time + %cpu + %wall` columns and their separators. */
   private val FixedTailWidth: Int = 5 + 1 + 9 + 1 + 6 + 1 + 6 // alloc(5) + time(9) + %cpu(6) + %wall(6) with three separators between
@@ -70,7 +73,7 @@ object Layout {
     * columns by passing `showCounts` (mono / opt / inl / cls / size) and
     * `showCns` (cns / tv / ev) — Layout itself doesn't know which UI mode
     * they correspond to. When a flag is false the column is hidden and the
-    * reclaimed width expands the sym / location text columns instead.
+    * reclaimed width expands the name column instead.
     *
     * At most one of `showCounts` and `showCns` is true under the current
     * UI gating, but the algorithm accepts any combination — both false
@@ -79,8 +82,6 @@ object Layout {
   def compute(cols: Int, showCounts: Boolean, showCns: Boolean): Layout = {
     // Width contribution of the "fixed" half: separator before time + tail.
     val tail = 1 + FixedTailWidth
-    // Width of just the text section (sym + 1 + location) at default sizes.
-    def textWidth(symW: Int, locW: Int): Int = symW + 1 + locW
 
     val countsW = if (showCounts) CountsColWidth else 0
     val cnsW = if (showCns) FrontendColsWidth else 0
@@ -89,49 +90,42 @@ object Layout {
 
     /**
       * Returns a [[Layout]] for `tierFixed` chars of non-text columns
-      * (lines / counts / phase / tail) plus a sym + loc text section that
-      * expands to fill any surplus over [[DefaultSymWidth]] /
-      * [[DefaultLocWidth]]. The resulting `totalWidth` equals `cols`
-      * exactly, so the divider and rows fill the terminal regardless of
-      * which tier we landed in.
+      * (lines / counts / phase / tail) plus a name column that expands to
+      * fill any surplus over [[DefaultNameWidth]]. The resulting
+      * `totalWidth` equals `cols` exactly, so the divider and rows fill
+      * the terminal regardless of which tier we landed in.
       */
     def fillTier(tierFixed: Int, showLines: Boolean, showCountsOut: Boolean, showCnsOut: Boolean, showPhase: Boolean): Layout = {
-      val baseText = textWidth(DefaultSymWidth, DefaultLocWidth)
-      val extra = (cols - (baseText + tierFixed)).max(0)
-      val extraSym = extra * 46 / 100
-      val extraLoc = extra - extraSym
-      val symW = DefaultSymWidth + extraSym
-      val locW = DefaultLocWidth + extraLoc
-      Layout(symW, locW, showLines = showLines, showCounts = showCountsOut, showCns = showCnsOut, showPhase = showPhase,
-        totalWidth = textWidth(symW, locW) + tierFixed)
+      val extra = (cols - (DefaultNameWidth + tierFixed)).max(0)
+      val nameW = DefaultNameWidth + extra
+      Layout(nameW, showLines = showLines, showCounts = showCountsOut, showCns = showCnsOut, showPhase = showPhase,
+        totalWidth = nameW + tierFixed)
     }
 
-    // Try tiers in descending feature order. Each tier expands sym/loc
-    // into whatever width is left over after its fixed columns.
-    val full = textWidth(DefaultSymWidth, DefaultLocWidth) + LinesColWidth + extraColsW + PhaseColWidth + tail
+    // Try tiers in descending feature order. Each tier expands name into
+    // whatever width is left over after its fixed columns.
+    val full = DefaultNameWidth + LinesColWidth + extraColsW + PhaseColWidth + tail
     if (cols >= full)
       return fillTier(LinesColWidth + extraColsW + PhaseColWidth + tail, showLines = true, showCountsOut = showCounts, showCnsOut = showCns, showPhase = true)
 
     // Tier: drop phase.
-    val noPhase = textWidth(DefaultSymWidth, DefaultLocWidth) + LinesColWidth + extraColsW + tail
+    val noPhase = DefaultNameWidth + LinesColWidth + extraColsW + tail
     if (cols >= noPhase)
       return fillTier(LinesColWidth + extraColsW + tail, showLines = true, showCountsOut = showCounts, showCnsOut = showCns, showPhase = false)
 
     // Tier: drop phase + the optional counts (mono/opt/inl/cls/size or cns/tv/ev).
-    val noPhaseNoExtras = textWidth(DefaultSymWidth, DefaultLocWidth) + LinesColWidth + tail
+    val noPhaseNoExtras = DefaultNameWidth + LinesColWidth + tail
     if (cols >= noPhaseNoExtras)
       return fillTier(LinesColWidth + tail, showLines = true, showCountsOut = false, showCnsOut = false, showPhase = false)
 
     // Tier: drop phase + extras + lines.
-    val noOptional = textWidth(DefaultSymWidth, DefaultLocWidth) + tail
+    val noOptional = DefaultNameWidth + tail
     if (cols >= noOptional)
       return fillTier(tail, showLines = false, showCountsOut = false, showCnsOut = false, showPhase = false)
 
-    // Even minimum tier doesn't fit; shrink sym/locWidth to floors.
-    val available = (cols - tail).max(MinSymWidth + 1 + MinLocWidth)
-    val symW = MinSymWidth.max(available * 46 / 100)
-    val locW = MinLocWidth.max(available - 1 - symW)
-    Layout(symW, locW, showLines = false, showCounts = false, showCns = false, showPhase = false,
-      textWidth(symW, locW) + tail)
+    // Even minimum tier doesn't fit; shrink name to its floor.
+    val nameW = (cols - tail).max(MinNameWidth)
+    Layout(nameW, showLines = false, showCounts = false, showCns = false, showPhase = false,
+      totalWidth = nameW + tail)
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -114,8 +114,9 @@ object Renderer {
   /**
     * A renderable table row. The numeric trailing columns are uniform
     * across def and module rows ([[RowCells]] / [[Renderer.appendNumericFields]]);
-    * only the leading "first cell" differs (sym + active marker + location
-    * for defs; a single wide module-name field for modules).
+    * only the contents of the leading [[Layout.nameWidth]]-wide cell
+    * differs — def rows pack `sym + marker + (file:line)` into it, module
+    * rows fill it with just the module name.
     */
   private sealed trait Row {
     /** The trailing numeric columns for this row, ready for [[Renderer.appendNumericFields]]. */
@@ -124,7 +125,7 @@ object Renderer {
     def appendFirstCell(sb: StringBuilder, layout: Layout): Unit
   }
 
-  /** Def-table row: hotness-colored sym, active marker, location column. */
+  /** Def-table row: hotness-colored sym, active marker, parenthesized location — all in one merged cell. */
   private final case class DefnRow(s: DefnStats, safeElapsed: Double, parallelism: Int) extends Row {
     private val lines = lineCount(s.loc)
 
@@ -148,17 +149,46 @@ object Renderer {
       )
     }
 
-    /** Appends the sym name (hotness-colored, with `*` if active) and a dim location field. */
+    /**
+      * Appends a single merged cell: hotness-colored sym, optional `*` active
+      * marker glued to the name, then a dim parenthesized `(file:line)`. If
+      * the cell can't fit the full pair, the location is truncated from the
+      * front first (`…flix:128`); only when even a minimal `…:N` location
+      * won't leave room for the sym does the sym itself get truncated.
+      * Synthetic defs (no real source location) render bare — no parens —
+      * since `(?)` is just noise.
+      *
+      * Decision (what to display) is separated from emission (how to lay it
+      * out): the truncation ladder picks a `(nameVisible, locVisible)` pair,
+      * and a single emit path then formats and pads to width. Padding is
+      * always derived from visible widths, so cells fill exactly even when
+      * the location is shorter than the minimum-tail budget.
+      */
     def appendFirstCell(sb: StringBuilder, layout: Layout): Unit = {
-      val nameMax  = layout.symWidth - 1
-      val nameText = truncate(s.sym.name, nameMax)
-      val locField = rpad(truncate(formatLocation(s.loc), layout.locWidth), layout.locWidth)
-      val marker   = if (s.isActive) yellow("*") else " "
-      sb.append(styleSym(nameText, s.totalNanos, lines))
+      val width     = layout.nameWidth
+      val name      = s.sym.name
+      val markerLen = if (s.isActive) 1 else 0
+      val marker    = if (s.isActive) yellow("*") else ""
+      val ChromeLen = 3  // " (" + ")"
+      val MinLocLen = 5  // minimum useful tail of a location, e.g. "…:128"
+
+      val (nameVisible, locVisible) =
+        if (!s.loc.isReal) (truncate(name, width - markerLen), "")
+        else {
+          val locStr = formatLocation(s.loc)
+          val ideal  = name.length + markerLen + ChromeLen + locStr.length
+          if (ideal <= width) (name, locStr)
+          else if (name.length + markerLen + ChromeLen + MinLocLen <= width)
+            (name, truncateFront(locStr, width - name.length - markerLen - ChromeLen))
+          else
+            (truncate(name, width - markerLen - ChromeLen - MinLocLen), truncateFront(locStr, MinLocLen))
+        }
+
+      val suffix = if (locVisible.isEmpty) "" else s" ($locVisible)"
+      sb.append(styleSym(nameVisible, s.totalNanos, lines))
       sb.append(marker)
-      sb.append(" " * (nameMax - nameText.length))
-      sb.append(' ')
-      sb.append(dim(locField))
+      if (suffix.nonEmpty) sb.append(dim(suffix))
+      sb.append(" " * (width - nameVisible.length - markerLen - suffix.length))
     }
   }
 
@@ -184,10 +214,9 @@ object Renderer {
       )
     }
 
-    /** Appends the module name, padded to span the def-table's sym + location columns. */
+    /** Appends the module name, padded to span the merged def-row name column. */
     def appendFirstCell(sb: StringBuilder, layout: Layout): Unit = {
-      val modWidth = layout.symWidth + 1 + layout.locWidth
-      sb.append(rpad(truncate(m.module, modWidth), modWidth))
+      sb.append(rpad(truncate(m.module, layout.nameWidth), layout.nameWidth))
     }
   }
 }
@@ -240,15 +269,14 @@ final class Renderer {
     val modRows: Vector[Row] = state.modules.map(m => ModuleRow(m, safeElapsed, state.parallelism))
 
     // Def table: header, then rows or a centered placeholder if empty.
-    renderHeaderRow(sb, rpad("def (hot)", state.layout.symWidth), withLocation = true, state.layout, state.activeSort)
+    renderHeaderRow(sb, "def (hot)", state.layout, state.activeSort)
     if (defRows.isEmpty) renderEmptyPlaceholder(sb, "(no timings yet)", state.layout)
     else renderTable(sb, defRows, state.layout)
 
     // Module table: only when non-empty, separated by a blank line.
     if (modRows.nonEmpty) {
-      val modWidth = state.layout.symWidth + 1 + state.layout.locWidth
       sb.append('\n')
-      renderHeaderRow(sb, rpad("module (hot)", modWidth), withLocation = false, state.layout, state.activeSort)
+      renderHeaderRow(sb, "module (hot)", state.layout, state.activeSort)
       renderTable(sb, modRows, state.layout)
     }
   }
@@ -366,14 +394,14 @@ final class Renderer {
 
   /**
     * Prints the parametrized header row + the divider underneath it. The
-    * `leading` argument is a pre-padded first-column label (either
-    * `"Def (hot)"` at `symWidth` or `"Module (hot)"` at the combined
-    * sym+loc width). `withLocation` toggles the second `"location"` header,
-    * which the def table has and the module table doesn't.
+    * `label` argument is the raw first-column label — `"def (hot)"` for the
+    * def table, `"module (hot)"` for the module table — and gets padded to
+    * [[Layout.nameWidth]] here. The location now sits inside the def cells
+    * in parens, so the header doesn't have a separate `"location"` column.
     */
-  private def renderHeaderRow(sb: StringBuilder, leading: String, withLocation: Boolean, layout: Layout, activeSort: Sort): Unit = {
+  private def renderHeaderRow(sb: StringBuilder, label: String, layout: Layout, activeSort: Sort): Unit = {
     sb.append(' ')
-    sb.append(buildHeader(leading, withLocation, layout, activeSort))
+    sb.append(buildHeader(rpad(label, layout.nameWidth), layout, activeSort))
     sb.append(' '); sb.append('\n')
     sb.append(' ')
     sb.append(dim("─" * layout.totalWidth))
@@ -381,24 +409,19 @@ final class Renderer {
   }
 
   /**
-    * Builds a table column header from a pre-padded leading-column label
-    * and a `withLocation` flag. Each sortable column underlines its
-    * [[Sort.key]] letter (`m̲ono`, `o̲pt`, `c̲ls`, `t̲ime`, …) and the leading
-    * "(h̲ot)" annotation marks the hotness sort key. The active column is
-    * rendered bold yellow; the rest bold cyan.
+    * Builds a table column header from a pre-padded leading-column label.
+    * Each sortable column underlines its [[Sort.key]] letter (`m̲ono`, `o̲pt`,
+    * `c̲ls`, `t̲ime`, …) and the leading "(h̲ot)" annotation marks the hotness
+    * sort key. The active column is rendered bold yellow; the rest bold cyan.
     *
-    * Two callers — `def (hot)` + a `"location"` column for the def table,
-    * `module (hot)` (single wide column, no location) for the module table.
+    * Two callers — `def (hot)` for the def table, `module (hot)` for the
+    * module table. Both pad their leading label to [[Layout.nameWidth]].
     */
-  private def buildHeader(leading: String, withLocation: Boolean, layout: Layout, activeSort: Sort): String = {
+  private def buildHeader(leading: String, layout: Layout, activeSort: Sort): String = {
     val sb = new StringBuilder
 
     sb.append(sortableColumn(leading, Sort.Hotness, activeSort))
 
-    if (withLocation) {
-      sb.append(' ')
-      sb.append(plainHeader(rpad("location", layout.locWidth)))
-    }
     if (layout.showLines) {
       sb.append(' '); sb.append(plainHeader(lpad("lines", 5)))
     }
@@ -474,8 +497,7 @@ final class Renderer {
     // common columns are always shown; frontend columns only appear under
     // the `frontend` filter; backend columns only under the `backend` filter.
     sb.append("  "); sb.append(bold(cyan("Common columns"))); sb.append('\n')
-    appendHelpCol(sb, "def",      "the fully qualified name of the def")
-    appendHelpCol(sb, "location", "the source file and line number of the def")
+    appendHelpCol(sb, "def",      "the fully qualified name of the def, followed by its source location (file:line) in parens")
     appendHelpCol(sb, "lines",    "the number of source-code lines spanned by the def's signature and body")
     appendHelpCol(sb, "phase",    "the compiler phase that consumed the most wall-clock time for the def")
     appendHelpCol(sb, "alloc",    "the amount of memory the compiler allocated while processing the def")


### PR DESCRIPTION
## Summary
- Merge the separate def-name and location columns into a single `nameWidth`-padded cell where the location floats next to the def name in dim parens (`Foo.bar (Main.flix:42)`); module rows fill the same cell with just the module name.
- Truncation prefers keeping the def name readable: when the cell overflows, the location is shortened from the front first (`…flix:128`); the sym is only truncated when even a minimal `…:N` location can't co-exist.
- The freed width (~9 chars at default sizes) lets the optional `phase` / counts / `lines` columns survive at correspondingly narrower terminals.

## Test plan
- [x] `./mill flix.run --top <file>` at full terminal width: merged cell renders, dim parens, no separate `location` column
- [x] Resize narrower to trigger location front-truncation (`…flix:NNN`); confirm sym stays full
- [x] Resize further to trigger sym truncation alongside `…:N`; confirm cell is exactly `nameWidth` chars
- [x] Module rows render correctly (single wide field, no parens)
- [x] Synthetic-location defs (no real `SourceLocation`) render without `(?)` chrome
- [x] Help screen (`?`) shows a single merged `def` row instead of separate `def` + `location`

🤖 Generated with [Claude Code](https://claude.com/claude-code)