### PR TITLE
feat: add custom phase picker view to compilertop

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -28,9 +28,10 @@ object Aggregation {
 
   /** True if `phase` should be accounted for under the current `f`. */
   def matchesFilter(phase: String, f: PhaseFilter): Boolean = f match {
-    case PhaseFilter.All      => true
-    case PhaseFilter.Frontend => FrontendPhases.contains(phase)
-    case PhaseFilter.Backend  => phase != "?" && !FrontendPhases.contains(phase)
+    case PhaseFilter.All           => true
+    case PhaseFilter.Frontend      => FrontendPhases.contains(phase)
+    case PhaseFilter.Backend       => phase != "?" && !FrontendPhases.contains(phase)
+    case PhaseFilter.Custom(phases) => phases.contains(phase)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.tools.compilertop.Ansi.*
 import ca.uwaterloo.flix.tools.compilertop.Formatting.*
 import ca.uwaterloo.flix.tools.compilertop.Model.*
 import org.jline.terminal.{Attributes, Terminal, TerminalBuilder}
+import org.jline.utils.NonBlockingReader
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
@@ -108,6 +109,24 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
   private val sort = new AtomicReference[Sort](Sort.Time)
 
   /**
+    * Active screen. [[View.Main]] is the regular dashboard; [[View.Picker]]
+    * overlays a two-column phase-selector replacing the def / module tables.
+    * Written by the input thread, read by the renderer thread; [[buildFrameState]]
+    * snapshots once per frame so a swap mid-render isn't observable.
+    */
+  private val view = new AtomicReference[View](View.Main)
+
+  /**
+    * Sorted phase lists shown in the picker. Frozen at construction so the
+    * cursor index is meaningful across frames; new phase names that the
+    * compiler introduces later simply aren't pickable until a Flix recompile
+    * (which is also when the renamed phase would land in
+    * [[Model.FrontendPhases]] / [[Model.BackendPhases]] anyway).
+    */
+  private val pickerFrontend: Vector[String] = FrontendPhases.toVector.sorted
+  private val pickerBackend: Vector[String] = BackendPhases.toVector.sorted
+
+  /**
     * Counted down by the input thread when the user presses `q` (only after
     * [[completed]] is set). [[stop]] awaits it before tearing the renderer
     * down so the user can keep toggling the filter post-compile.
@@ -182,13 +201,23 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     * Input-thread body: reads keypresses with a [[InputPollMs]] timeout so
     * shutdown is responsive to `running.get() == false`.
     *
-    *   - `f` / `F` → filter to frontend phases
-    *   - `b` / `B` → filter to backend phases
-    *   - `a` / `A` → reset to all phases
-    *   - `q` / `Q` / Ctrl-C / EOF → if compilation has completed, signal
-    *     [[stop]] to finish teardown; otherwise ignored (pressing `q`
-    *     mid-compile must not abort the build).
-    *   - Any other key is ignored.
+    * The dispatch depends on the active [[View]]:
+    *
+    *   - **Main view**:
+    *     - `f` / `F`, `b` / `B`, `a` / `A` → set the phase filter
+    *     - `u` / `U` → open the picker (seeded from the current custom
+    *       selection, or empty if the active filter isn't [[PhaseFilter.Custom]])
+    *     - any sort key (`t`, `h`, `m`, …) → set the sort
+    *     - `q` / `Q` / Ctrl-C / EOF → quit if compilation has completed
+    *   - **Picker view**:
+    *     - ↑ / ↓ → move cursor in the focused list
+    *     - ← / → → switch focus between the Frontend and Backend lists
+    *     - space → toggle inclusion of the highlighted phase
+    *     - Enter → commit the working selection as [[PhaseFilter.Custom]] and
+    *       return to main
+    *     - Esc → discard the working selection and return to main
+    *     - `q` / `Q` / Ctrl-C / EOF → same as Esc before compilation completes;
+    *       quits afterwards (same rule as main view)
     */
   private def inputLoop(): Unit = {
     if (terminal == null) return
@@ -199,22 +228,155 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
         catch { case _: InterruptedException => return; case _: Throwable => -1 }
       c match {
         case -2 => // timeout — loop and re-check `running`
-        case -1 | 3 | 'q' | 'Q' =>
+        case -1 | 3 =>
+          // EOF / Ctrl-C: from any view, treat as quit when compilation is done.
           if (completed.get()) {
             quitLatch.countDown()
             return
           }
+        case 27 =>
+          // Escape (also the prefix byte of CSI sequences). Try to read the
+          // continuation bytes with a very short timeout; a lone Esc keypress
+          // has no follow-up and falls through to the `cancelPicker` branch.
+          handleEscape(r)
         case ch if ch > 0 =>
-          // Dispatch via the Sort / PhaseFilter ADTs so the key ↔ value
-          // mapping lives in one place ([[Model.Sort.fromKey]],
-          // [[Model.PhaseFilter.fromKey]]) rather than being duplicated
-          // across this match and the renderer's header / legend code.
           val char = ch.toChar
-          Sort.fromKey(char).foreach(sort.set)
-          PhaseFilter.fromKey(char).foreach(filter.set)
+          view.get() match {
+            case View.Main =>
+              handleMainKey(char)
+            case p: View.Picker =>
+              handlePickerKey(p, char)
+          }
         case _ => // ignored
       }
     }
+  }
+
+  /**
+    * Reads the bytes following an Esc to decide whether the user pressed Esc
+    * itself or one of the arrow keys. Arrow keys are encoded as either
+    * `Esc [ A/B/C/D` (normal cursor mode, xterm default) or `Esc O A/B/C/D`
+    * (application cursor mode — what some terminals send after enabling
+    * DECCKM). We accept both.
+    *
+    * Only a real timeout on the continuation read (`b1 == -2`) cancels the
+    * picker — a byte we didn't recognize is treated as a stray sequence
+    * and ignored, so a half-recognized arrow key never kicks the user out
+    * of the picker. The continuation timeout is 200 ms because on Windows
+    * the bytes after `Esc` can arrive noticeably after the `Esc` byte
+    * itself (JLine's native console reader delivers them in separate
+    * reads), and 50 ms was eating real arrow-key presses.
+    */
+  private def handleEscape(r: NonBlockingReader): Unit = {
+    val EscapeContinuationMs: Long = 200L
+    val ReadExpired = -2
+    val b1 =
+      try r.read(EscapeContinuationMs)
+      catch { case _: Throwable => -1 }
+    if (b1 == ReadExpired) {
+      // Confirmed lone Esc — cancel the picker if open; ignored in main view.
+      view.get() match {
+        case _: View.Picker => view.set(View.Main)
+        case _ => // main: ignored
+      }
+      return
+    }
+    if (b1 != '[' && b1 != 'O') return // stray byte after Esc: ignore in any view
+    val b2 =
+      try r.read(EscapeContinuationMs)
+      catch { case _: Throwable => -1 }
+    view.get() match {
+      case p: View.Picker => b2 match {
+        case 'A' => view.compareAndSet(p, movePickerCursor(p, -1))
+        case 'B' => view.compareAndSet(p, movePickerCursor(p, +1))
+        case 'C' => view.compareAndSet(p, p.copy(column = PickerColumn.Backend))
+        case 'D' => view.compareAndSet(p, p.copy(column = PickerColumn.Frontend))
+        case _   => // unknown CSI: ignore
+      }
+      case _ => // main view: arrows ignored
+    }
+  }
+
+  /** Main-view key dispatch (filter, sort, quit, picker entry). */
+  private def handleMainKey(char: Char): Unit = char match {
+    case 'q' | 'Q' =>
+      if (completed.get()) {
+        quitLatch.countDown()
+      }
+    case 'u' | 'U' =>
+      // Seed the picker from the current custom selection so re-opening
+      // resumes where the user left off; on first open, default to *all*
+      // phases checked so the user deselects what they don't want rather
+      // than hunting through both lists to opt in.
+      val seed = filter.get() match {
+        case PhaseFilter.Custom(sel) => sel
+        case _ => FrontendPhases ++ BackendPhases
+      }
+      view.set(View.Picker(PickerColumn.Frontend, frontendCursor = 0, backendCursor = 0, selected = seed))
+    case _ =>
+      // Dispatch via the Sort / PhaseFilter ADTs so the key ↔ value mapping
+      // lives in one place ([[Model.Sort.fromKey]], [[Model.PhaseFilter.fromKey]])
+      // rather than being duplicated across this match and the renderer's
+      // header / legend code. The legend lookup `PhaseFilter.fromKey('u')` would
+      // match `PhaseFilter.Custom(Set.empty)` — handled above so we never
+      // overwrite an in-progress selection.
+      Sort.fromKey(char).foreach(sort.set)
+      PhaseFilter.fromKey(char).foreach {
+        case _: PhaseFilter.Custom => // handled by the 'u' branch above
+        case f => filter.set(f)
+      }
+  }
+
+  /** Picker-view key dispatch (toggle, commit, cancel, quit-after-done). */
+  private def handlePickerKey(p: View.Picker, char: Char): Unit = char match {
+    case 'q' | 'Q' =>
+      if (completed.get()) {
+        quitLatch.countDown()
+      } else {
+        view.set(View.Main)
+      }
+    case ' ' =>
+      currentPickerPhase(p).foreach { phase =>
+        val next = if (p.selected.contains(phase)) p.selected - phase else p.selected + phase
+        view.compareAndSet(p, p.copy(selected = next))
+      }
+    case 'a' | 'A' =>
+      // Add every phase from the focused column to the working selection.
+      // Scoped to the focused column so the user can build asymmetric sets
+      // (e.g. "all frontend, only one backend phase") in a couple of strokes.
+      view.compareAndSet(p, p.copy(selected = p.selected ++ phasesInColumn(p.column)))
+    case 'n' | 'N' =>
+      // Drop every phase from the focused column out of the working selection.
+      // Mnemonic: "none". Doesn't touch the other column.
+      view.compareAndSet(p, p.copy(selected = p.selected -- phasesInColumn(p.column)))
+    case '\r' | '\n' =>
+      filter.set(PhaseFilter.Custom(p.selected))
+      view.set(View.Main)
+    case _ => // any other plain key in the picker is ignored
+  }
+
+  /** The full phase set for the given picker column. */
+  private def phasesInColumn(col: PickerColumn): Set[String] = col match {
+    case PickerColumn.Frontend => FrontendPhases
+    case PickerColumn.Backend  => BackendPhases
+  }
+
+  /** Returns the phase name under the picker cursor, or None if its list is empty. */
+  private def currentPickerPhase(p: View.Picker): Option[String] = p.column match {
+    case PickerColumn.Frontend =>
+      if (pickerFrontend.isEmpty) None else Some(pickerFrontend(p.frontendCursor.min(pickerFrontend.size - 1).max(0)))
+    case PickerColumn.Backend =>
+      if (pickerBackend.isEmpty) None else Some(pickerBackend(p.backendCursor.min(pickerBackend.size - 1).max(0)))
+  }
+
+  /** Moves the cursor of the focused list by `delta`, clamped to the list bounds. */
+  private def movePickerCursor(p: View.Picker, delta: Int): View.Picker = p.column match {
+    case PickerColumn.Frontend =>
+      val n = pickerFrontend.size
+      if (n == 0) p else p.copy(frontendCursor = ((p.frontendCursor + delta) % n + n) % n)
+    case PickerColumn.Backend =>
+      val n = pickerBackend.size
+      if (n == 0) p else p.copy(backendCursor = ((p.backendCursor + delta) % n + n) % n)
   }
 
   /**
@@ -299,14 +461,24 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
 
     val activeFilter = filter.get()
     val activeSort = sort.get()
+    val activeView = view.get()
 
     // The mono / opt / cls columns only render under the backend view (the
     // phases that populate them only fire in the backend pipeline). The cns /
     // tv / ev columns only render under the frontend view (constraint
-    // generation is purely a Typer concern). Layout itself doesn't know about
-    // PhaseFilter; we hand it booleans.
-    val showCounts = activeFilter == PhaseFilter.Backend
-    val showCns    = activeFilter == PhaseFilter.Frontend
+    // generation is purely a Typer concern). For Custom we mirror the same
+    // rule: show backend-specific columns only when the selection is purely
+    // backend, frontend-specific only when purely frontend, neither when
+    // mixed. Layout itself doesn't know about PhaseFilter; we hand it booleans.
+    val (showCounts, showCns) = activeFilter match {
+      case PhaseFilter.All           => (false, false)
+      case PhaseFilter.Frontend      => (false, true)
+      case PhaseFilter.Backend       => (true, false)
+      case PhaseFilter.Custom(sel)   =>
+        val anyFrontend = sel.exists(FrontendPhases.contains)
+        val anyBackend  = sel.exists(BackendPhases.contains)
+        (anyBackend && !anyFrontend, anyFrontend && !anyBackend)
+    }
     // Compute the column layout based on the current terminal width,
     // reserving 2 columns for the 1-space left and right table padding.
     val layout = Layout.compute((terminalCols() - 2).max(1), showCounts, showCns)
@@ -315,7 +487,7 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     val visible = snap.take(defN)
     val modules = aggregateByModule(snap, activeSort).take(moduleN)
 
-    FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, layout, visible, modules)
+    FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, activeView, layout, visible, modules, pickerFrontend, pickerBackend)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -24,26 +24,43 @@ object Model {
 
   /**
     * Restricts which phases' time the dashboard accounts for. Toggled
-    * interactively via the input thread (`f` / `b` / `a`). The split tracks
-    * `Flix.check` (frontend) vs the phases that follow in `Flix.compile`'s
-    * `codeGen` (backend) — see [[FrontendPhases]].
+    * interactively via the input thread (`f` / `b` / `a`, plus `u` to open
+    * the custom-selection picker). The split tracks `Flix.check` (frontend)
+    * vs the phases that follow in `Flix.compile`'s `codeGen` (backend) — see
+    * [[FrontendPhases]].
     *
-    * `label` is the legend word; `key` is the keystroke that selects this
-    * filter (by convention the first character of `label`). The renderer
-    * derives the legend from these fields and the input loop dispatches via
-    * [[PhaseFilter.fromKey]] — neither encodes the mapping inline.
+    * `label` is the legend word; `key` is the keystroke. By convention
+    * `key = label.head` for All / Frontend / Backend; [[Custom]] uses `'u'`
+    * because `'c'` is already taken by [[Sort.Cls]] (the input loop fans
+    * every key into both ADTs, so a shared letter would change both).
     */
   sealed trait PhaseFilter {
     def label: String
-    final def key: Char = label.head
+    def key: Char
   }
   object PhaseFilter {
-    case object All      extends PhaseFilter { val label = "all" }
-    case object Frontend extends PhaseFilter { val label = "frontend" }
-    case object Backend  extends PhaseFilter { val label = "backend" }
+    case object All      extends PhaseFilter { val label = "all";      val key = 'a' }
+    case object Frontend extends PhaseFilter { val label = "frontend"; val key = 'f' }
+    case object Backend  extends PhaseFilter { val label = "backend";  val key = 'b' }
 
-    /** All filter values in legend display order. */
-    val all: List[PhaseFilter] = List(All, Frontend, Backend)
+    /**
+      * User-curated subset of phases. The renderer treats the underlined
+      * keystroke as `u` (not the first letter of the label) — see [[key]].
+      * `selected` is empty by default; the input loop replaces the whole
+      * filter atomically when the picker is committed.
+      */
+    final case class Custom(selected: Set[String]) extends PhaseFilter {
+      val label = "custom"
+      val key = 'u'
+    }
+
+    /**
+      * Filter constructors in legend display order. The [[Custom]] entry is
+      * a sentinel used only for the legend's keystroke / label — the active
+      * filter (with its real `selected` set) lives in
+      * [[CompilerTop]]'s `filter` atomic.
+      */
+    val all: List[PhaseFilter] = List(All, Frontend, Backend, Custom(Set.empty))
 
     /** The filter whose `key` matches `c` (case-insensitive), or `None`. */
     def fromKey(c: Char): Option[PhaseFilter] = all.find(_.key == c.toLower)
@@ -62,6 +79,24 @@ object Model {
     "Reader", "Lexer", "Parser2", "Weeder2", "Desugar", "Namer", "Resolver",
     "Kinder", "Deriver", "Typer", "EntryPoints", "Instances", "PredDeps",
     "Stratifier", "PatMatch", "Redundancy", "Safety", "Terminator", "Dependencies",
+  )
+
+  /**
+    * Phase-name strings that count as "backend" — phases that run inside
+    * `Flix.compile`'s `codeGen` pipeline. Strings must match the literals each
+    * phase passes to `flix.phase("…")` / `flix.phaseNew("…")`. Verified against
+    * the instrumentation table in [[Profiler]]'s scaladoc.
+    *
+    * Disjoint from [[FrontendPhases]]; together they enumerate the universe of
+    * named phases the custom-filter picker can list. Phases not in either set
+    * (and not the fallback `"?"`) are ignored by the picker — but kept in the
+    * profiler snapshot — so a renamed phase shows up as a missing entry in
+    * the picker rather than silently disappearing from the dashboard.
+    */
+  val BackendPhases: Set[String] = Set(
+    "TreeShaker1", "Monomorpher", "LambdaDrop", "Optimizer", "OccurrenceAnalyzer",
+    "Inliner", "Simplifier", "ClosureConv", "LambdaLift", "TreeShaker2",
+    "EffectBinder", "TailPos", "Eraser", "Reducer", "CodeGen",
   )
 
   /**
@@ -135,5 +170,43 @@ object Model {
     /** Returns the phase that consumed the most time in this module, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
+  }
+
+  /**
+    * Which of [[FrontendPhases]] / [[BackendPhases]] the cursor is focused
+    * on in the picker view. Left/right arrows toggle focus; up/down move
+    * the cursor inside the focused list.
+    */
+  sealed trait PickerColumn
+  object PickerColumn {
+    case object Frontend extends PickerColumn
+    case object Backend  extends PickerColumn
+  }
+
+  /**
+    * Active screen for the TUI. CompilerTop swaps the [[View]] reference on
+    * `u` (enter picker), Enter / Esc (leave picker), and the renderer
+    * dispatches one frame layout vs the other from a single field on
+    * [[Renderer.FrameState]].
+    *
+    * The picker keeps its working selection on the `View` itself rather than
+    * mutating the active `PhaseFilter.Custom`. Esc therefore discards the
+    * draft cleanly and the dashboard's column-set doesn't shift while the
+    * user is curating.
+    */
+  sealed trait View
+  object View {
+    case object Main extends View
+
+    /**
+      * Picker screen state.
+      *
+      * @param column   which list the cursor is inside
+      * @param frontendCursor 0-based row in the sorted Frontend list
+      * @param backendCursor  0-based row in the sorted Backend list
+      * @param selected the working set of phase names — committed to
+      *                 [[PhaseFilter.Custom.selected]] on Enter, discarded on Esc
+      */
+    final case class Picker(column: PickerColumn, frontendCursor: Int, backendCursor: Int, selected: Set[String]) extends View
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -43,10 +43,13 @@ import scala.collection.mutable
   *                        [[Renderer.TotalPhases]] for the progress bar.
   * @param activeFilter    user-toggled phase filter (drives the legend).
   * @param activeSort      user-toggled sort key (drives header underlines).
+  * @param activeView      active screen — main dashboard or picker overlay.
   * @param layout          column layout produced by [[Layout.compute]].
   * @param visible         def-table rows, already filtered / sorted / trimmed.
   * @param modules         module-table rows, already aggregated / sorted /
   *                        trimmed.
+  * @param pickerFrontend  sorted phase names rendered in the picker's left column.
+  * @param pickerBackend   sorted phase names rendered in the picker's right column.
   */
 final case class FrameState(parallelism: Int,
                             isDone: Boolean,
@@ -57,9 +60,12 @@ final case class FrameState(parallelism: Int,
                             phaseTimersSize: Int,
                             activeFilter: PhaseFilter,
                             activeSort: Sort,
+                            activeView: View,
                             layout: Layout,
                             visible: Vector[DefnStats],
-                            modules: Vector[ModuleStats])
+                            modules: Vector[ModuleStats],
+                            pickerFrontend: Vector[String],
+                            pickerBackend: Vector[String])
 
 object Renderer {
 
@@ -207,7 +213,9 @@ final class Renderer {
   def render(state: FrameState): String = {
     // Active-threads sparkline: history of thread-pool occupancy. Stops
     // updating once compilation is done so the bar reflects the work, not
-    // a long tail of zero-occupancy samples while waiting for `q`.
+    // a long tail of zero-occupancy samples while waiting for `q`. Driven
+    // on every tick regardless of view, so flipping between Main and Picker
+    // doesn't leave a gap in the sparkline.
     if (!state.isDone) {
       threadsHistory.enqueue(state.activeThreads.toDouble)
       while (threadsHistory.size > SparkWidth) threadsHistory.dequeue()
@@ -222,6 +230,19 @@ final class Renderer {
     renderStats(sb, state)
     sb.append('\n')
 
+    state.activeView match {
+      case View.Main =>
+        renderMainBody(sb, state)
+      case p: View.Picker =>
+        renderPicker(sb, state, p)
+    }
+
+    sb.append(EndSync)
+    sb.toString
+  }
+
+  /** Renders the regular def + module tables (the body of the main view). */
+  private def renderMainBody(sb: StringBuilder, state: FrameState): Unit = {
     val safeElapsed = state.elapsed.max(1L).toDouble
     val defRows: Vector[Row] = state.visible.map(s => DefnRow(s, safeElapsed, state.parallelism))
     val modRows: Vector[Row] = state.modules.map(m => ModuleRow(m, safeElapsed, state.parallelism))
@@ -238,9 +259,85 @@ final class Renderer {
       renderHeaderRow(sb, rpad("Module (hot)", modWidth), withLocation = false, state.layout, state.activeSort)
       renderTable(sb, modRows, state.layout)
     }
+  }
 
-    sb.append(EndSync)
-    sb.toString
+  /**
+    * Renders the picker overlay: two side-by-side lists of phase names with
+    * `[x]` / `[ ]` checkboxes and a footer of key hints. The cursor row is
+    * bold yellow; the focused column's title is also bold yellow so it's
+    * obvious where ↑ / ↓ will move. Cancelling discards the working
+    * selection; committing replaces the active filter with
+    * [[PhaseFilter.Custom]].
+    */
+  private def renderPicker(sb: StringBuilder, state: FrameState, p: View.Picker): Unit = {
+    val rows = state.pickerFrontend.size.max(state.pickerBackend.size)
+    val frontendColWidth = pickerColumnWidth(state.pickerFrontend)
+    val backendColWidth = pickerColumnWidth(state.pickerBackend)
+    val gap = "  "
+
+    sb.append(' ')
+    sb.append(pickerColumnTitle("Frontend phases", frontendColWidth, p.column == PickerColumn.Frontend))
+    sb.append(gap)
+    sb.append(pickerColumnTitle("Backend phases", backendColWidth, p.column == PickerColumn.Backend))
+    sb.append('\n')
+
+    sb.append(' ')
+    sb.append(dim("─" * frontendColWidth))
+    sb.append(gap)
+    sb.append(dim("─" * backendColWidth))
+    sb.append('\n')
+
+    for (i <- 0 until rows) {
+      sb.append(' ')
+      appendPickerCell(sb, state.pickerFrontend, i, p.selected, frontendColWidth, p.column == PickerColumn.Frontend && p.frontendCursor == i)
+      sb.append(gap)
+      appendPickerCell(sb, state.pickerBackend, i, p.selected, backendColWidth, p.column == PickerColumn.Backend && p.backendCursor == i)
+      sb.append('\n')
+    }
+
+    sb.append('\n')
+    sb.append("  ")
+    sb.append(dim("↑/↓ move   ←/→ switch list   space toggle   a all   n none   enter apply   esc cancel"))
+    sb.append('\n')
+    sb.append("  ")
+    sb.append(dim(s"selected: ${p.selected.size}"))
+    sb.append('\n')
+  }
+
+  /** Returns the rendered width of a picker column: `[x] PhaseName` for the longest phase, or 0 if empty. */
+  private def pickerColumnWidth(phases: Vector[String]): Int = {
+    val maxName = if (phases.isEmpty) 0 else phases.iterator.map(_.length).max
+    // "[x] " prefix (4 chars) + max phase name.
+    4 + maxName
+  }
+
+  /** Renders a picker column title: bold yellow when focused, bold cyan otherwise. Right-padded to `width`. */
+  private def pickerColumnTitle(label: String, width: Int, focused: Boolean): String = {
+    val padded = rpad(label, width)
+    val c = if (focused) Yellow else Cyan
+    s"$BoldCode$c$padded$Reset"
+  }
+
+  /**
+    * Renders one row in a picker column. Out-of-range rows render as `width`
+    * spaces (so the two columns stay aligned even when one is taller). The
+    * cursor row is bold yellow; selected entries get a green `[x]` marker;
+    * unselected get a dim `[ ]`.
+    */
+  private def appendPickerCell(sb: StringBuilder, phases: Vector[String], i: Int, selected: Set[String], width: Int, isCursor: Boolean): Unit = {
+    if (i >= phases.size) {
+      sb.append(" " * width)
+      return
+    }
+    val name = phases(i)
+    val checked = selected.contains(name)
+    val marker = if (checked) green("[x]") else dim("[ ]")
+    val padding = " " * (width - 4 - name.length).max(0)
+    val nameStyled = if (isCursor) s"$BoldCode$Yellow$name$Reset" else name
+    sb.append(marker)
+    sb.append(' ')
+    sb.append(nameStyled)
+    sb.append(padding)
   }
 
   /**
@@ -282,29 +379,52 @@ final class Renderer {
   }
 
   /**
-    * Renders the `[a|f|b]` legend with the active filter highlighted in
-    * bold yellow. Always visible so the user sees the available toggles
+    * Renders the `[a|f|b|custom]` legend with the active filter highlighted
+    * in bold yellow. Always visible so the user sees the available toggles
     * whether the filter is active or not. Driven entirely by
     * [[PhaseFilter.all]]: adding a new filter is a one-line change in
     * [[Model]] and the legend follows automatically.
+    *
+    * Match-by-type rather than equality so that
+    * `PhaseFilter.Custom(non-empty)` lights up under the legend's
+    * `Custom(Set.empty)` sentinel.
     */
   private def renderFilterLegend(active: PhaseFilter): String = {
-    val entries = PhaseFilter.all.map(f => filterLegendEntry(f, f == active))
+    def isActiveType(f: PhaseFilter): Boolean = (f, active) match {
+      case (PhaseFilter.All, PhaseFilter.All)                 => true
+      case (PhaseFilter.Frontend, PhaseFilter.Frontend)       => true
+      case (PhaseFilter.Backend, PhaseFilter.Backend)         => true
+      case (_: PhaseFilter.Custom, _: PhaseFilter.Custom)     => true
+      case _ => false
+    }
+    val entries = PhaseFilter.all.map(f => filterLegendEntry(f, isActiveType(f), active))
     s"${dim("[")}${entries.mkString(dim("|"))}${dim("]")}"
   }
 
   /**
     * Renders one filter-legend entry: the keystroke letter is underlined.
     * The whole word is bold yellow when this is the active filter, dim
-    * otherwise. Underline state is toggled surgically so the inactive
-    * dim styling and the active bold+yellow styling pass through unchanged
-    * on the remaining letters.
+    * otherwise. When the filter is [[PhaseFilter.Custom]] and active, the
+    * legend appends `(N)` with the selection size so the user can see at a
+    * glance whether the custom set is empty without re-opening the picker.
+    *
+    * The keystroke is matched by [[PhaseFilter.key]] rather than `label.head`:
+    * `Custom`'s underlined letter is `u`, not the leading `c`.
     */
-  private def filterLegendEntry(f: PhaseFilter, active: Boolean): String = {
-    val key = f.key.toString
-    val rest = f.label.tail
-    if (active) s"$BoldCode$Yellow$UnderlineCode$key$NoUnderlineCode$rest$Reset"
-    else        s"$DimCode$UnderlineCode$key$NoUnderlineCode$rest$Reset"
+  private def filterLegendEntry(f: PhaseFilter, active: Boolean, activeFilter: PhaseFilter): String = {
+    val label = f.label
+    val keyIdx = label.indexOf(f.key)
+    val before = if (keyIdx > 0) label.take(keyIdx) else ""
+    val key = if (keyIdx >= 0) label.slice(keyIdx, keyIdx + 1) else label.take(1)
+    val after = if (keyIdx >= 0) label.drop(keyIdx + 1) else label.drop(1)
+    // Show the working size only on the *active* Custom — the legend's
+    // Custom sentinel is always empty, so we read the count off the live filter.
+    val suffix = (f, activeFilter) match {
+      case (_: PhaseFilter.Custom, c: PhaseFilter.Custom) if active => s"(${c.selected.size})"
+      case _ => ""
+    }
+    if (active) s"$BoldCode$Yellow$before$UnderlineCode$key$NoUnderlineCode$after$suffix$Reset"
+    else        s"$DimCode$before$UnderlineCode$key$NoUnderlineCode$after$Reset"
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds a `PhaseFilter.Custom` filter so the compilertop dashboard can be scoped to an arbitrary set of phases (in addition to the existing All / Frontend / Backend filters).
- Adds a picker overlay (entered with `u`) that replaces the def / module tables with a two-column phase selector (frontend / backend), navigated with arrow keys plus space / a / n / enter / esc.

## Test plan
- [ ] Run `./mill flix.run out/example.flix` with `compilertop` enabled and verify the dashboard still renders normally.
- [ ] Press `u` to open the picker; navigate with arrow keys across both columns.
- [ ] Toggle phases with space; use `a` (all) and `n` (none) bulk actions.
- [ ] Press enter to apply — verify dashboard now aggregates only the selected phases.
- [ ] Press esc to cancel — verify the previously active filter is preserved.
- [ ] Cycle through All / Frontend / Backend / Custom and confirm aggregation matches each filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)