### PR TITLE
refactor: remove opt column from compiler-top TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -66,7 +66,6 @@ object Aggregation {
     case Sort.Time    => s.totalNanos.toDouble
     case Sort.Hotness => Formatting.hotnessMsPerLine(s.totalNanos, lineCount(s.loc))
     case Sort.Mono  => sumPhaseCounts(s.byPhaseCount, MonoCountPhases).toDouble
-    case Sort.Opt   => sumPhaseCounts(s.byPhaseCount, OptCountPhases).toDouble
     case Sort.Inl   => s.inlined.toDouble
     case Sort.Cls   => sumPhaseCounts(s.byPhaseCount, ClsCountPhases).toDouble
     case Sort.Size  => s.classBytes.toDouble
@@ -81,7 +80,6 @@ object Aggregation {
     case Sort.Time    => m.totalNanos.toDouble
     case Sort.Hotness => Formatting.hotnessMsPerLine(m.totalNanos, m.totalLines)
     case Sort.Mono  => sumPhaseCounts(m.byPhaseCount, MonoCountPhases).toDouble
-    case Sort.Opt   => sumPhaseCounts(m.byPhaseCount, OptCountPhases).toDouble
     case Sort.Inl   => m.totalInlined.toDouble
     case Sort.Cls   => sumPhaseCounts(m.byPhaseCount, ClsCountPhases).toDouble
     case Sort.Size  => m.totalClassBytes.toDouble

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -322,7 +322,7 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     val activeFilter = filter.get()
     val activeSort = sort.get()
 
-    // The mono / opt / cls columns only render under the backend view (the
+    // The mono / inl / cls columns only render under the backend view (the
     // phases that populate them only fire in the backend pipeline). The cns /
     // tv / ev columns only render under the frontend view (constraint
     // generation is purely a Typer concern). Layout itself doesn't know about

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Layout.scala
@@ -25,7 +25,7 @@ package ca.uwaterloo.flix.tools.compilertop
   *
   * @param nameWidth   width of the merged name column (def + `(file:line)` on def rows, module name on module rows).
   * @param showLines   whether to render the lines column.
-  * @param showCounts  whether to render the mono / opt / cls per-phase count columns.
+  * @param showCounts  whether to render the mono / inl / cls per-phase count columns.
   * @param showCns     whether to render the cns / tv / ev columns.
   * @param showPhase   whether to render the dominant-phase column.
   * @param totalWidth  total rendered width of the row, less leading/trailing pad.
@@ -51,8 +51,8 @@ object Layout {
 
   /** Width contribution of the optional lines column (separator + width). */
   private val LinesColWidth: Int = 1 + 5
-  /** Width contribution of the optional mono / opt / inl / cls / size per-phase count columns (4 × 4-char + 1 × 5-char, with separators). */
-  private val CountsColWidth: Int = 4 * (1 + 4) + (1 + 5)
+  /** Width contribution of the optional mono / inl / cls / size per-phase count columns (3 × 4-char + 1 × 5-char, with separators). */
+  private val CountsColWidth: Int = 3 * (1 + 4) + (1 + 5)
   /** Width contribution of the optional cns column (separator + 5-char numeric field). */
   private val CnsColWidth: Int = 1 + 5
   /** Width contribution of the optional tvars column (separator + 4-char numeric field). */
@@ -70,7 +70,7 @@ object Layout {
   /**
     * Picks a [[Layout]] for the given terminal width by trying tiers in
     * descending feature order. The caller gates the optional count-style
-    * columns by passing `showCounts` (mono / opt / inl / cls / size) and
+    * columns by passing `showCounts` (mono / inl / cls / size) and
     * `showCns` (cns / tv / ev) — Layout itself doesn't know which UI mode
     * they correspond to. When a flag is false the column is hidden and the
     * reclaimed width expands the name column instead.
@@ -113,7 +113,7 @@ object Layout {
     if (cols >= noPhase)
       return fillTier(LinesColWidth + extraColsW + tail, showLines = true, showCountsOut = showCounts, showCnsOut = showCns, showPhase = false)
 
-    // Tier: drop phase + the optional counts (mono/opt/inl/cls/size or cns/tv/ev).
+    // Tier: drop phase + the optional counts (mono/inl/cls/size or cns/tv/ev).
     val noPhaseNoExtras = DefaultNameWidth + LinesColWidth + tail
     if (cols >= noPhaseNoExtras)
       return fillTier(LinesColWidth + tail, showLines = true, showCountsOut = false, showCnsOut = false, showPhase = false)

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -99,8 +99,6 @@ object Model {
     case object Hotness extends Sort { val key = 'h' }
     /** Most monomorphic instances first — surfaces generic-explosion hotspots. */
     case object Mono    extends Sort { val key = 'm' }
-    /** Most optimizer fixed-point re-visits first — surfaces inliner / occurrence-analyzer thrashing. */
-    case object Opt     extends Sort { val key = 'o' }
     /** Most times inlined at a call site first — surfaces small leaf defs that get duplicated everywhere. */
     case object Inl     extends Sort { val key = 'i' }
     /** Most class files emitted first — surfaces JVM fan-out from polymorphism / closures. */
@@ -117,7 +115,7 @@ object Model {
     case object Evars   extends Sort { val key = 'e' }
 
     /** All sort values. */
-    val all: List[Sort] = List(Time, Hotness, Mono, Opt, Inl, Cls, Size, Alloc, Cns, Tvars, Evars)
+    val all: List[Sort] = List(Time, Hotness, Mono, Inl, Cls, Size, Alloc, Cns, Tvars, Evars)
 
     /** The sort whose `key` matches `c` (case-insensitive), or `None`. */
     def fromKey(c: Char): Option[Sort] = all.find(_.key == c.toLower)
@@ -125,8 +123,6 @@ object Model {
 
   /** Phases whose `track` count maps to the `mono` column — number of monomorphic instances created. */
   val MonoCountPhases: Set[String] = Set("Monomorpher")
-  /** Phases whose `track` count maps to the `opt` column — optimizer fixed-point re-visits. */
-  val OptCountPhases: Set[String] = Set("Optimizer", "LambdaDrop")
   /** Phases whose `track` count maps to the `cls` column — class files emitted post-specialization. */
   val ClsCountPhases: Set[String] = Set("CodeGen")
 

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -413,7 +413,7 @@ final class Renderer {
 
   /**
     * Builds a table column header from a pre-padded leading-column label.
-    * Each sortable column underlines its [[Sort.key]] letter (`m̲ono`, `o̲pt`,
+    * Each sortable column underlines its [[Sort.key]] letter (`m̲ono`, `i̲nl`,
     * `c̲ls`, `t̲ime`, …) and the leading "(h̲ot)" annotation marks the hotness
     * sort key. The active column is rendered bold yellow; the rest bold cyan.
     *

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -430,7 +430,6 @@ final class Renderer {
     }
     if (layout.showCounts) {
       sb.append(' '); sb.append(sortableColumn(lpad("mono", 4), Sort.Mono, activeSort))
-      sb.append(' '); sb.append(sortableColumn(lpad("opt",  4), Sort.Opt,  activeSort))
       sb.append(' '); sb.append(sortableColumn(lpad("inl",  4), Sort.Inl,  activeSort))
       sb.append(' '); sb.append(sortableColumn(lpad("cls",  4), Sort.Cls,  activeSort))
       sb.append(' '); sb.append(sortableColumn(lpad("size", 5), Sort.Size, activeSort))
@@ -517,7 +516,6 @@ final class Renderer {
 
     sb.append("  "); sb.append(bold(cyan("Backend columns"))); sb.append('\n')
     appendHelpCol(sb, "mono",     "the number of monomorphic copies created during monomorphization")
-    appendHelpCol(sb, "opt",      "the number of optimizer fixed-point re-visits across Optimizer and LambdaDrop")
     appendHelpCol(sb, "inl",      "the number of times the def was inlined at a call site")
     appendHelpCol(sb, "cls",      "the number of .class files emitted for the def")
     appendHelpCol(sb, "size",     "the total bytecode size of all .class files emitted for the def")
@@ -533,7 +531,7 @@ final class Renderer {
   }
 
   /**
-    * Appends the trailing numeric columns (LOC, mono / opt / cls, cns,
+    * Appends the trailing numeric columns (LOC, mono / inl / cls, cns,
     * phase, time, %cpu, %wall) for one row, honoring the layout's
     * visibility flags. Always emits a leading separator before each column
     * it writes.
@@ -541,7 +539,7 @@ final class Renderer {
     * [[RowCells.aggregate]] skips all warning colors on `time` / `%cpu` /
     * `%wall`. The `style*` thresholds are calibrated for individual defs;
     * at module scale, sums-across-defs trip the thresholds unconditionally
-    * and the colors become noise. Counts (mono / opt / cls / cns) render
+    * and the colors become noise. Counts (mono / inl / cls / cns) render
     * plain in both tables.
     */
   private def appendNumericFields(sb: StringBuilder, cells: RowCells, layout: Layout): Unit = {
@@ -552,10 +550,8 @@ final class Renderer {
     }
     if (layout.showCounts) {
       val mono = sumPhaseCounts(cells.byPhaseCount, MonoCountPhases)
-      val opt  = sumPhaseCounts(cells.byPhaseCount, OptCountPhases)
       val cls  = sumPhaseCounts(cells.byPhaseCount, ClsCountPhases)
       sb.append(' '); sb.append(lpad(mono.toString, 4))
-      sb.append(' '); sb.append(lpad(opt.toString, 4))
       sb.append(' '); sb.append(lpad(cells.inlined.toString, 4))
       sb.append(' '); sb.append(lpad(cls.toString, 4))
       sb.append(' '); sb.append(lpad(formatBytes(cells.classBytes), 5))


### PR DESCRIPTION
## Summary

Removes the `opt` column (Optimizer + LambdaDrop fixed-point re-visit count) from the compiler-top TUI. An investigation found it carries no rank information independent of the existing `mono` and `inl` columns.

## Why

The optimizer fixed point is **global**: every surviving def is re-visited once per round until the whole program converges, so `opt = (surviving copies) × (global round count)`. Consequently:

- `opt` is **collinear with `mono`** — it's `mono` scaled by a near-constant.
- The only deviation below the per-instance ceiling comes from **inlining** (copies eliminated early stop accruing rounds), which the `inl` column already shows directly.

On stdlib + Fixpoint3 workloads the global round count is effectively constant (~11), so `opt` is a redundant column rather than an outlier axis. This was confirmed empirically: a derived `rnds = opt / mono` experiment collapsed to a wall of ties at the global round count (the `mono` term cancels), since `rnds = opt/mono = globalRounds`.

## Changes

- **Model** — remove `Sort.Opt` (frees key `o`), drop it from `Sort.all`, and remove the now-dead `OptCountPhases` classifier.
- **Aggregation** — remove both `Sort.Opt` sort-key cases.
- **Renderer** — remove the `opt` header cell, value, and help-legend line; columns now run `mono → inl → cls → size`.
- **Layout** — `CountsColWidth` shrinks by one 4-char slot, reclaiming 5 chars for the name column.
- **CompilerTop** — comment reference.

## Notes

Display-only; no compiler-pipeline impact. `./mill flix.compile` succeeds and no `Opt` / `OptCountPhases` / `"opt"` references remain in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)