### PR TITLE
feat: toggle between defs and modules views in compiler-top TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -41,21 +41,18 @@ object CompilerTop {
 
 
   /**
-    * Fixed-overhead rows: blank + 2 dashboard/stats lines + blank + 2 def-chrome +
-    * 1 blank-before-modules + 2 module-chrome + 1 cursor-parking row.
+    * Fixed-overhead rows: blank + 2 dashboard/stats lines + blank +
+    * 2 table-chrome (header + divider) + 1 cursor-parking row. Only one
+    * table is visible at a time now, so there is no second-table chrome to
+    * reserve.
     */
-  private val ChromeRows: Int = 10
+  private val ChromeRows: Int = 7
 
   /** Reserved breathing room above and below the rendered view. */
   private val RowMargin: Int = 2
 
-  /** Floor on the total data-row budget. */
-  private val MinDataRows: Int = 8
-
-  /** Floor on the def-table row count. */
-  private val MinDefN: Int = 5
-  /** Floor on the module-table row count. */
-  private val MinModuleN: Int = 3
+  /** Floor on the table's data-row budget. */
+  private val MinTableRows: Int = 8
 
 }
 
@@ -108,12 +105,13 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
   private val sort = new AtomicReference[Sort](Sort.Time)
 
   /**
-    * Active top-level view (tables vs. help screen). Written by the input
-    * thread on `?` / `Esc`, read by the renderer thread. Default is
-    * [[View.Main]]. Compilation keeps running regardless of which view is
-    * showing; toggling does not interfere with the build.
+    * Active top-level view (defs table / modules table / help screen).
+    * Written by the input thread on `Tab` / `?` / `Esc`, read by the
+    * renderer thread. Default is [[View.Defs]]. Compilation keeps running
+    * regardless of which view is showing; toggling does not interfere with
+    * the build.
     */
-  private val view = new AtomicReference[View](View.Main)
+  private val view = new AtomicReference[View](View.Defs)
 
   /**
     * Counted down by the input thread when the user presses `q` (only after
@@ -193,8 +191,10 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     *   - `f` / `F` → filter to frontend phases
     *   - `b` / `B` → filter to backend phases
     *   - `a` / `A` → reset to all phases
+    *   - Tab (`9`) → flip between the defs and modules tables (from help,
+    *     lands on the defs table).
     *   - `?`       → toggle the help view (column / keystroke legend).
-    *   - Esc (`27`) → return to the main view (no-op if already there).
+    *   - Esc (`27`) → return to the defs view (no-op if already there).
     *   - `q` / `Q` / Ctrl-C / EOF → if compilation has completed, signal
     *     [[stop]] to finish teardown; otherwise ignored (pressing `q`
     *     mid-compile must not abort the build).
@@ -214,25 +214,28 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
             quitLatch.countDown()
             return
           }
-        case 27 => // Esc — return to the "all" view: filter All, main view.
+        case 9 => // Tab — flip the table; from help, land on the defs table.
+          view.updateAndGet(v => if (v == View.Help) View.Defs else v.toggledTable)
+        case 27 => // Esc — return to the "all" view: filter All, defs view.
           filter.set(PhaseFilter.All)
-          view.set(View.Main)
+          view.set(View.Defs)
         case '?' =>
-          view.updateAndGet(v => if (v == View.Help) View.Main else View.Help)
+          view.updateAndGet(v => if (v == View.Help) View.Defs else View.Help)
         case ch if ch > 0 =>
           // Dispatch via the Sort / PhaseFilter ADTs so the key ↔ value
           // mapping lives in one place ([[Model.Sort.fromKey]],
           // [[Model.PhaseFilter.fromKey]]) rather than being duplicated
           // across this match and the renderer's header / legend code.
           //
-          // Pressing a filter key from the help view also returns to the main
-          // view so the user can see the filter take effect — otherwise the
-          // toggle happens invisibly behind the help screen.
+          // Pressing a filter key from the help view also leaves help (onto
+          // the defs table) so the user can see the filter take effect —
+          // otherwise the toggle happens invisibly behind the help screen.
+          // From a table view the current table is preserved.
           val char = ch.toChar
           Sort.fromKey(char).foreach(sort.set)
           PhaseFilter.fromKey(char).foreach { f =>
             filter.set(f)
-            view.set(View.Main)
+            view.updateAndGet(v => if (v == View.Help) View.Defs else v)
           }
         case _ => // ignored
       }
@@ -312,13 +315,13 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     val currentPhase = if (isDone) "done" else flix.getCurrentPhaseName.getOrElse("starting")
     val phaseTimersSize = flix.phaseTimers.size
 
-    // Budget rows for the two tables based on the current terminal height,
-    // reserving an extra `RowMargin` rows so the view never quite touches
-    // the top or bottom edge of the terminal.
-    val dataRows = (terminalRows() - ChromeRows - RowMargin).max(MinDataRows)
-    val moduleN = (dataRows / 3).max(MinModuleN)
-    val defN = (dataRows - moduleN).max(MinDefN)
+    // Budget rows for the single visible table based on the current terminal
+    // height, reserving an extra `RowMargin` rows so the view never quite
+    // touches the top or bottom edge of the terminal. Only one table shows at
+    // a time, so it gets the whole budget.
+    val tableRows = (terminalRows() - ChromeRows - RowMargin).max(MinTableRows)
 
+    val activeView = view.get()
     val activeFilter = filter.get()
     val activeSort = sort.get()
 
@@ -333,11 +336,14 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     // reserving 2 columns for the 1-space left and right table padding.
     val layout = Layout.compute((terminalCols() - 2).max(1), showCounts, showCns)
 
+    // Only build the rows the active view actually renders: the def list when
+    // on Defs / Help, the module aggregate when on Modules. `snap` is computed
+    // either way since module aggregation rolls up from it.
     val snap = applyFilter(profiler.snapshot(), activeFilter).sortBy(s => -defSortKey(s, activeSort))
-    val visible = snap.take(defN)
-    val modules = aggregateByModule(snap, activeSort).take(moduleN)
+    val visible = if (activeView == View.Modules) Vector.empty else snap.take(tableRows)
+    val modules = if (activeView == View.Modules) aggregateByModule(snap, activeSort).take(tableRows) else Vector.empty
 
-    FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, view.get(), layout, visible, modules)
+    FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, activeView, layout, visible, modules)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -23,19 +23,34 @@ package ca.uwaterloo.flix.tools.compilertop
 object Model {
 
   /**
-    * Which top-level screen the renderer should draw. Toggled by `?` /
-    * `Esc` in the input thread. The dashboard and stats lines render the
-    * same in either view; only the body below them changes.
+    * Which top-level screen the renderer should draw. Switched by `Tab`
+    * (flip table), `?` (help), and `Esc` (back to defs) in the input thread.
+    * The dashboard and stats lines render the same in every view; only the
+    * body below them changes.
     *
-    *   - [[View.Main]]: the def + module tables (default).
+    *   - [[View.Defs]]: the per-def table (default), full terminal height.
+    *   - [[View.Modules]]: the per-module aggregate table, full terminal
+    *     height. `Tab` flips between [[View.Defs]] and this.
     *   - [[View.Help]]: a static legend explaining each column and
     *     keystroke, so the user doesn't have to guess what e.g. `tv` or
     *     `rnd` mean.
     */
-  sealed trait View
+  sealed trait View {
+    /**
+      * The other table view — `Tab` flips [[View.Defs]] ↔ [[View.Modules]].
+      * From [[View.Help]] there is no "other table", so it maps to itself;
+      * the input loop special-cases leaving help separately.
+      */
+    final def toggledTable: View = this match {
+      case View.Defs    => View.Modules
+      case View.Modules => View.Defs
+      case View.Help    => View.Help
+    }
+  }
   object View {
-    case object Main extends View
-    case object Help extends View
+    case object Defs    extends View
+    case object Modules extends View
+    case object Help    extends View
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -43,11 +43,15 @@ import scala.collection.mutable
   *                        [[Renderer.TotalPhases]] for the progress bar.
   * @param activeFilter    user-toggled phase filter (drives the legend).
   * @param activeSort      user-toggled sort key (drives header underlines).
-  * @param activeView      user-toggled top-level view: tables or help.
+  * @param activeView      user-toggled top-level view: defs table, modules
+  *                        table, or help. Only the active table's rows are
+  *                        populated below.
   * @param layout          column layout produced by [[Layout.compute]].
   * @param visible         def-table rows, already filtered / sorted / trimmed.
+  *                        Empty when [[activeView]] is [[Model.View.Modules]].
   * @param modules         module-table rows, already aggregated / sorted /
-  *                        trimmed.
+  *                        trimmed. Empty unless [[activeView]] is
+  *                        [[Model.View.Modules]].
   */
 final case class FrameState(parallelism: Int,
                             isDone: Boolean,
@@ -257,31 +261,33 @@ final class Renderer {
     sb.append('\n')
 
     state.activeView match {
-      case View.Main => renderTables(sb, state)
-      case View.Help => renderHelp(sb)
+      case View.Defs    => renderDefTable(sb, state)
+      case View.Modules => renderModuleTable(sb, state)
+      case View.Help    => renderHelp(sb)
     }
 
     sb.append(EndSync)
     sb.toString
   }
 
-  /** Renders the def + module tables (the default body of the main view). */
-  private def renderTables(sb: StringBuilder, state: FrameState): Unit = {
+  /** Renders the per-def table (the body of the defs view). */
+  private def renderDefTable(sb: StringBuilder, state: FrameState): Unit = {
     val safeElapsed = state.elapsed.max(1L).toDouble
     val defRows: Vector[Row] = state.visible.map(s => DefnRow(s, safeElapsed, state.parallelism))
-    val modRows: Vector[Row] = state.modules.map(m => ModuleRow(m, safeElapsed, state.parallelism))
 
-    // Def table: header, then rows or a centered placeholder if empty.
     renderHeaderRow(sb, "def (hot)", state.layout, state.activeSort)
     if (defRows.isEmpty) renderEmptyPlaceholder(sb, "(no timings yet)", state.layout)
     else renderTable(sb, defRows, state.layout)
+  }
 
-    // Module table: only when non-empty, separated by a blank line.
-    if (modRows.nonEmpty) {
-      sb.append('\n')
-      renderHeaderRow(sb, "module (hot)", state.layout, state.activeSort)
-      renderTable(sb, modRows, state.layout)
-    }
+  /** Renders the per-module aggregate table (the body of the modules view). */
+  private def renderModuleTable(sb: StringBuilder, state: FrameState): Unit = {
+    val safeElapsed = state.elapsed.max(1L).toDouble
+    val modRows: Vector[Row] = state.modules.map(m => ModuleRow(m, safeElapsed, state.parallelism))
+
+    renderHeaderRow(sb, "mod (hot)", state.layout, state.activeSort)
+    if (modRows.isEmpty) renderEmptyPlaceholder(sb, "(no modules yet)", state.layout)
+    else renderTable(sb, modRows, state.layout)
   }
 
   /**
@@ -334,7 +340,7 @@ final class Renderer {
     * "press a/f/b to leave help" rather than "you are currently filtering".
     */
   private def renderFilterLegend(active: PhaseFilter, view: View): String = {
-    val entries = PhaseFilter.all.map(f => filterLegendEntry(f, view == View.Main && f == active))
+    val entries = PhaseFilter.all.map(f => filterLegendEntry(f, view != View.Help && f == active))
     s"${dim("[")}${entries.mkString(dim("|"))}${dim("]")}"
   }
 
@@ -398,7 +404,7 @@ final class Renderer {
   /**
     * Prints the parametrized header row + the divider underneath it. The
     * `label` argument is the raw first-column label — `"def (hot)"` for the
-    * def table, `"module (hot)"` for the module table — and gets padded to
+    * def table, `"mod (hot)"` for the module table — and gets padded to
     * [[Layout.nameWidth]] here. The location now sits inside the def cells
     * in parens, so the header doesn't have a separate `"location"` column.
     */
@@ -417,7 +423,7 @@ final class Renderer {
     * `c̲ls`, `t̲ime`, …) and the leading "(h̲ot)" annotation marks the hotness
     * sort key. The active column is rendered bold yellow; the rest bold cyan.
     *
-    * Two callers — `def (hot)` for the def table, `module (hot)` for the
+    * Two callers — `def (hot)` for the def table, `mod (hot)` for the
     * module table. Both pad their leading label to [[Layout.nameWidth]].
     */
   private def buildHeader(leading: String, layout: Layout, activeSort: Sort): String = {
@@ -499,13 +505,13 @@ final class Renderer {
     // common columns are always shown; frontend columns only appear under
     // the `frontend` filter; backend columns only under the `backend` filter.
     sb.append("  "); sb.append(bold(cyan("Common columns"))); sb.append('\n')
-    appendHelpCol(sb, "def",      "the fully qualified name of the def, followed by its source location (file:line) in parens")
+    appendHelpCol(sb, "def",      "the fully qualified name of the def, with its source location (file:line) in parens")
     appendHelpCol(sb, "lines",    "the number of source-code lines spanned by the def's signature and body")
     appendHelpCol(sb, "phase",    "the compiler phase that consumed the most wall-clock time for the def")
     appendHelpCol(sb, "alloc",    "the amount of memory the compiler allocated while processing the def")
     appendHelpCol(sb, "time",     "the cumulative wall-clock time spent compiling the def")
     appendHelpCol(sb, "%cpu",     "the def's share of total CPU time, computed as time / (elapsed × threads)")
-    appendHelpCol(sb, "%wall",    "the def's share of wall-clock time (time / elapsed); upper bound on savings if removed")
+    appendHelpCol(sb, "%wall",    "the def's share of wall-clock time (time / elapsed); max savings if removed")
     sb.append('\n')
 
     sb.append("  "); sb.append(bold(cyan("Frontend columns"))); sb.append('\n')
@@ -519,6 +525,12 @@ final class Renderer {
     appendHelpCol(sb, "inl",      "the number of times the def was inlined at a call site")
     appendHelpCol(sb, "cls",      "the number of .class files emitted for the def")
     appendHelpCol(sb, "size",     "the total bytecode size of all .class files emitted for the def")
+    sb.append('\n')
+
+    sb.append("  "); sb.append(bold(cyan("Navigation"))); sb.append('\n')
+    appendHelpCol(sb, "Tab",      "switch between the per-def and per-module tables")
+    appendHelpCol(sb, "a/f/b",    "filter to all / frontend / backend phases")
+    appendHelpCol(sb, "?",        "toggle this help screen; Esc returns to the defs table")
   }
 
   /** Appends one column-description row. */


### PR DESCRIPTION
## Summary

The compiler-top TUI previously stacked the per-def and per-module tables vertically, splitting the row budget between them (`moduleN = dataRows/3`, `defN = rest`). This replaces that split with two independent **full-height** views the user flips between with **Tab**, keeping the help screen as the third view.

## Changes

- **`Model.scala`** — `View` ADT is now `Defs | Modules | Help` (was `Main | Help`), default `Defs`. Added `View.toggledTable` so the flip logic lives in the type.
- **`CompilerTop.scala`** — `Tab` flips the table (from Help → Defs); `Esc`/`?` return to `Defs`; filter keys leave Help but preserve the current table. `buildFrameState` drops the `defN`/`moduleN` split — the active table gets the full row budget and only its rows are built. `ChromeRows` 10 → 7 (no second-table chrome); `MinDefN`/`MinModuleN`/`MinDataRows` collapsed to one `MinTableRows`.
- **`Renderer.scala`** — three-way `render` match; `renderTables` split into `renderDefTable` + `renderModuleTable`, each full-height with its own empty placeholder (the modules view gains `(no modules yet)`). The module header reads `mod (hot)` for consistency with `def (hot)`. Added a **Navigation** section to the help screen documenting `Tab`, `a/f/b`, `?`/`Esc`, and trimmed the `def`/`%wall` column descriptions to fit width.

`Layout`, `Aggregation`, `Styling`, `Formatting`, `Ansi`, `Profiler` are untouched.

## Verification

- `./mill flix.compile` — clean.
- `./mill flix.run out/empty.flix` — stdlib still compiles.
- Live TUI (`--top`) requires interactive Tab presses; not driven in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)