### PR TITLE
feat: color module names by hotness in compiler-top TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -221,9 +221,16 @@ object Renderer {
       )
     }
 
-    /** Appends the module name, padded to span the merged def-row name column. */
+    /**
+      * Appends the module name, hotness-colored (ms-per-line over the module's
+      * summed time / lines) and padded to span the merged def-row name column.
+      * Styling is applied to the visible text only, then padded by visible
+      * width so the ANSI codes don't throw off column alignment.
+      */
     def appendFirstCell(sb: StringBuilder, layout: Layout): Unit = {
-      sb.append(rpad(truncate(m.module, layout.nameWidth), layout.nameWidth))
+      val name = truncate(m.module, layout.nameWidth)
+      sb.append(styleModule(name, m.totalNanos, m.totalLines))
+      sb.append(" " * (layout.nameWidth - name.length))
     }
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
@@ -35,6 +35,8 @@ object Styling {
   private val HeapYellowThresholdRatio:        Double = 0.7
   private val HotnessRedThresholdMsPerLine:    Double = 25.0
   private val HotnessYellowThresholdMsPerLine: Double = 15.0
+  private val ModuleHotnessRedThresholdMsPerLine:    Double = 4.0
+  private val ModuleHotnessYellowThresholdMsPerLine: Double = 2.0
   private val PctCpuRedThreshold:              Double = 5.0
   private val PctCpuYellowThreshold:           Double = 1.0
   private val PctWallRedThreshold:             Double = 15.0
@@ -67,6 +69,21 @@ object Styling {
     val msPerLine = Formatting.hotnessMsPerLine(nanos, lines)
     if (msPerLine >= HotnessRedThresholdMsPerLine) red(name)
     else if (msPerLine >= HotnessYellowThresholdMsPerLine) yellow(name)
+    else name
+  }
+
+  /**
+    * Module-row analogue of [[styleSym]]: colors a module name by its
+    * aggregate hotness (summed ms / summed source lines). Uses the same
+    * absolute two-tier red/yellow scheme but with much lower cutoffs —
+    * averaging a module's cost over all its lines dilutes the per-line
+    * figure, so it never approaches the per-def thresholds. Calibrated so
+    * the densest modules light up while the bulk stay plain.
+    */
+  def styleModule(name: String, nanos: Long, lines: Int): String = {
+    val msPerLine = Formatting.hotnessMsPerLine(nanos, lines)
+    if (msPerLine >= ModuleHotnessRedThresholdMsPerLine) red(name)
+    else if (msPerLine >= ModuleHotnessYellowThresholdMsPerLine) yellow(name)
     else name
   }
 


### PR DESCRIPTION
## Summary

Module rows in the compiler-top TUI rendered entirely plain — no yellow/red — while def rows color their name by hotness. This adds the same hotness coloring to module names.

Two reasons modules were uncolored:
1. `ModuleRow.appendFirstCell` emitted the name via plain `rpad`, with no `styleSym` call (unlike `DefnRow`).
2. The numeric warning colors (time/%cpu/%wall) are intentionally suppressed for aggregate rows, since module-scale sums trip the per-def thresholds unconditionally.

## Changes

- **`Styling.scala`** — new `styleModule`, the module analogue of `styleSym`. Same absolute two-tier red/yellow scheme on ms-per-line, but with module-scaled cutoffs (`ModuleHotnessYellow/RedThresholdMsPerLine = 2.0 / 4.0`). A module averages its cost over all its lines, which dilutes the per-line figure well below the per-def thresholds (15/25), so reusing those would leave every module plain.
- **`Renderer.scala`** — `ModuleRow.appendFirstCell` now colors the name via `styleModule(name, m.totalNanos, m.totalLines)`, padding by visible width so the ANSI codes don't break column alignment.

Only the module **name** is colored; the numeric columns stay plain for modules, as before.

## Verification

`./mill flix.compile` — clean. Coloring is a render-only change; on a representative run the densest modules (e.g. ~4.5 ms/line) go red and mid-density (~2.4) go yellow, with the bulk staying plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)