### PR TITLE
fix: reclaim one table row in compiler-top TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -48,8 +48,13 @@ object CompilerTop {
     */
   private val ChromeRows: Int = 7
 
-  /** Reserved breathing room above and below the rendered view. */
-  private val RowMargin: Int = 2
+  /**
+    * Reserved breathing room below the rendered view, on top of the
+    * cursor-parking row already counted in [[ChromeRows]]. Just one cosmetic
+    * blank line — the parking row alone is enough to prevent the terminal
+    * from scrolling.
+    */
+  private val RowMargin: Int = 1
 
   /** Floor on the table's data-row budget. */
   private val MinTableRows: Int = 8


### PR DESCRIPTION
## Summary

The compiler-top TUI was sizing its table one row shorter than the terminal could fit.

`ChromeRows = 7` already reserves the cursor-parking row at the bottom (the cursor lands one row below the last data row after its trailing newline, and that bound is exactly scroll-safe). `RowMargin = 2` then subtracted two *more* rows, double-counting the bottom breathing room — leaving 3 blank rows at the bottom vs. 1 at the top.

Dropping `RowMargin` to `1` reclaims one data row: leading blank (top) + N data rows + parking row + one cosmetic blank (bottom), which is symmetric and scroll-safe.

## Testing

Pure layout-constant change (`terminalRows − 9` → `terminalRows − 8` data rows); no behavioral or compilation impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)