### PR TITLE
perf: add fast path to JvmName.mangle

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -104,25 +104,70 @@ object JvmName {
   /**
     * Performs name mangling on the given string `s` to avoid issues with special characters.
     */
-  def mangle(s: String): String = s.
-    replace("+", Flix.Delimiter + "plus").
-    replace("-", Flix.Delimiter + "minus").
-    replace("*", Flix.Delimiter + "asterisk").
-    replace("/", Flix.Delimiter + "fslash").
-    replace("\\", Flix.Delimiter + "bslash").
-    replace("<", Flix.Delimiter + "less").
-    replace(">", Flix.Delimiter + "greater").
-    replace("=", Flix.Delimiter + "eq").
-    replace("&", Flix.Delimiter + "ampersand").
-    replace("|", Flix.Delimiter + "bar").
-    replace("^", Flix.Delimiter + "caret").
-    replace("~", Flix.Delimiter + "tilde").
-    replace("!", Flix.Delimiter + "exclamation").
-    replace("#", Flix.Delimiter + "hashtag").
-    replace(":", Flix.Delimiter + "colon").
-    replace("?", Flix.Delimiter + "question").
-    replace("@", Flix.Delimiter + "at").
-    replace(".", Flix.Delimiter + "dot")
+  def mangle(s: String): String = {
+    // Fast path: most names contain no special characters, so we avoid
+    // allocating a new string entirely.
+    if (!containsSpecialChar(s)) s else mangleSlow(s)
+  }
+
+  /**
+    * Returns `true` if `s` contains at least one character that must be mangled.
+    */
+  private def containsSpecialChar(s: String): Boolean = {
+    var i = 0
+    while (i < s.length) {
+      if (mangleReplacement(s.charAt(i)) != null) {
+        return true
+      }
+      i = i + 1
+    }
+    false
+  }
+
+  /**
+    * Mangles `s` in a single pass, replacing every special character with its mangled form.
+    */
+  private def mangleSlow(s: String): String = {
+    val sb = new StringBuilder(s.length + 16)
+    var i = 0
+    while (i < s.length) {
+      val c = s.charAt(i)
+      val replacement = mangleReplacement(c)
+      if (replacement != null) {
+        sb.append(Flix.Delimiter)
+        sb.append(replacement)
+      } else {
+        sb.append(c)
+      }
+      i = i + 1
+    }
+    sb.toString
+  }
+
+  /**
+    * Returns the mangled replacement for the special character `c`, or `null` if `c` is not special.
+    */
+  private def mangleReplacement(c: Char): String = c match {
+    case '+' => "plus"
+    case '-' => "minus"
+    case '*' => "asterisk"
+    case '/' => "fslash"
+    case '\\' => "bslash"
+    case '<' => "less"
+    case '>' => "greater"
+    case '=' => "eq"
+    case '&' => "ampersand"
+    case '|' => "bar"
+    case '^' => "caret"
+    case '~' => "tilde"
+    case '!' => "exclamation"
+    case '#' => "hashtag"
+    case ':' => "colon"
+    case '?' => "question"
+    case '@' => "at"
+    case '.' => "dot"
+    case _ => null
+  }
 
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Java Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Problem

`JvmName.mangle` (JvmName.scala:107) was 18 chained `.replace()` calls. Each `replace` scans the whole string and allocates a new `String` even when the special character is absent. Almost every name contains none of these characters, so a single name allocated ~18 throwaway strings. This showed up at ~3% in profiling.

## Fix

Replace the chain with a single-pass implementation:

- `mangle` checks `containsSpecialChar(s)` and returns the original string unchanged when no special character is present (the common case — zero allocation).
- `mangleSlow` builds the result in a single `StringBuilder` pass, only when a special character actually exists.
- `mangleReplacement` defines the special-character set in one place, shared by both the detection scan and the build pass.

Output is identical to the original: the inserted replacement words are alphanumeric, so they were never re-processed by later `replace` calls in the old code either.

## Testing

- `./mill flix.compile` succeeds.
- `./mill flix.run out/empty.flix` compiles the standard library, which heavily exercises `mangle` during class-name generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)