### PR TITLE
perf: avoid string allocation in EffSym/AssocTypeSym compare

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -834,11 +834,8 @@ object Symbol {
     /**
       * Compares `this` and `that` assoc type sym.
       */
-    override def compare(that: AssocTypeSym): Int = {
-      val s1 = this.namespace.mkString(".") + "." + this.name
-      val s2 = that.namespace.mkString(".") + "." + that.name
-      s1.compare(s2)
-    }
+    override def compare(that: AssocTypeSym): Int =
+      compareQualifiedName(this.namespace, this.name, that.namespace, that.name)
 
     /**
       * Human readable representation.
@@ -873,11 +870,8 @@ object Symbol {
     /**
       * Compares `this` and `that` effect sym.
       */
-    override def compare(that: EffSym): Int = {
-      val s1 = this.namespace.mkString(".") + "." + this.name
-      val s2 = that.namespace.mkString(".") + "." + that.name
-      s1.compare(s2)
-    }
+    override def compare(that: EffSym): Int =
+      compareQualifiedName(this.namespace, this.name, that.namespace, that.name)
 
     /**
       * Human readable representation.
@@ -991,6 +985,25 @@ object Symbol {
     val namespace = split.init.toList
     val name = split.last
     Some((namespace, name))
+  }
+
+  /**
+    * Compares two qualified names — given as namespace segments plus a final name — without
+    * allocating the joined strings. Orders by namespace segments lexicographically, then by name.
+    */
+  private def compareQualifiedName(ns1: List[String], name1: String, ns2: List[String], name2: String): Int = {
+    var l1 = ns1
+    var l2 = ns2
+    while (l1.nonEmpty && l2.nonEmpty) {
+      val c = l1.head.compareTo(l2.head)
+      if (c != 0) return c
+      l1 = l1.tail
+      l2 = l2.tail
+    }
+    // Shorter namespace sorts first; equal-length namespaces fall back to the name.
+    if (l1.nonEmpty) 1
+    else if (l2.nonEmpty) -1
+    else name1.compareTo(name2)
   }
 
 }


### PR DESCRIPTION
## Problem

`EffSym.compare` (Symbol.scala) built two fully-qualified name strings on **every** comparison:

```scala
override def compare(that: EffSym): Int = {
  val s1 = this.namespace.mkString(".") + "." + this.name
  val s2 = that.namespace.mkString(".") + "." + that.name
  s1.compare(s2)
}
```

That's 2 `mkString` calls + 4 string-concat allocations per comparison. Effect symbols are compared constantly on the hot effect-unification path: `EffUnification3` collects effect atoms into a `SortedSet[Atom]`/`SortedBimap[Atom, Int]`, and `Atom.compare` delegates to `EffSym.compare` for `Atom.Eff`. So this allocation fed straight into unification cost. `AssocTypeSym.compare` had the identical pattern and is on the same atom-ordering path.

## Fix

Add a shared `compareQualifiedName` helper that compares the namespace segments lexicographically, then the name — no string allocation. Both `EffSym.compare` and `AssocTypeSym.compare` delegate to it.

The result is still a deterministic total order. Nothing depends on the *specific* concatenated-string order:
- The `SortedBimap` in unification needs only a stable atom↔index bijection; the Zhegalkin result is mapped back through the bimap, so the final effect set is identical regardless of numbering.
- `SortedSet[EffSym]` collections (`Type.effects`, `Symbol.PrimitiveEffs`, entry-point checks, cofinite sets) use ordering for membership/subset math, not iteration sequence.
- The one display sorter (`HtmlDocumentor`) sorts by `.name`, bypassing `compare` entirely.

## Testing

- `./mill flix.compile` succeeds.
- `./mill flix.run out/empty.flix` compiles the standard library.
- `./mill flix.test.testForked -oC`: **16,279 tests pass, 0 failures** — the reordering produced no snapshot churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)