### PR TITLE
fix: report kind error instead of crashing on parameterized effects

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -125,6 +125,7 @@ object ErrorCode {
   case object E3394 extends ErrorCode
   case object E3407 extends ErrorCode
   case object E3414 extends ErrorCode
+  case object E3417 extends ErrorCode
   case object E3421 extends ErrorCode
   case object E3428 extends ErrorCode
   case object E3435 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/KindError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/KindError.scala
@@ -31,6 +31,33 @@ sealed trait KindError extends CompilationMessage {
 object KindError {
 
   /**
+    * An error raised to indicate wrong number of type arguments for an effect.
+    *
+    * @param sym           the effect symbol.
+    * @param expectedArity the expected number of type arguments.
+    * @param actualArity   the actual number of type arguments.
+    * @param loc           the location where the error occurred.
+    */
+  case class MismatchedArityOfEffect(sym: Symbol.EffSym, expectedArity: Int, actualArity: Int, loc: SourceLocation) extends KindError {
+    def code: ErrorCode = ErrorCode.E3417
+
+    private val expected = Grammar.n_things(expectedArity, "type argument")
+    private val actual = Grammar.n_things(actualArity, "type argument")
+    private val wasOrWere = if (actualArity == 1) "was" else "were"
+
+    def summary: String =
+      s"Mismatched arity: effect '${sym.name}' expects $expected but $actual $wasOrWere given."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Mismatched arity: effect '${cyan(sym.name)}' expects $expected but $actual $wasOrWere given.
+         |
+         |${highlight(loc, "wrong number of type arguments", fmt)}
+         |""".stripMargin
+    }
+  }
+
+  /**
     * An error raised to indicate wrong number of type arguments for an enum.
     *
     * @param sym           the enum symbol.

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1205,7 +1205,14 @@ object Kinder {
       unify(kind, expectedKind) match {
         case Some(k) => Type.Cst(TypeConstructor.Effect(sym, k), loc)
         case None =>
-          sctx.errors.add(mkUnexpectedKindError(expectedKind, kind, loc))
+          val expectedArity = Kind.kindArgs(kind).length
+          val actualArity = Kind.kindArgs(expectedKind).length
+          val error = if (expectedArity != actualArity) {
+            KindError.MismatchedArityOfEffect(sym, expectedArity, actualArity, loc)
+          } else {
+            mkUnexpectedKindError(expectedKind, kind, loc)
+          }
+          sctx.errors.add(error)
           Type.freshError(Kind.Error, loc)
       }
 
@@ -1572,8 +1579,8 @@ object Kinder {
     case UnkindedType.Effect(sym, _) =>
       val tyconKind = getEffectKind(root.effects(sym))
       val args = Kind.kindArgs(tyconKind)
-      // We do not truncate because partial application is not allowed here
-      ListOps.zip(tpe.typeArguments, args).foldLeft(KindEnv.empty) {
+      // We zipTruncate because the number of arguments may not match (the mismatch is reported in visitType).
+      ListOps.zipTruncate(tpe.typeArguments, args).foldLeft(KindEnv.empty) {
         case (acc, (targ, kind)) => acc ++ inferType(targ, kind, kenv0, root)
       }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -650,6 +650,43 @@ class TestKinder extends AnyFunSuite with TestUtils {
   }
 
   // ---------------------------------------------------------------------------
+  // --- KindError.MismatchedArityOfEffect ---
+  // ---------------------------------------------------------------------------
+
+  test("KindError.MismatchedArityOfEffect.Def.Effect.01") {
+    val input =
+      """
+        |eff E
+        |
+        |def foo(): Unit \ E[String] = ()
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.MismatchedArityOfEffect](result)
+  }
+
+  test("KindError.MismatchedArityOfEffect.Def.Effect.02") {
+    val input =
+      """
+        |eff E
+        |
+        |def foo(): Unit \ E[String, Int32] = ()
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.MismatchedArityOfEffect](result)
+  }
+
+  test("KindError.MismatchedArityOfEffect.Def.Param.01") {
+    val input =
+      """
+        |eff E
+        |
+        |def foo(x: E[String]): Unit = ()
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.MismatchedArityOfEffect](result)
+  }
+
+  // ---------------------------------------------------------------------------
   // --- KindError.MismatchedArityOfEnum ---
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Using an effect with type arguments crashes the compiler. The program from #12801:

```flix
def foo(): Unit \ IO[String] = println()
```

fails with an `InternalCompilerException`:

```
Zipped lists of length 1 and 0. (unknown:1:1)
  at ca.uwaterloo.flix.language.phase.Kinder$.inferType(Kinder.scala)
```

`Kinder.inferType` used non-truncating `ListOps.zip` for the `Effect` case. Since effect *declarations* cannot carry type parameters (already rejected earlier in the parser with `IllegalEffectTypeParams`), an effect's kind is always `Eff` (arity 0), so any type argument is over-application — and the zip of mismatched lengths threw.

## Fix

- `Kinder.inferType` (Effect case): use `ListOps.zipTruncate` so kind-env inference no longer crashes; the real check happens in `visitType`.
- `Kinder.visitType` (Effect case): on an arity mismatch, raise a new `KindError.MismatchedArityOfEffect`, mirroring the existing enum/struct handling.
- New error `MismatchedArityOfEffect` (code `E3417`).
- Regression tests in `TestKinder`.

The error is now:

```
-- Kind Error [E3417] --
>> Mismatched arity: effect 'IO' expects 0 type arguments but 1 type argument was given.
```

## Testing

Full suite passes (16,282 tests). New `TestKinder` cases cover single-arg, multi-arg, and parameter-position usages.

Closes #12801

🤖 Generated with [Claude Code](https://claude.com/claude-code)