### PR TITLE
perf: sort stale defs by decreasing size in Typer

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -184,15 +184,19 @@ object Typer {
     * Reconstructs types in the given defs.
     */
   private def visitDefs(root: KindedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, TypedAst.Def] = {
-    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_) {
-      case defn => flix.profile(defn.sym, defn.loc) {
-        // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs.
-        // If no effect is specified, we assume the function is pure
-        val eff1 = defn.spec.eff.getOrElse(Type.Pure)
-        val enableSubeffects = shouldSubeffect(eff1, Subeffecting.ModDefs)
-        visitDef(defn, tconstrs0 = Nil, econstrs0 = Nil, RigidityEnv.empty, root, traitEnv, eqEnv, enableSubeffects)
-      }
-    })
+    changeSet.updateStaleValues(root.defs, oldRoot.defs) { staleDefs =>
+      // Sort the stale defs by size to increase throughput (i.e. to start work early on the biggest tasks).
+      val staleByDecreasingSize = staleDefs.toList.sortBy { case (_, defn) => defn.loc.startLine - defn.loc.endLine }
+      ParOps.parMap(staleByDecreasingSize) {
+        case (sym, defn) => flix.profile(defn.sym, defn.loc) {
+          // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs.
+          // If no effect is specified, we assume the function is pure
+          val eff1 = defn.spec.eff.getOrElse(Type.Pure)
+          val enableSubeffects = shouldSubeffect(eff1, Subeffecting.ModDefs)
+          sym -> visitDef(defn, tconstrs0 = Nil, econstrs0 = Nil, RigidityEnv.empty, root, traitEnv, eqEnv, enableSubeffects)
+        }
+      }.toMap
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Sorts the stale defs by size (longest first) before `ParOps.parMap` in `Typer.visitDefs`, so the thread pool starts work early on the biggest tasks instead of potentially scheduling them last and idling at the tail. This is the same trick already used in `Lexer` and `Parser2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)