### PR TITLE
perf: add ParOps.parMapValuesWithPriority and parMapWithPriority

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -229,12 +229,11 @@ object Lexer {
       // Compute the stale and fresh sources.
       val (stale, fresh) = changeSet.partition(root.sources, oldTokens)
 
-      // Sort the stale inputs by size to increase throughput to start work early on the biggest
-      // tasks.
-      val staleByDecreasingSize = stale.keys.toList.sortBy(s => -s.data.length)
+      // Schedule the biggest sources first to increase throughput.
+      def sortBy(src: Source): Int = -src.data.length
 
       // Lex each stale source file in parallel.
-      val (results, errors) = ParOps.parMap(staleByDecreasingSize) {
+      val (results, errors) = ParOps.parMapWithPriority(stale.keys, sortBy) {
         src =>
           val (tokens, errors) = lex(src)
           (src -> tokens, errors)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -126,11 +126,11 @@ object Parser2 {
     // Compute the stale and fresh sources.
     val (stale, fresh) = changeSet.partition(tokens0, oldRoot.units)
 
-    // Sort the stale inputs by size to increase throughput (i.e. to start work early on the biggest tasks).
-    val staleByDecreasingSize = stale.toList.sortBy(p => -p._2.length)
+    // Schedule the biggest sources first to increase throughput.
+    def sortBy(p: (Source, Array[Token])): Int = -p._2.length
 
     // Parse each stale source in parallel and join them into a WeededAst.Root.
-    val (refreshed, errors) = ParOps.parMap(staleByDecreasingSize) {
+    val (refreshed, errors) = ParOps.parMapWithPriority(stale, sortBy) {
       case (src, tokens) =>
         val (tree, errors) = parse(src, tokens)
         (src -> tree, errors)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -184,19 +184,18 @@ object Typer {
     * Reconstructs types in the given defs.
     */
   private def visitDefs(root: KindedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, TypedAst.Def] = {
-    changeSet.updateStaleValues(root.defs, oldRoot.defs) { staleDefs =>
-      // Sort the stale defs by size to increase throughput (i.e. to start work early on the biggest tasks).
-      val staleByDecreasingSize = staleDefs.toList.sortBy { case (_, defn) => defn.loc.startLine - defn.loc.endLine }
-      ParOps.parMap(staleByDecreasingSize) {
-        case (sym, defn) => flix.profile(defn.sym, defn.loc) {
-          // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs.
-          // If no effect is specified, we assume the function is pure
-          val eff1 = defn.spec.eff.getOrElse(Type.Pure)
-          val enableSubeffects = shouldSubeffect(eff1, Subeffecting.ModDefs)
-          sym -> visitDef(defn, tconstrs0 = Nil, econstrs0 = Nil, RigidityEnv.empty, root, traitEnv, eqEnv, enableSubeffects)
-        }
-      }.toMap
-    }
+    // Schedule the biggest defs first to increase throughput.
+    def sortBy(defn: KindedAst.Def): Int = defn.loc.startLine - defn.loc.endLine
+
+    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValuesWithPriority(_, sortBy) {
+      case defn => flix.profile(defn.sym, defn.loc) {
+        // SUB-EFFECTING: Check if sub-effecting is enabled for module-level defs.
+        // If no effect is specified, we assume the function is pure
+        val eff1 = defn.spec.eff.getOrElse(Type.Pure)
+        val enableSubeffects = shouldSubeffect(eff1, Subeffecting.ModDefs)
+        visitDef(defn, tconstrs0 = Nil, econstrs0 = Nil, RigidityEnv.empty, root, traitEnv, eqEnv, enableSubeffects)
+      }
+    })
   }
 
   /**
@@ -282,7 +281,10 @@ object Typer {
   private def visitInstances(root: KindedAst.Root, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): ListMap[Symbol.TraitSym, TypedAst.Instance] = {
     val instances0 = root.instances.values
 
-    val instances = ParOps.parMap(instances0)(visitInstance(_, root, traitEnv, eqEnv))
+    // Schedule the biggest instances first to increase throughput.
+    def sortBy(inst: KindedAst.Instance): Int = inst.loc.startLine - inst.loc.endLine
+
+    val instances = ParOps.parMapWithPriority(instances0, sortBy)(visitInstance(_, root, traitEnv, eqEnv))
     val mapping = instances.map {
       case instance => instance.trt.sym -> instance
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -53,8 +53,12 @@ object Weeder2 {
     flix.phaseNew("Weeder2") {
       implicit val sctx: SharedContext = SharedContext.mk()
       val (stale, fresh) = changeSet.partition(root.units, oldRoot.units)
+
+      // Schedule the biggest sources first to increase throughput.
+      def sortBy(p: (Source, SyntaxTree.Tree)): Int = -p._1.data.length
+
       // Parse each source file in parallel and join them into a WeededAst.Root
-      val refreshed = ParOps.parMap(stale) {
+      val refreshed = ParOps.parMapWithPriority(stale, sortBy) {
         case (src, tree) => mapN(weed(tree))(tree => src -> tree)
       }
 

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.util.collection.ListMap
 
 import java.util
 import java.util.concurrent.{Callable, CountDownLatch, RecursiveTask}
+import scala.collection.immutable.ArraySeq
 import scala.jdk.CollectionConverters.*
 import scala.reflect.ClassTag
 
@@ -90,8 +91,11 @@ object ParOps {
     * `sortBy` value is started first. Pass e.g. negated sizes to start work early on the biggest
     * tasks and thus increase throughput.
     */
-  def parMapWithPriority[A, B: ClassTag](xs: Iterable[A], sortBy: A => Int)(f: A => B)(implicit flix: Flix): Iterable[B] =
-    parMap(xs.toList.sortBy(sortBy))(f)
+  def parMapWithPriority[A: ClassTag, B: ClassTag](xs: Iterable[A], sortBy: A => Int)(f: A => B)(implicit flix: Flix): Iterable[B] = {
+    val arr = xs.toArray
+    arr.sortInPlaceBy(sortBy)
+    parMap(ArraySeq.unsafeWrapArray(arr))(f)
+  }
 
   /**
     * Applies the function `f` to every value of the map `m` in parallel.
@@ -108,10 +112,13 @@ object ParOps {
     * `sortBy` value is started first. Pass e.g. negated sizes to start work early on the biggest
     * tasks and thus increase throughput.
     */
-  def parMapValuesWithPriority[K, A, B](m: Map[K, A], sortBy: A => Int)(f: A => B)(implicit flix: Flix): Map[K, B] =
-    parMap(m.toList.sortBy { case (_, v) => sortBy(v) }) {
+  def parMapValuesWithPriority[K, A, B](m: Map[K, A], sortBy: A => Int)(f: A => B)(implicit flix: Flix): Map[K, B] = {
+    val arr = m.toArray
+    arr.sortInPlaceBy { case (_, v) => sortBy(v) }
+    parMap(ArraySeq.unsafeWrapArray(arr)) {
       case (k, v) => (k, f(v))
     }.toMap
+  }
 
   /**
     * Applies the function `f` to every value of the map `m` in parallel.

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -84,10 +84,32 @@ object ParOps {
   }
 
   /**
+    * Applies the function `f` to every element of `xs` in parallel.
+    *
+    * The elements are scheduled in ascending `sortBy` order, i.e. the element with the smallest
+    * `sortBy` value is started first. Pass e.g. negated sizes to start work early on the biggest
+    * tasks and thus increase throughput.
+    */
+  def parMapWithPriority[A, B: ClassTag](xs: Iterable[A], sortBy: A => Int)(f: A => B)(implicit flix: Flix): Iterable[B] =
+    parMap(xs.toList.sortBy(sortBy))(f)
+
+  /**
     * Applies the function `f` to every value of the map `m` in parallel.
     */
   def parMapValues[K, A, B](m: Map[K, A])(f: A => B)(implicit flix: Flix): Map[K, B] =
     parMap(m) {
+      case (k, v) => (k, f(v))
+    }.toMap
+
+  /**
+    * Applies the function `f` to every value of the map `m` in parallel.
+    *
+    * The values are scheduled in ascending `sortBy` order, i.e. the value with the smallest
+    * `sortBy` value is started first. Pass e.g. negated sizes to start work early on the biggest
+    * tasks and thus increase throughput.
+    */
+  def parMapValuesWithPriority[K, A, B](m: Map[K, A], sortBy: A => Int)(f: A => B)(implicit flix: Flix): Map[K, B] =
+    parMap(m.toList.sortBy { case (_, v) => sortBy(v) }) {
       case (k, v) => (k, f(v))
     }.toMap
 


### PR DESCRIPTION
## Summary

Follow-up to #12815. Adds two helpers to `ParOps` that schedule parallel work in ascending `sortBy` order, so call sites can start the biggest tasks first and avoid idling the thread pool at the tail:

- `parMapWithPriority(xs, sortBy)(f)` — `Iterable` version, for call sites that map over keys or key/value pairs and thread errors through the result.
- `parMapValuesWithPriority(m, sortBy)(f)` — `Map` version.

Each call site declares a named `def sortBy(...)` above the call.

## Call sites

- **Lexer** — refactor of the existing hand-rolled sort (`-src.data.length`).
- **Parser2** — refactor of the existing hand-rolled sort (`-tokens.length`).
- **Typer.visitDefs** — collapses the #12815 change back to a one-liner via the new helper.
- **Typer.visitInstances** — newly sorted by instance size.
- **Weeder2** — newly sorted by source size.

Remaining `parMap`/`parMapValues` sites were surveyed: Redundancy and Deriver do trivial per-item work; the backend phases over `root.defs` could adopt the helper as a separate sweep.

## Verification

`./mill flix.compile` passes and `./mill flix.run` on an empty file compiles the full standard library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)