### PR TITLE
experiment: add flags bitfield to Type for fast-path traversals

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -44,6 +44,28 @@ sealed trait Type {
   def loc: SourceLocation
 
   /**
+    * A bitfield of structural properties of `this` type (see [[Type.Flags]]).
+    * Computed eagerly at construction in O(1) from the flags of the subterms.
+    */
+  def flags: Int
+
+  /**
+    * Returns `true` if `this` type contains no type variables.
+    *
+    * O(1) and allocation-free; prefer this over `typeVars.isEmpty`, which
+    * materializes a [[SortedSet]].
+    */
+  def isGround: Boolean = (flags & Type.Flags.HasVar) == 0
+
+  /**
+    * Returns `true` if `this` type contains a node the reducer may rewrite
+    * (see [[Type.Flags.Reducible]]).
+    *
+    * O(1) and allocation-free.
+    */
+  def isReducible: Boolean = (flags & Type.Flags.Reducible) != 0
+
+  /**
     * Returns the type variables in `this` type.
     *
     * Returns a sorted set to ensure that the compiler is deterministic.
@@ -270,6 +292,21 @@ sealed trait Type {
 object Type {
 
   /////////////////////////////////////////////////////////////////////////////
+  // Flags                                                                   //
+  /////////////////////////////////////////////////////////////////////////////
+
+  /**
+    * Bit values for the [[Type.flags]] bitfield.
+    */
+  object Flags {
+    /** Set if the type contains a [[Type.Var]] anywhere. */
+    final val HasVar: Int = 1
+    /** Set if the type contains a node the reducer may rewrite:
+      * Alias, AssocType, JvmToType, JvmToEff, or UnresolvedJvmType. */
+    final val Reducible: Int = 2
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
   // Constants                                                               //
   /////////////////////////////////////////////////////////////////////////////
 
@@ -489,6 +526,8 @@ object Type {
 
     def kind: Kind = sym.kind
 
+    def flags: Int = Flags.HasVar
+
     /**
       * Returns `true` if `this` type variable is equal to `o`.
       */
@@ -514,6 +553,8 @@ object Type {
   case class Cst(tc: TypeConstructor, loc: SourceLocation) extends Type with BaseType {
     def kind: Kind = tc.kind
 
+    def flags: Int = 0
+
     override def hashCode(): Int = tc.hashCode()
 
     override def equals(o: Any): Boolean = o match {
@@ -526,6 +567,9 @@ object Type {
     * A type expression that a represents a type application tpe1[tpe2].
     */
   case class Apply(tpe1: Type, tpe2: Type, loc: SourceLocation) extends Type {
+
+    val flags: Int = tpe1.flags | tpe2.flags
+
     /**
       * Returns the kind of `this` type.
       *
@@ -562,12 +606,25 @@ object Type {
     */
   case class Alias(symUse: TypeAliasSymUse, args: List[Type], tpe: Type, loc: SourceLocation) extends Type with BaseType {
     override def kind: Kind = tpe.kind
+
+    val flags: Int = {
+      var f = Flags.Reducible | tpe.flags
+      var rest = args
+      while (rest.nonEmpty) {
+        f |= rest.head.flags
+        rest = rest.tail
+      }
+      f
+    }
   }
 
   /**
     * An associated type.
     */
   case class AssocType(symUse: AssocTypeSymUse, arg: Type, kind: Kind, loc: SourceLocation) extends Type with BaseType {
+
+    val flags: Int = Flags.Reducible | arg.flags
+
     override def equals(obj: Any): Boolean = obj match {
       case that: AssocType => this.symUse.sym == that.symUse.sym && this.arg == that.arg
       case _ => false
@@ -581,6 +638,8 @@ object Type {
     */
   case class JvmToType(tpe: Type, loc: SourceLocation) extends Type with BaseType {
     override def kind: Kind = Kind.Star
+
+    val flags: Int = Flags.Reducible | tpe.flags
   }
 
   /**
@@ -588,6 +647,8 @@ object Type {
     */
   case class JvmToEff(tpe: Type, loc: SourceLocation) extends Type with BaseType {
     override def kind: Kind = Kind.Eff
+
+    val flags: Int = Flags.Reducible | tpe.flags
   }
 
   /**
@@ -595,6 +656,16 @@ object Type {
     */
   case class UnresolvedJvmType(member: JvmMember, loc: SourceLocation) extends Type with BaseType {
     override def kind: Kind = Kind.Jvm
+
+    val flags: Int = {
+      var f = Flags.Reducible
+      var rest = member.getTypeArguments
+      while (rest.nonEmpty) {
+        f |= rest.head.flags
+        rest = rest.tail
+      }
+      f
+    }
   }
 
   /**
@@ -1284,6 +1355,26 @@ object Type {
     case JvmToType(tpe, _) => hasAssocType(tpe)
     case JvmToEff(tpe, _) => hasAssocType(tpe)
     case UnresolvedJvmType(member, _) => member.getTypeArguments.exists(hasAssocType)
+  }
+
+  /**
+    * Returns true if the type variable `sym` occurs in the given type `tpe`.
+    *
+    * Visits exactly the variables that [[Type.typeVars]] collects, but prunes
+    * subtrees whose flags show they contain no variables and allocates nothing.
+    */
+  def occurs(sym: Symbol.KindedTypeVarSym, tpe: Type): Boolean = {
+    if (tpe.isGround) return false
+    tpe match {
+      case Type.Var(sym2, _) => sym == sym2
+      case Type.Cst(_, _) => false
+      case Type.Apply(tpe1, tpe2, _) => occurs(sym, tpe1) || occurs(sym, tpe2)
+      case Type.Alias(_, args, t, _) => args.exists(occurs(sym, _)) || occurs(sym, t)
+      case Type.AssocType(_, arg, _, _) => occurs(sym, arg)
+      case Type.JvmToType(t, _) => occurs(sym, t)
+      case Type.JvmToEff(t, _) => occurs(sym, t)
+      case Type.UnresolvedJvmType(member, _) => member.getTypeArguments.exists(occurs(sym, _))
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -308,7 +308,7 @@ object EntryPoints {
     */
   private def checkNoTypeVariables(defn: TypedAst.Def): Option[EntryPointError] = {
     // `tparams` lies sometimes when explicit tparams are given and _ are used.
-    val monomorphic = defn.spec.tparams.isEmpty && typesOf(defn).forall(_.typeVars.isEmpty)
+    val monomorphic = defn.spec.tparams.isEmpty && typesOf(defn).forall(_.isGround)
     if (monomorphic) None
     else Some(EntryPointError.IllegalEntryPointTypeVariables(defn.sym.loc))
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -610,7 +610,7 @@ object ConstraintSolver2 {
     renv.isFlexible(sym) &&
       sym.kind == tpe.kind &&
       hasIdempotentSubstitution(sym.kind) &&
-      !tpe.typeVars.exists { tvar => tvar.sym == sym } &&
+      !Type.occurs(sym, tpe) &&
       !Type.hasJvmType(tpe)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/RecordConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/RecordConstraintSolver.scala
@@ -38,14 +38,14 @@ object RecordConstraintSolver {
     //    α ∉ fv(ρ)
     // ----------------
     // α ~ ρ  =>  {α ↦ ρ}
-    case (Type.Var(sym, _), tpe) if !tpe.typeVars.exists(_.sym == sym) && renv.isFlexible(sym)(scope) =>
+    case (Type.Var(sym, _), tpe) if !Type.occurs(sym, tpe) && renv.isFlexible(sym)(scope) =>
       progress.markProgress()
       (Nil, Substitution.singleton(sym, tpe))
 
     //    α ∉ fv(ρ)
     // ----------------
     //  ρ ~ α  =>  {α ↦ ρ}
-    case (tpe, Type.Var(sym, _)) if !tpe.typeVars.exists(_.sym == sym) && renv.isFlexible(sym)(scope) =>
+    case (tpe, Type.Var(sym, _)) if !Type.occurs(sym, tpe) && renv.isFlexible(sym)(scope) =>
       progress.markProgress()
       (Nil, Substitution.singleton(sym, tpe))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
@@ -41,14 +41,14 @@ object SchemaConstraintSolver {
     //    α ∉ fv(ρ)
     // ----------------
     // α ~ ρ  =>  {α ↦ ρ}
-    case (Type.Var(sym, _), tpe) if !tpe.typeVars.exists(_.sym == sym) && renv.isFlexible(sym)(scope) =>
+    case (Type.Var(sym, _), tpe) if !Type.occurs(sym, tpe) && renv.isFlexible(sym)(scope) =>
       progress.markProgress()
       (Nil, Substitution.singleton(sym, tpe))
 
     //    α ∉ fv(ρ)
     // ----------------
     //  ρ ~ α  =>  {α ↦ ρ}
-    case (tpe, Type.Var(sym, _)) if !tpe.typeVars.exists(_.sym == sym) && renv.isFlexible(sym)(scope) =>
+    case (tpe, Type.Var(sym, _)) if !Type.occurs(sym, tpe) && renv.isFlexible(sym)(scope) =>
       progress.markProgress()
       (Nil, Substitution.singleton(sym, tpe))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
@@ -31,7 +31,7 @@ import ca.uwaterloo.flix.util.collection.{ListOps, MapOps}
   */
 class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.RegionSym, SubstitutionTree]) {
 
-  def isEmpty: Boolean = root.isEmpty && branches.forall { case (_, tree) => tree.isEmpty }
+  val isEmpty: Boolean = root.isEmpty && branches.forall { case (_, tree) => tree.isEmpty }
 
   /**
     * Applies this substitution tree to the given type constraint.
@@ -45,14 +45,14 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
     constr match {
       case eq@TypeConstraint.Equality(tpe1, tpe2, _) =>
         // Check whether the substitution has to be applied.
-        val t1 = if (tpe1.typeVars.isEmpty) tpe1 else root(tpe1)
-        val t2 = if (tpe2.typeVars.isEmpty) tpe2 else root(tpe2)
+        val t1 = if (tpe1.isGround) tpe1 else root(tpe1)
+        val t2 = if (tpe2.isGround) tpe2 else root(tpe2)
         // Performance: Reuse eq, if possible.
         eq.renew(t1, t2)
 
       case TypeConstraint.Trait(sym, tpe, loc) =>
         // Check whether the substitution has to be applied.
-        val t = if (tpe.typeVars.isEmpty) tpe else root(tpe)
+        val t = if (tpe.isGround) tpe else root(tpe)
         // Performance: Reuse this, if possible.
         if (t eq tpe)
           constr
@@ -66,8 +66,8 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
         // We use the root as a fallback (as all branches are supersets of root)
         val subtree = branches.getOrElse(sym, this)
         // Check whether the substitution has to be applied.
-        val e1 = if (eff1.typeVars.isEmpty) eff1 else root(eff1)
-        val e2 = if (eff2.typeVars.isEmpty) eff2 else subtree(eff2)
+        val e1 = if (eff1.isGround) eff1 else root(eff1)
+        val e2 = if (eff2.isGround) eff2 else subtree(eff2)
         val ns = ListOps.mapWithReuse(nested)(subtree.apply)
         // Performance: Reuse this, if possible.
         if ((e1 eq eff1) && (e2 eq eff2) && (ns eq nested))
@@ -77,8 +77,8 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
 
       case TypeConstraint.Conflicted(tpe1, tpe2, prov) =>
         // Check whether the substitution has to be applied.
-        val t1 = if (tpe1.typeVars.isEmpty) tpe1 else root(tpe1)
-        val t2 = if (tpe2.typeVars.isEmpty) tpe2 else root(tpe2)
+        val t1 = if (tpe1.isGround) tpe1 else root(tpe1)
+        val t2 = if (tpe2.isGround) tpe2 else root(tpe2)
         // Performance: Reuse this, if possible.
         if ((t1 eq tpe1) && (t2 eq tpe2))
           constr

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -32,146 +32,151 @@ object TypeReduction2 {
   /**
     * Performs various reduction rules on the given type.
     */
-  def reduce(tpe0: Type)(implicit scope: RegionScope, renv: RigidityEnv, progress: Progress, eqenv: EqualityEnv, flix: Flix): (Type, List[TypeConstraint]) = tpe0 match {
-    case t: Type.Var => (t, Nil)
+  def reduce(tpe0: Type)(implicit scope: RegionScope, renv: RigidityEnv, progress: Progress, eqenv: EqualityEnv, flix: Flix): (Type, List[TypeConstraint]) = {
+    // Fast path: a type without aliases, associated types, or Jvm nodes cannot be reduced.
+    if (!tpe0.isReducible) return (tpe0, Nil)
 
-    case t: Type.Cst => (t, Nil)
+    tpe0 match {
+      case t: Type.Var => (t, Nil)
 
-    case Type.Apply(tpe1, tpe2, loc) =>
-      val (t1, cs1) = reduce(tpe1)
-      val (t2, cs2) = reduce(tpe2)
-      // Performance: Reuse this, if possible.
-      val tpe = if ((t1 eq tpe1) && (t2 eq tpe2))
-        tpe0
-      else
-        Type.Apply(t1, t2, loc)
-      (tpe, cs1 ::: cs2)
+      case t: Type.Cst => (t, Nil)
 
-    case Type.Alias(_, _, tpe, _) => (tpe, Nil)
+      case Type.Apply(tpe1, tpe2, loc) =>
+        val (t1, cs1) = reduce(tpe1)
+        val (t2, cs2) = reduce(tpe2)
+        // Performance: Reuse this, if possible.
+        val tpe = if ((t1 eq tpe1) && (t2 eq tpe2))
+          tpe0
+        else
+          Type.Apply(t1, t2, loc)
+        (tpe, cs1 ::: cs2)
 
-    case Type.AssocType(AssocTypeSymUse(sym, _), tpe, _, _) =>
-      val (t, cs) = reduce(tpe)
+      case Type.Alias(_, _, tpe, _) => (tpe, Nil)
 
-      // Get all the associated types from the context
-      val assocOpt = eqenv.getAssocDef(sym, t)
+      case Type.AssocType(AssocTypeSymUse(sym, _), tpe, _, _) =>
+        val (t, cs) = reduce(tpe)
 
-      // Find the instance that matches
-      val matches = assocOpt.flatMap {
-        case AssocTypeDef(tparams, assocTpe0, ret0) =>
+        // Get all the associated types from the context
+        val assocOpt = eqenv.getAssocDef(sym, t)
 
-
-          // We fully rigidify `tpe`, because we need the substitution to go from instance type to constraint type.
-          // For example, if our constraint is ToString[Map[Int32, a]] and our instance is ToString[Map[k, v]],
-          // then we want the substitution to include "v -> a" but NOT "a -> v".
-          val assocRenv = t.typeVars.map(_.sym).foldLeft(renv)(_.markRigid(_))
+        // Find the instance that matches
+        val matches = assocOpt.flatMap {
+          case AssocTypeDef(tparams, assocTpe0, ret0) =>
 
 
-          // Refresh the flexible variables in the instance
-          // (variables may be rigid if the instance comes from a constraint on the definition)
-          val assocVarMap = tparams.map {
-            case fromSym => fromSym -> Type.freshVar(fromSym.kind, fromSym.loc)(scope, flix)
-          }.toMap
-          val assocSubst = Substitution(assocVarMap)
-          val assocTpe = assocSubst(assocTpe0)
-          val ret = assocSubst(ret0)
+            // We fully rigidify `tpe`, because we need the substitution to go from instance type to constraint type.
+            // For example, if our constraint is ToString[Map[Int32, a]] and our instance is ToString[Map[k, v]],
+            // then we want the substitution to include "v -> a" but NOT "a -> v".
+            val assocRenv = t.typeVars.map(_.sym).foldLeft(renv)(_.markRigid(_))
 
-          // Instantiate all the instance constraints according to the substitution.
-          ConstraintSolver2.fullyUnify(t, assocTpe, scope, assocRenv).map {
-            case subst => subst(ret)
-          }
-      }
 
-      matches match {
-        // Case 1: No match. Can't reduce the type.
-        case None => (tpe0, cs)
+            // Refresh the flexible variables in the instance
+            // (variables may be rigid if the instance comes from a constraint on the definition)
+            val assocVarMap = tparams.map {
+              case fromSym => fromSym -> Type.freshVar(fromSym.kind, fromSym.loc)(scope, flix)
+            }.toMap
+            val assocSubst = Substitution(assocVarMap)
+            val assocTpe = assocSubst(assocTpe0)
+            val ret = assocSubst(ret0)
 
-        // Case 2: One match. Use it.
-        case Some(newTpe) =>
-          progress.markProgress()
-          (newTpe, cs)
-      }
-
-    case Type.JvmToType(tpe, loc) =>
-      val (t, cs) = reduce(tpe)
-      t match {
-        case Type.Cst(TypeConstructor.JvmConstructor(constructor), _) =>
-          progress.markProgress()
-          (instantiateJavaTypeWithFreshVars(constructor.getDeclaringClass, scope, loc), cs)
-
-        case Type.Cst(TypeConstructor.JvmField(field), _) =>
-          progress.markProgress()
-          (instantiateJavaTypeWithFreshVars(field.getType, scope, loc), cs)
-
-        case t1 => t1.typeConstructor match {
-          case Some(TypeConstructor.JvmMethod(method)) =>
-            progress.markProgress()
-            (resolveMethodReturnType(method, t1.typeArguments, scope, loc), cs)
-
-          case _ => (Type.JvmToType(t1, loc), cs)
+            // Instantiate all the instance constraints according to the substitution.
+            ConstraintSolver2.fullyUnify(t, assocTpe, scope, assocRenv).map {
+              case subst => subst(ret)
+            }
         }
-      }
 
-    case Type.JvmToEff(tpe, loc) =>
-      val (t, cs) = reduce(tpe)
-      t match {
-        case Type.Cst(TypeConstructor.JvmConstructor(constructor), _) =>
-          progress.markProgress()
-          (PrimitiveEffects.getConstructorEffs(constructor, loc), cs)
+        matches match {
+          // Case 1: No match. Can't reduce the type.
+          case None => (tpe0, cs)
 
-        case t1 => t1.typeConstructor match {
-          case Some(TypeConstructor.JvmMethod(method)) =>
+          // Case 2: One match. Use it.
+          case Some(newTpe) =>
             progress.markProgress()
-            (PrimitiveEffects.getMethodEffs(method, loc), cs)
-
-          case _ => (Type.JvmToEff(t1, loc), cs)
+            (newTpe, cs)
         }
-      }
 
-    case unresolved@Type.UnresolvedJvmType(member, loc) =>
-      member match {
-        case JvmMember.JvmConstructor(clazz, tpes) =>
-          val (reducedTpes, css) = tpes.map(reduce(_)).unzip
-          val cs = css.flatten
-          lookupConstructor(clazz, reducedTpes) match {
-            case JavaConstructorResolution.Resolved(constructor) =>
-              progress.markProgress()
-              (Type.Cst(TypeConstructor.JvmConstructor(constructor), loc), cs)
-            case _ => (unresolved, cs)
-          }
+      case Type.JvmToType(tpe, loc) =>
+        val (t, cs) = reduce(tpe)
+        t match {
+          case Type.Cst(TypeConstructor.JvmConstructor(constructor), _) =>
+            progress.markProgress()
+            (instantiateJavaTypeWithFreshVars(constructor.getDeclaringClass, scope, loc), cs)
 
-        case JvmMember.JvmField(_, tpe, name) =>
-          val (reducedTpe, cs) = reduce(tpe)
-          lookupField(reducedTpe, name.name) match {
-            case JavaFieldResolution.Resolved(field) =>
-              progress.markProgress()
-              (Type.Cst(TypeConstructor.JvmField(field), loc), cs)
-            case _ => (unresolved, cs)
-          }
+          case Type.Cst(TypeConstructor.JvmField(field), _) =>
+            progress.markProgress()
+            (instantiateJavaTypeWithFreshVars(field.getType, scope, loc), cs)
 
-        case JvmMember.JvmMethod(tpe, name, tpes) =>
-          val (reducedTpe, cs0) = reduce(tpe)
-          val (reducedTpes, css) = tpes.map(reduce(_)).unzip
-          val cs = cs0 ::: css.flatten
-          lookupMethod(reducedTpe, name.name, reducedTpes) match {
-            case JavaMethodResolution.Resolved(method) =>
-              val classTypeArgs = extractClassTypeArgs(method, reducedTpe, scope, loc)
-              val (tpe, cs0) = instantiateMethod(method, classTypeArgs, reducedTpes, scope, loc)
+          case t1 => t1.typeConstructor match {
+            case Some(TypeConstructor.JvmMethod(method)) =>
               progress.markProgress()
-              (tpe, cs ::: cs0)
-            case _ => (unresolved, cs)
-          }
+              (resolveMethodReturnType(method, t1.typeArguments, scope, loc), cs)
 
-        case JvmMember.JvmStaticMethod(clazz, name, tpes) =>
-          val (reducedTpes, css) = tpes.map(reduce(_)).unzip
-          val cs = css.flatten
-          lookupStaticMethod(clazz, name.name, reducedTpes) match {
-            case JavaMethodResolution.Resolved(method) =>
-              val (tpe, cs0) = instantiateMethod(method, Nil, reducedTpes, scope, loc)
-              progress.markProgress()
-              (tpe, cs ::: cs0)
-            case _ => (unresolved, cs)
+            case _ => (Type.JvmToType(t1, loc), cs)
           }
-      }
+        }
+
+      case Type.JvmToEff(tpe, loc) =>
+        val (t, cs) = reduce(tpe)
+        t match {
+          case Type.Cst(TypeConstructor.JvmConstructor(constructor), _) =>
+            progress.markProgress()
+            (PrimitiveEffects.getConstructorEffs(constructor, loc), cs)
+
+          case t1 => t1.typeConstructor match {
+            case Some(TypeConstructor.JvmMethod(method)) =>
+              progress.markProgress()
+              (PrimitiveEffects.getMethodEffs(method, loc), cs)
+
+            case _ => (Type.JvmToEff(t1, loc), cs)
+          }
+        }
+
+      case unresolved@Type.UnresolvedJvmType(member, loc) =>
+        member match {
+          case JvmMember.JvmConstructor(clazz, tpes) =>
+            val (reducedTpes, css) = tpes.map(reduce(_)).unzip
+            val cs = css.flatten
+            lookupConstructor(clazz, reducedTpes) match {
+              case JavaConstructorResolution.Resolved(constructor) =>
+                progress.markProgress()
+                (Type.Cst(TypeConstructor.JvmConstructor(constructor), loc), cs)
+              case _ => (unresolved, cs)
+            }
+
+          case JvmMember.JvmField(_, tpe, name) =>
+            val (reducedTpe, cs) = reduce(tpe)
+            lookupField(reducedTpe, name.name) match {
+              case JavaFieldResolution.Resolved(field) =>
+                progress.markProgress()
+                (Type.Cst(TypeConstructor.JvmField(field), loc), cs)
+              case _ => (unresolved, cs)
+            }
+
+          case JvmMember.JvmMethod(tpe, name, tpes) =>
+            val (reducedTpe, cs0) = reduce(tpe)
+            val (reducedTpes, css) = tpes.map(reduce(_)).unzip
+            val cs = cs0 ::: css.flatten
+            lookupMethod(reducedTpe, name.name, reducedTpes) match {
+              case JavaMethodResolution.Resolved(method) =>
+                val classTypeArgs = extractClassTypeArgs(method, reducedTpe, scope, loc)
+                val (tpe, cs0) = instantiateMethod(method, classTypeArgs, reducedTpes, scope, loc)
+                progress.markProgress()
+                (tpe, cs ::: cs0)
+              case _ => (unresolved, cs)
+            }
+
+          case JvmMember.JvmStaticMethod(clazz, name, tpes) =>
+            val (reducedTpes, css) = tpes.map(reduce(_)).unzip
+            val cs = css.flatten
+            lookupStaticMethod(clazz, name.name, reducedTpes) match {
+              case JavaMethodResolution.Resolved(method) =>
+                val (tpe, cs0) = instantiateMethod(method, Nil, reducedTpes, scope, loc)
+                progress.markProgress()
+                (tpe, cs ::: cs0)
+              case _ => (unresolved, cs)
+            }
+        }
+    }
   }
 
   /** Tries to find a constructor of `clazz` that takes arguments of type `ts`. */

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetZhegalkinUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetZhegalkinUnification.scala
@@ -35,10 +35,10 @@ object CaseSetZhegalkinUnification {
     }
 
     (tpe1, tpe2) match {
-      case (t1@Type.Var(x, _), t2) if renv0.isFlexible(x) && !t2.typeVars.contains(t1) =>
+      case (Type.Var(x, _), t2) if renv0.isFlexible(x) && !Type.occurs(x, t2) =>
         return Some(Substitution.singleton(x, t2))
 
-      case (t1, t2@Type.Var(x, _)) if renv0.isFlexible(x) && !t1.typeVars.contains(t2) =>
+      case (t1, Type.Var(x, _)) if renv0.isFlexible(x) && !Type.occurs(x, t1) =>
         return Some(Substitution.singleton(x, t1))
 
       case _ => // nop

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
@@ -62,47 +62,52 @@ case class Substitution(m: Map[Symbol.KindedTypeVarSym, Type]) {
     if (isEmpty) tpe0 else visitType(tpe0)
   }
 
-  private def visitType(t: Type): Type = t match {
-    // NB: The order of cases has been determined by code coverage analysis.
-    case x: Type.Var =>
-      // Performance: A non-capturing default avoids a thunk allocation per lookup.
-      val tpe = m.getOrElse(x.sym, null)
-      if (tpe == null) x else tpe
+  private def visitType(t: Type): Type = {
+    // Fast path: a type without type variables is unchanged by substitution.
+    if (t.isGround) return t
 
-    case Type.Cst(_, _) => t
+    t match {
+      // NB: The order of cases has been determined by code coverage analysis.
+      case x: Type.Var =>
+        // Performance: A non-capturing default avoids a thunk allocation per lookup.
+        val tpe = m.getOrElse(x.sym, null)
+        if (tpe == null) x else tpe
 
-    case app@Type.Apply(t1, t2, loc) =>
-      // Note: While we could perform simplifications here,
-      // experimental results have shown that it is not worth it.
-      val x = visitType(t1)
-      val y = visitType(t2)
-      // Performance: Reuse t, if possible.
-      app.renew(x, y, loc)
+      case Type.Cst(_, _) => t
 
-    case Type.Alias(sym, args0, tpe0, loc) =>
-      val args = ListOps.mapWithReuse(args0)(visitType)
-      val tpe = visitType(tpe0)
-      // Performance: Reuse t, if possible.
-      if ((args eq args0) && (tpe eq tpe0)) t else Type.Alias(sym, args, tpe, loc)
+      case app@Type.Apply(t1, t2, loc) =>
+        // Note: While we could perform simplifications here,
+        // experimental results have shown that it is not worth it.
+        val x = visitType(t1)
+        val y = visitType(t2)
+        // Performance: Reuse t, if possible.
+        app.renew(x, y, loc)
 
-    case Type.AssocType(cst, args0, kind, loc) =>
-      val args = args0.map(visitType)
-      // Performance: Reuse t, if possible.
-      if (args eq args0) t else Type.AssocType(cst, args, kind, loc)
+      case Type.Alias(sym, args0, tpe0, loc) =>
+        val args = ListOps.mapWithReuse(args0)(visitType)
+        val tpe = visitType(tpe0)
+        // Performance: Reuse t, if possible.
+        if ((args eq args0) && (tpe eq tpe0)) t else Type.Alias(sym, args, tpe, loc)
 
-    case Type.JvmToType(tpe0, loc) =>
-      val tpe = visitType(tpe0)
-      // Performance: Reuse t, if possible.
-      if (tpe eq tpe0) t else Type.JvmToType(tpe, loc)
+      case Type.AssocType(cst, args0, kind, loc) =>
+        val args = args0.map(visitType)
+        // Performance: Reuse t, if possible.
+        if (args eq args0) t else Type.AssocType(cst, args, kind, loc)
 
-    case Type.JvmToEff(tpe0, loc) =>
-      val tpe = visitType(tpe0)
-      // Performance: Reuse t, if possible.
-      if (tpe eq tpe0) t else Type.JvmToEff(tpe, loc)
+      case Type.JvmToType(tpe0, loc) =>
+        val tpe = visitType(tpe0)
+        // Performance: Reuse t, if possible.
+        if (tpe eq tpe0) t else Type.JvmToType(tpe, loc)
 
-    case Type.UnresolvedJvmType(member0, loc) =>
-      val member = member0.map(visitType)
-      Type.UnresolvedJvmType(member, loc)
+      case Type.JvmToEff(tpe0, loc) =>
+        val tpe = visitType(tpe0)
+        // Performance: Reuse t, if possible.
+        if (tpe eq tpe0) t else Type.JvmToEff(tpe, loc)
+
+      case Type.UnresolvedJvmType(member0, loc) =>
+        val member = member0.map(visitType)
+        Type.UnresolvedJvmType(member, loc)
+    }
   }
 
 


### PR DESCRIPTION
## Summary

Every `Type` node now carries an eagerly computed `Int` bitfield of structural facts, computed O(1) at construction from the subterms' flags:

- `Flags.HasVar` — the type contains a `Type.Var` somewhere.
- `Flags.Reducible` — the type contains a node the reducer may rewrite (`Alias`, `AssocType`, `JvmToType`, `JvmToEff`, `UnresolvedJvmType`).

Two predicates expose them — `Type.isGround` (`HasVar` unset) and `Type.isReducible` (`Reducible` set) — both O(1) and allocation-free. Hot traversals use them to bail out early on subtrees with nothing to find. This is purely an optimization: no observable behavior changes.

## Consumers

- **`Substitution.visitType`** — returns ground types unchanged before matching (exact: a type without variables is a fixpoint of any substitution).
- **`TypeReduction2.reduce`** — returns `(tpe0, Nil)` for non-reducible types (exact: nothing to rewrite, no constraints produced).
- **New `Type.occurs`** — a flag-pruned, allocation-free occurs check replacing `tpe.typeVars.exists(_.sym == sym)` (which materializes a `SortedSet` per call) in `ConstraintSolver2.canSubstitute`, `RecordConstraintSolver.solve`, `SchemaConstraintSolver.solve`, and `CaseSetZhegalkinUnification.unify`.
- **`SubstitutionTree.apply`** — its per-case guards now test `isGround` instead of `typeVars.isEmpty`, avoiding a `SortedSet` allocation on every constraint application; `isEmpty` is now a cached `val`.
- **`EntryPoints.checkNoTypeVariables`** — the monomorphism check uses `isGround` instead of `typeVars.isEmpty`.

`Type.typeVars`, equality, and `hashCode` are untouched. The raw diff is mostly re-indentation from wrapping a match body; `git diff -w` is +119/−18.

## Performance

`Xperf --frontend --par --n 500` (10 threads, 89,909 lines, frontend-only, parallel, non-incremental):

| Throughput (lines/sec) | Baseline `master` | This branch | Δ |
|---|--:|--:|--:|
| median | 162,542 | 159,110 | −2.1% |
| avg | 159,187 | 154,840 | −2.7% |
| best | 175,737 | 170,378 | −3.0% |

**The benchmark does not support a throughput improvement.** Repeated runs swing across a ~±3% band and the sign of the delta flips between them — feature median was +3.4%, then −0.6% (both n=250), then −2.1% (n=500 above). The unchanged `master` jar alone varied ~6% across sessions (median 150,943 → 160,616), so the between-run noise (JIT path, GC timing, scheduler/thermal state) exceeds any per-change effect; doubling iterations to n=500 did not tighten it, because the variance is between-run, not within-run.

The substitution/reduction fast paths are a small slice of frontend-wide work, so a real local win — if any — is below this macro-benchmark's resolution. **This change is therefore motivated by eliminating per-call `SortedSet` allocation on the constraint-solver hot path and by clarity, not by a measured speedup.** A defensible number would need a forked-JVM microbenchmark on `Substitution.apply` / `TypeReduction2.reduce`, not this end-to-end benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
