### PR TITLE
perf: stop iterating in Soup.exhaustively when all constraints are solved

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -85,7 +85,8 @@ object ConstraintSolver2 {
     def exhaustively(progress: Progress)(f: (Soup, Progress) => Soup): Soup = {
       val innerProgress = Progress()
       val res = f(this, innerProgress)
-      if (innerProgress.query()) {
+      // Performance: If all constraints are solved there is nothing left to iterate on.
+      if (innerProgress.query() && res.constrs.nonEmpty) {
         progress.markProgress()
         res.exhaustively(progress)(f)
       } else {


### PR DESCRIPTION
## Summary

`Soup.exhaustively` loops while progress is marked — even when the previous iteration
solved *all* constraints. Since every pass is per-constraint, an empty soup can never
produce more work, so that final iteration is a guaranteed no-op sweep of the whole
`solveOne` pipeline.

This wasted iteration happens on every fully-successful solve. Notably, every
`fullyUnify` call from `contextReduction`'s instance matching (a hot path) paid one
extra `solveOne` pass over an empty constraint list.

## Changes

One line: `exhaustively` now stops when the resulting soup has no constraints, even if
progress was marked:

```scala
if (innerProgress.query() && res.constrs.nonEmpty) {
```

Verified empirically (via temporary instrumentation that threw if the outer loop in
`solveAll` re-iterated): before this change, even sub-solves that fully succeeded on the
first iteration re-ran the pipeline; after it, only solves with leftover constraints
iterate again.

## Testing

- Full test suite: 16,575 tests, 0 failures.
- Standard library compiles (`flix.run` on an empty file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)