### PR TITLE
perf: reuse unchanged constraints in SubstitutionTree.apply

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -521,8 +521,8 @@ object ConstraintSolver2 {
       // If it's a purification constraint, solve the nested constraints
       // and put the substitution in the tree
       case c@TypeConstraint.Purification(sym, eff1, eff2_0, prov, nested0) =>
-        val nested1 = ListOps.mapWithReuse(nested0)(tree0.apply)
-        val (nested, subst2) = blockEffectUnification(nested1, progress)(scope.enter(sym), renv, flix)
+        // Note: `tree0` has already been applied to `nested0` by the mapping over `rest0a` above.
+        val (nested, subst2) = blockEffectUnification(nested0, progress)(scope.enter(sym), renv, flix)
         branches = branches + (sym -> subst2)
 
         // apply the inner substitution to the to-be-purified effect

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.language.phase.typer
 
 import ca.uwaterloo.flix.language.ast.{Symbol, Type}
 import ca.uwaterloo.flix.language.phase.unification.Substitution
-import ca.uwaterloo.flix.util.collection.MapOps
+import ca.uwaterloo.flix.util.collection.{ListOps, MapOps}
 
 /**
   * The substitution tree represents the substitutions that apply to different region scopes.
@@ -54,7 +54,13 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
           TypeConstraint.Equality(t1, t2, prov)
 
       case TypeConstraint.Trait(sym, tpe, loc) =>
-        TypeConstraint.Trait(sym, root(tpe), loc)
+        // Check whether the substitution has to be applied.
+        val t = if (tpe.typeVars.isEmpty) tpe else root(tpe)
+        // Performance: Reuse this, if possible.
+        if (t eq tpe)
+          constr
+        else
+          TypeConstraint.Trait(sym, t, loc)
 
       case TypeConstraint.Purification(sym, eff1, eff2, prov, nested) =>
         // Use the root substitution for the external effects.
@@ -62,7 +68,15 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
 
         // We use the root as a fallback (as all branches are supersets of root)
         val subtree = branches.getOrElse(sym, this)
-        TypeConstraint.Purification(sym, root(eff1), subtree(eff2), prov, nested.map(subtree.apply))
+        // Check whether the substitution has to be applied.
+        val e1 = if (eff1.typeVars.isEmpty) eff1 else root(eff1)
+        val e2 = if (eff2.typeVars.isEmpty) eff2 else subtree(eff2)
+        val ns = ListOps.mapWithReuse(nested)(subtree.apply)
+        // Performance: Reuse this, if possible.
+        if ((e1 eq eff1) && (e2 eq eff2) && (ns eq nested))
+          constr
+        else
+          TypeConstraint.Purification(sym, e1, e2, prov, ns)
 
       case TypeConstraint.Conflicted(tpe1, tpe2, prov) =>
         // Check whether the substitution has to be applied.


### PR DESCRIPTION
## What

Reduces allocation in the constraint solver by adding reuse checks to `SubstitutionTree.apply` and removing a redundant substitution application:

1. **`SubstitutionTree.apply`**: The `Trait` and `Purification` cases now mirror the `Equality` case — they skip the substitution when the type has no type variables, use `mapWithReuse` for nested constraints, and return the original constraint when nothing changed. Previously these cases allocated a fresh constraint on every application, which defeated downstream `eq`-based reuse (`ListOps.mapWithReuse`, `Soup.renew`, and the `s1 eq soup` check in `simplifyAndSubstitute` that skips extra simplify passes).

2. **`ConstraintSolver2.blockEffectUnification`**: Removes a redundant second application of `tree0` to nested constraints — the mapping over `rest0a` already applied it, since `SubstitutionTree.apply` recurses into `Purification.nested`.

## Benchmark

`Xperf --frontend --par --n 100`, two interleaved runs per side:

| Run | master (median) | this PR (median) |
|-----|-----------------|------------------|
| 1 | 140,652 lines/sec | 141,802 lines/sec |
| 2 | 140,103 lines/sec | 141,298 lines/sec |

Consistently ahead by ~1%, at the edge of noise. The main value is that constraint identity is now preserved across substitution applications, which downstream reuse-based optimizations depend on.

## Verification

- Standard library compiles (`flix.run` on an empty file)
- `TestTyper`: 181/181 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)