### PR TITLE
perf: add syntactic pre-solver for atomic effect equations

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
@@ -43,15 +43,12 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
     }
 
     constr match {
-      case TypeConstraint.Equality(tpe1, tpe2, prov) =>
+      case eq@TypeConstraint.Equality(tpe1, tpe2, _) =>
         // Check whether the substitution has to be applied.
         val t1 = if (tpe1.typeVars.isEmpty) tpe1 else root(tpe1)
         val t2 = if (tpe2.typeVars.isEmpty) tpe2 else root(tpe2)
-        // Performance: Reuse this, if possible.
-        if ((t1 eq tpe1) && (t2 eq tpe2))
-          constr
-        else
-          TypeConstraint.Equality(t1, t2, prov)
+        // Performance: Reuse eq, if possible.
+        eq.renew(t1, t2)
 
       case TypeConstraint.Trait(sym, tpe, loc) =>
         // Check whether the substitution has to be applied.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
@@ -56,6 +56,17 @@ object TypeConstraint {
     */
   case class Equality(tpe1: Type, tpe2: Type, prov: Provenance) extends TypeConstraint {
     def loc: SourceLocation = prov.loc
+
+    /**
+      * Creates a new Equality, reusing this one if the types are unchanged.
+      */
+    def renew(newTpe1: Type, newTpe2: Type): Equality = {
+      if ((tpe1 eq newTpe1) && (tpe2 eq newTpe2)) {
+        this
+      } else {
+        Equality(newTpe1, newTpe2, prov)
+      }
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
 import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint.Provenance
+import ca.uwaterloo.flix.language.phase.unification.PreEffUnification.PreSolveResult
 import ca.uwaterloo.flix.language.phase.unification.set.Equation.Status
 import ca.uwaterloo.flix.language.phase.unification.set.{Equation, SetFormula, SetSubstitution, SetUnification}
 import ca.uwaterloo.flix.language.phase.unification.shared.CofiniteIntSet
@@ -70,6 +71,33 @@ object EffUnification3 {
     // Add to implicit context.
     implicit val scopeImplicit: RegionScope = scope
     implicit val renvImplicit: RigidityEnv = renv
+
+    //
+    // Phase 0: Try to solve the system syntactically if all equations are atomic.
+    //
+    if (EnableSmartSubeffecting) {
+      PreEffUnification.preSolve(eqs) match {
+        case PreSolveResult.Solved(subst) =>
+          // The whole system was atomic and exactly solvable.
+          return Result.Ok(subst)
+        case PreSolveResult.Partial(subst0, rest) =>
+          // The atomic equations were eliminated; try to solve the (smaller) remainder
+          // exactly. On failure we redo the full system below, so that subeffecting
+          // (which may add slack to any equation) sees the original equations.
+          try {
+            val bimap0: SortedBimap[Atom, Int] = mkBidirectionalVarMap(getAtomsFromConstraints(rest))
+            val equations = toEquations(rest, withSlack = false)(scope, renv, bimap0)
+            val (unsolvedEqns, resultSubst) = SetUnification.solve(equations)
+            if (unsolvedEqns.isEmpty) {
+              return Result.Ok(fromSetSubst(resultSubst)(withSlack = false, m = bimap0) @@ subst0)
+            }
+            // Otherwise we fall through and redo the full system.
+          } catch {
+            case InvalidType(_) => // We fall through.
+          }
+        case PreSolveResult.Opaque => () // Fall through to full solving.
+      }
+    }
 
     // Choose a unique number for each atom.
     implicit val bimap: SortedBimap[Atom, Int] = mkBidirectionalVarMap(getAtomsFromConstraints(eqs))

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.language.ast.{RigidityEnv, Symbol, Type, TypeConstructo
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 
 /**
   * A syntactic pre-solver for effect equations.
@@ -71,8 +72,9 @@ object PreEffUnification {
   def preSolve(eqs: List[TypeConstraint.Equality])(implicit scope: RegionScope, renv: RigidityEnv): PreSolveResult = {
     var m = Map.empty[Symbol.KindedTypeVarSym, Type]
 
-    val rest = List.newBuilder[TypeConstraint.Equality]
-    var restEmpty = true
+    // The equations that could not be eliminated and must go to the full solver.
+    val leftover = mutable.ListBuffer.empty[TypeConstraint.Equality]
+    // The equations that remain to be processed.
     var rem = eqs
     while (rem.nonEmpty) {
       val eq = rem.head
@@ -97,24 +99,23 @@ object PreEffUnification {
         }
       }
       if (deferred) {
-        rest += eq
-        restEmpty = false
+        leftover += eq
       }
     }
     if (m.isEmpty) {
-      if (restEmpty) PreSolveResult.Solved(Substitution.empty) else PreSolveResult.Opaque
+      if (leftover.isEmpty) PreSolveResult.Solved(Substitution.empty) else PreSolveResult.Opaque
     } else {
       val subst = mkSubstitution(m)
-      if (restEmpty) {
+      if (leftover.isEmpty) {
         PreSolveResult.Solved(subst)
       } else {
         // Apply the eliminations to the remaining equations.
-        val restEqs = rest.result().map { eq =>
+        val leftoverEqs = leftover.result().map { eq =>
           val t1 = subst(eq.tpe1)
           val t2 = subst(eq.tpe2)
           eq.renew(t1, t2)
         }
-        PreSolveResult.Partial(subst, restEqs)
+        PreSolveResult.Partial(subst, leftoverEqs)
       }
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
@@ -112,8 +112,7 @@ object PreEffUnification {
         val restEqs = rest.result().map { eq =>
           val t1 = subst(eq.tpe1)
           val t2 = subst(eq.tpe2)
-          // Performance: Reuse eq, if possible.
-          if ((t1 eq eq.tpe1) && (t2 eq eq.tpe2)) eq else TypeConstraint.Equality(t1, t2, eq.prov)
+          eq.renew(t1, t2)
         }
         PreSolveResult.Partial(subst, restEqs)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
@@ -1,0 +1,156 @@
+/*
+ *  Copyright 2026 Magnus Madsen
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.unification
+
+import ca.uwaterloo.flix.language.ast.shared.RegionScope
+import ca.uwaterloo.flix.language.ast.{RigidityEnv, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
+
+import scala.annotation.tailrec
+
+/**
+  * A syntactic pre-solver for effect equations.
+  *
+  * Eliminates atomic equations by pure variable elimination, without the set algebra
+  * machinery of [[EffUnification3]].
+  *
+  * For example, given the equation system:
+  *
+  *   - `ef1 ~ ef2`
+  *   - `ef2 ~ IO`
+  *   - `ef3 ~ Pure`
+  *
+  * every equation is atomic, so the system is solved exactly by the substitution
+  * `{ef1 ↦ IO, ef2 ↦ IO, ef3 ↦ Pure}` ([[PreSolveResult.Solved]]). If the system also
+  * contained `ef4 ~ ef1 ∪ Crash` then that equation is not atomic: it would be returned
+  * as the remainder of a [[PreSolveResult.Partial]] with the substitution applied to it,
+  * i.e. `ef4 ~ IO ∪ Crash`.
+  */
+object PreEffUnification {
+
+  /** The result of [[preSolve]]. */
+  sealed trait PreSolveResult
+
+  object PreSolveResult {
+    /** Every equation was atomic and the system was solved exactly by `subst`. */
+    case class Solved(subst: Substitution) extends PreSolveResult
+
+    /** The atomic equations were solved by `subst0`; `rest` are the remaining equations with `subst0` applied. */
+    case class Partial(subst0: Substitution, rest: List[TypeConstraint.Equality]) extends PreSolveResult
+
+    /** No atomic equations could be eliminated. */
+    case object Opaque extends PreSolveResult
+  }
+
+  /**
+    * Eliminates the atomic equations of the given system syntactically, without the set
+    * algebra machinery.
+    *
+    * An equation is atomic if it relates two atoms (variables, `Pure`, effect constants, or
+    * regions) where at least one side is a flexible variable (or the sides are identical).
+    * Such equations are solvable by pure variable elimination: atoms need no normalization,
+    * and the variable orientation mirrors `Equation.mk` (a variable on the right-hand side
+    * is bound first) and the elimination order of `SetUnification` (in equation order).
+    *
+    * Non-atomic equations (and atomic conflicts, which the full solver must report or solve
+    * with subeffecting) are returned as the remainder.
+    */
+  def preSolve(eqs: List[TypeConstraint.Equality])(implicit scope: RegionScope, renv: RigidityEnv): PreSolveResult = {
+    var m = Map.empty[Symbol.KindedTypeVarSym, Type]
+
+    // Follows variable bindings to their representative. Terminates since bindings are acyclic.
+    @tailrec
+    def resolve(t: Type): Type = t match {
+      case Type.Var(sym, _) => m.get(sym) match {
+        case Some(t2) => resolve(t2)
+        case None => t
+      }
+      case _ => t
+    }
+
+    def isAtom(t: Type): Boolean = t match {
+      case Type.Var(_, _) => true
+      case Type.Cst(TypeConstructor.Pure, _) => true
+      case Type.Cst(TypeConstructor.Effect(_, _), _) => true
+      case Type.Cst(TypeConstructor.Region(_), _) => true
+      case _ => false
+    }
+
+    def sameAtom(t1: Type, t2: Type): Boolean = (t1, t2) match {
+      case (Type.Var(s1, _), Type.Var(s2, _)) => s1 == s2
+      case (Type.Cst(TypeConstructor.Pure, _), Type.Cst(TypeConstructor.Pure, _)) => true
+      case (Type.Cst(TypeConstructor.Effect(s1, _), _), Type.Cst(TypeConstructor.Effect(s2, _), _)) => s1 == s2
+      case (Type.Cst(TypeConstructor.Region(s1), _), Type.Cst(TypeConstructor.Region(s2), _)) => s1 == s2
+      case _ => false
+    }
+
+    val rest = List.newBuilder[TypeConstraint.Equality]
+    var restEmpty = true
+    var rem = eqs
+    while (rem.nonEmpty) {
+      val eq = rem.head
+      rem = rem.tail
+      var deferred = true
+      if (isAtom(eq.tpe1) && isAtom(eq.tpe2)) {
+        val t1 = resolve(eq.tpe1)
+        val t2 = resolve(eq.tpe2)
+        if (sameAtom(t1, t2)) {
+          deferred = false
+        } else {
+          (t1, t2) match {
+            case (_, Type.Var(sym, _)) if renv.isFlexible(sym) =>
+              m = m.updated(sym, t1)
+              deferred = false
+            case (Type.Var(sym, _), _) if renv.isFlexible(sym) =>
+              m = m.updated(sym, t2)
+              deferred = false
+            case _ =>
+              () // Atomic conflict or rigid variables: defer to the full solver.
+          }
+        }
+      }
+      if (deferred) {
+        rest += eq
+        restEmpty = false
+      }
+    }
+    if (m.isEmpty) {
+      if (restEmpty) PreSolveResult.Solved(Substitution.empty) else PreSolveResult.Opaque
+    } else {
+      // Path-compress the ranges so the substitution needs no repeated application.
+      // Performance: Ranges are resolved at insertion time, so an entry is stale only if its
+      // range variable was bound later. Skip the rebuild unless some entry needs compression.
+      val needsCompression = m.exists {
+        case (_, Type.Var(sym, _)) => m.contains(sym)
+        case _ => false
+      }
+      val subst = Substitution(if (needsCompression) m.map { case (k, v) => k -> resolve(v) } else m)
+      if (restEmpty) {
+        PreSolveResult.Solved(subst)
+      } else {
+        // Apply the eliminations to the remaining equations.
+        val restEqs = rest.result().map { eq =>
+          val t1 = subst(eq.tpe1)
+          val t2 = subst(eq.tpe2)
+          // Performance: Reuse eq, if possible.
+          if ((t1 eq eq.tpe1) && (t2 eq eq.tpe2)) eq else TypeConstraint.Equality(t1, t2, eq.prov)
+        }
+        PreSolveResult.Partial(subst, restEqs)
+      }
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
@@ -79,26 +79,24 @@ object PreEffUnification {
     while (queue.nonEmpty) {
       val eq = queue.head
       queue = queue.tail
-      var deferred = true
       if (isAtom(eq.tpe1) && isAtom(eq.tpe2)) {
         val t1 = resolve(eq.tpe1, m)
         val t2 = resolve(eq.tpe2, m)
         if (sameAtom(t1, t2)) {
-          deferred = false
+          () // The equation is trivially satisfied.
         } else {
           (t1, t2) match {
             case (_, Type.Var(sym, _)) if renv.isFlexible(sym) =>
               m = m.updated(sym, t1)
-              deferred = false
             case (Type.Var(sym, _), _) if renv.isFlexible(sym) =>
               m = m.updated(sym, t2)
-              deferred = false
             case _ =>
-              () // Atomic conflict or rigid variables: defer to the full solver.
+              // Atomic conflict or rigid variables: defer to the full solver.
+              rest += eq
           }
         }
-      }
-      if (deferred) {
+      } else {
+        // Non-atomic equation: defer to the full solver.
         rest += eq
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
@@ -71,32 +71,6 @@ object PreEffUnification {
   def preSolve(eqs: List[TypeConstraint.Equality])(implicit scope: RegionScope, renv: RigidityEnv): PreSolveResult = {
     var m = Map.empty[Symbol.KindedTypeVarSym, Type]
 
-    // Follows variable bindings to their representative. Terminates since bindings are acyclic.
-    @tailrec
-    def resolve(t: Type): Type = t match {
-      case Type.Var(sym, _) => m.get(sym) match {
-        case Some(t2) => resolve(t2)
-        case None => t
-      }
-      case _ => t
-    }
-
-    def isAtom(t: Type): Boolean = t match {
-      case Type.Var(_, _) => true
-      case Type.Cst(TypeConstructor.Pure, _) => true
-      case Type.Cst(TypeConstructor.Effect(_, _), _) => true
-      case Type.Cst(TypeConstructor.Region(_), _) => true
-      case _ => false
-    }
-
-    def sameAtom(t1: Type, t2: Type): Boolean = (t1, t2) match {
-      case (Type.Var(s1, _), Type.Var(s2, _)) => s1 == s2
-      case (Type.Cst(TypeConstructor.Pure, _), Type.Cst(TypeConstructor.Pure, _)) => true
-      case (Type.Cst(TypeConstructor.Effect(s1, _), _), Type.Cst(TypeConstructor.Effect(s2, _), _)) => s1 == s2
-      case (Type.Cst(TypeConstructor.Region(s1), _), Type.Cst(TypeConstructor.Region(s2), _)) => s1 == s2
-      case _ => false
-    }
-
     val rest = List.newBuilder[TypeConstraint.Equality]
     var restEmpty = true
     var rem = eqs
@@ -105,8 +79,8 @@ object PreEffUnification {
       rem = rem.tail
       var deferred = true
       if (isAtom(eq.tpe1) && isAtom(eq.tpe2)) {
-        val t1 = resolve(eq.tpe1)
-        val t2 = resolve(eq.tpe2)
+        val t1 = resolve(eq.tpe1, m)
+        val t2 = resolve(eq.tpe2, m)
         if (sameAtom(t1, t2)) {
           deferred = false
         } else {
@@ -137,7 +111,7 @@ object PreEffUnification {
         case (_, Type.Var(sym, _)) => m.contains(sym)
         case _ => false
       }
-      val subst = Substitution(if (needsCompression) m.map { case (k, v) => k -> resolve(v) } else m)
+      val subst = Substitution(if (needsCompression) m.map { case (k, v) => k -> resolve(v, m) } else m)
       if (restEmpty) {
         PreSolveResult.Solved(subst)
       } else {
@@ -151,6 +125,44 @@ object PreEffUnification {
         PreSolveResult.Partial(subst, restEqs)
       }
     }
+  }
+
+  /**
+    * Returns `true` if `t` is an atom: a variable, `Pure`, an effect constant, or a region.
+    */
+  private def isAtom(t: Type): Boolean = t match {
+    case Type.Var(_, _) => true
+    case Type.Cst(TypeConstructor.Pure, _) => true
+    case Type.Cst(TypeConstructor.Effect(_, _), _) => true
+    case Type.Cst(TypeConstructor.Region(_), _) => true
+    case _ => false
+  }
+
+  /**
+    * Returns `true` if `t1` and `t2` are the same atom, ignoring source locations.
+    *
+    * Assumes that `t1` and `t2` satisfy [[isAtom]].
+    */
+  private def sameAtom(t1: Type, t2: Type): Boolean = (t1, t2) match {
+    case (Type.Var(s1, _), Type.Var(s2, _)) => s1 == s2
+    case (Type.Cst(TypeConstructor.Pure, _), Type.Cst(TypeConstructor.Pure, _)) => true
+    case (Type.Cst(TypeConstructor.Effect(s1, _), _), Type.Cst(TypeConstructor.Effect(s2, _), _)) => s1 == s2
+    case (Type.Cst(TypeConstructor.Region(s1), _), Type.Cst(TypeConstructor.Region(s2), _)) => s1 == s2
+    case _ => false
+  }
+
+  /**
+    * Follows variable bindings in `m` to the representative of `t`.
+    *
+    * Terminates since the bindings in `m` are acyclic.
+    */
+  @tailrec
+  private def resolve(t: Type, m: Map[Symbol.KindedTypeVarSym, Type]): Type = t match {
+    case Type.Var(sym, _) => m.get(sym) match {
+      case Some(t2) => resolve(t2, m)
+      case None => t
+    }
+    case _ => t
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
@@ -104,14 +104,7 @@ object PreEffUnification {
     if (m.isEmpty) {
       if (restEmpty) PreSolveResult.Solved(Substitution.empty) else PreSolveResult.Opaque
     } else {
-      // Path-compress the ranges so the substitution needs no repeated application.
-      // Performance: Ranges are resolved at insertion time, so an entry is stale only if its
-      // range variable was bound later. Skip the rebuild unless some entry needs compression.
-      val needsCompression = m.exists {
-        case (_, Type.Var(sym, _)) => m.contains(sym)
-        case _ => false
-      }
-      val subst = Substitution(if (needsCompression) m.map { case (k, v) => k -> resolve(v, m) } else m)
+      val subst = mkSubstitution(m)
       if (restEmpty) {
         PreSolveResult.Solved(subst)
       } else {
@@ -125,6 +118,22 @@ object PreEffUnification {
         PreSolveResult.Partial(subst, restEqs)
       }
     }
+  }
+
+  /**
+    * Returns a [[Substitution]] from the binding map `m` with every range path-compressed,
+    * so the substitution needs no repeated application.
+    *
+    * Performance: Ranges are resolved at insertion time, so an entry is stale only if its
+    * range variable was bound later. Skips the rebuild unless some entry needs compression.
+    */
+  private def mkSubstitution(m: Map[Symbol.KindedTypeVarSym, Type]): Substitution = {
+    val needsCompression = m.exists {
+      case (_, Type.Var(sym, _)) => m.contains(sym)
+      case _ => false
+    }
+    val compressed = if (needsCompression) m.map { case (k, v) => k -> resolve(v, m) } else m
+    Substitution(compressed)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
@@ -73,12 +73,12 @@ object PreEffUnification {
     var m = Map.empty[Symbol.KindedTypeVarSym, Type]
 
     // The equations that could not be eliminated and must go to the full solver.
-    val leftover = mutable.ListBuffer.empty[TypeConstraint.Equality]
+    val rest = mutable.ListBuffer.empty[TypeConstraint.Equality]
     // The equations that remain to be processed.
-    var rem = eqs
-    while (rem.nonEmpty) {
-      val eq = rem.head
-      rem = rem.tail
+    var queue = eqs
+    while (queue.nonEmpty) {
+      val eq = queue.head
+      queue = queue.tail
       var deferred = true
       if (isAtom(eq.tpe1) && isAtom(eq.tpe2)) {
         val t1 = resolve(eq.tpe1, m)
@@ -99,23 +99,23 @@ object PreEffUnification {
         }
       }
       if (deferred) {
-        leftover += eq
+        rest += eq
       }
     }
     if (m.isEmpty) {
-      if (leftover.isEmpty) PreSolveResult.Solved(Substitution.empty) else PreSolveResult.Opaque
+      if (rest.isEmpty) PreSolveResult.Solved(Substitution.empty) else PreSolveResult.Opaque
     } else {
       val subst = mkSubstitution(m)
-      if (leftover.isEmpty) {
+      if (rest.isEmpty) {
         PreSolveResult.Solved(subst)
       } else {
         // Apply the eliminations to the remaining equations.
-        val leftoverEqs = leftover.result().map { eq =>
+        val restEqs = rest.result().map { eq =>
           val t1 = subst(eq.tpe1)
           val t2 = subst(eq.tpe2)
           eq.renew(t1, t2)
         }
-        PreSolveResult.Partial(subst, leftoverEqs)
+        PreSolveResult.Partial(subst, restEqs)
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a **Phase 0** to `EffUnification3.unifyAll`: a syntactic pre-solver (new file `PreEffUnification.scala`) that eliminates atomic equations — atom ~ atom where an atom is a variable, `Pure`, an effect constant, or a region, and at least one side is a flexible variable — by pure variable elimination with path compression, before any set algebra machinery runs.

- If the **whole system** is atomic, it is solved outright and the set solver is skipped entirely.
- If only **part** is atomic (`Partial`), the substitution is applied to the smaller remainder, which gets one exact no-slack solve attempt.
- On any failure, control falls through to the existing Phases 1–2 on the **original, untouched** equations, so subeffecting (which may add slack to any equation) is unaffected. Phases 1–2 are byte-for-byte unchanged.

## Measurements

Compiling the standard library (10,760 `preSolve` calls):

| Outcome | Count | Share |
|---|---|---|
| Fully solved syntactically | 6,218 | 58% |
| Partial, remainder solved exactly | 4,260 | 40% (all of them) |
| Opaque (old path) | 282 | 2.6% |

83% of all effect equations (58,960 of 70,937) are eliminated before reaching the set solver.

`Xperf --frontend --par`, back-to-back on the same machine:

**`--n 500`** (final PR state):

| lines/sec | master | this PR | Delta |
|---|---|---|---|
| Best | 168,775 | 173,573 | +2.8% |
| Median | 149,644 | 160,395 | +7.2% |
| Average | 149,285 | 157,230 | +5.3% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)