### PR TITLE
refactor: extract Atom from EffUnification3 into EffAtom.scala

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
@@ -18,40 +18,39 @@ package ca.uwaterloo.flix.language.phase.unification
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
 import ca.uwaterloo.flix.language.ast.{RigidityEnv, Type}
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
-import ca.uwaterloo.flix.language.phase.unification.EffUnification3.Atom
 
 import scala.collection.mutable
 
 private object AtomBimap {
 
   /**
-    * Returns an [[AtomBimap]] numbering the [[Atom]]s of `eqs` using [[Atom.collectAtoms]].
+    * Returns an [[AtomBimap]] numbering the [[EffAtom]]s of `eqs` using [[EffAtom.collectAtoms]].
     *
     * The atoms are sorted before numbering: the assignment must be deterministic across
     * runs since it determines the solving order in
     * [[ca.uwaterloo.flix.language.phase.unification.set.SetUnification]].
     */
   def fromConstraints(eqs: List[TypeConstraint.Equality])(implicit scope: RegionScope, renv: RigidityEnv): AtomBimap = {
-    val buf = mutable.HashSet.empty[Atom]
+    val buf = mutable.HashSet.empty[EffAtom]
     for (eq <- eqs) {
-      Atom.collectAtoms(eq.tpe1, buf)
-      Atom.collectAtoms(eq.tpe2, buf)
+      EffAtom.collectAtoms(eq.tpe1, buf)
+      EffAtom.collectAtoms(eq.tpe2, buf)
     }
     fromAtoms(buf)
   }
 
-  /** Returns an [[AtomBimap]] numbering the [[Atom]]s of `tpe` using [[Atom.collectAtoms]]. */
+  /** Returns an [[AtomBimap]] numbering the [[EffAtom]]s of `tpe` using [[EffAtom.collectAtoms]]. */
   def fromType(tpe: Type)(implicit scope: RegionScope, renv: RigidityEnv): AtomBimap = {
-    val buf = mutable.HashSet.empty[Atom]
-    Atom.collectAtoms(tpe, buf)
+    val buf = mutable.HashSet.empty[EffAtom]
+    EffAtom.collectAtoms(tpe, buf)
     fromAtoms(buf)
   }
 
   /** Returns an [[AtomBimap]] numbering the given atoms `0..n-1` in sorted order. */
-  private def fromAtoms(atoms: mutable.HashSet[Atom]): AtomBimap = {
+  private def fromAtoms(atoms: mutable.HashSet[EffAtom]): AtomBimap = {
     val arr = atoms.toArray
-    java.util.Arrays.sort(arr, implicitly[Ordering[Atom]])
-    var forward = Map.empty[Atom, Int]
+    java.util.Arrays.sort(arr, implicitly[Ordering[EffAtom]])
+    var forward = Map.empty[EffAtom, Int]
     var i = 0
     while (i < arr.length) {
       forward = forward.updated(arr(i), i)
@@ -62,17 +61,17 @@ private object AtomBimap {
 }
 
 /**
-  * A bidirectional mapping between [[Atom]]s and dense indices `0..n-1`.
+  * A bidirectional mapping between [[EffAtom]]s and dense indices `0..n-1`.
   *
   * Performance: The forward map is hash-based and the backward map is an array, avoiding
   * the ordered-comparison cost of sorted maps on the hot path of effect unification. The
   * index assignment itself must be deterministic; it is always derived from atoms in
   * sorted order.
   */
-private final class AtomBimap(forward: Map[Atom, Int], backward: Array[Atom]) {
+private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAtom]) {
 
   /** Returns the index of `a`, or -1 if absent (allocation-free). */
-  def getForwardIndex(a: Atom): Int = forward.getOrElse(a, -1)
+  def getForwardIndex(a: EffAtom): Int = forward.getOrElse(a, -1)
 
   /**
     * Optionally returns the atom at index `i`.
@@ -80,6 +79,6 @@ private final class AtomBimap(forward: Map[Atom, Int], backward: Array[Atom]) {
     * Callers probe indices outside `0..n-1` (e.g. slack variables introduced during
     * solving) and rely on `None` for those — the bounds check is load-bearing.
     */
-  def getBackward(i: Int): Option[Atom] =
+  def getBackward(i: Int): Option[EffAtom] =
     if (i >= 0 && i < backward.length) Some(backward(i)) else None
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
@@ -1,0 +1,158 @@
+/*
+ *  Copyright 2024 Jonathan Lindegaard Starup
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.unification
+
+import ca.uwaterloo.flix.language.ast.shared.RegionScope
+import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
+import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+/**
+  * Atomic effects that can be represented as atoms in
+  * [[ca.uwaterloo.flix.language.phase.unification.set.SetFormula]]. Atomic effects are
+  * variables, effects, errors, or simple associated effects, described in the grammar below.
+  *
+  * atom ::= VarFlex | VarRigid | Eff | Error | atomAssoc
+  * atomAssoc ::= Assoc atomAssoc | VarRigid
+  */
+private sealed trait EffAtom extends Ordered[EffAtom] {
+  override def compare(that: EffAtom): Int = (this, that) match {
+    case (EffAtom.VarFlex(sym1), EffAtom.VarFlex(sym2)) => sym1.id - sym2.id
+    case (EffAtom.VarRigid(sym1), EffAtom.VarRigid(sym2)) => sym1.id - sym2.id
+    case (EffAtom.Eff(sym1), EffAtom.Eff(sym2)) => sym1.compare(sym2)
+    case (EffAtom.Region(sym1), EffAtom.Region(sym2)) => sym1.compare(sym2)
+    case (EffAtom.Assoc(sym1, arg1), EffAtom.Assoc(sym2, arg2)) =>
+      val symCmp = sym1.compare(sym2)
+      if (symCmp != 0) symCmp else arg1.compare(arg2)
+    case (EffAtom.Error(id1), EffAtom.Error(id2)) => id1 - id2
+    case _ =>
+      def ordinal(a: EffAtom): Int = a match {
+        case EffAtom.VarFlex(_) => 0
+        case EffAtom.VarRigid(_) => 1
+        case EffAtom.Region(_) => 2
+        case EffAtom.Eff(_) => 3
+        case EffAtom.Assoc(_, _) => 4
+        case EffAtom.Error(_) => 5
+      }
+
+      ordinal(this) - ordinal(that)
+  }
+}
+
+private object EffAtom {
+  /** Representing a flexible variable. */
+  case class VarFlex(sym: Symbol.KindedTypeVarSym) extends EffAtom
+
+  /** Representing a rigid variable. */
+  case class VarRigid(sym: Symbol.KindedTypeVarSym) extends EffAtom
+
+  /** Representing an effect constant. */
+  case class Eff(sym: Symbol.EffSym) extends EffAtom
+
+  /** Represents an associated effect. */
+  case class Assoc(sym: Symbol.AssocTypeSym, arg: EffAtom) extends EffAtom
+
+  /** Represents a region. */
+  case class Region(sym: Symbol.RegionSym) extends EffAtom
+
+  /** Represents an error type. */
+  case class Error(id: Int) extends EffAtom
+
+  /** Returns the [[EffAtom]] representation of `t` or throws [[InvalidType]]. */
+  @tailrec
+  def fromType(t: Type)(implicit scope: RegionScope, renv: RigidityEnv): EffAtom = t match {
+    case Type.Var(sym, _) if renv.isRigid(sym) => EffAtom.VarRigid(sym)
+    case Type.Var(sym, _) => EffAtom.VarFlex(sym)
+    case Type.Cst(TypeConstructor.Effect(sym, _), _) => EffAtom.Eff(sym)
+    case Type.Cst(TypeConstructor.Region(sym), _) => EffAtom.Region(sym)
+    case assoc@Type.AssocType(_, _, _, _) => assocFromType(assoc)
+    case Type.Cst(TypeConstructor.Error(id, _), _) => EffAtom.Error(id)
+    case Type.Alias(_, _, tpe, _) => fromType(tpe)
+    case _ => throw InvalidType(t)
+  }
+
+  /** Returns the [[EffAtom]] representation of `t` or throws [[InvalidType]]. */
+  private def assocFromType(t: Type)(implicit scope: RegionScope, renv: RigidityEnv): EffAtom = t match {
+    case Type.Var(sym, _) if renv.isRigid(sym) => EffAtom.VarRigid(sym)
+    case Type.AssocType(AssocTypeSymUse(sym, _), arg, _, _) => EffAtom.Assoc(sym, assocFromType(arg))
+    case Type.Alias(_, _, tpe, _) => assocFromType(tpe)
+    case _ => throw InvalidType(t)
+  }
+
+  /**
+    * Adds the valid [[EffAtom]]s that occur in `t` (according to [[EffAtom.fromType]]) to `acc`.
+    * Invalid or unrelated types are ignored.
+    *
+    * The validity of atoms are checked top-down, so even though `MyTrait.MyType[x]` is a valid
+    * atom where `x` is rigid, `collectAtoms(MyTrait.MyType[MyTrait.MyType[x] ∪ IO], acc)` will
+    * add nothing since the outermost associated type is not valid. This behaviour aligns with
+    * the needs of [[EffUnification3.toSetFormula]].
+    *
+    * Examples:
+    *   - `collectAtoms(Crash ∪ ef, acc)` adds `Eff(Crash)` and `VarFlex(ef)` (if
+    *     [[RigidityEnv.isRigid]] is false for `ef`)
+    *   - `collectAtoms(Indexable.Aef[Error], acc)` adds nothing
+    */
+  def collectAtoms(t: Type, acc: mutable.HashSet[EffAtom])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
+    case Type.Var(sym, _) if renv.isRigid(sym) => acc += EffAtom.VarRigid(sym)
+    case Type.Var(sym, _) => acc += EffAtom.VarFlex(sym)
+    case Type.Cst(TypeConstructor.Effect(sym, _), _) => acc += EffAtom.Eff(sym)
+    case Type.Cst(TypeConstructor.Region(sym), _) => acc += EffAtom.Region(sym)
+    case Type.Cst(TypeConstructor.Error(id, _), _) => acc += EffAtom.Error(id)
+    case Type.Apply(tpe1, tpe2, _) =>
+      collectAtoms(tpe1, acc)
+      collectAtoms(tpe2, acc)
+    case Type.Alias(_, _, tpe, _) => collectAtoms(tpe, acc)
+    case assoc@Type.AssocType(_, _, _, _) => getAssocAtoms(assoc).foreach(acc += _)
+    case _ => ()
+  }
+
+  /**
+    * Returns the [[EffAtom]] of `t` if it is a valid associated [[EffAtom]] (according to
+    * [[EffAtom.assocFromType]]). Invalid or unrelated types return [[None]].
+    */
+  private def getAssocAtoms(t: Type)(implicit scope: RegionScope, renv: RigidityEnv): Option[EffAtom] = t match {
+    case Type.Var(sym, _) if renv.isRigid(sym) => Some(EffAtom.VarRigid(sym))
+    case Type.AssocType(AssocTypeSymUse(sym, _), arg, _, _) =>
+      getAssocAtoms(arg).map(EffAtom.Assoc(sym, _))
+    case Type.Alias(_, _, tpe, _) => getAssocAtoms(tpe)
+    case _ => None
+  }
+
+  /**
+    * Returns the [[Type]] represented by `atom` with location `loc`. The kind of errors and
+    * associated types are set to be [[Kind.Eff]].
+    */
+  def toType(atom: EffAtom, loc: SourceLocation): Type = atom match {
+    case EffAtom.Eff(sym) => Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc)
+    case EffAtom.Region(sym) => Type.Cst(TypeConstructor.Region(sym), loc)
+    case EffAtom.VarRigid(sym) => Type.Var(sym, loc)
+    case EffAtom.VarFlex(sym) => Type.Var(sym, loc)
+    case EffAtom.Assoc(sym, arg0) =>
+      Type.AssocType(AssocTypeSymUse(sym, loc), toType(arg0, loc), Kind.Eff, loc)
+    case EffAtom.Error(id) => Type.Cst(TypeConstructor.Error(id, Kind.Eff), loc)
+  }
+}
+
+/**
+  * An exception used for partial functions that convert [[Type]] into [[EffAtom]].
+  *
+  * This exception should not leak outside this phase - it should always be caught. It is used to
+  * avoid having [[Option]] types on recursive functions.
+  */
+private case class InvalidType(tpe: Type) extends RuntimeException

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
@@ -17,8 +17,7 @@ package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.api.{Flix, FlixEvent}
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
-import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
-import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint.Provenance
 import ca.uwaterloo.flix.language.phase.unification.PreEffUnification.PreSolveResult
@@ -27,9 +26,6 @@ import ca.uwaterloo.flix.language.phase.unification.set.{Equation, SetFormula, S
 import ca.uwaterloo.flix.language.phase.unification.shared.CofiniteIntSet
 import ca.uwaterloo.flix.language.phase.unification.zhegalkin.{Zhegalkin, ZhegalkinAlgebra}
 import ca.uwaterloo.flix.util.{ChaosMonkey, InternalCompilerException, Result}
-
-import scala.annotation.tailrec
-import scala.collection.mutable
 
 object EffUnification3 {
 
@@ -164,11 +160,11 @@ object EffUnification3 {
     case Type.Pure => SetFormula.Empty
 
     case tpe@Type.Var(_, _) =>
-      val atom = Atom.fromType(tpe)
+      val atom = EffAtom.fromType(tpe)
       val x = m.getForwardIndex(atom)
       if (x < 0) throw InternalCompilerException(s"Unexpected unbound type variable: '$tpe'.", tpe.loc)
       atom match {
-        case Atom.VarFlex(sym) =>
+        case EffAtom.VarFlex(sym) =>
           if (sym.isSlack && !withSlack) {
             // Special Case: We have a slack variable and we want to ignore it. Return the empty set.
             SetFormula.Empty
@@ -176,27 +172,27 @@ object EffUnification3 {
             // General Case: A flexible type variable is a real Set variable.
             SetFormula.Var(x)
           }
-        case Atom.VarRigid(_) => SetFormula.Cst(x) // A rigid variable is a constant.
+        case EffAtom.VarRigid(_) => SetFormula.Cst(x) // A rigid variable is a constant.
         case _ => throw InternalCompilerException(s"Unexpected atom representation ($atom) of variable ($tpe)", tpe.loc)
       }
 
     case tpe@Type.Cst(TypeConstructor.Effect(_, _), _) =>
-      val x = m.getForwardIndex(Atom.fromType(tpe))
+      val x = m.getForwardIndex(EffAtom.fromType(tpe))
       if (x < 0) throw InternalCompilerException(s"Unexpected unbound effect: '$tpe'.", tpe.loc)
       SetFormula.mkElemSet(x)
 
     case tpe@Type.Cst(TypeConstructor.Region(_), _) =>
-      val x = m.getForwardIndex(Atom.fromType(tpe))
+      val x = m.getForwardIndex(EffAtom.fromType(tpe))
       if (x < 0) throw InternalCompilerException(s"Unexpected unbound effect: '$tpe'.", tpe.loc)
       SetFormula.mkElemSet(x)
 
     case tpe@Type.AssocType(_, _, _, _) =>
-      val x = m.getForwardIndex(Atom.fromType(tpe))
+      val x = m.getForwardIndex(EffAtom.fromType(tpe))
       if (x < 0) throw InternalCompilerException(s"Unexpected unbound associated type: '$tpe'.", tpe.loc)
       SetFormula.Cst(x)
 
     case tpe@Type.Cst(TypeConstructor.Error(_, _), _) =>
-      val x = m.getForwardIndex(Atom.fromType(tpe))
+      val x = m.getForwardIndex(EffAtom.fromType(tpe))
       if (x < 0) throw InternalCompilerException(s"Unexpected unbound error type: '$tpe'.", tpe.loc)
       SetFormula.Var(x)
 
@@ -228,7 +224,7 @@ object EffUnification3 {
       case (macc, (k, SetFormula.Var(x))) if k == x => macc
       case (macc, (k, v)) =>
         m.getBackward(k) match {
-          case Some(Atom.VarFlex(sym)) =>
+          case Some(EffAtom.VarFlex(sym)) =>
             // A proper var. Add it to the substitution.
             if (sym.isSlack && !withSlack) {
               // Special Case: The slack variable was set to the empty set.
@@ -238,7 +234,7 @@ object EffUnification3 {
               macc + (sym -> fromSetFormula(v, sym.loc))
             }
 
-          case Some(Atom.Error(_)) =>
+          case Some(EffAtom.Error(_)) =>
             // An error type. Don't add it to the substitution.
             macc
 
@@ -279,16 +275,16 @@ object EffUnification3 {
     case SetFormula.Univ => Type.Univ
     case SetFormula.Empty => Type.Pure
     case SetFormula.Cst(c) => m.getBackward(c) match {
-      case Some(atom) => Atom.toType(atom, loc)
+      case Some(atom) => EffAtom.toType(atom, loc)
       case None => throw InternalCompilerException(s"Unexpected unbound constant identifier '$c'", loc)
     }
     case SetFormula.Var(x) => m.getBackward(x) match {
-      case Some(atom) => Atom.toType(atom, loc)
+      case Some(atom) => EffAtom.toType(atom, loc)
       case None => throw InternalCompilerException(s"Unexpected unbound variable identifier '$x'", loc)
     }
     case SetFormula.ElemSet(s) =>
       val elementTypes = s.toList.map(e => m.getBackward(e) match {
-        case Some(atom) => Atom.toType(atom, loc)
+        case Some(atom) => EffAtom.toType(atom, loc)
         case None => throw InternalCompilerException(s"Unexpected unbound element identifier '$e'", loc)
       })
       Type.mkUnion(elementTypes, loc)
@@ -302,132 +298,6 @@ object EffUnification3 {
 
     case SetFormula.Xor(other) =>
       Type.mkSymmetricDiff(other.map(fromSetFormula(_, loc)), loc)
-  }
-
-  /**
-    * Atomic effects that can be represented as atoms in [[SetFormula]]. Atomic effects are
-    * variables, effects, errors, or simple associated effects, described in the grammar below.
-    *
-    * atom ::= VarFlex | VarRigid | Eff | Error | atomAssoc
-    * atomAssoc ::= Assoc atomAssoc | VarRigid
-    */
-  private[unification] sealed trait Atom extends Ordered[Atom] {
-    override def compare(that: Atom): Int = (this, that) match {
-      case (Atom.VarFlex(sym1), Atom.VarFlex(sym2)) => sym1.id - sym2.id
-      case (Atom.VarRigid(sym1), Atom.VarRigid(sym2)) => sym1.id - sym2.id
-      case (Atom.Eff(sym1), Atom.Eff(sym2)) => sym1.compare(sym2)
-      case (Atom.Region(sym1), Atom.Region(sym2)) => sym1.compare(sym2)
-      case (Atom.Assoc(sym1, arg1), Atom.Assoc(sym2, arg2)) =>
-        val symCmp = sym1.compare(sym2)
-        if (symCmp != 0) symCmp else arg1.compare(arg2)
-      case (Atom.Error(id1), Atom.Error(id2)) => id1 - id2
-      case _ =>
-        def ordinal(a: Atom): Int = a match {
-          case Atom.VarFlex(_) => 0
-          case Atom.VarRigid(_) => 1
-          case Atom.Region(_) => 2
-          case Atom.Eff(_) => 3
-          case Atom.Assoc(_, _) => 4
-          case Atom.Error(_) => 5
-        }
-
-        ordinal(this) - ordinal(that)
-    }
-  }
-
-  private[unification] object Atom {
-    /** Representing a flexible variable. */
-    case class VarFlex(sym: Symbol.KindedTypeVarSym) extends Atom
-
-    /** Representing a rigid variable. */
-    case class VarRigid(sym: Symbol.KindedTypeVarSym) extends Atom
-
-    /** Representing an effect constant. */
-    case class Eff(sym: Symbol.EffSym) extends Atom
-
-    /** Represents an associated effect. */
-    case class Assoc(sym: Symbol.AssocTypeSym, arg: Atom) extends Atom
-
-    /** Represents a region. */
-    case class Region(sym: Symbol.RegionSym) extends Atom
-
-    /** Represents an error type. */
-    case class Error(id: Int) extends Atom
-
-    /** Returns the [[Atom]] representation of `t` or throws [[InvalidType]]. */
-    @tailrec
-    def fromType(t: Type)(implicit scope: RegionScope, renv: RigidityEnv): Atom = t match {
-      case Type.Var(sym, _) if renv.isRigid(sym) => Atom.VarRigid(sym)
-      case Type.Var(sym, _) => Atom.VarFlex(sym)
-      case Type.Cst(TypeConstructor.Effect(sym, _), _) => Atom.Eff(sym)
-      case Type.Cst(TypeConstructor.Region(sym), _) => Atom.Region(sym)
-      case assoc@Type.AssocType(_, _, _, _) => assocFromType(assoc)
-      case Type.Cst(TypeConstructor.Error(id, _), _) => Atom.Error(id)
-      case Type.Alias(_, _, tpe, _) => fromType(tpe)
-      case _ => throw InvalidType(t)
-    }
-
-    /** Returns the [[Atom]] representation of `t` or throws [[InvalidType]]. */
-    private def assocFromType(t: Type)(implicit scope: RegionScope, renv: RigidityEnv): Atom = t match {
-      case Type.Var(sym, _) if renv.isRigid(sym) => Atom.VarRigid(sym)
-      case Type.AssocType(AssocTypeSymUse(sym, _), arg, _, _) => Atom.Assoc(sym, assocFromType(arg))
-      case Type.Alias(_, _, tpe, _) => assocFromType(tpe)
-      case _ => throw InvalidType(t)
-    }
-
-    /**
-      * Adds the valid [[Atom]]s that occur in `t` (according to [[Atom.fromType]]) to `acc`.
-      * Invalid or unrelated types are ignored.
-      *
-      * The validity of atoms are checked top-down, so even though `MyTrait.MyType[x]` is a valid
-      * atom where `x` is rigid, `collectAtoms(MyTrait.MyType[MyTrait.MyType[x] ∪ IO], acc)` will
-      * add nothing since the outermost associated type is not valid. This behaviour aligns with
-      * the needs of [[toSetFormula]].
-      *
-      * Examples:
-      *   - `collectAtoms(Crash ∪ ef, acc)` adds `Eff(Crash)` and `VarFlex(ef)` (if
-      *     [[RigidityEnv.isRigid]] is false for `ef`)
-      *   - `collectAtoms(Indexable.Aef[Error], acc)` adds nothing
-      */
-    def collectAtoms(t: Type, acc: mutable.HashSet[Atom])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
-      case Type.Var(sym, _) if renv.isRigid(sym) => acc += Atom.VarRigid(sym)
-      case Type.Var(sym, _) => acc += Atom.VarFlex(sym)
-      case Type.Cst(TypeConstructor.Effect(sym, _), _) => acc += Atom.Eff(sym)
-      case Type.Cst(TypeConstructor.Region(sym), _) => acc += Atom.Region(sym)
-      case Type.Cst(TypeConstructor.Error(id, _), _) => acc += Atom.Error(id)
-      case Type.Apply(tpe1, tpe2, _) =>
-        collectAtoms(tpe1, acc)
-        collectAtoms(tpe2, acc)
-      case Type.Alias(_, _, tpe, _) => collectAtoms(tpe, acc)
-      case assoc@Type.AssocType(_, _, _, _) => getAssocAtoms(assoc).foreach(acc += _)
-      case _ => ()
-    }
-
-    /**
-      * Returns the [[Atom]] of `t` if it is a valid associated [[Atom]] (according to
-      * [[Atom.assocFromType]]). Invalid or unrelated types return [[None]].
-      */
-    private def getAssocAtoms(t: Type)(implicit scope: RegionScope, renv: RigidityEnv): Option[Atom] = t match {
-      case Type.Var(sym, _) if renv.isRigid(sym) => Some(Atom.VarRigid(sym))
-      case Type.AssocType(AssocTypeSymUse(sym, _), arg, _, _) =>
-        getAssocAtoms(arg).map(Atom.Assoc(sym, _))
-      case Type.Alias(_, _, tpe, _) => getAssocAtoms(tpe)
-      case _ => None
-    }
-
-    /**
-      * Returns the [[Type]] represented by `atom` with location `loc`. The kind of errors and
-      * associated types are set to be [[Kind.Eff]].
-      */
-    def toType(atom: Atom, loc: SourceLocation)(implicit m: AtomBimap): Type = atom match {
-      case Atom.Eff(sym) => Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc)
-      case Atom.Region(sym) => Type.Cst(TypeConstructor.Region(sym), loc)
-      case Atom.VarRigid(sym) => Type.Var(sym, loc)
-      case Atom.VarFlex(sym) => Type.Var(sym, loc)
-      case Atom.Assoc(sym, arg0) =>
-        Type.AssocType(AssocTypeSymUse(sym, loc), toType(arg0, loc), Kind.Eff, loc)
-      case Atom.Error(id) => Type.Cst(TypeConstructor.Error(id, Kind.Eff), loc)
-    }
   }
 
   /**
@@ -461,13 +331,4 @@ object EffUnification3 {
       // The type is invalid. We cannot simplify it.
       tpe
   }
-
-  /**
-    * An exception used for partial functions that convert [[Type]] into [[Atom]].
-    *
-    * This exception should not leak outside this phase - it should always be caught. It is used to
-    * avoid having [[Option]] types on recursive functions.
-    */
-  private case class InvalidType(tpe: Type) extends RuntimeException
-
 }


### PR DESCRIPTION
## Motivation

After #12824, `AtomBimap.scala` referenced the nested `EffUnification3.Atom`, which forced the `private[unification]` qualifier on a nested type. Extracting the atom representation into its own file gives the package a cleaner shape — `EffUnification3` (the algorithm), `EffAtom` (the representation), `AtomBimap` (the numbering) — with plain package-private visibility throughout.

## Change

- Move the nested `Atom` trait/companion and `InvalidType` out of `object EffUnification3` into a new top-level `EffAtom` in `EffAtom.scala`, renamed since bare `Atom` is heavily overloaded in the codebase (Datalog predicate `Atom`s in every AST; `CaseSetUnification` has its own nested `Atom` in the same package).
- As top-level package-private definitions, `EffAtom` and `InvalidType` need no `private[unification]` qualifier, and `AtomBimap` no longer imports a nested type from `EffUnification3`.
- Drop the unused `implicit AtomBimap` parameter on `toType` (never used in the body; would otherwise make `EffAtom.scala` depend on `AtomBimap`).
- Remove four now-unused imports from `EffUnification3`. Bodies are otherwise unchanged — no behavior change.

## Verification

Full test suite passes: 16,575/16,575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)