### PR TITLE
feat: profile instance-method typing and kinding

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -253,7 +253,7 @@ object Kinder {
           visitEqualityConstraint(symUse, arg, tpe2, loc, kenv, root)
       }
       val assocs = assocs0.map(visitAssocTypeDef(_, kind, kenv, root))
-      val defs = defs0.map(visitDef(_, kenv, root))
+      val defs = defs0.map(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn, kenv, root)))
       KindedAst.Instance(doc, ann, mod, symUse, tparams, t, tconstrs, econstrs, assocs, defs, ns, loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -308,11 +308,13 @@ object Typer {
 
       val defs = defs0.map {
         defn =>
-          // SUB-EFFECTING: Check if sub-effecting is enabled for instance-level defs.
-          // If no effect is specified, we assume the function is pure
-          val eff1 = defn.spec.eff.getOrElse(Type.Pure)
-          val open = shouldSubeffect(eff1, Subeffecting.InsDefs)
-          visitDef(defn, tconstrs, econstrs, renv, root, traitEnv, eqEnv, open)
+          flix.profile(defn.sym, defn.loc) {
+            // SUB-EFFECTING: Check if sub-effecting is enabled for instance-level defs.
+            // If no effect is specified, we assume the function is pure
+            val eff1 = defn.spec.eff.getOrElse(Type.Pure)
+            val open = shouldSubeffect(eff1, Subeffecting.InsDefs)
+            visitDef(defn, tconstrs, econstrs, renv, root, traitEnv, eqEnv, open)
+          }
       }
       val typedEconstrs = econstrs.map(ec => TypedAst.EqualityConstraint(Type.AssocType(ec.symUse, ec.tpe1, ec.tpe2.kind, ec.loc), ec.tpe2, ec.loc))
       TypedAst.Instance(doc, ann, mod, symUse, tparams, tpe, tconstrs, typedEconstrs, assocs, defs, ns, loc)


### PR DESCRIPTION
## What

Wrap the per-instance-def `visitDef` calls in `flix.profile` in both `Typer.visitInstance` (`Typer.scala:309`) and `Kinder.visitInstance` (`Kinder.scala:256`).

## Why

The per-`DefnSym` compiler profiler (`compilertop`) attributes time via `flix.profile(sym, loc)(...)`, but every instrumented frontend phase only wraps `root.defs`. Instance method bodies live in `root.instances`, so in the frontend their Kinder/Typer time was unattributed — absorbed into the coarse `phaseTimers` total rather than appearing in the per-def table. For stdlib-heavy programs (lots of `Eq`/`Order`/`ToString` instances) that is a large, invisible slice.

Backend phases already cover instance methods, because monomorphization specializes them into `root.defs`. This change closes the frontend gap.

## Notes

- Pure instrumentation wrap — `flix.profile` is a no-op when no profiler is installed, so there is no behavior change to compilation.
- Both `visitInstance` methods already have `flix` in implicit scope and the instance defs carry their own `sym`/`loc`; no new plumbing.
- The existing `Profiler.DefnSymWithLoc` keying keeps each instance method in its own table row instead of collapsing.
- Trait signatures and laws remain unattributed (sigs are `SigSym`-keyed and would need a profiler key generalization); left for a follow-up.

## Verification

- `./mill flix.compile` — clean.
- `./mill flix.run out/empty.flix` — standard library compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)