### PR TITLE
feat: profile def resolution in Resolver

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -473,10 +473,12 @@ object Resolver {
     */
   private def resolveDef(d0: NamedAst.Declaration.Def, tconstr: Option[ResolvedAst.TraitConstraint], scp0: LocalScope)(implicit ns0: Name.NName, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): ResolvedAst.Declaration.Def = d0 match {
     case NamedAst.Declaration.Def(sym, spec0, exp0, loc) =>
-      val spec = resolveSpec(spec0, tconstr, scp0, taenv, ns0, root)
-      val scp = scp0 ++ mkSpecScp(spec)
-      val exp = resolveExp(exp0, scp)(RegionScope.Top, ns0, taenv, sctx, root, flix)
-      ResolvedAst.Declaration.Def(sym, spec, exp, loc)
+      flix.profile(sym, loc) {
+        val spec = resolveSpec(spec0, tconstr, scp0, taenv, ns0, root)
+        val scp = scp0 ++ mkSpecScp(spec)
+        val exp = resolveExp(exp0, scp)(RegionScope.Top, ns0, taenv, sctx, root, flix)
+        ResolvedAst.Declaration.Def(sym, spec, exp, loc)
+      }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
@@ -47,7 +47,7 @@ import scala.jdk.CollectionConverters.*
   * | Weeder2            | No           | -- same --                                                                                                    |
   * | Desugar            | No           | -- same --                                                                                                    |
   * | Namer              | No           | -- same --                                                                                                    |
-  * | Resolver           | No           | Per-def work is nested inside trait/instance walks rather than a clean `parMapValues` over `root.defs`.       |
+  * | Resolver           | Yes          | `resolveDef` chokepoint covers module, instance, and trait-law defs; sigs (no `DefnSym`) excluded.               |
   * | Deriver            | No           | Generates new instances from enum derivations; iterates over enums, not existing defs.                        |
   * | Instances          | No           | Per-instance-def work interleaves with trait conformance checks; instrumentable but not a one-line wrap.      |
   * | Kinder             | Yes          | `visitDefSpecs` + `visitDefs`.                                                                                |


### PR DESCRIPTION
## What

Wrap the body of `resolveDef` (`Resolver.scala:475`) in `flix.profile(sym, loc)`.

## Why

Resolver was the largest frontend phase with **no** per-`DefnSym` profiling in the `compilertop` table. Its per-def work is nested inside the recursive declaration walk (`visitUnit` → `visitDecl` → `resolve*`) rather than a clean `parMapValues(root.defs)`, so there was no wrap point and the whole phase was invisible in the per-def view.

`resolveDef` is the single chokepoint through which all def resolution flows, so one wrap attributes Resolver time for:
- **module defs** (`visitDecl:358`)
- **instance methods** (`resolveInstance:448`)
- **trait laws** (`resolveTrait:425`)

each keyed by its own `DefnSym`. This is a direct follow-up to the Kinder/Typer instance-method profiling in #12826.

## Notes

- Pure instrumentation wrap — `flix.profile` is a no-op when no profiler is installed, so there is no behavior change.
- Trait **signatures** stay excluded: they are `SigSym`-keyed and `resolveSig` cannot use the `DefnSym` key. Generalizing the profiler key to cover sigs is tracked separately.
- `resolveExp` handles nested local defs internally, so there is no nested `resolveDef`; the profiler's in-flight CAS would handle it regardless.
- Updated the coverage table in `Profiler.scala` (Resolver: No → Yes).

## Verification

- `./mill flix.compile` — clean.
- `./mill flix.run out/empty.flix` — standard library compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)