### PR TITLE
feat: add observed-coverage figure to compilertop TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -15,6 +15,7 @@
  */
 package ca.uwaterloo.flix.tools.compilertop
 
+import ca.uwaterloo.flix.api.PhaseTime
 import ca.uwaterloo.flix.tools.compilertop.Formatting.lineCount
 import ca.uwaterloo.flix.tools.compilertop.Model.*
 import ca.uwaterloo.flix.tools.compilertop.Profiler.DefnStats
@@ -56,6 +57,38 @@ object Aggregation {
   /** Sums `byPhaseCount` entries for the given phase set. */
   def sumPhaseCounts(byPhaseCount: Map[String, Long], phases: Set[String]): Long =
     byPhaseCount.iterator.collect { case (p, n) if phases.contains(p) => n }.sum
+
+  /**
+    * Splits attributable phase wall time into accounted vs unaccounted for the
+    * dashboard coverage line — see [[Model.Coverage]] for the semantics and
+    * the why-not-subtract-thread-time caveat.
+    *
+    * A phase is accounted if *any* def recorded time in it. Phases in
+    * [[Model.NonAttributablePhases]] are dropped entirely (they have no per-def
+    * unit), so what remains in `unaccounted` is only closeable blind spots.
+    * Phase wall times are summed by name first, since a phase can run more than
+    * once (e.g. `OccurrenceAnalyzer` / `Inliner` across optimizer rounds). The
+    * unknown-phase bucket `"?"` never appears as a real phase-timer entry, so it
+    * can't leak in.
+    */
+  def computeCoverage(snapshot: Vector[DefnStats], phaseTimers: Vector[PhaseTime]): Coverage = {
+    val accounted = snapshot.iterator.flatMap(_.byPhase.iterator.collect { case (p, n) if n > 0L => p }).toSet
+
+    val wallByPhase = phaseTimers.foldLeft(Map.empty[String, Long]) {
+      case (acc, pt) => acc.updated(pt.phase, acc.getOrElse(pt.phase, 0L) + pt.time)
+    }
+
+    var accountedNanos = 0L
+    var unaccountedNanos = 0L
+    var uncovered = List.empty[(String, Long)]
+    wallByPhase.foreach {
+      case (phase, _) if NonAttributablePhases.contains(phase) => // excluded: no per-def unit
+      case (phase, wall) =>
+        if (accounted.contains(phase)) accountedNanos += wall
+        else { unaccountedNanos += wall; uncovered ::= (phase -> wall) }
+    }
+    Coverage(accountedNanos, unaccountedNanos, uncovered.sortBy { case (_, w) => -w })
+  }
 
   /**
     * Returns the descending sort key for a def under the given sort mode.

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -60,7 +60,7 @@ object Aggregation {
 
   /**
     * Splits attributable phase wall time into accounted vs unaccounted for the
-    * dashboard coverage line — see [[Model.Coverage]] for the semantics and
+    * dashboard `tracked` figure — see [[Model.Coverage]] for the semantics and
     * the why-not-subtract-thread-time caveat.
     *
     * A phase is accounted if *any* def recorded time in it. Phases in
@@ -80,14 +80,13 @@ object Aggregation {
 
     var accountedNanos = 0L
     var unaccountedNanos = 0L
-    var uncovered = List.empty[(String, Long)]
     wallByPhase.foreach {
       case (phase, _) if NonAttributablePhases.contains(phase) => // excluded: no per-def unit
       case (phase, wall) =>
         if (accounted.contains(phase)) accountedNanos += wall
-        else { unaccountedNanos += wall; uncovered ::= (phase -> wall) }
+        else unaccountedNanos += wall
     }
-    Coverage(accountedNanos, unaccountedNanos, uncovered.sortBy { case (_, w) => -w })
+    Coverage(accountedNanos, unaccountedNanos)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -60,23 +60,34 @@ object Aggregation {
 
   /**
     * Splits attributable phase wall time into accounted vs unaccounted for the
-    * dashboard `tracked` figure — see [[Model.Coverage]] for the semantics and
-    * the why-not-subtract-thread-time caveat.
+    * dashboard `observed` figure — see [[Model.Coverage]] for the semantics.
     *
-    * A phase is accounted if *any* def recorded time in it. Phases in
-    * [[Model.NonAttributablePhases]] are dropped entirely (they have no per-def
-    * unit), so what remains in `unaccounted` is only closeable blind spots.
-    * Phase wall times are summed by name first, since a phase can run more than
-    * once (e.g. `OccurrenceAnalyzer` / `Inliner` across optimizer rounds). The
-    * unknown-phase bucket `"?"` never appears as a real phase-timer entry, so it
-    * can't leak in.
+    * For each phase we estimate how much of its wall slice the per-def table
+    * actually attributes: the thread-summed per-def time spread across `par`
+    * threads, i.e. `attributedWall ≈ threadSummed / par`, clamped to the phase
+    * wall. This *optimistically assumes full parallelism* — accurate for a
+    * saturated parallel phase (where `threadSummed ≈ par × wall`), but it
+    * under-counts a sequential phase (which ran on one thread, yet is divided by
+    * `par`), so such a phase reads as a partial blind spot even when fully
+    * instrumented.
+    *
+    * Phase wall and per-def times are summed by name first, since a phase can
+    * run more than once (e.g. `OccurrenceAnalyzer` / `Inliner` across optimizer
+    * rounds). Phases in [[Model.NonAttributablePhases]] are dropped entirely
+    * (they have no per-def unit). The unknown-phase bucket `"?"` never appears
+    * as a real phase-timer entry, so it can't leak in.
     *
     * Scoped to the active filter `f` via [[matchesFilter]] — the same predicate
     * the def table uses — so the figure covers exactly the phases the visible
     * table covers (e.g. under `Frontend` only `FrontendPhases` count).
     */
-  def computeCoverage(snapshot: Vector[DefnStats], phaseTimers: Vector[PhaseTime], f: PhaseFilter): Coverage = {
-    val accounted = snapshot.iterator.flatMap(_.byPhase.iterator.collect { case (p, n) if n > 0L => p }).toSet
+  def computeCoverage(snapshot: Vector[DefnStats], phaseTimers: Vector[PhaseTime], f: PhaseFilter, par: Int): Coverage = {
+    val threads = par.max(1)
+
+    // Thread-summed per-def time attributed to each phase.
+    val attributedByPhase = snapshot.foldLeft(Map.empty[String, Long]) {
+      case (acc, s) => s.byPhase.foldLeft(acc) { case (m, (p, n)) => m.updated(p, m.getOrElse(p, 0L) + n) }
+    }
 
     val wallByPhase = phaseTimers.foldLeft(Map.empty[String, Long]) {
       case (acc, pt) => acc.updated(pt.phase, acc.getOrElse(pt.phase, 0L) + pt.time)
@@ -88,8 +99,10 @@ object Aggregation {
       case (phase, _) if !matchesFilter(phase, f)              => // outside the active filter's phases
       case (phase, _) if NonAttributablePhases.contains(phase) => // excluded: no per-def unit
       case (phase, wall) =>
-        if (accounted.contains(phase)) accountedNanos += wall
-        else unaccountedNanos += wall
+        // Optimistically assume full parallelism: thread-summed time / threads.
+        val attributedWall = (attributedByPhase.getOrElse(phase, 0L) / threads).min(wall)
+        accountedNanos += attributedWall
+        unaccountedNanos += wall - attributedWall
     }
     Coverage(accountedNanos, unaccountedNanos)
   }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -70,8 +70,12 @@ object Aggregation {
     * once (e.g. `OccurrenceAnalyzer` / `Inliner` across optimizer rounds). The
     * unknown-phase bucket `"?"` never appears as a real phase-timer entry, so it
     * can't leak in.
+    *
+    * Scoped to the active filter `f` via [[matchesFilter]] — the same predicate
+    * the def table uses — so the figure covers exactly the phases the visible
+    * table covers (e.g. under `Frontend` only `FrontendPhases` count).
     */
-  def computeCoverage(snapshot: Vector[DefnStats], phaseTimers: Vector[PhaseTime]): Coverage = {
+  def computeCoverage(snapshot: Vector[DefnStats], phaseTimers: Vector[PhaseTime], f: PhaseFilter): Coverage = {
     val accounted = snapshot.iterator.flatMap(_.byPhase.iterator.collect { case (p, n) if n > 0L => p }).toSet
 
     val wallByPhase = phaseTimers.foldLeft(Map.empty[String, Long]) {
@@ -81,6 +85,7 @@ object Aggregation {
     var accountedNanos = 0L
     var unaccountedNanos = 0L
     wallByPhase.foreach {
+      case (phase, _) if !matchesFilter(phase, f)              => // outside the active filter's phases
       case (phase, _) if NonAttributablePhases.contains(phase) => // excluded: no per-def unit
       case (phase, wall) =>
         if (accounted.contains(phase)) accountedNanos += wall

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -41,12 +41,12 @@ object CompilerTop {
 
 
   /**
-    * Fixed-overhead rows: blank + 2 dashboard/stats lines + blank +
-    * 2 table-chrome (header + divider) + 1 cursor-parking row. Only one
+    * Fixed-overhead rows: blank + 2 dashboard/stats lines + 1 coverage line +
+    * blank + 2 table-chrome (header + divider) + 1 cursor-parking row. Only one
     * table is visible at a time now, so there is no second-table chrome to
     * reserve.
     */
-  private val ChromeRows: Int = 7
+  private val ChromeRows: Int = 8
 
   /**
     * Reserved breathing room below the rendered view, on top of the
@@ -344,11 +344,16 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     // Only build the rows the active view actually renders: the def list when
     // on Defs / Help, the module aggregate when on Modules. `snap` is computed
     // either way since module aggregation rolls up from it.
-    val snap = applyFilter(profiler.snapshot(), activeFilter).sortBy(s => -defSortKey(s, activeSort))
+    val raw = profiler.snapshot()
+    val snap = applyFilter(raw, activeFilter).sortBy(s => -defSortKey(s, activeSort))
     val visible = if (activeView == View.Modules) Vector.empty else snap.take(tableRows)
     val modules = if (activeView == View.Modules) aggregateByModule(snap, activeSort).take(tableRows) else Vector.empty
 
-    FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, activeView, layout, visible, modules)
+    // Coverage is computed from the unfiltered snapshot so the accounted /
+    // unaccounted split is independent of the active phase filter.
+    val coverage = computeCoverage(raw, flix.phaseTimers.toVector)
+
+    FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, activeView, layout, visible, modules, coverage)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -349,9 +349,10 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     val visible = if (activeView == View.Modules) Vector.empty else snap.take(tableRows)
     val modules = if (activeView == View.Modules) aggregateByModule(snap, activeSort).take(tableRows) else Vector.empty
 
-    // Coverage is computed from the unfiltered snapshot so the accounted /
-    // unaccounted split is independent of the active phase filter.
-    val coverage = computeCoverage(raw, flix.phaseTimers.toVector)
+    // Coverage scopes to the active phase filter (via `matchesFilter`), so the
+    // tracked figure narrows to the same phases the visible table covers: press
+    // `f`/`b` and both the rows and the coverage % follow.
+    val coverage = computeCoverage(raw, flix.phaseTimers.toVector, activeFilter)
 
     FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, activeView, layout, visible, modules, coverage)
   }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -41,12 +41,12 @@ object CompilerTop {
 
 
   /**
-    * Fixed-overhead rows: blank + 2 dashboard/stats lines + 1 coverage line +
-    * blank + 2 table-chrome (header + divider) + 1 cursor-parking row. Only one
+    * Fixed-overhead rows: blank + 2 dashboard/stats lines + blank +
+    * 2 table-chrome (header + divider) + 1 cursor-parking row. Only one
     * table is visible at a time now, so there is no second-table chrome to
     * reserve.
     */
-  private val ChromeRows: Int = 8
+  private val ChromeRows: Int = 7
 
   /**
     * Reserved breathing room below the rendered view, on top of the

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -350,9 +350,10 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     val modules = if (activeView == View.Modules) aggregateByModule(snap, activeSort).take(tableRows) else Vector.empty
 
     // Coverage scopes to the active phase filter (via `matchesFilter`), so the
-    // tracked figure narrows to the same phases the visible table covers: press
-    // `f`/`b` and both the rows and the coverage % follow.
-    val coverage = computeCoverage(raw, flix.phaseTimers.toVector, activeFilter)
+    // observed figure narrows to the same phases the visible table covers: press
+    // `f`/`b` and both the rows and the coverage % follow. `parallelism` divides
+    // the thread-summed per-def time into an estimated attributed wall slice.
+    val coverage = computeCoverage(raw, flix.phaseTimers.toVector, activeFilter, parallelism)
 
     FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, activeView, layout, visible, modules, coverage)
   }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -187,7 +187,7 @@ object Model {
   }
 
   /**
-    * Phase-level wall-time reconciliation backing the dashboard coverage line.
+    * Phase-level wall-time reconciliation backing the dashboard `tracked` figure.
     *
     * The compiler runs its phases sequentially and `Flix.phaseTimers` records
     * each one's single-threaded wall time. A phase is *accounted* if the per-def
@@ -208,7 +208,6 @@ object Model {
     *
     * @param accountedNanos   summed wall time of phases with per-def attribution.
     * @param unaccountedNanos summed wall time of phases with none.
-    * @param uncovered        `(phase, wallNanos)` per unaccounted phase, descending by wall.
     */
-  final case class Coverage(accountedNanos: Long, unaccountedNanos: Long, uncovered: List[(String, Long)])
+  final case class Coverage(accountedNanos: Long, unaccountedNanos: Long)
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -96,6 +96,29 @@ object Model {
   )
 
   /**
+    * Phases that inherently have no per-`DefnSym` unit to attribute time to, so
+    * the dashboard coverage line excludes them from the accounted / unaccounted
+    * split rather than reporting their wall time as a (false) closeable blind
+    * spot. Three structural reasons, mirroring the coverage table in
+    * [[Profiler]]:
+    *
+    *   - Pre-naming passes (`Reader`, `Lexer`, `Parser2`, `Weeder2`, `Desugar`,
+    *     `Namer`) run before any `DefnSym` exists, so there is no key to attribute.
+    *   - Pure filter passes (`TreeShaker1`, `TreeShaker2`) do no per-def work.
+    *   - The `Optimizer` fixpoint wrapper does no work of its own; its time is
+    *     captured transitively through the `OccurrenceAnalyzer` / `Inliner` phases
+    *     it drives, so counting it here would be redundant.
+    *
+    * Phases that *could* be attributed but currently aren't (`Resolver`,
+    * `Deriver`, `Instances`) are deliberately NOT in this set — they are real,
+    * closeable blind spots and belong in the unaccounted tally.
+    */
+  val NonAttributablePhases: Set[String] = Set(
+    "Reader", "Lexer", "Parser2", "Weeder2", "Desugar", "Namer",
+    "TreeShaker1", "Optimizer", "TreeShaker2",
+  )
+
+  /**
     * Selects the descending sort key applied to the def and module tables.
     * Each option surfaces a different kind of suspect, so the same def can
     * top one ranking and not another.
@@ -162,4 +185,30 @@ object Model {
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
   }
+
+  /**
+    * Phase-level wall-time reconciliation backing the dashboard coverage line.
+    *
+    * The compiler runs its phases sequentially and `Flix.phaseTimers` records
+    * each one's single-threaded wall time. A phase is *accounted* if the per-def
+    * profiler attributed any time to it, and *unaccounted* otherwise — meaning
+    * its whole wall slice is invisible in the per-def and per-module tables.
+    *
+    * This split is intentionally binary (does the table see the phase *at all*),
+    * not a measure of how complete the attribution is: a partially-instrumented
+    * phase like CodeGen still reads as accounted. Crucially, we never subtract
+    * the profiler's thread-summed nanoseconds from the single-threaded phase wall
+    * time — within a parallel phase the former can exceed the latter several-fold,
+    * so the difference is not a meaningful "unattributed" quantity.
+    *
+    * Phases in [[NonAttributablePhases]] are excluded from both figures: they have
+    * no per-def unit by construction, so the denominator here is "attributable
+    * phase wall time", and `unaccounted` therefore reflects only closeable blind
+    * spots (e.g. `Instances`, `Deriver`).
+    *
+    * @param accountedNanos   summed wall time of phases with per-def attribution.
+    * @param unaccountedNanos summed wall time of phases with none.
+    * @param uncovered        `(phase, wallNanos)` per unaccounted phase, descending by wall.
+    */
+  final case class Coverage(accountedNanos: Long, unaccountedNanos: Long, uncovered: List[(String, Long)])
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -187,27 +187,29 @@ object Model {
   }
 
   /**
-    * Phase-level wall-time reconciliation backing the dashboard `tracked` figure.
+    * Phase-level wall-time reconciliation backing the dashboard `observed` figure.
     *
-    * The compiler runs its phases sequentially and `Flix.phaseTimers` records
-    * each one's single-threaded wall time. A phase is *accounted* if the per-def
-    * profiler attributed any time to it, and *unaccounted* otherwise — meaning
-    * its whole wall slice is invisible in the per-def and per-module tables.
+    * `Flix.phaseTimers` records each phase's wall time. For each phase we
+    * estimate the slice the per-def table attributes by spreading its
+    * thread-summed per-def time across the available threads:
+    * `attributedWall ≈ threadSummed / parallelism`, clamped to the phase wall.
+    * `accounted` sums those estimates; `unaccounted` is the remaining wall.
     *
-    * This split is intentionally binary (does the table see the phase *at all*),
-    * not a measure of how complete the attribution is: a partially-instrumented
-    * phase like CodeGen still reads as accounted. Crucially, we never subtract
-    * the profiler's thread-summed nanoseconds from the single-threaded phase wall
-    * time — within a parallel phase the former can exceed the latter several-fold,
-    * so the difference is not a meaningful "unattributed" quantity.
+    * The estimate *optimistically assumes full parallelism*. For a saturated
+    * parallel phase (`threadSummed ≈ parallelism × wall`) it recovers the true
+    * attributed wall, so a partially-instrumented parallel phase now reads as
+    * partially covered rather than fully covered. The flip side: a sequential
+    * phase ran on one thread yet is still divided by `parallelism`, so it is
+    * under-counted and reads as a partial blind spot even when fully
+    * instrumented — the unit mix (thread-summed ÷ threads vs single-threaded
+    * wall) is only exact at the parallel extreme.
     *
-    * Phases in [[NonAttributablePhases]] are excluded from both figures: they have
-    * no per-def unit by construction, so the denominator here is "attributable
-    * phase wall time", and `unaccounted` therefore reflects only closeable blind
-    * spots (e.g. `Instances`, `Deriver`).
+    * Phases in [[NonAttributablePhases]] are excluded entirely: they have no
+    * per-def unit by construction, so the denominator is "attributable phase
+    * wall time".
     *
-    * @param accountedNanos   summed wall time of phases with per-def attribution.
-    * @param unaccountedNanos summed wall time of phases with none.
+    * @param accountedNanos   summed estimated attributed wall across phases.
+    * @param unaccountedNanos summed remaining (unattributed) wall across phases.
     */
   final case class Coverage(accountedNanos: Long, unaccountedNanos: Long)
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -417,16 +417,13 @@ final class Renderer {
     sb.append(styleHeap(heapUsedField, heapRatio))
     sb.append(dim(" / "))
     sb.append(heapMaxField)
-    // Key hints, anchored to the right under the dashboard's filter legend.
-    // `<tab> to cycle` always reads gray — it's a standing hint, never the
-    // active mode. When help is the active view only the "? for help" tip
-    // carries the "active mode" signal (bold yellow); the filter legend goes
-    // plain because no filter is currently being applied to a visible table.
-    // The "?" itself is underlined to match the keystroke-underline convention
-    // used in the column headers and the filter legend.
+    // Align under the `[all|frontend|backend]` legend on the dashboard line above.
+    // When help is the active view, the tip carries the "active mode" signal
+    // (bold yellow) — the filter legend goes plain because no filter is
+    // currently being applied to a visible table. The "?" itself is underlined
+    // to match the keystroke-underline convention used in the column headers
+    // and the filter legend.
     sb.append("     ")
-    sb.append(color("<tab> to cycle", Gray))
-    sb.append("   ")
     val tipText = s"$UnderlineCode?$NoUnderlineCode for help"
     val tipStyled =
       if (state.activeView == View.Help) bold(color(tipText, Yellow))

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -41,6 +41,8 @@ import scala.collection.mutable
   *                        `"done"`, or `"starting"`).
   * @param phaseTimersSize raw `flix.phaseTimers.size`; the renderer caps to
   *                        [[Renderer.TotalPhases]] for the progress bar.
+  * @param coverage        accounted/unaccounted phase-wall split for the
+  *                        dashboard coverage line (see [[Model.Coverage]]).
   * @param activeFilter    user-toggled phase filter (drives the legend).
   * @param activeSort      user-toggled sort key (drives header underlines).
   * @param activeView      user-toggled top-level view: defs table, modules
@@ -65,7 +67,8 @@ final case class FrameState(parallelism: Int,
                             activeView: View,
                             layout: Layout,
                             visible: Vector[DefnStats],
-                            modules: Vector[ModuleStats])
+                            modules: Vector[ModuleStats],
+                            coverage: Coverage)
 
 object Renderer {
 
@@ -265,6 +268,7 @@ final class Renderer {
 
     renderDashboard(sb, state)
     renderStats(sb, state)
+    renderCoverage(sb, state)
     sb.append('\n')
 
     state.activeView match {
@@ -407,6 +411,47 @@ final class Renderer {
     sb.append(tipStyled)
     sb.append('\n')
   }
+
+  /**
+    * Coverage line: how much sequential phase wall-clock time lives in phases
+    * the per-def table attributes nothing to. `accounted` / `unaccounted` are
+    * percentages of total phase wall time, followed by the biggest unaccounted
+    * phases by their wall share so the user can see *where* the blind spots are
+    * (e.g. `Namer`, `Instances`). The unaccounted figure is colored by
+    * magnitude. Always emits exactly one line so the table below doesn't jump
+    * as phases complete; before any phase finishes it shows a placeholder.
+    *
+    * These percentages are wall-time, deliberately kept apart from the
+    * thread-summed `time` column in the tables — see [[Model.Coverage]].
+    */
+  private def renderCoverage(sb: StringBuilder, state: FrameState): Unit = {
+    val cov = state.coverage
+    val total = cov.accountedNanos + cov.unaccountedNanos
+    sb.append("  ")
+    if (total <= 0L) {
+      sb.append(dim("coverage  (awaiting attributable phases)"))
+      sb.append('\n')
+      return
+    }
+    val unaccPct = 100.0 * cov.unaccountedNanos / total
+    val accPct = 100.0 - unaccPct
+    sb.append(dim("accounted "))
+    sb.append(f"$accPct%5.1f%%")
+    sb.append(dim("   unaccounted "))
+    sb.append(styleUnaccounted(f"$unaccPct%5.1f%%", unaccPct))
+    if (cov.uncovered.nonEmpty) {
+      val parts = cov.uncovered.iterator.take(3).map {
+        case (phase, wall) => f"$phase ${100.0 * wall / total}%.0f%%"
+      }.mkString(" · ")
+      sb.append(dim("   "))
+      sb.append(dim(truncate(parts, (state.layout.totalWidth - 36).max(12))))
+    }
+    sb.append('\n')
+  }
+
+  /** Colors the unaccounted-percentage field: green when low, yellow mid, red high. */
+  private def styleUnaccounted(s: String, pct: Double): String =
+    if (pct >= 25.0) red(s) else if (pct >= 10.0) yellow(s) else green(s)
 
   /**
     * Prints the parametrized header row + the divider underneath it. The

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -42,7 +42,7 @@ import scala.collection.mutable
   * @param phaseTimersSize raw `flix.phaseTimers.size`; the renderer caps to
   *                        [[Renderer.TotalPhases]] for the progress bar.
   * @param coverage        accounted/unaccounted phase-wall split behind the
-  *                        stats-line `tracked` figure (see [[Model.Coverage]]).
+  *                        stats-line `observed` figure (see [[Model.Coverage]]).
   * @param activeFilter    user-toggled phase filter (drives the legend).
   * @param activeSort      user-toggled sort key (drives header underlines).
   * @param activeView      user-toggled top-level view: defs table, modules
@@ -368,20 +368,20 @@ final class Renderer {
     else        s"$DimCode$UnderlineCode$key$NoUnderlineCode$rest$Reset"
   }
 
-  /** Plain-text width of the tracked field, fixed so the stats line never reflows. */
-  private val TrackedFieldLen: Int = "tracked  --%".length
+  /** Plain-text width of the observed field, fixed so the stats line never reflows. */
+  private val ObservedFieldLen: Int = "observed  --%".length
 
   /**
-    * Stats line: a `tracked xx%` figure in the left gutter (under the current
+    * Stats line: an `observed xx%` figure in the left gutter (under the current
     * phase), then elapsed (right-aligned under `progress`) and heap
     * (right-aligned under `threads`).
     *
-    * `tracked` is the share of *attributable* phase wall time the per-def table
-    * actually sees — see [[Model.Coverage]]. It reads `--%` until the first
-    * attributable phase finishes so the field never jumps, and is colored by
-    * magnitude (green high / yellow mid / red low, since high coverage is good).
-    * This is wall-time, deliberately kept apart from the thread-summed `time`
-    * column in the tables.
+    * `observed` is the estimated share of *attributable* phase wall time the
+    * per-def table actually sees — see [[Model.Coverage]]. It reads `--%` until
+    * the first attributable phase finishes so the field never jumps, and is
+    * colored by magnitude (gray when healthy, then yellow, then red as coverage
+    * drops). This is wall-time, deliberately kept apart from the thread-summed
+    * `time` column in the tables.
     */
   private def renderStats(sb: StringBuilder, state: FrameState): Unit = {
     val (heapUsedMb, heapMaxMb) = state.heap
@@ -397,16 +397,16 @@ final class Renderer {
 
     val cov = state.coverage
     val covTotal = cov.accountedNanos + cov.unaccountedNanos
-    val trackedField =
-      if (covTotal <= 0L) dim("tracked  --%")
+    val observedField =
+      if (covTotal <= 0L) dim("observed  --%")
       else {
         val pct = 100.0 * cov.accountedNanos / covTotal
-        dim("tracked ") + styleTracked(f"$pct%3.0f%%", pct)
+        dim("observed ") + styleObserved(f"$pct%3.0f%%", pct)
       }
 
     sb.append("  ")
-    sb.append(trackedField)
-    sb.append(" " * (elapsedStartCol - 3 - TrackedFieldLen).max(1))
+    sb.append(observedField)
+    sb.append(" " * (elapsedStartCol - 3 - ObservedFieldLen).max(1))
     sb.append(dim("elapsed "))
     sb.append(elapsedField)
 

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -41,8 +41,8 @@ import scala.collection.mutable
   *                        `"done"`, or `"starting"`).
   * @param phaseTimersSize raw `flix.phaseTimers.size`; the renderer caps to
   *                        [[Renderer.TotalPhases]] for the progress bar.
-  * @param coverage        accounted/unaccounted phase-wall split for the
-  *                        dashboard coverage line (see [[Model.Coverage]]).
+  * @param coverage        accounted/unaccounted phase-wall split behind the
+  *                        stats-line `tracked` figure (see [[Model.Coverage]]).
   * @param activeFilter    user-toggled phase filter (drives the legend).
   * @param activeSort      user-toggled sort key (drives header underlines).
   * @param activeView      user-toggled top-level view: defs table, modules
@@ -268,7 +268,6 @@ final class Renderer {
 
     renderDashboard(sb, state)
     renderStats(sb, state)
-    renderCoverage(sb, state)
     sb.append('\n')
 
     state.activeView match {
@@ -369,9 +368,20 @@ final class Renderer {
     else        s"$DimCode$UnderlineCode$key$NoUnderlineCode$rest$Reset"
   }
 
+  /** Plain-text width of the tracked field, fixed so the stats line never reflows. */
+  private val TrackedFieldLen: Int = "tracked  --%".length
+
   /**
-    * Stats line: elapsed (right-aligned under `progress`) and heap
+    * Stats line: a `tracked xx%` figure in the left gutter (under the current
+    * phase), then elapsed (right-aligned under `progress`) and heap
     * (right-aligned under `threads`).
+    *
+    * `tracked` is the share of *attributable* phase wall time the per-def table
+    * actually sees — see [[Model.Coverage]]. It reads `--%` until the first
+    * attributable phase finishes so the field never jumps, and is colored by
+    * magnitude (green high / yellow mid / red low, since high coverage is good).
+    * This is wall-time, deliberately kept apart from the thread-summed `time`
+    * column in the tables.
     */
   private def renderStats(sb: StringBuilder, state: FrameState): Unit = {
     val (heapUsedMb, heapMaxMb) = state.heap
@@ -385,8 +395,18 @@ final class Renderer {
     // "heap" (4 chars) right-aligned with "threads" (7 chars) → start at ThreadsStartCol + 3.
     val heapStartCol = ThreadsStartCol + 3
 
+    val cov = state.coverage
+    val covTotal = cov.accountedNanos + cov.unaccountedNanos
+    val trackedField =
+      if (covTotal <= 0L) dim("tracked  --%")
+      else {
+        val pct = 100.0 * cov.accountedNanos / covTotal
+        dim("tracked ") + styleTracked(f"$pct%3.0f%%", pct)
+      }
+
     sb.append("  ")
-    sb.append(" " * (elapsedStartCol - 3).max(0))
+    sb.append(trackedField)
+    sb.append(" " * (elapsedStartCol - 3 - TrackedFieldLen).max(1))
     sb.append(dim("elapsed "))
     sb.append(elapsedField)
 
@@ -397,13 +417,16 @@ final class Renderer {
     sb.append(styleHeap(heapUsedField, heapRatio))
     sb.append(dim(" / "))
     sb.append(heapMaxField)
-    // Align under the `[all|frontend|backend]` legend on the dashboard line above.
-    // When help is the active view, the tip carries the "active mode" signal
-    // (bold yellow) — the filter legend goes plain because no filter is
-    // currently being applied to a visible table. The "?" itself is underlined
-    // to match the keystroke-underline convention used in the column headers
-    // and the filter legend.
+    // Key hints, anchored to the right under the dashboard's filter legend.
+    // `<tab> to cycle` always reads gray — it's a standing hint, never the
+    // active mode. When help is the active view only the "? for help" tip
+    // carries the "active mode" signal (bold yellow); the filter legend goes
+    // plain because no filter is currently being applied to a visible table.
+    // The "?" itself is underlined to match the keystroke-underline convention
+    // used in the column headers and the filter legend.
     sb.append("     ")
+    sb.append(color("<tab> to cycle", Gray))
+    sb.append("   ")
     val tipText = s"$UnderlineCode?$NoUnderlineCode for help"
     val tipStyled =
       if (state.activeView == View.Help) bold(color(tipText, Yellow))
@@ -411,47 +434,6 @@ final class Renderer {
     sb.append(tipStyled)
     sb.append('\n')
   }
-
-  /**
-    * Coverage line: how much sequential phase wall-clock time lives in phases
-    * the per-def table attributes nothing to. `accounted` / `unaccounted` are
-    * percentages of total phase wall time, followed by the biggest unaccounted
-    * phases by their wall share so the user can see *where* the blind spots are
-    * (e.g. `Namer`, `Instances`). The unaccounted figure is colored by
-    * magnitude. Always emits exactly one line so the table below doesn't jump
-    * as phases complete; before any phase finishes it shows a placeholder.
-    *
-    * These percentages are wall-time, deliberately kept apart from the
-    * thread-summed `time` column in the tables — see [[Model.Coverage]].
-    */
-  private def renderCoverage(sb: StringBuilder, state: FrameState): Unit = {
-    val cov = state.coverage
-    val total = cov.accountedNanos + cov.unaccountedNanos
-    sb.append("  ")
-    if (total <= 0L) {
-      sb.append(dim("coverage  (awaiting attributable phases)"))
-      sb.append('\n')
-      return
-    }
-    val unaccPct = 100.0 * cov.unaccountedNanos / total
-    val accPct = 100.0 - unaccPct
-    sb.append(dim("accounted "))
-    sb.append(f"$accPct%5.1f%%")
-    sb.append(dim("   unaccounted "))
-    sb.append(styleUnaccounted(f"$unaccPct%5.1f%%", unaccPct))
-    if (cov.uncovered.nonEmpty) {
-      val parts = cov.uncovered.iterator.take(3).map {
-        case (phase, wall) => f"$phase ${100.0 * wall / total}%.0f%%"
-      }.mkString(" · ")
-      sb.append(dim("   "))
-      sb.append(dim(truncate(parts, (state.layout.totalWidth - 36).max(12))))
-    }
-    sb.append('\n')
-  }
-
-  /** Colors the unaccounted-percentage field: green when low, yellow mid, red high. */
-  private def styleUnaccounted(s: String, pct: Double): String =
-    if (pct >= 25.0) red(s) else if (pct >= 10.0) yellow(s) else green(s)
 
   /**
     * Prints the parametrized header row + the divider underneath it. The

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
@@ -37,14 +37,14 @@ object Styling {
   private val HotnessYellowThresholdMsPerLine: Double = 15.0
   private val ModuleHotnessRedThresholdMsPerLine:    Double = 4.0
   private val ModuleHotnessYellowThresholdMsPerLine: Double = 2.0
+  private val ObservedRedThresholdPct:         Double = 25.0
+  private val ObservedYellowThresholdPct:      Double = 50.0
   private val PctCpuRedThreshold:              Double = 5.0
   private val PctCpuYellowThreshold:           Double = 1.0
   private val PctWallRedThreshold:             Double = 15.0
   private val PctWallYellowThreshold:          Double = 5.0
   private val TimeRedThresholdMs:              Long   = 1000L
   private val TimeYellowThresholdMs:           Long   = 50L
-  private val TrackedRedThresholdPct:          Double = 60.0
-  private val TrackedYellowThresholdPct:       Double = 80.0
 
   // -- Conditional styling -------------------------------------------------
 
@@ -121,14 +121,14 @@ object Styling {
   }
 
   /**
-    * Colors the dashboard `tracked` percentage. Inverted from the other tiers
+    * Colors the dashboard `observed` percentage. Inverted from the other tiers
     * because *high* coverage is the good outcome: a healthy figure stays the
     * default dim/gray (no warning), dropping to yellow below the yellow cutoff
     * and red below the red cutoff.
     */
-  def styleTracked(formatted: String, pct: Double): String = {
-    if (pct < TrackedRedThresholdPct) red(formatted)
-    else if (pct < TrackedYellowThresholdPct) yellow(formatted)
+  def styleObserved(formatted: String, pct: Double): String = {
+    if (pct < ObservedRedThresholdPct) red(formatted)
+    else if (pct < ObservedYellowThresholdPct) yellow(formatted)
     else dim(formatted)
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
@@ -43,6 +43,8 @@ object Styling {
   private val PctWallYellowThreshold:          Double = 5.0
   private val TimeRedThresholdMs:              Long   = 1000L
   private val TimeYellowThresholdMs:           Long   = 50L
+  private val TrackedGreenThresholdPct:        Double = 90.0
+  private val TrackedYellowThresholdPct:       Double = 75.0
 
   // -- Conditional styling -------------------------------------------------
 
@@ -116,5 +118,16 @@ object Styling {
     if (ratio >= HeapRedThresholdRatio) bold(red(formatted))
     else if (ratio >= HeapYellowThresholdRatio) yellow(formatted)
     else green(formatted)
+  }
+
+  /**
+    * Colors the dashboard `tracked` percentage. Inverted from the other tiers
+    * because *high* coverage is the good outcome: green at/above the green
+    * cutoff, yellow in the middle band, red below.
+    */
+  def styleTracked(formatted: String, pct: Double): String = {
+    if (pct >= TrackedGreenThresholdPct) green(formatted)
+    else if (pct >= TrackedYellowThresholdPct) yellow(formatted)
+    else red(formatted)
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
@@ -43,8 +43,8 @@ object Styling {
   private val PctWallYellowThreshold:          Double = 5.0
   private val TimeRedThresholdMs:              Long   = 1000L
   private val TimeYellowThresholdMs:           Long   = 50L
-  private val TrackedGreenThresholdPct:        Double = 90.0
-  private val TrackedYellowThresholdPct:       Double = 75.0
+  private val TrackedRedThresholdPct:          Double = 60.0
+  private val TrackedYellowThresholdPct:       Double = 80.0
 
   // -- Conditional styling -------------------------------------------------
 
@@ -122,12 +122,13 @@ object Styling {
 
   /**
     * Colors the dashboard `tracked` percentage. Inverted from the other tiers
-    * because *high* coverage is the good outcome: green at/above the green
-    * cutoff, yellow in the middle band, red below.
+    * because *high* coverage is the good outcome: a healthy figure stays the
+    * default dim/gray (no warning), dropping to yellow below the yellow cutoff
+    * and red below the red cutoff.
     */
   def styleTracked(formatted: String, pct: Double): String = {
-    if (pct >= TrackedGreenThresholdPct) green(formatted)
-    else if (pct >= TrackedYellowThresholdPct) yellow(formatted)
-    else red(formatted)
+    if (pct < TrackedRedThresholdPct) red(formatted)
+    else if (pct < TrackedYellowThresholdPct) yellow(formatted)
+    else dim(formatted)
   }
 }


### PR DESCRIPTION
## What

Adds a compact `observed xx%` figure to the `--top` TUI showing how much of the compiler's phase wall-clock time the per-def table actually accounts for. It sits in the left gutter of the stats line, directly under the current phase:

```
  Typer         progress [████████░░░░]  9/32   threads ▁▃▅ 6/8   [all|frontend|backend]
  observed  62%            elapsed  4.2s       heap  512 / 2048 MB     ? for help
```

Before any attributable phase finishes it reads `observed  --%` so the field never jumps. The percentage is colored by magnitude — gray when healthy (≥50%), yellow (25–50%), red (<25%).

## Why

The per-def / per-module tables rank individual defs, but give no sense of how much compile time the table fails to attribute — whole phases it never touches, plus the un-instrumented slice within phases it partially covers. This figure surfaces that blind spot as a single number, making "is it worth instrumenting phase X" a data-driven decision, without spending a whole dashboard line on it.

## How it's computed

`Aggregation.computeCoverage` reconciles two signals per phase:

- `flix.phaseTimers` — each phase's wall time (a phase can run multiple times, e.g. `OccurrenceAnalyzer`/`Inliner` across optimizer rounds, so wall is summed by name).
- the live profiler snapshot — thread-summed per-def time, also summed by phase name.

For each phase, the **attributed wall** is estimated as `threadSummed / parallelism`, clamped to the phase wall; `accounted` sums those estimates and `unaccounted` is the remaining wall. `observed %` = `accounted / (accounted + unaccounted)`.

- **Graded, not binary.** A partially-instrumented phase reads as partially observed rather than fully covered — the estimate captures within-phase blind spots, not just whole-phase ones.
- **Optimistically assumes full parallelism.** Dividing thread-summed time by `parallelism` is exact for a saturated parallel phase (`threadSummed ≈ parallelism × wall`) but under-counts a sequential phase (which ran on one thread yet is still divided), so such a phase reads as a partial blind spot even when fully instrumented. The figure moves with `-Xthreads`; at `threads=1` the divisor is 1.
- **Non-attributable phases excluded.** Phases with no per-`DefnSym` unit by construction — pre-naming passes (`Reader`/`Lexer`/`Parser2`/`Weeder2`/`Desugar`/`Namer`), pure filter passes (`TreeShaker1`/`TreeShaker2`), and the `Optimizer` fixpoint wrapper — are listed in `Model.NonAttributablePhases` and dropped, so the denominator is *attributable* phase wall time.
- **Filter-aware.** Scoped to the active `a`/`f`/`b` filter via `matchesFilter` — the same predicate the def table uses — so the figure covers exactly the phases the visible table covers. Press `f`/`b` and both the rows and the `observed %` follow.

## Implementation

- `Model.Coverage` (pure data: `accountedNanos` / `unaccountedNanos`) + `Model.NonAttributablePhases`.
- `Aggregation.computeCoverage(snapshot, phaseTimers, filter, parallelism)` — the pure estimate.
- `Renderer.renderStats` renders the `observed` field; `CompilerTop` computes it from the *unfiltered* snapshot, passing the active filter and the threadpool parallelism. Coloring lives in `Styling.styleObserved` with named threshold constants (`ObservedYellowThresholdPct` / `ObservedRedThresholdPct`), consistent with the other `style*` helpers.

## Caveat

The within-phase estimate is honest only at the parallel extreme; sequential phases are systematically under-counted by ~the parallelism factor. The trade-off (binary "does the table see the phase at all" vs graded "how much of the phase did the table see") is documented in `Model.Coverage`.

## Verification

- `./mill flix.compile` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
