### PR TITLE
feat: add <tab> to cycle key hint to compilertop TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -393,13 +393,16 @@ final class Renderer {
     sb.append(styleHeap(heapUsedField, heapRatio))
     sb.append(dim(" / "))
     sb.append(heapMaxField)
-    // Align under the `[all|frontend|backend]` legend on the dashboard line above.
-    // When help is the active view, the tip carries the "active mode" signal
-    // (bold yellow) — the filter legend goes plain because no filter is
-    // currently being applied to a visible table. The "?" itself is underlined
-    // to match the keystroke-underline convention used in the column headers
-    // and the filter legend.
+    // Key hints, anchored to the right under the dashboard's filter legend.
+    // `<tab> to cycle` always reads gray — it's a standing hint, never the
+    // active mode. When help is the active view only the "? for help" tip
+    // carries the "active mode" signal (bold yellow); the filter legend goes
+    // plain because no filter is currently being applied to a visible table.
+    // The "?" itself is underlined to match the keystroke-underline convention
+    // used in the column headers and the filter legend.
     sb.append("     ")
+    sb.append(color("<tab> to cycle", Gray))
+    sb.append("   ")
     val tipText = s"$UnderlineCode?$NoUnderlineCode for help"
     val tipStyled =
       if (state.activeView == View.Help) bold(color(tipText, Yellow))


### PR DESCRIPTION
## What

Adds a gray `<tab> to cycle` key hint to the `--top` TUI, just before the existing `? for help` tip on the stats line:

```
       elapsed  4.2s       heap  512 / 2048 MB     <tab> to cycle   ? for help
```

## Why

`Tab` already flips the defs ↔ modules tables, but the keybinding was only discoverable from the help screen. Surfacing it inline makes it visible at a glance, matching how the `[a|f|b]` filter legend already advertises its keys.

## Details

- The hint always reads gray — it's a standing hint, never an "active mode" indicator.
- Only `? for help` flips to bold yellow while the help view is open, so the active-mode signal stays unambiguous.
- No behavior change beyond the rendered line; purely a discoverability nudge.

## Verification

- `./mill flix.compile` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
