### PR TITLE
feat: add per-phase view to compilertop TUI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Aggregation.scala
@@ -108,6 +108,42 @@ object Aggregation {
   }
 
   /**
+    * Builds one [[PhaseStats]] row per phase that ran, for the per-phase table.
+    *
+    * Phase wall time comes from `phaseTimers` (the authoritative list of phases,
+    * summed by name since a phase can run more than once); the per-def time and
+    * alloc come from the snapshot's `byPhase` / `byPhaseAlloc`. `attributedWall`
+    * reuses [[computeCoverage]]'s optimistic-parallelism estimate
+    * (`threadSummed / par`, clamped to wall), so the per-row `pctObserved`
+    * matches the dashboard `observed` figure phase-for-phase.
+    *
+    * Unlike [[computeCoverage]], [[Model.NonAttributablePhases]] are NOT dropped:
+    * the table deliberately shows phases like `Lexer` / `Parser2` with their real
+    * `%wall` and `0%` observed. Rows are filtered by `f` (so `a`/`f`/`b` narrow the
+    * phase list like the other tables) and sorted by wall time descending.
+    */
+  def aggregateByPhase(snapshot: Vector[DefnStats], phaseTimers: Vector[PhaseTime], f: PhaseFilter, par: Int): Vector[PhaseStats] = {
+    val threads = par.max(1)
+
+    val timeByPhase = snapshot.foldLeft(Map.empty[String, Long]) {
+      case (acc, s) => s.byPhase.foldLeft(acc) { case (m, (p, n)) => m.updated(p, m.getOrElse(p, 0L) + n) }
+    }
+    val allocByPhase = snapshot.foldLeft(Map.empty[String, Long]) {
+      case (acc, s) => s.byPhaseAlloc.foldLeft(acc) { case (m, (p, n)) => m.updated(p, m.getOrElse(p, 0L) + n) }
+    }
+    val wallByPhase = phaseTimers.foldLeft(Map.empty[String, Long]) {
+      case (acc, pt) => acc.updated(pt.phase, acc.getOrElse(pt.phase, 0L) + pt.time)
+    }
+
+    wallByPhase.iterator.collect {
+      case (phase, wall) if matchesFilter(phase, f) =>
+        val threadSummed = timeByPhase.getOrElse(phase, 0L)
+        val attributedWall = (threadSummed / threads).min(wall)
+        PhaseStats(phase, wall, threadSummed, allocByPhase.getOrElse(phase, 0L), attributedWall)
+    }.toVector.sortBy(p => -p.wallNanos)
+  }
+
+  /**
     * Returns the descending sort key for a def under the given sort mode.
     * `Hotness` (time / LOC) is 0 for synthetic defs with no real source
     * span (`locLines <= 0`) so they sink to the bottom rather than dominating.

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -220,7 +220,7 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     *   - `f` / `F` → filter to frontend phases
     *   - `b` / `B` → filter to backend phases
     *   - `a` / `A` → reset to all phases
-    *   - Tab (`9`) → flip between the defs and modules tables (from help,
+    *   - Tab (`9`) → cycle the defs → modules → phases tables (from help,
     *     lands on the defs table).
     *   - `?`       → toggle the help view (column / keystroke legend).
     *   - `↑` / `↓` (CSI `ESC [ A` / `ESC [ B`) → scroll the active table up /
@@ -247,7 +247,7 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
             quitLatch.countDown()
             return
           }
-        case 9 => // Tab — flip the table; from help, land on the defs table.
+        case 9 => // Tab — cycle the table; from help, land on the defs table.
           view.updateAndGet(v => if (v == View.Help) View.Defs else v.toggledTable)
           scrollOffset.set(0)
         case 27 =>
@@ -390,6 +390,10 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     val raw = profiler.snapshot()
     val snap = applyFilter(raw, activeFilter).sortBy(s => -defSortKey(s, activeSort))
     val mods = if (activeView == View.Modules) aggregateByModule(snap, activeSort) else Vector.empty
+    // Phase rows roll up from the unfiltered `raw` snapshot + phaseTimers; the
+    // active filter selects which phases show (inside aggregateByPhase) rather
+    // than re-projecting per-def time, so each phase's alloc / cpu stay correct.
+    val phaseRows = if (activeView == View.Phases) aggregateByPhase(raw, flix.phaseTimers.toVector, activeFilter, parallelism) else Vector.empty
 
     // Scroll window over the active table. `maxScroll` is published so the input
     // thread can clamp `↓`; the offset is also re-clamped here because a filter
@@ -398,6 +402,7 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     val total = activeView match {
       case View.Defs    => snap.length
       case View.Modules => mods.length
+      case View.Phases  => phaseRows.length
       case View.Help    => 0
     }
     val maxOff = (total - tableRows).max(0)
@@ -406,6 +411,7 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
 
     val visible = if (activeView == View.Defs)    snap.slice(offset, offset + tableRows) else Vector.empty
     val modules = if (activeView == View.Modules) mods.slice(offset, offset + tableRows) else Vector.empty
+    val phases  = if (activeView == View.Phases)  phaseRows.slice(offset, offset + tableRows) else Vector.empty
 
     // Coverage scopes to the active phase filter (via `matchesFilter`), so the
     // observed figure narrows to the same phases the visible table covers: press
@@ -413,7 +419,7 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     // the thread-summed per-def time into an estimated attributed wall slice.
     val coverage = computeCoverage(raw, flix.phaseTimers.toVector, activeFilter, parallelism)
 
-    FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, activeView, layout, visible, modules, coverage)
+    FrameState(parallelism, isDone, elapsed, activeThreads, heap, currentPhase, phaseTimersSize, activeFilter, activeSort, activeView, layout, visible, modules, phases, coverage)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -30,26 +30,32 @@ object Model {
     *
     *   - [[View.Defs]]: the per-def table (default), full terminal height.
     *   - [[View.Modules]]: the per-module aggregate table, full terminal
-    *     height. `Tab` flips between [[View.Defs]] and this.
+    *     height. `Tab` cycles into this from [[View.Defs]].
+    *   - [[View.Phases]]: the per-phase aggregate table (phase name, time,
+    *     alloc, par, %cpu, %wall, blind, %observed). `Tab` cycles into this
+    *     from [[View.Modules]].
     *   - [[View.Help]]: a static legend explaining each column and
     *     keystroke, so the user doesn't have to guess what e.g. `tv` or
     *     `rnd` mean.
     */
   sealed trait View {
     /**
-      * The other table view — `Tab` flips [[View.Defs]] ↔ [[View.Modules]].
-      * From [[View.Help]] there is no "other table", so it maps to itself;
+      * The next table view in the `Tab` cycle:
+      * [[View.Defs]] → [[View.Modules]] → [[View.Phases]] → [[View.Defs]].
+      * From [[View.Help]] there is no "next table", so it maps to itself;
       * the input loop special-cases leaving help separately.
       */
     final def toggledTable: View = this match {
       case View.Defs    => View.Modules
-      case View.Modules => View.Defs
+      case View.Modules => View.Phases
+      case View.Phases  => View.Defs
       case View.Help    => View.Help
     }
   }
   object View {
     case object Defs    extends View
     case object Modules extends View
+    case object Phases  extends View
     case object Help    extends View
   }
 
@@ -184,6 +190,25 @@ object Model {
     /** Returns the phase that consumed the most time in this module, or None if empty. */
     def dominantPhase: Option[String] =
       if (byPhase.isEmpty) None else Some(byPhase.maxBy(_._2)._1)
+  }
+
+  /**
+    * A row in the per-phase aggregate table. One per phase that ran (driven by
+    * `Flix.phaseTimers`, so non-attributable phases like `Lexer` / `Parser2`
+    * appear too, with `0` observed). The renderer derives `%cpu` / `%wall`
+    * against the per-frame `elapsed` / `parallelism`, the same late-binding the
+    * def / module rows use for their percentages.
+    *
+    * @param phase               the phase name (as passed to `flix.phase(...)`).
+    * @param wallNanos           real phase wall time, summed across repeats, from `Flix.phaseTimers`.
+    * @param threadSummedNanos   thread-summed per-def time attributed to this phase (`Σ DefnStats.byPhase`).
+    * @param allocBytes          compiler-side heap bytes attributed to this phase (`Σ DefnStats.byPhaseAlloc`).
+    * @param attributedWallNanos estimated attributed wall slice: `(threadSummed / parallelism).min(wall)`, mirroring [[Coverage]].
+    */
+  final case class PhaseStats(phase: String, wallNanos: Long, threadSummedNanos: Long, allocBytes: Long, attributedWallNanos: Long) {
+    /** Share of this phase's wall time the per-def table attributes (the per-phase `observed` figure). */
+    def pctObserved: Double =
+      if (wallNanos <= 0L) 0.0 else 100.0 * attributedWallNanos / wallNanos
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -50,10 +50,13 @@ import scala.collection.mutable
   *                        populated below.
   * @param layout          column layout produced by [[Layout.compute]].
   * @param visible         def-table rows, already filtered / sorted / trimmed.
-  *                        Empty when [[activeView]] is [[Model.View.Modules]].
+  *                        Empty unless [[activeView]] is [[Model.View.Defs]].
   * @param modules         module-table rows, already aggregated / sorted /
   *                        trimmed. Empty unless [[activeView]] is
   *                        [[Model.View.Modules]].
+  * @param phases          phase-table rows, already aggregated / sorted /
+  *                        trimmed. Empty unless [[activeView]] is
+  *                        [[Model.View.Phases]].
   */
 final case class FrameState(parallelism: Int,
                             isDone: Boolean,
@@ -68,6 +71,7 @@ final case class FrameState(parallelism: Int,
                             layout: Layout,
                             visible: Vector[DefnStats],
                             modules: Vector[ModuleStats],
+                            phases: Vector[PhaseStats],
                             coverage: Coverage)
 
 object Renderer {
@@ -80,6 +84,12 @@ object Renderer {
 
   /** Width (in characters) of the phase-progress bar. */
   private val BarWidth: Int = 12
+
+  /** Fixed width of the phase-table numeric tail: `time(9) + alloc(5) + par(5) + %cpu(6) + %wall(6) + blind(9) + %obs(6)`, each with a leading separator. */
+  private val PhaseTailWidth: Int = (1 + 9) + (1 + 5) + (1 + 5) + (1 + 6) + (1 + 6) + (1 + 9) + (1 + 6)
+
+  /** Floor on the phase-table name column when the terminal is narrow. */
+  private val MinPhaseNameWidth: Int = 12
 
   /** 1-indexed column where the `progress` label starts on the dashboard. */
   private lazy val ProgressStartCol: Int = 5 + MaxPhaseLen
@@ -273,6 +283,7 @@ final class Renderer {
     state.activeView match {
       case View.Defs    => renderDefTable(sb, state)
       case View.Modules => renderModuleTable(sb, state)
+      case View.Phases  => renderPhaseTable(sb, state)
       case View.Help    => renderHelp(sb)
     }
 
@@ -298,6 +309,80 @@ final class Renderer {
     renderHeaderRow(sb, "mod (hot)", state.layout, state.activeSort)
     if (modRows.isEmpty) renderEmptyPlaceholder(sb, "(no modules yet)", state.layout)
     else renderTable(sb, modRows, state.layout)
+  }
+
+  /**
+    * Renders the per-phase aggregate table (the body of the phases view). This
+    * view has its own column set — `phase`, `time`, `alloc`, `par`, `%cpu`,
+    * `%wall`, `blind`, `%obs` — so it doesn't reuse the def / module [[Row]] /
+    * [[buildHeader]] machinery.
+    *
+    *   - `time` is the phase's real wall time; `%wall` is its share of elapsed
+    *     (`phaseTimers` time / elapsed), so non-attributable phases (`Lexer`, …)
+    *     still show their true cost.
+    *   - `par` is the observed effective parallelism (`threadSummed / wall`):
+    *     ≈1 for a sequential phase, ≈threads for a saturated parallel one. `-`
+    *     when no per-def work is observed (the ratio is meaningless then).
+    *   - `%cpu` is the thread-summed per-def share (`threadSummed / (elapsed ×
+    *     parallelism)`), matching the def / module `%cpu` definition.
+    *   - `blind` is the wall time NOT attributed to any def (`wall − observed`),
+    *     the absolute-time complement to the `%obs` ratio; `%obs` is the
+    *     per-phase `observed` figure ([[Model.PhaseStats.pctObserved]]).
+    *
+    * Only `layout.totalWidth` is consumed (to keep the divider flush with the
+    * other tables); the def / module column flags are ignored. The name column
+    * expands to fill whatever the fixed numeric tail leaves.
+    */
+  private def renderPhaseTable(sb: StringBuilder, state: FrameState): Unit = {
+    val safeElapsed = state.elapsed.max(1L).toDouble
+    val nameWidth = (state.layout.totalWidth - PhaseTailWidth).max(MinPhaseNameWidth)
+
+    // Header: phase (left) + right-aligned numeric columns. None are sortable in
+    // this view, so every column is a plain (bold-cyan) header.
+    sb.append(' ')
+    sb.append(plainHeader(rpad("phase", nameWidth)))
+    sb.append(' '); sb.append(plainHeader(lpad("time",  9)))
+    sb.append(' '); sb.append(plainHeader(lpad("alloc", 5)))
+    sb.append(' '); sb.append(plainHeader(lpad("par",   5)))
+    sb.append(' '); sb.append(plainHeader(lpad("%cpu",  6)))
+    sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
+    sb.append(' '); sb.append(plainHeader(lpad("blind", 9)))
+    sb.append(' '); sb.append(plainHeader(lpad("%obs",  6)))
+    sb.append(' '); sb.append('\n')
+    sb.append(' ')
+    sb.append(dim("─" * (nameWidth + PhaseTailWidth)))
+    sb.append(' '); sb.append('\n')
+
+    if (state.phases.isEmpty) {
+      renderEmptyPlaceholder(sb, "(no phases yet)", state.layout)
+      return
+    }
+
+    for (p <- state.phases) {
+      val pctWall = 100.0 * p.wallNanos / safeElapsed
+      val pctCpu  = 100.0 * p.threadSummedNanos / (safeElapsed * state.parallelism)
+      // Observed effective parallelism. Meaningless when no per-def work landed
+      // in the phase (non-attributable phases), so show `-` rather than 0.0x.
+      val parField =
+        if (p.threadSummedNanos <= 0L) lpad("-", 5)
+        else lpad(f"${p.threadSummedNanos.toDouble / p.wallNanos.max(1L)}%4.1fx", 5)
+      val blindNanos = (p.wallNanos - p.attributedWallNanos).max(0L)
+      // A literally-zero alloc / %cpu reads as `-` rather than `0B` / `0.0%` —
+      // both happen for phases that do no per-def work, and the dash keeps that
+      // visually distinct from a phase that did tracked work near zero.
+      val allocField = if (p.allocBytes == 0L) lpad("-", 5) else lpad(formatBytes(p.allocBytes), 5)
+      val cpuField   = if (p.threadSummedNanos == 0L) lpad("-", 6) else stylePctCpu(f"$pctCpu%5.1f%%", pctCpu)
+      sb.append(' ')
+      sb.append(rpad(truncate(p.phase, nameWidth), nameWidth))
+      sb.append(' '); sb.append(lpad(formatMillis(p.wallNanos), 9))
+      sb.append(' '); sb.append(allocField)
+      sb.append(' '); sb.append(parField)
+      sb.append(' '); sb.append(cpuField)
+      sb.append(' '); sb.append(stylePctWall(f"$pctWall%5.1f%%", pctWall))
+      sb.append(' '); sb.append(lpad(formatMillis(blindNanos), 9))
+      sb.append(' '); sb.append(styleObserved(f"${p.pctObserved}%5.1f%%", p.pctObserved))
+      sb.append(' '); sb.append('\n')
+    }
   }
 
   /**
@@ -561,8 +646,17 @@ final class Renderer {
     appendHelpCol(sb, "size",     "the total bytecode size of all .class files emitted for the def")
     sb.append('\n')
 
+    sb.append("  "); sb.append(bold(cyan("Phase columns"))); sb.append('\n')
+    appendHelpCol(sb, "time",     "the phase's real wall-clock time")
+    appendHelpCol(sb, "par",      "observed effective parallelism (thread-summed time / wall); ~1 sequential, ~threads parallel")
+    appendHelpCol(sb, "%cpu",     "the phase's share of CPU time (thread-summed time / (elapsed × threads))")
+    appendHelpCol(sb, "%wall",    "the phase's share of wall-clock time (real phase wall / elapsed)")
+    appendHelpCol(sb, "blind",    "the phase's wall time not attributed to any def (wall − observed)")
+    appendHelpCol(sb, "%obs",     "the share of the phase's wall time attributed to per-def tracking")
+    sb.append('\n')
+
     sb.append("  "); sb.append(bold(cyan("Navigation"))); sb.append('\n')
-    appendHelpCol(sb, "Tab",      "switch between the per-def and per-module tables")
+    appendHelpCol(sb, "Tab",      "cycle through the per-def, per-module, and per-phase tables")
     appendHelpCol(sb, "↑/↓",      "scroll the active table up and down one row")
     appendHelpCol(sb, "a/f/b",    "filter to all / frontend / backend phases")
     appendHelpCol(sb, "?",        "toggle this help screen; Esc returns to the defs table")

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -85,8 +85,11 @@ object Renderer {
   /** Width (in characters) of the phase-progress bar. */
   private val BarWidth: Int = 12
 
-  /** Fixed width of the phase-table numeric tail: `time(9) + blind(9) + %obs(6) + alloc(5) + par(5) + %cpu(6) + %wall(6)`, each with a leading separator. */
-  private val PhaseTailWidth: Int = (1 + 9) + (1 + 5) + (1 + 5) + (1 + 6) + (1 + 6) + (1 + 9) + (1 + 6)
+  /** Width (in characters) of the per-phase wall-time bar drawn left of the `time` column. */
+  private val PhaseBarWidth: Int = 16
+
+  /** Fixed width of the phase-table numeric tail: `bar(16) + time(9) + blind(9) + %obs(6) + alloc(5) + par(5) + %cpu(6) + %wall(6)`, each with a leading separator. */
+  private val PhaseTailWidth: Int = (1 + PhaseBarWidth) + (1 + 9) + (1 + 5) + (1 + 5) + (1 + 6) + (1 + 6) + (1 + 9) + (1 + 6)
 
   /** Floor on the phase-table name column when the terminal is narrow. */
   private val MinPhaseNameWidth: Int = 12
@@ -313,10 +316,13 @@ final class Renderer {
 
   /**
     * Renders the per-phase aggregate table (the body of the phases view). This
-    * view has its own column set — `phase`, `time`, `blind`, `%obs`, `alloc`,
-    * `par`, `%cpu`, `%wall` — so it doesn't reuse the def / module [[Row]] /
-    * [[buildHeader]] machinery.
+    * view has its own column set — `phase`, `bar`, `time`, `blind`, `%obs`,
+    * `alloc`, `par`, `%cpu`, `%wall` — so it doesn't reuse the def / module
+    * [[Row]] / [[buildHeader]] machinery.
     *
+    *   - `bar` is a two-tone wall-time bar scaled to the largest phase: the
+    *     observed slice in the `%wall` heat, the blind slice dim, so a phase
+    *     whose wall is entirely blind (e.g. `Lexer`) shows an all-dim bar.
     *   - `time` is the phase's real wall time; `%wall` is its share of elapsed
     *     (`phaseTimers` time / elapsed), so non-attributable phases (`Lexer`, …)
     *     still show their true cost.
@@ -341,6 +347,7 @@ final class Renderer {
     // this view, so every column is a plain (bold-cyan) header.
     sb.append(' ')
     sb.append(plainHeader(rpad("phase", nameWidth)))
+    sb.append(' '); sb.append(plainHeader(rpad("bar",   PhaseBarWidth)))
     sb.append(' '); sb.append(plainHeader(lpad("time",  9)))
     sb.append(' '); sb.append(plainHeader(lpad("blind", 9)))
     sb.append(' '); sb.append(plainHeader(lpad("%obs",  6)))
@@ -358,9 +365,19 @@ final class Renderer {
       return
     }
 
+    // Reference for the wall-time bar: the largest phase's wall time, so the
+    // top (longest) phase fills the bar and the rest scale against it. Rows are
+    // already sorted by wall descending, so this is `head`, but `maxOption`
+    // keeps it robust if that ever changes; floored at 1 to avoid a zero divide.
+    val maxWall = state.phases.iterator.map(_.wallNanos).maxOption.getOrElse(1L).max(1L)
+
     for (p <- state.phases) {
       val pctWall = 100.0 * p.wallNanos / safeElapsed
       val pctCpu  = 100.0 * p.threadSummedNanos / (safeElapsed * state.parallelism)
+      // Two-tone wall-time bar, total length relative to the largest phase: the
+      // observed (attributed) slice in the %wall heat, the blind slice dim, so a
+      // fully-blind phase (e.g. Parser2) renders an all-dim bar.
+      val barField = stackedBar(p.attributedWallNanos.toDouble / maxWall, p.wallNanos.toDouble / maxWall, PhaseBarWidth, s => stylePctWall(s, pctWall))
       // Observed effective parallelism. Meaningless when no per-def work landed
       // in the phase (non-attributable phases), so show `-` rather than 0.0x.
       val parField =
@@ -374,6 +391,7 @@ final class Renderer {
       val cpuField   = if (p.threadSummedNanos == 0L) lpad("-", 6) else stylePctCpu(f"$pctCpu%5.1f%%", pctCpu)
       sb.append(' ')
       sb.append(rpad(truncate(p.phase, nameWidth), nameWidth))
+      sb.append(' '); sb.append(barField)
       sb.append(' '); sb.append(lpad(formatMillis(p.wallNanos), 9))
       sb.append(' '); sb.append(lpad(formatMillis(blindNanos), 9))
       sb.append(' '); sb.append(styleObserved(f"${p.pctObserved}%5.1f%%", p.pctObserved))
@@ -647,6 +665,7 @@ final class Renderer {
     sb.append('\n')
 
     sb.append("  "); sb.append(bold(cyan("Phase columns"))); sb.append('\n')
+    appendHelpCol(sb, "bar",      "wall-time bar vs the largest phase; solid = observed (heat by %wall), dim = blind")
     appendHelpCol(sb, "time",     "the phase's real wall-clock time")
     appendHelpCol(sb, "blind",    "the phase's wall time not attributed to any def (wall − observed)")
     appendHelpCol(sb, "%obs",     "the share of the phase's wall time attributed to per-def tracking")
@@ -714,6 +733,27 @@ final class Renderer {
     sb.append(' '); sb.append(if (cells.aggregate) timeField else styleTime(timeField, cells.nanos))
     sb.append(' '); sb.append(if (cells.aggregate) cpuField else stylePctCpu(cpuField, cells.pctCpu))
     sb.append(' '); sb.append(if (cells.aggregate) wallField else stylePctWall(wallField, cells.pctWall))
+  }
+
+  /**
+    * Renders a left-growing two-tone bar `width` cells wide: an observed run
+    * (`█`, handed to `fill` — typically the `%wall` heat), then a blind run
+    * (dim `▒`) for wall time not attributed to any def, then a dim `░` track.
+    * `observedFrac` and `totalFrac` are both relative to the same reference
+    * (the largest phase's wall), with `observedFrac ≤ totalFrac`, so the total
+    * filled length stays proportional to wall while the solid run shows how
+    * much of the phase the per-def tracking accounts for. A phase that ran at
+    * all keeps at least one filled cell so it never disappears entirely. The
+    * color codes are zero-width, so the visible width is exactly `width`.
+    */
+  private def stackedBar(observedFrac: Double, totalFrac: Double, width: Int, fill: String => String): String = {
+    val total = totalFrac.max(0.0).min(1.0)
+    val obs   = observedFrac.max(0.0).min(total)
+    val wallCells  = if (total <= 0.0) 0 else math.round(total * width).toInt.max(1).min(width)
+    val obsCells   = math.round(obs * width).toInt.min(wallCells)
+    val blindCells = wallCells - obsCells
+    val trackCells = width - wallCells
+    fill("█" * obsCells) + dim("▒" * blindCells) + dim("░" * trackCells)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -85,7 +85,7 @@ object Renderer {
   /** Width (in characters) of the phase-progress bar. */
   private val BarWidth: Int = 12
 
-  /** Fixed width of the phase-table numeric tail: `time(9) + alloc(5) + par(5) + %cpu(6) + %wall(6) + blind(9) + %obs(6)`, each with a leading separator. */
+  /** Fixed width of the phase-table numeric tail: `time(9) + blind(9) + %obs(6) + alloc(5) + par(5) + %cpu(6) + %wall(6)`, each with a leading separator. */
   private val PhaseTailWidth: Int = (1 + 9) + (1 + 5) + (1 + 5) + (1 + 6) + (1 + 6) + (1 + 9) + (1 + 6)
 
   /** Floor on the phase-table name column when the terminal is narrow. */
@@ -313,8 +313,8 @@ final class Renderer {
 
   /**
     * Renders the per-phase aggregate table (the body of the phases view). This
-    * view has its own column set — `phase`, `time`, `alloc`, `par`, `%cpu`,
-    * `%wall`, `blind`, `%obs` — so it doesn't reuse the def / module [[Row]] /
+    * view has its own column set — `phase`, `time`, `blind`, `%obs`, `alloc`,
+    * `par`, `%cpu`, `%wall` — so it doesn't reuse the def / module [[Row]] /
     * [[buildHeader]] machinery.
     *
     *   - `time` is the phase's real wall time; `%wall` is its share of elapsed
@@ -342,12 +342,12 @@ final class Renderer {
     sb.append(' ')
     sb.append(plainHeader(rpad("phase", nameWidth)))
     sb.append(' '); sb.append(plainHeader(lpad("time",  9)))
+    sb.append(' '); sb.append(plainHeader(lpad("blind", 9)))
+    sb.append(' '); sb.append(plainHeader(lpad("%obs",  6)))
     sb.append(' '); sb.append(plainHeader(lpad("alloc", 5)))
     sb.append(' '); sb.append(plainHeader(lpad("par",   5)))
     sb.append(' '); sb.append(plainHeader(lpad("%cpu",  6)))
     sb.append(' '); sb.append(plainHeader(lpad("%wall", 6)))
-    sb.append(' '); sb.append(plainHeader(lpad("blind", 9)))
-    sb.append(' '); sb.append(plainHeader(lpad("%obs",  6)))
     sb.append(' '); sb.append('\n')
     sb.append(' ')
     sb.append(dim("─" * (nameWidth + PhaseTailWidth)))
@@ -375,12 +375,12 @@ final class Renderer {
       sb.append(' ')
       sb.append(rpad(truncate(p.phase, nameWidth), nameWidth))
       sb.append(' '); sb.append(lpad(formatMillis(p.wallNanos), 9))
+      sb.append(' '); sb.append(lpad(formatMillis(blindNanos), 9))
+      sb.append(' '); sb.append(styleObserved(f"${p.pctObserved}%5.1f%%", p.pctObserved))
       sb.append(' '); sb.append(allocField)
       sb.append(' '); sb.append(parField)
       sb.append(' '); sb.append(cpuField)
       sb.append(' '); sb.append(stylePctWall(f"$pctWall%5.1f%%", pctWall))
-      sb.append(' '); sb.append(lpad(formatMillis(blindNanos), 9))
-      sb.append(' '); sb.append(styleObserved(f"${p.pctObserved}%5.1f%%", p.pctObserved))
       sb.append(' '); sb.append('\n')
     }
   }
@@ -648,11 +648,11 @@ final class Renderer {
 
     sb.append("  "); sb.append(bold(cyan("Phase columns"))); sb.append('\n')
     appendHelpCol(sb, "time",     "the phase's real wall-clock time")
+    appendHelpCol(sb, "blind",    "the phase's wall time not attributed to any def (wall − observed)")
+    appendHelpCol(sb, "%obs",     "the share of the phase's wall time attributed to per-def tracking")
     appendHelpCol(sb, "par",      "observed effective parallelism (thread-summed time / wall); ~1 sequential, ~threads parallel")
     appendHelpCol(sb, "%cpu",     "the phase's share of CPU time (thread-summed time / (elapsed × threads))")
     appendHelpCol(sb, "%wall",    "the phase's share of wall-clock time (real phase wall / elapsed)")
-    appendHelpCol(sb, "blind",    "the phase's wall time not attributed to any def (wall − observed)")
-    appendHelpCol(sb, "%obs",     "the share of the phase's wall time attributed to per-def tracking")
     sb.append('\n')
 
     sb.append("  "); sb.append(bold(cyan("Navigation"))); sb.append('\n')

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -86,9 +86,9 @@ object Renderer {
   private val BarWidth: Int = 12
 
   /** Width (in characters) of the per-phase wall-time bar drawn left of the `time` column. */
-  private val PhaseBarWidth: Int = 16
+  private val PhaseBarWidth: Int = 18
 
-  /** Fixed width of the phase-table numeric tail: `bar(16) + time(9) + blind(9) + %obs(6) + alloc(5) + par(5) + %cpu(6) + %wall(6)`, each with a leading separator. */
+  /** Fixed width of the phase-table numeric tail: `profile(18) + time(9) + blind(9) + %obs(6) + alloc(5) + par(5) + %cpu(6) + %wall(6)`, each with a leading separator. */
   private val PhaseTailWidth: Int = (1 + PhaseBarWidth) + (1 + 9) + (1 + 5) + (1 + 5) + (1 + 6) + (1 + 6) + (1 + 9) + (1 + 6)
 
   /** Floor on the phase-table name column when the terminal is narrow. */
@@ -347,7 +347,7 @@ final class Renderer {
     // this view, so every column is a plain (bold-cyan) header.
     sb.append(' ')
     sb.append(plainHeader(rpad("phase", nameWidth)))
-    sb.append(' '); sb.append(plainHeader(rpad("bar",   PhaseBarWidth)))
+    sb.append(' '); sb.append(plainHeader(rpad("profile", PhaseBarWidth)))
     sb.append(' '); sb.append(plainHeader(lpad("time",  9)))
     sb.append(' '); sb.append(plainHeader(lpad("blind", 9)))
     sb.append(' '); sb.append(plainHeader(lpad("%obs",  6)))
@@ -375,9 +375,10 @@ final class Renderer {
       val pctWall = 100.0 * p.wallNanos / safeElapsed
       val pctCpu  = 100.0 * p.threadSummedNanos / (safeElapsed * state.parallelism)
       // Two-tone wall-time bar, total length relative to the largest phase: the
-      // observed (attributed) slice in the %wall heat, the blind slice dim, so a
-      // fully-blind phase (e.g. Parser2) renders an all-dim bar.
-      val barField = stackedBar(p.attributedWallNanos.toDouble / maxWall, p.wallNanos.toDouble / maxWall, PhaseBarWidth, s => stylePctWall(s, pctWall))
+      // observed (attributed) slice in the %wall heat, the blind slice the same
+      // hue one shade darker, so a fully-blind phase (e.g. Parser2) renders as
+      // an all-dark bar in that phase's color.
+      val barField = stackedBar(p.attributedWallNanos.toDouble / maxWall, p.wallNanos.toDouble / maxWall, PhaseBarWidth, s => stylePctWall(s, pctWall), s => stylePctWallDim(s, pctWall))
       // Observed effective parallelism. Meaningless when no per-def work landed
       // in the phase (non-attributable phases), so show `-` rather than 0.0x.
       val parField =
@@ -665,7 +666,7 @@ final class Renderer {
     sb.append('\n')
 
     sb.append("  "); sb.append(bold(cyan("Phase columns"))); sb.append('\n')
-    appendHelpCol(sb, "bar",      "wall-time bar vs the largest phase; solid = observed (heat by %wall), dim = blind")
+    appendHelpCol(sb, "profile",  "wall-time bar vs the largest phase; solid = observed (heat by %wall), darker shade = blind")
     appendHelpCol(sb, "time",     "the phase's real wall-clock time")
     appendHelpCol(sb, "blind",    "the phase's wall time not attributed to any def (wall − observed)")
     appendHelpCol(sb, "%obs",     "the share of the phase's wall time attributed to per-def tracking")
@@ -738,22 +739,24 @@ final class Renderer {
   /**
     * Renders a left-growing two-tone bar `width` cells wide: an observed run
     * (`█`, handed to `fill` — typically the `%wall` heat), then a blind run
-    * (dim `▒`) for wall time not attributed to any def, then a dim `░` track.
-    * `observedFrac` and `totalFrac` are both relative to the same reference
-    * (the largest phase's wall), with `observedFrac ≤ totalFrac`, so the total
-    * filled length stays proportional to wall while the solid run shows how
-    * much of the phase the per-def tracking accounts for. A phase that ran at
-    * all keeps at least one filled cell so it never disappears entirely. The
-    * color codes are zero-width, so the visible width is exactly `width`.
+    * (`▒`, handed to `blindFill` — the same hue one shade darker) for wall time
+    * not attributed to any def, then a dim `░` track. `observedFrac` and
+    * `totalFrac` are both relative to the same reference (the largest phase's
+    * wall), with `observedFrac ≤ totalFrac`, so the total filled length stays
+    * proportional to wall while the solid run shows how much of the phase the
+    * per-def tracking accounts for. The half-tone `▒` glyph makes the blind run
+    * read as a darker shade even where the dim attribute is weak. A phase that
+    * ran at all keeps at least one filled cell so it never disappears entirely.
+    * The color codes are zero-width, so the visible width is exactly `width`.
     */
-  private def stackedBar(observedFrac: Double, totalFrac: Double, width: Int, fill: String => String): String = {
+  private def stackedBar(observedFrac: Double, totalFrac: Double, width: Int, fill: String => String, blindFill: String => String): String = {
     val total = totalFrac.max(0.0).min(1.0)
     val obs   = observedFrac.max(0.0).min(total)
     val wallCells  = if (total <= 0.0) 0 else math.round(total * width).toInt.max(1).min(width)
     val obsCells   = math.round(obs * width).toInt.min(wallCells)
     val blindCells = wallCells - obsCells
     val trackCells = width - wallCells
-    fill("█" * obsCells) + dim("▒" * blindCells) + dim("░" * trackCells)
+    fill("█" * obsCells) + blindFill("▒" * blindCells) + dim("░" * trackCells)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Styling.scala
@@ -103,6 +103,18 @@ object Styling {
     else formatted
   }
 
+  /**
+    * Darker-shade companion to [[stylePctWall]] for the unaccounted (blind)
+    * run of the phase wall-time bar: the *same* heat hue as [[stylePctWall]]
+    * but dimmed (and without the red tier's bold), so the blind run reads as a
+    * darker shade of the observed run's color rather than a different color.
+    */
+  def stylePctWallDim(formatted: String, pct: Double): String = {
+    if (pct >= PctWallRedThreshold) dim(red(formatted))
+    else if (pct >= PctWallYellowThreshold) dim(yellow(formatted))
+    else dim(formatted)
+  }
+
   /** Colors the active/parallelism field by occupancy: full=green bold, ≥50%=green, idle=gray, else yellow. */
   def styleThreads(active: Int, par: Int): String = {
     val s = f"$active%2d/$par%-2d"


### PR DESCRIPTION
## What

Adds a fourth top-level view to the `compilertop` TUI: a **per-phase aggregate table**, reached by `Tab` after the module view. The `Tab` cycle is now **defs → modules → phases → defs**. It answers *"which compiler phase is expensive?"* rather than which def/module.

## Columns

```
phase | time | alloc | par | %cpu | %wall | blind | %obs
```

| Column | Meaning |
|---|---|
| `time`  | real phase wall time (from `flix.phaseTimers`) |
| `alloc` | compiler-side heap bytes attributed to the phase |
| `par`   | observed effective parallelism (`threadSummed / wall`) — ~1 sequential, ~threads parallel |
| `%cpu`  | thread-summed per-def share — `threadSummed / (elapsed × parallelism)` |
| `%wall` | real wall share — `phase wall / elapsed` |
| `blind` | wall time not attributed to any def — `wall − observed` |
| `%obs`  | per-phase observed figure — `attributed wall / phase wall` |

## Notes

- The per-phase observed math reuses `computeCoverage`'s optimistic-parallelism estimate, so `%obs` matches the dashboard `observed` figure phase-for-phase.
- Non-attributable phases (`Lexer`, `Parser2`, …) still appear with their real `%wall` and `0%` observed; `alloc` / `%cpu` / `par` render as `-` when there is no observed per-def work.
- Rows honor the existing `a`/`f`/`b` filter and sort by wall time descending.
- TUI-only, additive change — no compiler-semantics impact. The help screen (`?`) documents the new columns and the updated `Tab` cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)