### PR TITLE
refactor: convert predicate arity error to soft failure in Weeder2

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3514,20 +3514,20 @@ object Weeder2 {
   private def visitPredicateAndArity(tree: Tree)(implicit sctx: SharedContext): Validation[PredicateAndArity, CompilationMessage] = {
     val identVal = pickNameIdent(tree)
     val arityTokenVal = pickToken(TokenKind.LiteralInt, tree)
-    flatMapN(identVal, arityTokenVal) {
+    mapN(identVal, arityTokenVal) {
       case (ident, arityToken) =>
-        mapN(tryParsePredicateArity(arityToken)) {
-          case arity =>
-            PredicateAndArity(Name.mkPred(ident), arity)
-        }
+        val arity = tryParsePredicateArity(arityToken)
+        PredicateAndArity(Name.mkPred(ident), arity)
     }
   }
 
-  private def tryParsePredicateArity(token: Token): Validation[Int, CompilationMessage] = {
+  private def tryParsePredicateArity(token: Token)(implicit sctx: SharedContext): Int = {
     token.text.toIntOption match {
-      case Some(i) if i >= 1 => Success(i)
-      case Some(_) => Failure(WeederError.IllegalPredicateArity(token.mkSourceLocation()))
-      case None => Failure(WeederError.IllegalPredicateArity(token.mkSourceLocation()))
+      case Some(i) if i >= 1 => i
+      case _ =>
+        // Soft failure: report the error and fall back on an arity of 0.
+        sctx.errors.add(WeederError.IllegalPredicateArity(token.mkSourceLocation()))
+        0
     }
   }
 


### PR DESCRIPTION
## Summary

Converts `tryParsePredicateArity` in `Weeder2` from a hard `Validation.Failure` to a **soft failure**: the `IllegalPredicateArity` error is now reported via the `SharedContext` side-channel and the arity falls back to `0`, instead of returning a `Validation.Failure` that aborts weeding.

This is a small step in the ongoing migration away from `Validation`'s error-accumulation channel toward the `SharedContext` side-channel for error reporting. It removes 2 of the 4 explicit `Validation.Failure` sites in the file (the `pick`/`pickToken` helpers remain).

### Changes

- `tryParsePredicateArity`: return type `Validation[Int, CompilationMessage]` → `Int`, taking an implicit `SharedContext`. The two former failure branches (`< 1` and unparseable) collapse into one `case _`.
- `visitPredicateAndArity`: `flatMapN` → `mapN`, calling `tryParsePredicateArity` directly as a plain `Int`.

### Behavior change

When an illegal predicate arity is found (e.g. `inject xs into P/0`), weeding no longer aborts — the error is still reported, and compilation proceeds into later phases (which may surface additional errors). Previously the hard failure stopped the front-end at weeding.

## Testing

- `./mill flix.compile` — compiles cleanly.
- Empty-file run — stdlib compiles.
- Manual check with `inject xs into P/0` confirms the error is reported and compilation continues into the typer.
- `./mill flix.test.testForked "-oC"` — all 16,575 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)