### PR TITLE
refactor: route Weeder2 hard failures through PickException

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -68,8 +68,12 @@ object Weeder2 {
   }
 
   private def weed(tree: Tree)(implicit sctx: SharedContext, flix: Flix): Validation[CompilationUnit, CompilationMessage] = {
-    mapN(pickAllUsesAndImports(tree), Decls.pickAllDeclarations(tree)) {
-      (usesAndImports, declarations) => CompilationUnit(usesAndImports, declarations, tree.loc)
+    try {
+      mapN(pickAllUsesAndImports(tree), Decls.pickAllDeclarations(tree)) {
+        (usesAndImports, declarations) => CompilationUnit(usesAndImports, declarations, tree.loc)
+      }
+    } catch {
+      case PickException(error) => Validation.Failure(Chain(error))
     }
   }
 
@@ -3646,7 +3650,7 @@ object Weeder2 {
       case Some(t) => Validation.Success(t)
       case None =>
         val error = NeedAtleastOne(NamedTokenSet.FromTreeKinds(Set(kind)), synctx, loc = tree.loc)
-        Validation.Failure(Chain(error))
+        throw PickException(error)
     }
   }
 
@@ -3660,7 +3664,7 @@ object Weeder2 {
       case Some(t) => Validation.Success(t)
       case _ =>
         val error = NeedAtleastOne(NamedTokenSet.FromKinds(Set(kind)), synctx, loc = tree.loc)
-        Validation.Failure(Chain(error))
+        throw PickException(error)
     }
   }
 
@@ -3736,5 +3740,14 @@ object Weeder2 {
     * @param errors the [[WeederError]]s or [[ParseError]]s in the AST, if any.
     */
   private case class SharedContext(errors: ConcurrentLinkedQueue[CompilationMessage])
+
+  /**
+    * An exception thrown by [[pick]] and [[pickToken]] when a required sub-tree or token is missing.
+    *
+    * This bypasses the [[Validation]] machinery: the exception is thrown deep inside weeding and
+    * caught in [[weed]], where it is converted into a [[Validation.Failure]]. It exists so that the
+    * remaining hard failures no longer rely on [[Validation]], which is slated for removal.
+    */
+  private case class PickException(error: NeedAtleastOne) extends RuntimeException
 
 }


### PR DESCRIPTION
## Summary

Routes the two remaining hard-failure sites in `Weeder2` through an exception instead of `Validation.Failure`, bypassing the `Validation` machinery for hard failures.

This is a step toward removing `Validation` from `Weeder2` entirely (planned follow-up PR). After the earlier soft-failure change to `tryParsePredicateArity`, the only `Validation.Failure` producers left were the `pick`/`pickToken` helpers; those are now exception-based.

### Changes

- New `PickException(error: NeedAtleastOne)` exception at the bottom of `Weeder2`.
- `pick` and `pickToken` now `throw PickException(error)` instead of returning `Validation.Failure(Chain(error))`.
- `weed(tree)` wraps its body in a `try`/`catch` that converts `PickException` back into a `Validation.Failure`, preserving the existing return type and behavior.

All weeding flows through `weed(tree)` (called per source file in `run`'s `parMapWithPriority`), so the catch covers every `pick`/`pickToken` call, and each file still fails independently.

### Behavior

Unchanged. A missing required sub-tree/token still produces the same `NeedAtleastOne` error (E6405) and aborts weeding for that source file — e.g. `trait Foo[] {}` reports `Expected at least one <Parameter>` exactly as before.

## Testing

- `./mill flix.compile` — compiles cleanly.
- Empty-file run — stdlib compiles.
- `trait Foo[] {}` — confirms the hard-failure path still reports `NeedAtleastOne` and fails.
- `./mill flix.test.testForked "-oC"` — all 16,575 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)