### PR TITLE
chore: document PR description conventions in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,11 @@ Branch names must be prefixed with the same categories as commit messages:
 
 Example: `refactor/simplify-type-reduction`
 
+## GitHub Pull Requests
+
+- Omit the testing section from the PR description.
+- Omit the "Generated with Claude Code" line from the PR description.
+
 ## Writing Flix Code
 
 If you are unsure about Flix syntax, consult: https://doc.flix.dev/for-llms.html


### PR DESCRIPTION
## Summary

Adds a **GitHub Pull Requests** section to `.claude/CLAUDE.md` documenting two conventions for PR descriptions:

- Omit the testing section.
- Omit the "Generated with Claude Code" line.