### PR TITLE
chore: document performance benchmarking in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,6 +38,18 @@ Examples:
 
 **Note:** Flix test files that reference `dev.flix.test.*` classes (test Java classes) will fail when run via `flix.run` because those classes are only on the classpath during `flix.test`. These failures are expected — use the test suite to run them.
 
+## Benchmarking Performance
+
+When asked to benchmark the performance impact of a change, run:
+
+```bash
+Xperf --frontend --par --n 50
+```
+
+If the numbers are not stable, increase the sample count to `--n 100` or `--n 250`.
+
+Drop `--frontend` if the change affects the backend, so the benchmark covers the full pipeline.
+
 ## Commit Messages
 
 Commit messages must start with a lowercase prefix followed by a colon and space:


### PR DESCRIPTION
Add a "Benchmarking Performance" section to the developer guide describing how to benchmark the performance impact of a change:

- Run `Xperf --frontend --par --n 50`.
- Increase the sample count to `--n 100` or `--n 250` if the numbers are not stable.
- Drop `--frontend` when the change affects the backend, so the benchmark covers the full pipeline.