### PR TITLE
fix: make CodeHinter symbol lookups safe on soft-error roots

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -64,12 +64,16 @@ object CodeHinter {
     * @return A collection of code quality hints
     */
   private def visitDefSymUse(symUse: SymUse.DefSymUse)(implicit root: Root): List[CodeHint] = {
-    val defn = root.defs(symUse.sym)
-    val ann = defn.spec.ann
-    checkDeprecated(ann, symUse.loc) ++
-      checkExperimental(ann, symUse.loc) ++
-      checkLazy(ann, symUse.loc) ++
-      checkParallel(ann, symUse.loc)
+    // The root may have non-critical errors, so the symbol may no longer be present.
+    root.defs.get(symUse.sym) match {
+      case None => Nil
+      case Some(defn) =>
+        val ann = defn.spec.ann
+        checkDeprecated(ann, symUse.loc) ++
+          checkExperimental(ann, symUse.loc) ++
+          checkLazy(ann, symUse.loc) ++
+          checkParallel(ann, symUse.loc)
+    }
   }
 
   /**
@@ -81,9 +85,13 @@ object CodeHinter {
     * @return A collection of code hints.
     */
   private def visitEnumSymUse(sym: Symbol.EnumSym, loc: SourceLocation)(implicit root: Root): List[CodeHint] = {
-    val enm = root.enums(sym)
-    val ann = enm.ann
-    checkDeprecated(ann, loc) ++ checkExperimental(ann, loc)
+    // The root may have non-critical errors, so the symbol may no longer be present.
+    root.enums.get(sym) match {
+      case None => Nil
+      case Some(enm) =>
+        val ann = enm.ann
+        checkDeprecated(ann, loc) ++ checkExperimental(ann, loc)
+    }
   }
 
   /**
@@ -94,9 +102,13 @@ object CodeHinter {
     * @return A collection of code quality hints.
     */
   private def visitTraitSymUse(symUse: SymUse.TraitSymUse)(implicit root: Root): List[CodeHint] = {
-    val trt = root.traits(symUse.sym)
-    val ann = trt.ann
-    checkDeprecated(ann, symUse.loc) ++ checkExperimental(ann, symUse.loc)
+    // The root may have non-critical errors, so the symbol may no longer be present.
+    root.traits.get(symUse.sym) match {
+      case None => Nil
+      case Some(trt) =>
+        val ann = trt.ann
+        checkDeprecated(ann, symUse.loc) ++ checkExperimental(ann, symUse.loc)
+    }
   }
 
   /**
@@ -201,8 +213,8 @@ object CodeHinter {
     * and uses lazy evaluation when given a pure function argument.
     */
   private def lazyWhenPure(sym: Symbol.DefnSym)(implicit root: Root): Boolean = {
-    val defn = root.defs(sym)
-    defn.spec.ann.isLazyWhenPure
+    // The root may have non-critical errors, so the symbol may no longer be present.
+    root.defs.get(sym).exists(_.spec.ann.isLazyWhenPure)
   }
 
   /**
@@ -210,8 +222,8 @@ object CodeHinter {
     * and uses parallel evaluation when given a pure function argument.
     */
   private def parallelWhenPure(sym: Symbol.DefnSym)(implicit root: Root): Boolean = {
-    val defn = root.defs(sym)
-    defn.spec.ann.isParallelWhenPure
+    // The root may have non-critical errors, so the symbol may no longer be present.
+    root.defs.get(sym).exists(_.spec.ann.isParallelWhenPure)
   }
 
   /**


### PR DESCRIPTION
## Problem

The VSCode LSP server crashes with `java.util.NoSuchElementException: key not found: <X>` when editing — e.g. deleting a function definition that is still referenced elsewhere. Reported in #12840 (originally `key not found: mgu` in v0.72.0, still occurring as `key not found: Type` in v0.73.0).

The crash originates in `CodeHinter`, which is invoked from `VSCodeLspServer.processSuccessfulCheck` — including for the **non-critical error** case. On such soft-error roots, the typed AST can still reference symbols that are no longer present in the root's symbol maps. `CodeHinter` then performed unguarded `apply` lookups on those stale references and threw:

- `visitEnumSymUse` — `root.enums(sym)` (the `key not found: Type` crash)
- `lazyWhenPure` / `parallelWhenPure` — `root.defs(sym)` (the `key not found: mgu` crash)
- `visitDefSymUse` — `root.defs(symUse.sym)`
- `visitTraitSymUse` — `root.traits(symUse.sym)`

## Fix

Replace all five lookups with guarded `.get` lookups that yield no hint when the symbol is absent. When compilation is fully clean the maps are complete, so no hints are lost; this only changes behavior on soft-error roots, where it now skips the dangling reference instead of throwing.

Fixes #12840