### PR TITLE
refactor: return values directly from pickNameIdent in Weeder2

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -273,15 +273,15 @@ object Weeder2 {
         sctx.errors.add(IllegalNumberOfTraitParameters(tparamsList.loc))
       }
 
+      val ident = pickNameIdent(tree)
       flatMapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickSingleParameter(tree),
         Types.pickConstraints(tree),
         traverse(sigs)(visitSignatureDecl),
         traverse(laws)(visitLawDecl)
       ) {
-        (doc, ident, tparam, tconstr, sigs, laws) =>
+        (doc, tparam, tconstr, sigs, laws) =>
           val assocs = pickAll(TreeKind.Decl.AssociatedTypeSig, tree)
           mapN(traverse(assocs)(visitAssociatedTypeSigDecl(_, tparam))) {
             assocs => Declaration.Trait(doc, ann, mod, ident, tparam, tconstr, assocs, sigs, laws, tree.loc)
@@ -316,9 +316,9 @@ object Weeder2 {
       val maybeExpression = tryPick(TreeKind.Expr.Expr, tree)
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, allowed = Set(TokenKind.KeywordPub), mustBePublic = true)
+      val ident = pickNameIdent(tree)
       mapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickKindedParameters(tree),
         pickFormalParameters(tree),
         Types.pickType(tree),
@@ -327,7 +327,7 @@ object Weeder2 {
         pickEqualityConstraints(tree),
         traverseOpt(maybeExpression)(Exprs.visitExpr)
       ) {
-        (doc, ident, tparams, fparams, tpe, eff, tconstrs, econstrs, expr) =>
+        (doc, tparams, fparams, tpe, eff, tconstrs, econstrs, expr) =>
           Declaration.Sig(doc, ann, mod, ident, tparams, fparams, expr, tpe, eff, tconstrs, econstrs, tree.loc)
       }
     }
@@ -336,9 +336,9 @@ object Weeder2 {
       expect(tree, TreeKind.Decl.Def)
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, allowed = allowedModifiers, mustBePublic)
+      val ident = pickNameIdent(tree)
       mapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickKindedParameters(tree),
         pickFormalParameters(tree),
         Exprs.pickExpr(tree),
@@ -347,7 +347,7 @@ object Weeder2 {
         pickEqualityConstraints(tree),
         Types.tryPickEffect(tree)
       ) {
-        (doc, ident, tparams, fparams, exp, ttype, tconstrs, constrs, eff) =>
+        (doc, tparams, fparams, exp, ttype, tconstrs, constrs, eff) =>
           Declaration.Def(doc, ann, mod, ident, tparams, fparams, exp, ttype, eff, tconstrs, constrs, tree.loc)
       }
     }
@@ -357,9 +357,9 @@ object Weeder2 {
       val allowedModifiers: Set[TokenKind] = if (flix.options.xnodeprecated) Set.empty else Set(TokenKind.KeywordPub)
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, allowed = allowedModifiers)
+      val ident = pickNameIdent(tree)
       mapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickKindedParameters(tree),
         pickFormalParameters(tree),
         Exprs.pickExpr(tree),
@@ -368,7 +368,7 @@ object Weeder2 {
         pickEqualityConstraints(tree),
         Types.tryPickEffect(tree)
       ) {
-        (doc, ident, tparams, fparams, exp, ttype, tconstrs, constrs, eff) =>
+        (doc, tparams, fparams, exp, ttype, tconstrs, constrs, eff) =>
           Declaration.Redef(doc, ann, mod, ident, tparams, fparams, exp, ttype, eff, tconstrs, constrs, tree.loc)
       }
     }
@@ -376,16 +376,16 @@ object Weeder2 {
     private def visitLawDecl(tree: Tree)(implicit sctx: SharedContext): Validation[Declaration.Def, CompilationMessage] = {
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, allowed = Set.empty)
+      val ident = pickNameIdent(tree)
       mapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickConstraints(tree),
         pickEqualityConstraints(tree),
         Types.pickKindedParameters(tree),
         pickFormalParameters(tree),
         Exprs.pickExpr(tree)
       ) {
-        (doc, ident, tconstrs, econstrs, tparams, fparams, expr) =>
+        (doc, tconstrs, econstrs, tparams, fparams, expr) =>
           val eff = None
           val tpe = WeededAst.Type.Ambiguous(Name.mkQName("Bool"), ident.loc)
           // TODO: There is a `Declaration.Law` but old Weeder produces a Def
@@ -400,14 +400,14 @@ object Weeder2 {
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, allowed = Set(TokenKind.KeywordPub))
       val derivations = Types.pickDerivations(tree)
+      val ident = pickNameIdent(tree)
       flatMapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickParameters(tree),
         traverseOpt(shorthandBody)(Types.visitCaseType),
         traverse(cases)(visitEnumCase)
       ) {
-        (doc, ident, tparams, tpe, cases) =>
+        (doc, tparams, tpe, cases) =>
           val casesVal = (tpe, cases) match {
             // Illegal empty singleton enum (`enum A()`)
             case (Some(List(Type.Error(_))), Nil) =>
@@ -436,12 +436,12 @@ object Weeder2 {
     private def visitEnumCase(tree: Tree)(implicit sctx: SharedContext): Validation[Case, CompilationMessage] = {
       expect(tree, TreeKind.Case)
       val maybeType = tryPick(TreeKind.CaseBody, tree)
+      val ident = pickNameIdent(tree)
       mapN(
-        pickNameIdent(tree),
         traverseOpt(maybeType)(Types.visitCaseType),
         // TODO: Doc comments on enum cases. It is not available on [[Case]] yet.
       ) {
-        (ident, maybeType) =>
+        maybeType =>
           val tpes = maybeType.getOrElse(Nil)
           // Make a source location that spans the name and type, excluding 'case'.
           val loc = SourceLocation(isReal = true, ident.loc.source, ident.loc.start, tree.loc.end)
@@ -457,15 +457,15 @@ object Weeder2 {
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, allowed = Set(TokenKind.KeywordPub))
       val derivations = Types.pickDerivations(tree)
+      val ident = pickNameIdent(tree)
       flatMapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         restrictionParam,
         Types.pickParameters(tree),
         traverseOpt(shorthandBody)(Types.visitCaseType),
         traverse(cases)(visitRestrictableEnumCase)
       ) {
-        (doc, ident, rParam, tparams, tpe, cases) =>
+        (doc, rParam, tparams, tpe, cases) =>
           val casesVal = (tpe, cases) match {
             // Illegal empty singleton enum (`enum A()`)
             case (Some(List(Type.Error(_))), Nil) =>
@@ -494,12 +494,12 @@ object Weeder2 {
     private def visitRestrictableEnumCase(tree: Tree)(implicit sctx: SharedContext): Validation[RestrictableCase, CompilationMessage] = {
       expect(tree, TreeKind.Case)
       val maybeType = tryPick(TreeKind.CaseBody, tree)
+      val ident = pickNameIdent(tree)
       mapN(
-        pickNameIdent(tree),
         traverseOpt(maybeType)(Types.visitCaseType),
         // TODO: Doc comments on enum cases. It is not available on [[Case]] yet.
       ) {
-        (ident, maybeType) =>
+        maybeType =>
           val tpes = maybeType.getOrElse(Nil)
           RestrictableCase(ident, tpes, tree.loc)
       }
@@ -510,13 +510,13 @@ object Weeder2 {
       val fields = pickAll(TreeKind.StructField, tree)
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, allowed = Set(TokenKind.KeywordPub))
+      val ident = pickNameIdent(tree)
       flatMapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickParameters(tree),
         traverse(fields)(visitStructField)
       ) {
-        (doc, ident, tparams, fields) =>
+        (doc, tparams, fields) =>
           // Ensure that each name is unique
           val errors = SeqOps.getDuplicates(fields, (f: StructField) => f.name.name).map {
             case (field1, field2) => DuplicateStructField(ident.name, field1.name.name, field1.name.loc, field2.name.loc, ident.loc)
@@ -531,11 +531,11 @@ object Weeder2 {
     private def visitStructField(tree: Tree)(implicit sctx: SharedContext): Validation[StructField, CompilationMessage] = {
       expect(tree, TreeKind.StructField)
       val mod = pickModifiers(tree, allowed = Set(TokenKind.KeywordPub, TokenKind.KeywordMut))
+      val ident = pickNameIdent(tree)
       mapN(
-        pickNameIdent(tree),
         Types.pickType(tree)
       ) {
-        (ident, ttype) =>
+        ttype =>
           // Make a source location that spans the name and type
           val loc = SourceLocation(isReal = true, ident.loc.source, ident.loc.start, tree.loc.end)
           StructField(mod, Name.mkLabel(ident), ttype, loc)
@@ -546,13 +546,13 @@ object Weeder2 {
       expect(tree, TreeKind.Decl.TypeAlias)
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, Set(TokenKind.KeywordPub))
+      val ident = pickNameIdent(tree)
       mapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickParameters(tree),
         Types.pickType(tree)
       ) {
-        (doc, ident, tparams, tpe) =>
+        (doc, tparams, tpe) =>
           Declaration.TypeAlias(doc, ann, mod, ident, tparams, tpe, tree.loc)
       }
     }
@@ -560,12 +560,12 @@ object Weeder2 {
     private def visitAssociatedTypeSigDecl(tree: Tree, classTypeParam: TypeParam)(implicit sctx: SharedContext): Validation[Declaration.AssocTypeSig, CompilationMessage] = {
       expect(tree, TreeKind.Decl.AssociatedTypeSig)
       val mod = pickModifiers(tree, allowed = Set(TokenKind.KeywordPub))
+      val ident = pickNameIdent(tree)
       flatMapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickParameters(tree),
       ) {
-        (doc, ident, tparams) =>
+        (doc, tparams) =>
           val kind = Types.tryPickKind(tree).getOrElse(defaultKind(ident))
           val tpe = Types.tryPickTypeNoWild(tree)
           val tparam = tparams match {
@@ -588,13 +588,13 @@ object Weeder2 {
     private def visitAssociatedTypeDefDecl(tree: Tree, instType: Type)(implicit sctx: SharedContext): Validation[Declaration.AssocTypeDef, CompilationMessage] = {
       expect(tree, TreeKind.Decl.AssociatedTypeDef)
       val mod = pickModifiers(tree, Set(TokenKind.KeywordPub))
+      val ident = pickNameIdent(tree)
       flatMapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickArguments(tree),
         Types.pickType(tree)
       ) {
-        (doc, ident, typeArgs, tpe) =>
+        (doc, typeArgs, tpe) =>
           val typeArg = typeArgs match {
             // Use instance type if type arguments were elided
             case Nil => Validation.Success(instType)
@@ -617,13 +617,13 @@ object Weeder2 {
       val ops = pickAll(TreeKind.Decl.Op, tree)
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, allowed = Set(TokenKind.KeywordPub))
+      val ident = pickNameIdent(tree)
       mapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         Types.pickParameters(tree),
         traverse(ops)(visitOperationDecl)
       ) {
-        (doc, ident, tparams, ops) =>
+        (doc, tparams, ops) =>
           Declaration.Effect(doc, ann, mod, ident, tparams, ops, tree.loc)
       }
     }
@@ -632,14 +632,14 @@ object Weeder2 {
       expect(tree, TreeKind.Decl.Op)
       val ann = pickAnnotations(tree)
       val mod = pickModifiers(tree, allowed = Set.empty)
+      val ident = pickNameIdent(tree)
       mapN(
         pickDocumentation(tree),
-        pickNameIdent(tree),
         pickFormalParameters(tree),
         Types.pickType(tree),
         Types.pickConstraints(tree),
       ) {
-        (doc, ident, fparams, tpe, tconstrs) =>
+        (doc, fparams, tpe, tconstrs) =>
           Declaration.Op(doc, ann, mod, ident, fparams, tpe, tconstrs, tree.loc)
       }
     }
@@ -772,9 +772,8 @@ object Weeder2 {
           val tokens = pickAllTokens(modTree)
           // Check if pub is missing
           if (mustBePublic && !tokens.exists(_.kind == TokenKind.KeywordPub)) {
-            mapN(pickNameIdent(tree)) {
-              ident => errors :+= IllegalNonPublicSignature(ident, ident.loc)
-            }
+            val ident = pickNameIdent(tree)
+            errors :+= IllegalNonPublicSignature(ident, ident.loc)
           }
           // Check for duplicate modifiers
           errors = errors ++ SeqOps.getDuplicates(tokens.toSeq, (t: Token) => t.kind).map(pair => {
@@ -839,22 +838,20 @@ object Weeder2 {
 
     private def visitParameter(tree: Tree, presence: Presence)(implicit sctx: SharedContext): Validation[FormalParam, CompilationMessage] = {
       expect(tree, TreeKind.Parameter)
-      flatMapN(pickNameIdent(tree)) {
-        case ident =>
-          val maybeType = tryPick(TreeKind.Type.Type, tree)
-          // Check for missing or illegal type ascription
-          (maybeType, presence) match {
-            case (None, Presence.Required) =>
-              val error = MissingTypeAscription(ident.name, tree.loc)
-              sctx.errors.add(error)
-              Validation.Success(FormalParam(ident, Some(Type.Error(tree.loc.asSynthetic)), tree.loc))
-            case (Some(_), Presence.Forbidden) =>
-              val error = IllegalFormalParamAscription(tree.loc)
-              sctx.errors.add(error)
-              Validation.Success(FormalParam(ident, None, tree.loc))
-            case (Some(typeTree), _) => mapN(Types.visitType(typeTree)) { tpe => FormalParam(ident, Some(tpe), tree.loc) }
-            case (None, _) => Validation.Success(FormalParam(ident, None, tree.loc))
-          }
+      val ident = pickNameIdent(tree)
+      val maybeType = tryPick(TreeKind.Type.Type, tree)
+      // Check for missing or illegal type ascription
+      (maybeType, presence) match {
+        case (None, Presence.Required) =>
+          val error = MissingTypeAscription(ident.name, tree.loc)
+          sctx.errors.add(error)
+          Validation.Success(FormalParam(ident, Some(Type.Error(tree.loc.asSynthetic)), tree.loc))
+        case (Some(_), Presence.Forbidden) =>
+          val error = IllegalFormalParamAscription(tree.loc)
+          sctx.errors.add(error)
+          Validation.Success(FormalParam(ident, None, tree.loc))
+        case (Some(typeTree), _) => mapN(Types.visitType(typeTree)) { tpe => FormalParam(ident, Some(tpe), tree.loc) }
+        case (None, _) => Validation.Success(FormalParam(ident, None, tree.loc))
       }
     }
   }
@@ -1045,15 +1042,13 @@ object Weeder2 {
 
     private def visitHoleWithExpExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.HoleVariable)
-      mapN(pickNameIdent(tree)) {
-        ident =>
-          // Strip '?' suffix and update source location
-          val sp1 = ident.loc.start
-          val sp2 = SourcePosition.moveLeft(ident.loc.end)
-          val id = Name.Ident(ident.name.stripSuffix("?"), SourceLocation(isReal = true, ident.loc.source, sp1, sp2))
-          val expr = Expr.Ambiguous(Name.QName(Name.RootNS, id, id.loc), id.loc)
-          Expr.HoleWithExp(expr, tree.loc)
-      }
+      val ident = pickNameIdent(tree)
+      // Strip '?' suffix and update source location
+      val sp1 = ident.loc.start
+      val sp2 = SourcePosition.moveLeft(ident.loc.end)
+      val id = Name.Ident(ident.name.stripSuffix("?"), SourceLocation(isReal = true, ident.loc.source, sp1, sp2))
+      val expr = Expr.Ambiguous(Name.QName(Name.RootNS, id, id.loc), id.loc)
+      Validation.Success(Expr.HoleWithExp(expr, tree.loc))
     }
 
     private def visitExprUseExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
@@ -1092,7 +1087,9 @@ object Weeder2 {
           case TokenKind.LiteralRegex => Validation.Success(Constants.toRegex(token))
           case TokenKind.NameLowercase
                | TokenKind.NameUppercase
-               | TokenKind.NameMath => mapN(pickNameIdent(tree))(ident => Expr.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), tree.loc))
+               | TokenKind.NameMath =>
+            val ident = pickNameIdent(tree)
+            Validation.Success(Expr.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), tree.loc))
           case _ =>
             val error = UnexpectedToken(expected = NamedTokenSet.Literal, actual = None, SyntacticContext.Expr.OtherExpr, loc = tree.loc)
             sctx.errors.add(error)
@@ -1452,14 +1449,14 @@ object Weeder2 {
           (e, Expr.Error(error))
       }
 
+      val ident = pickNameIdent(tree)
       mapN(
         exprs,
         Decls.pickFormalParameters(tree, Presence.Optional),
-        pickNameIdent(tree),
         Types.tryPickType(tree),
         Types.tryPickEffect(tree),
       ) {
-        case ((exp1, exp2), fparams, ident, declaredTpe, declaredEff) =>
+        case ((exp1, exp2), fparams, declaredTpe, declaredEff) =>
           Expr.LocalDef(ann, ident, fparams, declaredTpe, declaredEff, exp1, exp2, tree.loc)
       }
     }
@@ -1467,8 +1464,9 @@ object Weeder2 {
     private def visitRegionExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.Region)
       val block = visitBlockExpr(pick(TreeKind.Expr.Block, tree))
-      mapN(pickNameIdent(tree), block) {
-        (ident, block) => Expr.Region(ident, block, tree.loc)
+      val ident = pickNameIdent(tree)
+      mapN(block) {
+        block => Expr.Region(ident, block, tree.loc)
       }
     }
 
@@ -1689,12 +1687,13 @@ object Weeder2 {
 
     private def visitExtTag(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.ExtTag)
-      mapN(pickNameIdent(tree), tryPickArguments(tree)) {
-        case (ident, None) =>
+      val ident = pickNameIdent(tree)
+      mapN(tryPickArguments(tree)) {
+        case None =>
           // Nullary constructor
           Expr.ExtTag(Name.mkLabel(ident), List.empty, tree.loc)
 
-        case (ident, Some(exps)) =>
+        case Some(exps) =>
           Expr.ExtTag(Name.mkLabel(ident), exps, tree.loc)
       }
     }
@@ -1737,8 +1736,9 @@ object Weeder2 {
     }
 
     private def visitLiteralRecordField(tree: Tree)(implicit sctx: SharedContext): Validation[(Name.Label, Expr, SourceLocation), CompilationMessage] = {
-      mapN(pickNameIdent(tree), pickExpr(tree)) {
-        (ident, expr) => (Name.mkLabel(ident), expr, tree.loc)
+      val ident = pickNameIdent(tree)
+      mapN(pickExpr(tree)) {
+        expr => (Name.mkLabel(ident), expr, tree.loc)
       }
     }
 
@@ -1774,14 +1774,15 @@ object Weeder2 {
       }
       Validation.foldRight(ops)(pickExpr(tree))((op, acc) =>
         op.kind match {
-          case TreeKind.Expr.RecordOpExtend => mapN(pickExpr(op), pickNameIdent(op))(
-            (expr, id) => Expr.RecordExtend(Name.mkLabel(id), expr, acc, op.loc)
-          )
-          case TreeKind.Expr.RecordOpRestrict => mapN(pickNameIdent(op))(
-            id => Expr.RecordRestrict(Name.mkLabel(id), acc, op.loc)
-          )
-          case TreeKind.Expr.RecordOpUpdate => mapN(pickExpr(op), pickNameIdent(op))(
-            (expr, id) => {
+          case TreeKind.Expr.RecordOpExtend =>
+            val id = pickNameIdent(op)
+            mapN(pickExpr(op))(expr => Expr.RecordExtend(Name.mkLabel(id), expr, acc, op.loc))
+          case TreeKind.Expr.RecordOpRestrict =>
+            val id = pickNameIdent(op)
+            Validation.Success(Expr.RecordRestrict(Name.mkLabel(id), acc, op.loc))
+          case TreeKind.Expr.RecordOpUpdate =>
+            val id = pickNameIdent(op)
+            mapN(pickExpr(op))(expr => {
               // An update is a restrict followed by an extension
               val restricted = Expr.RecordRestrict(Name.mkLabel(id), acc, op.loc)
               Expr.RecordExtend(Name.mkLabel(id), expr, restricted, op.loc)
@@ -1946,9 +1947,10 @@ object Weeder2 {
     private def visitTryCatchRule(tree: Tree)(implicit sctx: SharedContext): Validation[CatchRule, CompilationMessage] = {
       expect(tree, TreeKind.Expr.TryCatchRuleFragment)
       val qname = pickQName(tree)
-      mapN(pickNameIdent(tree), pickExpr(tree)) {
-        case (ident, expr) if qname.isUnqualified => CatchRule(ident, qname.ident, expr, tree.loc)
-        case (ident, expr) =>
+      val ident = pickNameIdent(tree)
+      mapN(pickExpr(tree)) {
+        case expr if qname.isUnqualified => CatchRule(ident, qname.ident, expr, tree.loc)
+        case expr =>
           val error = IllegalQualifiedName(qname.loc)
           sctx.errors.add(error)
           CatchRule(ident, qname.ident, expr, tree.loc)
@@ -1962,11 +1964,11 @@ object Weeder2 {
 
     private def visitRunWithRule(tree: Tree)(implicit sctx: SharedContext): Validation[HandlerRule, CompilationMessage] = {
       expect(tree, TreeKind.Expr.RunWithRuleFragment)
+      val ident = pickNameIdent(tree)
       mapN(
-        pickNameIdent(tree),
         Decls.pickFormalParameters(tree, Presence.Forbidden),
         pickExpr(tree)
-      )((ident, fparams0, expr) => {
+      )((fparams0, expr) => {
         // `def f()` becomes `def f(_unit: Unit)` (via Decls.pickFormalParameters).
         // `def f(x)` becomes `def f(_unit: Unit, x)`.
         // `def f(x, y, ..)` is unchanged.
@@ -2033,9 +2035,9 @@ object Weeder2 {
       val baseExp = pickExpr(tree)
       val method = pickNameIdent(tree)
       val argsExps = pickRawArguments(tree, synctx = SyntacticContext.Expr.OtherExpr)
-      mapN(baseExp, method, argsExps) {
-        case (b, m, as) =>
-          val result = Expr.InvokeMethod(b, m, as, tree.loc)
+      mapN(baseExp, argsExps) {
+        case (b, as) =>
+          val result = Expr.InvokeMethod(b, method, as, tree.loc)
           result
       }
     }
@@ -2044,8 +2046,8 @@ object Weeder2 {
       expect(tree, TreeKind.Expr.InvokeSuperMethod)
       val method = pickNameIdent(tree)
       val argsExps = pickRawArguments(tree, synctx = SyntacticContext.Expr.OtherExpr)
-      mapN(method, argsExps) {
-        case (m, as) => Expr.InvokeSuperMethod(m, as, tree.loc)
+      mapN(argsExps) {
+        as => Expr.InvokeSuperMethod(method, as, tree.loc)
       }
     }
 
@@ -2053,8 +2055,8 @@ object Weeder2 {
       expect(tree, TreeKind.Expr.GetField)
       val baseExp = pickExpr(tree)
       val method = pickNameIdent(tree)
-      mapN(baseExp, method) {
-        case (b, m) => Expr.GetField(b, m, tree.loc)
+      mapN(baseExp) {
+        b => Expr.GetField(b, method, tree.loc)
       }
     }
 
@@ -2078,8 +2080,9 @@ object Weeder2 {
 
     private def visitStructGetExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.StructGet)
-      mapN(pickExpr(tree), pickNameIdent(tree)) {
-        (expr, ident) => Expr.StructGet(expr, Name.mkLabel(ident), tree.loc)
+      val ident = pickNameIdent(tree)
+      mapN(pickExpr(tree)) {
+        expr => Expr.StructGet(expr, Name.mkLabel(ident), tree.loc)
       }
     }
 
@@ -2089,22 +2092,22 @@ object Weeder2 {
       val ident = pickNameIdent(tree)
       val rhs = pickExpr(pick(TreeKind.Expr.StructPutRHS, tree))
 
-      mapN(struct, ident, rhs) {
-        (struct, ident, rhs) => Expr.StructPut(struct, Name.mkLabel(ident), rhs, tree.loc)
+      mapN(struct, rhs) {
+        (struct, rhs) => Expr.StructPut(struct, Name.mkLabel(ident), rhs, tree.loc)
       }
     }
 
     private def visitJvmMethod(tree: Tree)(implicit sctx: SharedContext): Validation[JvmMethod, CompilationMessage] = {
       expect(tree, TreeKind.Expr.JvmMethod)
       val jvmAnns = pickJvmAnnotations(tree)
+      val ident = pickNameIdent(tree)
       mapN(
-        pickNameIdent(tree),
         pickExpr(tree),
         Decls.pickFormalParameters(tree),
         Types.pickType(tree),
         Types.tryPickEffect(tree),
       ) {
-        (ident, expr, fparams, tpe, eff) => JvmMethod(jvmAnns, ident, fparams, expr, tpe, eff, tree.loc)
+        (expr, fparams, tpe, eff) => JvmMethod(jvmAnns, ident, fparams, expr, tpe, eff, tree.loc)
       }
     }
 
@@ -2138,8 +2141,9 @@ object Weeder2 {
 
     private def visitNewStructField(tree: Tree)(implicit sctx: SharedContext): Validation[(Name.Label, Expr), CompilationMessage] = {
       expect(tree, TreeKind.Expr.LiteralStructFieldFragment)
-      mapN(pickNameIdent(tree), pickExpr(tree)) {
-        (ident, expr) => (Name.mkLabel(ident), expr)
+      val ident = pickNameIdent(tree)
+      mapN(pickExpr(tree)) {
+        expr => (Name.mkLabel(ident), expr)
       }
     }
 
@@ -2165,8 +2169,9 @@ object Weeder2 {
       expect(tree, TreeKind.Expr.SelectRuleFragment)
       val exprs = traverse(pickAll(TreeKind.Expr.Expr, tree))(visitExpr)
       val qname = pickQName(tree)
-      mapN(pickNameIdent(tree), exprs) {
-        case (ident, channel :: body :: Nil) => // Shape is correct
+      val ident = pickNameIdent(tree)
+      mapN(exprs) {
+        case channel :: body :: Nil => // Shape is correct
           val isRecvFunction = qname.toString == "Channel.recv" || qname.toString == "recv"
           if (isRecvFunction) {
             Result.Ok(SelectChannelRule(ident, channel, body, tree.loc))
@@ -2537,36 +2542,33 @@ object Weeder2 {
 
     private def visitExtTagDefaultPattern(tree: SyntaxTree.Tree)(implicit sctx: SharedContext): Validation[ExtPattern, CompilationMessage] = {
       expect(tree, TreeKind.Pattern.Variable)
-      mapN(pickNameIdent(tree)) {
+      pickNameIdent(tree) match {
         case ident if ident.name == "_" =>
-          ExtPattern.Default(tree.loc)
+          Validation.Success(ExtPattern.Default(tree.loc))
 
         case ident =>
           val error = IllegalExtPattern(ident.loc)
           sctx.errors.add(error)
-          ExtPattern.Error(tree.loc)
+          Validation.Success(ExtPattern.Error(tree.loc))
       }
     }
 
     private def visitVariablePat(tree: Tree, seen: collection.mutable.Map[String, Name.Ident])(implicit sctx: SharedContext): Validation[Pattern, CompilationMessage] = {
       expect(tree, TreeKind.Pattern.Variable)
-      mapN(pickNameIdent(tree))(
-        ident => {
-          if (ident.name == "_")
-            Pattern.Wild(tree.loc)
-          else {
-            seen.get(ident.name) match {
-              case Some(other) =>
-                val error = NonLinearPattern(ident.name, other.loc, tree.loc)
-                sctx.errors.add(error)
-                Pattern.Var(ident, tree.loc)
-              case None =>
-                seen += (ident.name -> ident)
-                Pattern.Var(ident, tree.loc)
-            }
-          }
+      val ident = pickNameIdent(tree)
+      if (ident.name == "_")
+        Validation.Success(Pattern.Wild(tree.loc))
+      else {
+        seen.get(ident.name) match {
+          case Some(other) =>
+            val error = NonLinearPattern(ident.name, other.loc, tree.loc)
+            sctx.errors.add(error)
+            Validation.Success(Pattern.Var(ident, tree.loc))
+          case None =>
+            seen += (ident.name -> ident)
+            Validation.Success(Pattern.Var(ident, tree.loc))
         }
-      )
+      }
     }
 
     private def visitLiteralPat(tree: Tree)(implicit sctx: SharedContext): Validation[Pattern, CompilationMessage] = {
@@ -2680,8 +2682,9 @@ object Weeder2 {
     private def visitRecordField(tree: Tree, seen: collection.mutable.Map[String, Name.Ident])(implicit sctx: SharedContext): Validation[Pattern.Record.RecordLabelPattern, CompilationMessage] = {
       expect(tree, TreeKind.Pattern.RecordFieldFragment)
       val maybePattern = tryPick(TreeKind.Pattern.Pattern, tree)
-      mapN(pickNameIdent(tree), traverseOpt(maybePattern)(visitPattern(_, seen))) {
-        case (ident, None) =>
+      val ident = pickNameIdent(tree)
+      mapN(traverseOpt(maybePattern)(visitPattern(_, seen))) {
+        case None =>
           seen.get(ident.name) match {
             case None =>
               seen += (ident.name -> ident)
@@ -2691,7 +2694,7 @@ object Weeder2 {
               sctx.errors.add(error)
               Pattern.Record.RecordLabelPattern(Name.mkLabel(ident), None, tree.loc)
           }
-        case (ident, pat) =>
+        case pat =>
           Pattern.Record.RecordLabelPattern(Name.mkLabel(ident), pat, tree.loc)
       }
     }
@@ -2932,8 +2935,9 @@ object Weeder2 {
     def pickHead(tree: Tree)(implicit sctx: SharedContext): Validation[Predicate.Head.Atom, CompilationMessage] = {
       val headTree = pick(TreeKind.Predicate.Head, tree)
       val maybeTermList = tryPick(TreeKind.Predicate.TermList, headTree)
-      mapN(pickNameIdent(headTree), traverseOpt(maybeTermList)(visitTermList)) {
-        (ident, maybeTermList) =>
+      val ident = pickNameIdent(headTree)
+      mapN(traverseOpt(maybeTermList)(visitTermList)) {
+        maybeTermList =>
           maybeTermList match {
             case None =>
               Predicate.Head.Atom(Name.mkPred(ident), Denotation.Relational, Nil, headTree.loc)
@@ -2971,8 +2975,9 @@ object Weeder2 {
       val fixity = if (hasToken(TokenKind.KeywordFix, tree)) Fixity.Fixed else Fixity.Loose
       val polarity = if (hasToken(TokenKind.KeywordNot, tree)) Polarity.Negative else Polarity.Positive
       val maybePatList = tryPick(TreeKind.Predicate.PatternList, tree)
-      flatMapN(pickNameIdent(tree), traverseOpt(maybePatList)(visitPatternList))(
-        (ident, maybePatList) => maybePatList match {
+      val ident = pickNameIdent(tree)
+      flatMapN(traverseOpt(maybePatList)(visitPatternList))(
+        maybePatList => maybePatList match {
           case None =>
             Validation.Success(Predicate.Body.Atom(Name.mkPred(ident), Denotation.Relational, polarity, fixity, Nil, tree.loc))
           case Some((pats, None)) =>
@@ -3016,10 +3021,11 @@ object Weeder2 {
       expectAny(tree, List(TreeKind.Predicate.Param, TreeKind.Predicate.ParamUntyped))
       val types0 = pickAll(TreeKind.Type.Type, tree)
       val maybeLatTerm = tryPickLatticeTermType(tree)
-      mapN(pickNameIdent(tree), traverse(types0)(Types.visitType), maybeLatTerm) {
-        case (ident, Nil, _) => PredicateParam.PredicateParamUntyped(Name.mkPred(ident), tree.loc)
-        case (ident, types, None) => PredicateParam.PredicateParamWithType(Name.mkPred(ident), Denotation.Relational, types, tree.loc)
-        case (ident, types, Some(latTerm)) => PredicateParam.PredicateParamWithType(Name.mkPred(ident), Denotation.Latticenal, types :+ latTerm, tree.loc)
+      val ident = pickNameIdent(tree)
+      mapN(traverse(types0)(Types.visitType), maybeLatTerm) {
+        case (Nil, _) => PredicateParam.PredicateParamUntyped(Name.mkPred(ident), tree.loc)
+        case (types, None) => PredicateParam.PredicateParamWithType(Name.mkPred(ident), Denotation.Relational, types, tree.loc)
+        case (types, Some(latTerm)) => PredicateParam.PredicateParamWithType(Name.mkPred(ident), Denotation.Latticenal, types :+ latTerm, tree.loc)
       }
     }
 
@@ -3154,7 +3160,8 @@ object Weeder2 {
 
     private def visitRecordField(tree: Tree)(implicit sctx: SharedContext): Validation[(Name.Label, Type), CompilationMessage] = {
       expect(tree, TreeKind.Type.RecordFieldFragment)
-      mapN(pickNameIdent(tree), pickType(tree))((ident, tpe) => (Name.mkLabel(ident), tpe))
+      val ident = pickNameIdent(tree)
+      mapN(pickType(tree))(tpe => (Name.mkLabel(ident), tpe))
     }
 
     private def visitSchemaType(tree: Tree)(implicit sctx: SharedContext): Validation[Type, CompilationMessage] = {
@@ -3392,12 +3399,12 @@ object Weeder2 {
 
     def visitParameter(tree: Tree)(implicit sctx: SharedContext): Validation[TypeParam, CompilationMessage] = {
       expect(tree, TreeKind.Parameter)
-      mapN(pickNameIdent(tree)) {
-        ident =>
-          tryPickKind(tree)
-            .map(kind => TypeParam.Kinded(ident, kind))
-            .getOrElse(TypeParam.Unkinded(ident))
-      }
+      val ident = pickNameIdent(tree)
+      Validation.Success(
+        tryPickKind(tree)
+          .map(kind => TypeParam.Kinded(ident, kind))
+          .getOrElse(TypeParam.Unkinded(ident))
+      )
     }
 
     def pickConstraints(tree: Tree)(implicit sctx: SharedContext): Validation[List[TraitConstraint], CompilationMessage] = {
@@ -3435,15 +3442,14 @@ object Weeder2 {
 
     private def visitKind(tree: Tree)(implicit sctx: SharedContext): Validation[Kind, CompilationMessage] = {
       expect(tree, TreeKind.Kind)
-      mapN(pickNameIdent(tree)) {
-        ident => {
-          val kind = Kind.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), ident.loc)
-          tryPick(TreeKind.Kind, tree)
-          tryPickKind(tree)
-            .map(Kind.Arrow(kind, _, tree.loc))
-            .getOrElse(kind)
-        }
-      }
+      val ident = pickNameIdent(tree)
+      val kind = Kind.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), ident.loc)
+      tryPick(TreeKind.Kind, tree)
+      Validation.Success(
+        tryPickKind(tree)
+          .map(Kind.Arrow(kind, _, tree.loc))
+          .getOrElse(kind)
+      )
     }
 
     private def pickKind(tree: Tree)(implicit sctx: SharedContext): Validation[Kind, CompilationMessage] = {
@@ -3489,8 +3495,8 @@ object Weeder2 {
     }
   }
 
-  private def pickNameIdent(tree: Tree)(implicit sctx: SharedContext): Validation[Name.Ident, CompilationMessage] = {
-    Validation.Success(tokenToIdent(pick(TreeKind.Ident, tree)))
+  private def pickNameIdent(tree: Tree)(implicit sctx: SharedContext): Name.Ident = {
+    tokenToIdent(pick(TreeKind.Ident, tree))
   }
 
   private def tryPickNameIdent(tree: Tree)(implicit sctx: SharedContext): Option[Name.Ident] = {
@@ -3504,11 +3510,9 @@ object Weeder2 {
 
   private def visitPredicateAndArity(tree: Tree)(implicit sctx: SharedContext): Validation[PredicateAndArity, CompilationMessage] = {
     val arityToken = pickToken(TokenKind.LiteralInt, tree)
-    mapN(pickNameIdent(tree)) {
-      ident =>
-        val arity = tryParsePredicateArity(arityToken)
-        PredicateAndArity(Name.mkPred(ident), arity)
-    }
+    val ident = pickNameIdent(tree)
+    val arity = tryParsePredicateArity(arityToken)
+    Validation.Success(PredicateAndArity(Name.mkPred(ident), arity))
   }
 
   private def tryParsePredicateArity(token: Token)(implicit sctx: SharedContext): Int = {


### PR DESCRIPTION
## Summary

Follow-up to #12846 and #12848, continuing the removal of `Validation` from `Weeder2`. After the earlier conversions, `pickNameIdent` was a trivial `Validation.Success(tokenToIdent(pick(...)))` one-liner — a pure leaf with the wrapper as dead weight.

This makes it return `Name.Ident` directly and updates all 47 call sites.

The rewrite is behavior-preserving (inputs were always `Success`):
- where the ident was the **sole** combinator argument, the `mapN`/`flatMapN` is dropped (`Success` pushed to the leaves for branchy bodies like `visitVariablePat`, `visitExtTagDefaultPattern`, `Types.visitParameter`, `visitKind`);
- in **multi-argument** combinators the ident is hoisted to a plain `val` and removed from the tuple — this is the bulk of the change (~16 declaration visitors plus expr/pattern/predicate/type visitors).

> **Stacked on #12848** (`refactor/weeder2-pickqname-direct-return`). Two functions (`visitTryCatchRule`, `visitSelectRule`) build on that branch's hoisting, so this PR's base is set accordingly; GitHub will retarget it to `master` once #12848 merges. Merge #12848 first.

Next/last in the series: the standalone value-leaves `pickDocumentation`, `visitStaticExpr`, `visitIntrinsic`, `visitConstantType`.