### PR TITLE
refactor: introduce Symbol.AnonClassSym for anonymous classes

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -99,4 +99,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Bertram Nellemann Thorsen](https://github.com/Palemand)
 - [Andreas Gotthelf Kühlwein Pedersen](https://github.com/ACoolWine)
 - [Fridolin Karger](https://github.com/LordBurtz)
-  
+- [Vipul Bhardwaj](https://github.com/vipulbhj)

--- a/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
@@ -84,7 +84,7 @@ object AtomicOp {
 
   case class InvokeMethod(method: Method) extends AtomicOp
 
-  case class InvokeSuperMethod(method: Method, sym: Symbol.AnonClassSym) extends AtomicOp
+  case class InvokeSuperMethod(sym: Symbol.AnonClassSym, method: Method) extends AtomicOp
 
   case class InvokeStaticMethod(method: Method) extends AtomicOp
 

--- a/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
@@ -84,7 +84,7 @@ object AtomicOp {
 
   case class InvokeMethod(method: Method) extends AtomicOp
 
-  case class InvokeSuperMethod(method: Method, className: String) extends AtomicOp
+  case class InvokeSuperMethod(method: Method, sym: Symbol.AnonClassSym) extends AtomicOp
 
   case class InvokeStaticMethod(method: Method) extends AtomicOp
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -103,7 +103,7 @@ object ErasedAst {
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
@@ -109,7 +109,7 @@ object JvmAst {
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -195,7 +195,7 @@ object KindedAst {
 
     case class PutStaticField(field: Field, exp: Expr, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], targs: List[Type], constructors: List[JvmConstructor], methods: List[JvmMethod], tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], targs: List[Type], constructors: List[JvmConstructor], methods: List[JvmMethod], tvar: Type.Var, loc: SourceLocation) extends Expr
 
     case class NewChannel(exp: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -86,7 +86,7 @@ object LiftedAst {
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -111,7 +111,7 @@ object MonoAst {
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], tpe: Type, eff: Type, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -192,7 +192,7 @@ object NamedAst {
 
     case class GetField(exp: Expr, fieldName: Name.Ident, loc: SourceLocation) extends Expr
 
-    case class AmbiguousNew(name: String, tpe: Type, region: Option[Expr], fields: List[(Name.Label, Expr)], constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class AmbiguousNew(tpe: Type, region: Option[Expr], fields: List[(Name.Label, Expr)], constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
     case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -100,7 +100,7 @@ object ReducedAst {
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -209,7 +209,7 @@ object ResolvedAst {
 
     case class PutStaticField(field: Field, exp: Expr, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], targs: List[UnkindedType], constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], targs: List[UnkindedType], constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
     case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -102,7 +102,7 @@ object SimplifiedAst {
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], tpe: SimpleType, purity: Purity, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -329,7 +329,7 @@ object Symbol {
   }
 
   /**
-    * Returns the anon class symbol.
+    * Returns a fresh uniquely generated name for a anonymous Java class.
     */
   def mkFreshAnonClassSym(loc: SourceLocation)(implicit flix: Flix): AnonClassSym = {
     val id = flix.genSym.freshId();
@@ -983,7 +983,7 @@ object Symbol {
   }
 
     /**
-    * AnonClass Symbol.
+    * Anonymous Java class symbol.
     */
   final class AnonClassSym(val id: Int, val loc: SourceLocation) extends Symbol with Locatable {
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -329,6 +329,15 @@ object Symbol {
   }
 
   /**
+    * Returns the anon class symbol.
+    */
+  def mkAnonClassSym(loc: SourceLocation)(implicit flix: Flix): AnonClassSym = {
+    val id = flix.genSym.freshId();
+    new AnonClassSym(id, loc);
+  }
+  
+
+  /**
     * Variable Symbol.
     *
     * @param id      the globally unique name of the symbol.
@@ -971,6 +980,35 @@ object Symbol {
       */
     override def toString: String = ns.mkString(".")
 
+  }
+
+    /**
+    * AnonClass Symbol.
+    */
+  final class AnonClassSym(val id: Int, val loc: SourceLocation) extends Symbol with Locatable {
+
+    /**
+      * Returns the name of `this` symbol.
+      */
+    def name: String = s"Anon$$${id}"
+
+    /**
+      * Returns `true` if this symbol is equal to `that` symbol.
+      */
+    override def equals(obj: Any): Boolean = obj match {
+      case that: AnonClassSym => this.id == that.id
+      case _ => false
+    }
+
+    /**
+      * Returns the hash code of this symbol.
+      */
+    override val hashCode: Int = Objects.hash(id)
+
+    /**
+      * Human-readable representation.
+      */
+    override def toString: String = name
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -331,7 +331,7 @@ object Symbol {
   /**
     * Returns the anon class symbol.
     */
-  def mkAnonClassSym(loc: SourceLocation)(implicit flix: Flix): AnonClassSym = {
+  def mkFreshAnonClassSym(loc: SourceLocation)(implicit flix: Flix): AnonClassSym = {
     val id = flix.genSym.freshId();
     new AnonClassSym(id, loc);
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -244,7 +244,7 @@ object TypedAst {
 
     case class PutStaticField(field: Field, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], tpe: Type, eff: Type, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
     case class NewChannel(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -134,7 +134,7 @@ object DocAst {
 
     case class Unsafe(d: Expr, runEff: Type, asEff: Option[Type]) extends Composite
 
-    case class NewObject(name: String, clazz: Class[?], tpe: Type, constructors: List[JvmConstructor], methods: List[JvmMethod]) extends Composite
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: Class[?], tpe: Type, constructors: List[JvmConstructor], methods: List[JvmMethod]) extends Composite
 
     case class Lambda(fparams: List[Expr.AscriptionTpe], body: Expr) extends Composite
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
@@ -66,7 +66,7 @@ object JvmAstPrinter {
       case JvmAst.HandlerRule(op, fparams, body) =>
         (op.sym, fparams.map(printFormalParam), print(body))
     })
-    case Expr.NewObject(name, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(name, clazz, SimpleTypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
+    case Expr.NewObject(sym, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(sym, clazz, SimpleTypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
   }
 
   /** Returns the [[DocAst.Expr.AscriptionTpe]] representation of `fp`. */

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -69,7 +69,7 @@ object LiftedAstPrinter {
       case LiftedAst.HandlerRule(symUse, fparams, body) =>
         (symUse.sym, fparams.map(printFormalParam), print(body))
     })
-    case NewObject(name, clazz, tpe, _, constructors, methods, _) =>
+    case NewObject(sym, clazz, tpe, _, constructors, methods, _) =>
       val cs = constructors.map {
         case LiftedAst.JvmConstructor(clo, retTpe, _, _) =>
           DocAst.JvmConstructor(print(clo), SimpleTypePrinter.print(retTpe))
@@ -78,7 +78,7 @@ object LiftedAstPrinter {
         case LiftedAst.JvmMethod(ann, ident, fparams, clo, retTpe, _, _) =>
           DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.map(printFormalParam), print(clo), SimpleTypePrinter.print(retTpe))
       }
-      DocAst.Expr.NewObject(name, clazz, SimpleTypePrinter.print(tpe), cs, ms)
+      DocAst.Expr.NewObject(sym, clazz, SimpleTypePrinter.print(tpe), cs, ms)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -46,7 +46,7 @@ object MonoAstPrinter {
     case Expr.Cast(exp, tpe, eff, _) => DocAst.Expr.UncheckedCast(print(exp), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)))
     case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule))
     case Expr.RunWith(exp, effUse, rules, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map(printHandlerRule))
-    case Expr.NewObject(name, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(name, clazz, TypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
+    case Expr.NewObject(sym, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(sym, clazz, TypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
   }
 
   /** Returns the [[DocAst.JvmConstructor]] representation of `constructor`. */

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
@@ -219,7 +219,7 @@ object OpPrinter {
     case (AtomicOp.PutField(field), List(d1, d2)) => JavaPutField(field, d1, d2)
     case (AtomicOp.ArrayStore, List(d1, d2, d3)) => ArrayStore(d1, d2, d3)
     case (AtomicOp.InvokeMethod(method), d :: rs) => JavaInvokeMethod(method, d, rs)
-    case (AtomicOp.InvokeSuperMethod(method, _), d :: rs) => JavaInvokeMethod(method, d, rs)
+    case (AtomicOp.InvokeSuperMethod(_, method), d :: rs) => JavaInvokeMethod(method, d, rs)
     // fall back if non other applies
     case (op1, ds1) => App(Meta(op1.toString), ds1)
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -70,7 +70,7 @@ object ReducedAstPrinter {
       case ReducedAst.HandlerRule(op, fparams, body) =>
         (op.sym, fparams.map(printFormalParam), print(body))
     })
-    case Expr.NewObject(name, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(name, clazz, SimpleTypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
+    case Expr.NewObject(sym, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(sym, clazz, SimpleTypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -74,7 +74,7 @@ object SimplifiedAstPrinter {
       case SimplifiedAst.HandlerRule(op, fparams, body) =>
         (op.sym, fparams.map(printFormalParam), print(body))
     })
-    case NewObject(name, clazz, tpe, _, constructors, methods, _) =>
+    case NewObject(sym, clazz, tpe, _, constructors, methods, _) =>
       val cs = constructors.map {
         case SimplifiedAst.JvmConstructor(exp, retTpe, _, _) =>
           DocAst.JvmConstructor(print(exp), SimpleTypePrinter.print(retTpe))
@@ -83,7 +83,7 @@ object SimplifiedAstPrinter {
         case SimplifiedAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _) =>
           DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.map(printFormalParam), print(exp), SimpleTypePrinter.print(retTpe))
       }
-      DocAst.Expr.NewObject(name, clazz, SimpleTypePrinter.print(tpe), cs, ms)
+      DocAst.Expr.NewObject(sym, clazz, SimpleTypePrinter.print(tpe), cs, ms)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -87,7 +87,7 @@ object TypedAstPrinter {
     case Expr.PutField(field, exp1, exp2, _, _, _) => DocAst.Expr.JavaPutField(field, print(exp1), print(exp2))
     case Expr.GetStaticField(field, _, _, _) => DocAst.Expr.JavaGetStaticField(field)
     case Expr.PutStaticField(field, exp, _, _, _) => DocAst.Expr.JavaPutStaticField(field, print(exp))
-    case Expr.NewObject(name, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(name, clazz, TypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
+    case Expr.NewObject(sym, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(sym, clazz, TypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
     case Expr.NewChannel(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.GetChannel(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.PutChannel(_, _, _, _, _) => DocAst.Expr.Unknown

--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -140,7 +140,7 @@ object ClosureConv {
       }
       Expr.RunWith(e, effUse, rs, tpe, purity, loc)
 
-    case Expr.NewObject(name, clazz, tpe, purity, constructors0, methods0, loc) =>
+    case Expr.NewObject(sym, clazz, tpe, purity, constructors0, methods0, loc) =>
       val constructors = constructors0 map {
         case JvmConstructor(exp, retTpe, constructorPurity, constructorLoc) =>
           exp match {
@@ -158,7 +158,7 @@ object ClosureConv {
           val clo = mkLambdaClosure(fparams, exp, cloType, methodLoc)
           JvmMethod(ann, ident, fparams, clo, retTpe, methodPurity, methodLoc)
       }
-      Expr.NewObject(name, clazz, tpe, purity, constructors, methods, loc)
+      Expr.NewObject(sym, clazz, tpe, purity, constructors, methods, loc)
 
     case Expr.LambdaClosure(_, _, _, _, _, loc) => throw InternalCompilerException(s"Unexpected expression: '$exp0'.", loc)
 
@@ -421,10 +421,10 @@ object ClosureConv {
         }
         Expr.RunWith(e, effUse, rs, tpe, purity, loc)
 
-      case Expr.NewObject(name, clazz, tpe, purity, constructors0, methods0, loc) =>
+      case Expr.NewObject(sym, clazz, tpe, purity, constructors0, methods0, loc) =>
         val constructors = constructors0.map(visitJvmConstructor)
         val methods = methods0.map(visitJvmMethod)
-        Expr.NewObject(name, clazz, tpe, purity, constructors, methods, loc)
+        Expr.NewObject(sym, clazz, tpe, purity, constructors, methods, loc)
 
     }
 
@@ -654,7 +654,7 @@ object ClosureConv {
         }
         Expr.RunWith(e, effUse, rs, tpe, purity, loc)
 
-      case Expr.NewObject(name, clazz, tpe, purity, constructors, methods, loc) =>
+      case Expr.NewObject(sym, clazz, tpe, purity, constructors, methods, loc) =>
         val cs = constructors.map {
           case JvmConstructor(exp, retTpe, constructorPurity, constructorLoc) =>
             val e = visit(exp)
@@ -665,7 +665,7 @@ object ClosureConv {
             val e = visit(exp)
             JvmMethod(ann, ident, fparams, e, retTpe, methodPurity, methodLoc)
         }
-        Expr.NewObject(name, clazz, tpe, purity, cs, ms, loc)
+        Expr.NewObject(sym, clazz, tpe, purity, cs, ms, loc)
     }
 
     visit(expr00)

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -329,10 +329,10 @@ object EffectBinder {
       }
       ReducedAst.Expr.RunWith(e, effUse, rs, ExpPosition.NonTail, tpe, purity, loc)
 
-    case LiftedAst.Expr.NewObject(name, clazz, tpe, purity, constructors, methods, loc) =>
+    case LiftedAst.Expr.NewObject(sym, clazz, tpe, purity, constructors, methods, loc) =>
       val cs = constructors.map(visitJvmConstructor)
       val ms = methods.map(visitJvmMethod)
-      ReducedAst.Expr.NewObject(name, clazz, tpe, purity, cs, ms, loc)
+      ReducedAst.Expr.NewObject(sym, clazz, tpe, purity, cs, ms, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -240,8 +240,8 @@ object Eraser {
     case ReducedAst.Expr.RunWith(exp, effUse, rules, ct, tpe, purity, loc) =>
       val tw = ErasedAst.Expr.RunWith(visitExp(exp), effUse, rules.map(visitHandlerRule), ct, box(tpe), purity, loc)
       castExp(unboxExp(tw, erase(tpe), purity, loc), visitType(tpe), purity, loc)
-    case ReducedAst.Expr.NewObject(name, clazz, tpe, purity, constructors, methods, loc) =>
-      ErasedAst.Expr.NewObject(name, clazz, visitType(tpe), purity, constructors.map(visitJvmConstructor), methods.map(visitJvmMethod), loc)
+    case ReducedAst.Expr.NewObject(sym, clazz, tpe, purity, constructors, methods, loc) =>
+      ErasedAst.Expr.NewObject(sym, clazz, visitType(tpe), purity, constructors.map(visitJvmConstructor), methods.map(visitJvmMethod), loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -765,12 +765,12 @@ object Kinder {
         val exp = visitExp(exp0, kenv0, root)
         KindedAst.Expr.PutStaticField(field, exp, loc)
 
-      case ResolvedAst.Expr.NewObject(name, clazz, targs0, constructors0, methods0, loc) =>
+      case ResolvedAst.Expr.NewObject(sym, clazz, targs0, constructors0, methods0, loc) =>
         val targs = targs0.map(visitType(_, Kind.Star, kenv0, root))
         val constructors = constructors0.map(visitJvmConstructor(_, kenv0, root))
         val methods = methods0.map(visitJvmMethod(_, kenv0, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-        KindedAst.Expr.NewObject(name, clazz, targs, constructors, methods, tvar, loc)
+        KindedAst.Expr.NewObject(sym, clazz, targs, constructors, methods, tvar, loc)
 
       case ResolvedAst.Expr.NewChannel(exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -233,10 +233,10 @@ object LambdaLift {
       }
       LiftedAst.Expr.RunWith(e, effUse, rs, tpe, purity, loc)
 
-    case SimplifiedAst.Expr.NewObject(name, clazz, tpe, purity, constructors0, methods0, loc) =>
+    case SimplifiedAst.Expr.NewObject(sym, clazz, tpe, purity, constructors0, methods0, loc) =>
       val constructors = constructors0.map(visitJvmConstructor)
       val methods = methods0.map(visitJvmMethod)
-      LiftedAst.Expr.NewObject(name, clazz, tpe, purity, constructors, methods, loc)
+      LiftedAst.Expr.NewObject(sym, clazz, tpe, purity, constructors, methods, loc)
 
     case SimplifiedAst.Expr.Lambda(_, _, _, loc) => throw InternalCompilerException(s"Unexpected expression.", loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1007,8 +1007,7 @@ object Namer {
       val fields = fields0.map(visitStructField)
       val cs = constructors.map(visitJvmConstructor)
       val ms = methods.map(visitJvmMethod)
-      val name = s"Anon$$${flix.genSym.freshId()}"
-      NamedAst.Expr.AmbiguousNew(name, t, region, fields, cs, ms, loc)
+      NamedAst.Expr.AmbiguousNew(t, region, fields, cs, ms, loc)
 
     case DesugaredAst.Expr.StructGet(exp, name, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -214,7 +214,7 @@ object Reducer {
         }
         JvmAst.Expr.RunWith(e, effUse, rs, ct, tpe, purity, loc)
 
-      case ErasedAst.Expr.NewObject(name, clazz, tpe, purity, constructors, methods, loc) =>
+      case ErasedAst.Expr.NewObject(sym, clazz, tpe, purity, constructors, methods, loc) =>
         val cs = constructors.map {
           case ErasedAst.JvmConstructor(clo, retTpe, cnsPurity, cnsLoc) =>
             val c = visitExpr(clo)
@@ -225,9 +225,9 @@ object Reducer {
             val c = visitExpr(clo)
             JvmAst.JvmMethod(ann, ident, fparams.map(visitFormalParam), c, retTpe, methPurity, methLoc)
         }
-        ctx.addAnonClass(JvmAst.AnonClass(name, clazz, tpe, cs, specs, Nil, loc))
+        ctx.addAnonClass(JvmAst.AnonClass(sym.name, clazz, tpe, cs, specs, Nil, loc))
 
-        JvmAst.Expr.NewObject(name, clazz, tpe, purity, cs, specs, loc)
+        JvmAst.Expr.NewObject(sym, clazz, tpe, purity, cs, specs, loc)
 
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -126,7 +126,7 @@ object Reducer {
 
       case ErasedAst.Expr.ApplyAtomic(op, exps, tpe, purity, loc) =>
         op match {
-          case AtomicOp.InvokeSuperMethod(method, sym) => ctx.addSuperMethod(sym.name, method)
+          case AtomicOp.InvokeSuperMethod(sym, method) => ctx.addSuperMethod(sym.name, method)
           case _ => ()
         }
         val es = exps.map(visitExpr)

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -126,7 +126,7 @@ object Reducer {
 
       case ErasedAst.Expr.ApplyAtomic(op, exps, tpe, purity, loc) =>
         op match {
-          case AtomicOp.InvokeSuperMethod(method, className) => ctx.addSuperMethod(className, method)
+          case AtomicOp.InvokeSuperMethod(method, sym) => ctx.addSuperMethod(sym.name, method)
           case _ => ()
         }
         val es = exps.map(visitExpr)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1041,7 +1041,7 @@ object Resolver {
       val b = resolveExp(exp, scp0)
       ResolvedAst.Expr.ArrayLength(b, loc)
 
-    case NamedAst.Expr.AmbiguousNew(anonName, tpe, region0, fields0, constructors, methods, loc) =>
+    case NamedAst.Expr.AmbiguousNew(tpe, region0, fields0, constructors, methods, loc) =>
       val qnameOpt = tpe match {
         case NamedAst.Type.Ambiguous(qname, _) => Some(qname)
         case _ => None
@@ -1050,7 +1050,7 @@ object Resolver {
       if (isStructShape)
         resolveAmbiguousNewAsStruct(qnameOpt, tpe, region0, fields0, scp0, loc)
       else
-        resolveAmbiguousNewAsObject(anonName, qnameOpt, tpe, constructors, methods, scp0, loc)
+        resolveAmbiguousNewAsObject(qnameOpt, tpe, constructors, methods, scp0, loc)
 
     case NamedAst.Expr.StructGet(exp, field0, loc) =>
       lookupStructField(field0, scp0, ns0, root) match {
@@ -1658,7 +1658,7 @@ object Resolver {
     * Resolves an ambiguous `new` expression where the body is object-shaped (JVM constructors/methods or empty).
     * The name must refer to a Java class. If it resolves to a Flix struct instead, emits `NewStructWithObjectConstructors` or `NewStructWithObjectMethods`.
     */
-  private def resolveAmbiguousNewAsObject(anonName: String, qnameOpt: Option[Name.QName], tpe: NamedAst.Type, constructors: List[NamedAst.JvmConstructor], methods: List[NamedAst.JvmMethod], scp0: LocalScope, loc: SourceLocation)(implicit scope: RegionScope, ns0: Name.NName, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): ResolvedAst.Expr = {
+  private def resolveAmbiguousNewAsObject(qnameOpt: Option[Name.QName], tpe: NamedAst.Type, constructors: List[NamedAst.JvmConstructor], methods: List[NamedAst.JvmMethod], scp0: LocalScope, loc: SourceLocation)(implicit scope: RegionScope, ns0: Name.NName, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): ResolvedAst.Expr = {
     val structOpt = qnameOpt.flatMap { qname =>
       lookupStruct(qname, scp0, ns0, root) match {
         case Result.Ok(st) => Some(st)
@@ -1684,7 +1684,8 @@ object Resolver {
             val superScp = scp0.withSuperClass(Some(clazz)).withSuperTargs(targs)
             val cs = constructors.map(visitJvmConstructor(_, superScp))
             val ms = methods.map(visitJvmMethod(_, superScp))
-            ResolvedAst.Expr.NewObject(anonName, clazz, targs, cs, ms, loc)
+            val anonClassSym = Symbol.mkAnonClassSym(loc);
+            ResolvedAst.Expr.NewObject(anonClassSym, clazz, targs, cs, ms, loc)
           case None =>
             erased match {
               case _: UnkindedType.Error =>
@@ -3321,6 +3322,7 @@ object Resolver {
     case sym: Symbol.UnkindedTypeVarSym => throw InternalCompilerException(s"unexpected symbol $sym", sym.loc)
     case sym: Symbol.LabelSym => throw InternalCompilerException(s"unexpected symbol $sym", SourceLocation.Unknown)
     case sym: Symbol.HoleSym => throw InternalCompilerException(s"unexpected symbol $sym", sym.loc)
+    case sym: Symbol.AnonClassSym => throw InternalCompilerException(s"unexpected symbol $sym", sym.loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1684,7 +1684,7 @@ object Resolver {
             val superScp = scp0.withSuperClass(Some(clazz)).withSuperTargs(targs)
             val cs = constructors.map(visitJvmConstructor(_, superScp))
             val ms = methods.map(visitJvmMethod(_, superScp))
-            val anonClassSym = Symbol.mkAnonClassSym(loc);
+            val anonClassSym = Symbol.mkFreshAnonClassSym(loc);
             ResolvedAst.Expr.NewObject(anonClassSym, clazz, targs, cs, ms, loc)
           case None =>
             erased match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -254,11 +254,11 @@ object Simplifier {
       val t = visitType(tpe)
       SimplifiedAst.Expr.RunWith(e, effUse, rs, t, simplifyEffect(eff), loc)
 
-    case MonoAst.Expr.NewObject(name, clazz, tpe, eff, constructors0, methods0, loc) =>
+    case MonoAst.Expr.NewObject(sym, clazz, tpe, eff, constructors0, methods0, loc) =>
       val t = visitType(tpe)
       val constructors = constructors0 map visitJvmConstructor
       val methods = methods0 map visitJvmMethod
-      SimplifiedAst.Expr.NewObject(name, clazz, t, simplifyEffect(eff), constructors, methods, loc)
+      SimplifiedAst.Expr.NewObject(sym, clazz, t, simplifyEffect(eff), constructors, methods, loc)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -358,10 +358,10 @@ object Stratifier {
       val e = visitExp(exp)
       if (e eq exp) exp0 else Expr.PutStaticField(field, e, tpe, eff, loc)
 
-    case Expr.NewObject(name, clazz, tpe, eff, constructors, methods, loc) =>
+    case Expr.NewObject(sym, clazz, tpe, eff, constructors, methods, loc) =>
       val cs = constructors.map(visitJvmConstructor)
       val ms = methods.map(visitJvmMethod)
-      Expr.NewObject(name, clazz, tpe, eff, cs, ms, loc)
+      Expr.NewObject(sym, clazz, tpe, eff, cs, ms, loc)
 
     case Expr.NewChannel(exp, tpe, eff, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
@@ -758,10 +758,10 @@ object Terminator {
           val e = visitExp(contexts, exp1, ApplyPosition.NonTail)
           if (e eq exp1) exp0 else Expr.PutStaticField(field, e, tpe, eff, loc)
 
-        case Expr.NewObject(name, clazz, tpe, eff, constructors, methods0, loc) =>
+        case Expr.NewObject(sym, clazz, tpe, eff, constructors, methods0, loc) =>
           checkForbidden(contexts, loc)
           val ms = methods0.map(visitJvmMethod(contexts, _))
-          Expr.NewObject(name, clazz, tpe, eff, constructors, ms, loc)
+          Expr.NewObject(sym, clazz, tpe, eff, constructors, ms, loc)
 
         case Expr.NewChannel(exp1, tpe, eff, loc) =>
           checkForbidden(contexts, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -522,12 +522,12 @@ object TypeReconstruction {
       val eff = Type.mkUnion(e.eff, Type.IO, loc)
       TypedAst.Expr.PutStaticField(field, e, tpe, eff, loc)
 
-    case KindedAst.Expr.NewObject(name, clazz, _, constructors, methods, tvar, loc) =>
+    case KindedAst.Expr.NewObject(sym, clazz, _, constructors, methods, tvar, loc) =>
       val tpe = subst(tvar)
       val eff = Type.IO
       val cs = constructors.map(visitJvmConstructor)
       val ms = methods.map(visitJvmMethod)
-      TypedAst.Expr.NewObject(name, clazz, tpe, eff, cs, ms, loc)
+      TypedAst.Expr.NewObject(sym, clazz, tpe, eff, cs, ms, loc)
 
     case KindedAst.Expr.NewChannel(exp, tvar, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -117,6 +117,7 @@ object Typer {
         case sym: Symbol.UnkindedTypeVarSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
         case sym: Symbol.LabelSym => throw InternalCompilerException(s"unexpected symbol: $sym", SourceLocation.Unknown)
         case sym: Symbol.HoleSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
+        case sym: Symbol.AnonClassSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
       }
 
       // Every module symbol that either appears as a key (has children) or has an

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1598,9 +1598,9 @@ object GenExpression {
         ARETURN()
       }
 
-    case Expr.NewObject(name, _, _, _, constructors, methods, _) =>
+    case Expr.NewObject(sym, _, _, _, constructors, methods, _) =>
       val methodExps = methods.map(_.exp)
-      val className = JvmName(ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage, name).toInternalName
+      val className = JvmName(ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage, sym.name).toInternalName
       mv.visitTypeInsn(NEW, className)
       mv.visitInsn(DUP)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -907,7 +907,7 @@ object GenExpression {
           mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
         }
 
-      case AtomicOp.InvokeSuperMethod(method, className) =>
+      case AtomicOp.InvokeSuperMethod(method, sym) =>
         // Add source line number for debugging
         BytecodeInstructions.addLoc(loc)
 
@@ -916,7 +916,7 @@ object GenExpression {
 
         // Evaluate the receiver object.
         compileExpr(receiver)
-        val anonClassInternalName = className.replace('.', '/')
+        val anonClassInternalName = sym.name.replace('.', '/')
         mv.visitTypeInsn(CHECKCAST, anonClassInternalName)
 
         // Evaluate and cast each argument.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -907,7 +907,7 @@ object GenExpression {
           mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
         }
 
-      case AtomicOp.InvokeSuperMethod(method, sym) =>
+      case AtomicOp.InvokeSuperMethod(sym, method) =>
         // Add source line number for debugging
         BytecodeInstructions.addLoc(loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -518,9 +518,9 @@ object Lowering {
     case TypedAst.Expr.InvokeSuperMethod(method, exps, tpe, eff, loc) =>
       val es = exps.map(lowerExp)
       val t = lowerType(tpe)
-      (lctx.className, lctx.thisRef) match {
-        case (Some(cn), Some(thisRef)) =>
-          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(method, cn), thisRef :: es, t, eff, loc)
+      (lctx.sym, lctx.thisRef) match {
+        case (Some(sym), Some(thisRef)) =>
+          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(method, sym), thisRef :: es, t, eff, loc)
         case _ =>
           throw InternalCompilerException("InvokeSuperMethod outside NewObject context", loc)
       }
@@ -563,7 +563,7 @@ object Lowering {
         val thisParam = m.fparams.head
         val thisTpe = lowerType(thisParam.tpe)
         val thisRef = MonoAst.Expr.Var(thisParam.bnd.sym, thisTpe, loc)
-        implicit val lctx: LocalContext = LocalContext(Some(sym.name), Some(thisRef))
+        implicit val lctx: LocalContext = LocalContext(Some(sym), Some(thisRef))
         lowerJvmMethod(m)
       }
       val t = lowerType(tpe)
@@ -2513,7 +2513,7 @@ object Lowering {
     * A local context threaded through `lowerExp` to carry information from an
     * enclosing `NewObject` to nested `InvokeSuperMethod` expressions.
     *
-    * @param className The internal name of the enclosing anonymous class (e.g. `"pkg.Anon$1"`).
+    * @param className The internal name of the enclosing anonymous class.
     *                  Set to `Some` when lowering a `NewObject` method body; `None` otherwise.
     *                  Injected into `AtomicOp.InvokeSuperMethod` so the backend can generate
     *                  the `CHECKCAST` and `INVOKEVIRTUAL super$methodName` instructions.
@@ -2521,7 +2521,7 @@ object Lowering {
     *                  parameter of the JvmMethod). Prepended to `InvokeSuperMethod` arguments
     *                  so the backend receives the receiver object as the first expression.
     */
-  private case class LocalContext(className: Option[String], thisRef: Option[MonoAst.Expr])
+  private case class LocalContext(sym: Option[Symbol.AnonClassSym], thisRef: Option[MonoAst.Expr])
 
   private object LocalContext {
     val empty: LocalContext = LocalContext(None, None)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -520,7 +520,7 @@ object Lowering {
       val t = lowerType(tpe)
       (lctx.sym, lctx.thisRef) match {
         case (Some(sym), Some(thisRef)) =>
-          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(method, sym), thisRef :: es, t, eff, loc)
+          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(sym, method), thisRef :: es, t, eff, loc)
         case _ =>
           throw InternalCompilerException("InvokeSuperMethod outside NewObject context", loc)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -557,17 +557,17 @@ object Lowering {
       val t = lowerType(tpe)
       MonoAst.Expr.ApplyAtomic(AtomicOp.PutStaticField(field), List(e), t, eff, loc)
 
-    case TypedAst.Expr.NewObject(name, clazz, tpe, eff, constructors, methods, loc) =>
+    case TypedAst.Expr.NewObject(sym, clazz, tpe, eff, constructors, methods, loc) =>
       val cs = constructors.map(lowerJvmConstructor)
       val ms = methods.map { m =>
         val thisParam = m.fparams.head
         val thisTpe = lowerType(thisParam.tpe)
         val thisRef = MonoAst.Expr.Var(thisParam.bnd.sym, thisTpe, loc)
-        implicit val lctx: LocalContext = LocalContext(Some(name), Some(thisRef))
+        implicit val lctx: LocalContext = LocalContext(Some(sym.name), Some(thisRef))
         lowerJvmMethod(m)
       }
       val t = lowerType(tpe)
-      MonoAst.Expr.NewObject(name, clazz, t, eff, cs, ms, loc)
+      MonoAst.Expr.NewObject(sym, clazz, t, eff, cs, ms, loc)
 
     case TypedAst.Expr.NewChannel(exp, tpe, eff, loc) =>
       val e = lowerExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -895,10 +895,10 @@ object Specialization {
       val t = subst(tpe)
       Expr.PutStaticField(field, e, t, subst(eff), loc)
 
-    case Expr.NewObject(name, clazz, tpe, eff, constructors0, methods0, loc) =>
+    case Expr.NewObject(sym, clazz, tpe, eff, constructors0, methods0, loc) =>
       val constructors = constructors0.map(specializeJvmConstructor(_, env0, subst))
       val methods = methods0.map(specializeJvmMethod(_, env0, subst))
-      Expr.NewObject(name, clazz, subst(tpe), subst(eff), constructors, methods, loc)
+      Expr.NewObject(sym, clazz, subst(tpe), subst(eff), constructors, methods, loc)
 
     case Expr.NewChannel(innerExp, tpe, eff, loc) =>
       val e = specializeExp(innerExp, env0, subst)

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -369,10 +369,10 @@ object Inliner {
       val rs = rules.map(visitHandlerRule(_, ctx0))
       Expr.RunWith(e, effUse, rs, tpe, eff, loc)
 
-    case Expr.NewObject(name, clazz, tpe, eff, constructors0, methods0, loc) =>
+    case Expr.NewObject(sym, clazz, tpe, eff, constructors0, methods0, loc) =>
       val constructors = constructors0.map(visitJvmConstructor(_, ctx0))
       val methods = methods0.map(visitJvmMethod(_, ctx0))
-      Expr.NewObject(name, clazz, tpe, eff, constructors, methods, loc)
+      Expr.NewObject(sym, clazz, tpe, eff, constructors, methods, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
@@ -355,7 +355,7 @@ object LambdaDrop {
       }
       Expr.RunWith(e1, effUse, rs, tpe, eff, loc)
 
-    case Expr.NewObject(name, clazz, tpe, eff1, constructors, methods, loc1) =>
+    case Expr.NewObject(sym, clazz, tpe, eff1, constructors, methods, loc1) =>
       val cs = constructors.map {
         case MonoAst.JvmConstructor(exp, retTpe, eff2, loc2) =>
           val e = rewriteExp(exp)
@@ -366,7 +366,7 @@ object LambdaDrop {
           val e = rewriteExp(exp)
           MonoAst.JvmMethod(ann, ident, fparams, e, retTpe, eff2, loc2)
       }
-      Expr.NewObject(name, clazz, tpe, eff1, cs, ms, loc1)
+      Expr.NewObject(sym, clazz, tpe, eff1, cs, ms, loc1)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -268,7 +268,7 @@ object OccurrenceAnalyzer {
           (Expr.RunWith(e, effUse, rs, tpe, eff, loc), ctx3)
         }
 
-      case Expr.NewObject(name, clazz, tpe, eff, constructors, methods, loc) =>
+      case Expr.NewObject(sym, clazz, tpe, eff, constructors, methods, loc) =>
         val (cs, cCtxs) = constructors.map(visitJvmConstructor).unzip
         val (ms, mCtxs) = methods.map(visitJvmMethod).unzip
         val ctx = (cCtxs ++ mCtxs).foldLeft(ExprContext.Empty)(combineBranch)
@@ -276,7 +276,7 @@ object OccurrenceAnalyzer {
             ListOps.zip(methods, ms).forall { case (m1, m2) => m1 eq m2 }) {
           (exp0, ctx) // Reuse exp0.
         } else {
-          (Expr.NewObject(name, clazz, tpe, eff, cs, ms, loc), ctx)
+          (Expr.NewObject(sym, clazz, tpe, eff, cs, ms, loc), ctx)
         }
     }
   }

--- a/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
@@ -330,7 +330,7 @@ object EffectVerifier {
       visitExp(exp)
       // TODO Java stuff
       ()
-    case Expr.NewObject(name, clazz, tpe, eff, constructors, methods, loc) =>
+    case Expr.NewObject(_, clazz, tpe, eff, constructors, methods, loc) =>
       constructors.foreach { c => visitExp(c.exp) }
       methods.foreach { m => visitExp(m.exp) }
       // TODO Java stuff

--- a/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
@@ -461,7 +461,7 @@ object TypeVerifier {
           checkJavaSubtype(t, method.getDeclaringClass, loc)
           checkJavaSubtype(tpe, method.getReturnType, loc)
 
-        case AtomicOp.InvokeSuperMethod(method, _) =>
+        case AtomicOp.InvokeSuperMethod(_, method) =>
           val t :: pts = ts
           checkJavaParameters(pts, method.getParameterTypes.toList, loc)
           checkJavaSubtype(t, method.getDeclaringClass, loc)


### PR DESCRIPTION
Anonymous classes were previously identified by a bare String (e.g. "Anon$42") generated in Namer and threaded through the entire compiler pipeline. This PR replaces that raw string with a dedicated Symbol.AnonClassSym type, consistent with how other compiler entities (DefnSym, EnumSym, StructSym, etc.) are tracked.

Changes:
- Adds Symbol.AnonClassSym and Symbol.mkAnonClassSym factory to Symbol.scala
- Replaces name: String with sym: Symbol.AnonClassSym in NewObject across all AST phases (NamedAst → JvmAst)
- Replaces className: String with sym: Symbol.AnonClassSym in AtomicOp.InvokeSuperMethod and updates Lowering, Reducer, and GenExpression accordingly.

This is a pure refactor — no behavior change (related to #12396)