### PR TITLE
refactor: return Kind directly from visitKind in Weeder2

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3313,8 +3313,9 @@ object Weeder2 {
 
     private def visitAscribeType(tree: Tree)(implicit sctx: SharedContext): Validation[Type, CompilationMessage] = {
       expect(tree, TreeKind.Type.Ascribe)
-      mapN(pickType(tree), pickKind(tree)) {
-        (tpe, kind) => Type.Ascribe(tpe, kind, tree.loc)
+      val kind = pickKind(tree)
+      mapN(pickType(tree)) {
+        tpe => Type.Ascribe(tpe, kind, tree.loc)
       }
     }
 
@@ -3441,25 +3442,23 @@ object Weeder2 {
       }
     }
 
-    private def visitKind(tree: Tree)(implicit sctx: SharedContext): Validation[Kind, CompilationMessage] = {
+    private def visitKind(tree: Tree)(implicit sctx: SharedContext): Kind = {
       expect(tree, TreeKind.Kind)
       val ident = pickNameIdent(tree)
       val kind = Kind.Ambiguous(Name.QName(Name.RootNS, ident, ident.loc), ident.loc)
       tryPick(TreeKind.Kind, tree)
-      Validation.Success(
-        tryPickKind(tree)
-          .map(Kind.Arrow(kind, _, tree.loc))
-          .getOrElse(kind)
-      )
+      tryPickKind(tree)
+        .map(Kind.Arrow(kind, _, tree.loc))
+        .getOrElse(kind)
     }
 
-    private def pickKind(tree: Tree)(implicit sctx: SharedContext): Validation[Kind, CompilationMessage] = {
+    private def pickKind(tree: Tree)(implicit sctx: SharedContext): Kind = {
       visitKind(pick(TreeKind.Kind, tree))
     }
 
     def tryPickKind(tree: Tree)(implicit sctx: SharedContext): Option[Kind] = {
       // Cast a missing kind to None because 'tryPick' means that it's okay not to find a kind here.
-      tryPick(TreeKind.Kind, tree).flatMap(visitKind(_).toResult.toOption)
+      tryPick(TreeKind.Kind, tree).map(visitKind)
     }
   }
 


### PR DESCRIPTION
## Summary

Continues the `Validation`-removal series in `Weeder2`. `visitKind` only ever produced `Validation.Success`, so it (and `pickKind`) now return `Kind` directly.

The payoff beyond dropping the wrapper: `tryPickKind` was unwrapping `visitKind`'s result with `.toResult.toOption` (re-wrapping a `Validation` only to immediately unwrap it). With `visitKind` returning a plain `Kind`, that collapses to `tryPick(TreeKind.Kind, tree).map(visitKind)`.

Behavior-preserving: `visitAscribeType` hoists `pickKind` to a plain `val` and drops it from the `mapN` tuple.

Next candidate: `Types.visitParameter`, which cascades into `pickParameters` / `pickKindedParameters` / `pickSingleParameter` toward the type-parameter roots.