### PR TITLE
perf: reduce allocations in Kinder kind-environment merging

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -129,7 +129,7 @@ object Kinder {
         kenv0
       } else {
         // The last add is simply to verify that the last tparam was marked as Eff
-        kenv0 + (tparams1.last.sym -> Kind.Eff)
+        kenv0.+(tparams1.last.sym, Kind.Eff)
       }
       val tparams = tparams1.map(visitTypeParam(_, kenv))
       val fields = fields0.map(visitStructField(_, kenv, root))
@@ -655,7 +655,7 @@ object Kinder {
         // which won't be found in the kenv of the function
         val kenvTpe = expectedType0.map(inferType(_, Kind.Star, kenv0, root)).getOrElse(KindEnv.empty)
         val kenvEff = expectedEff0.map(inferType(_, Kind.Eff, kenv0, root)).getOrElse(KindEnv.empty)
-        val kenv = KindEnv.merge(List(kenv0, kenvTpe, kenvEff))
+        val kenv = KindEnv.merge(kenv0, kenvTpe, kenvEff)
         val expectedType = expectedType0.map(visitType(_, Kind.Star, kenv, root))
         val expectedEff = expectedEff0.map(visitType(_, Kind.Eff, kenv, root))
         val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
@@ -1468,12 +1468,12 @@ object Kinder {
     */
   private def inferSpec(spec0: ResolvedAst.Spec, kenv: KindEnv, root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, sctx: SharedContext): KindEnv = spec0 match {
     case ResolvedAst.Spec(_, _, _, _, fparams, tpe, eff0, tconstrs, econstrs) =>
-      val fparamKenvs = fparams.map(inferFormalParam(_, kenv, root))
+      val fparamKenv = KindEnv.merge(fparams.map(inferFormalParam(_, kenv, root)))
       val tpeKenv = inferType(tpe, Kind.Star, kenv, root)
-      val effKenvs = eff0.map(inferType(_, Kind.Eff, kenv, root)).toList
-      val tconstrsKenvs = tconstrs.map(inferTraitConstraint(_, kenv, root))
-      val econstrsKenvs = econstrs.map(inferEqualityConstraint(_, kenv, root))
-      KindEnv.merge(fparamKenvs ::: tpeKenv :: effKenvs ::: tconstrsKenvs ::: econstrsKenvs)
+      val effKenv = eff0.map(inferType(_, Kind.Eff, kenv, root)).getOrElse(KindEnv.empty)
+      val tconstrsKenv = KindEnv.merge(tconstrs.map(inferTraitConstraint(_, kenv, root)))
+      val econstrsKenv = KindEnv.merge(econstrs.map(inferEqualityConstraint(_, kenv, root)))
+      KindEnv.merge(fparamKenv, tpeKenv, effKenv, tconstrsKenv, econstrsKenv)
   }
 
   /**
@@ -1562,11 +1562,11 @@ object Kinder {
       inferType(arg, kind, kenv0, root)
 
     case UnkindedType.Arrow(eff, _, _) =>
-      val effKenvs = eff.map(inferType(_, Kind.Eff, kenv0, root)).toList
+      val effKenv = eff.map(inferType(_, Kind.Eff, kenv0, root)).getOrElse(KindEnv.empty)
       val argKenv = tpe.typeArguments.foldLeft(KindEnv.empty) {
         case (acc, targ) => acc ++ inferType(targ, Kind.Star, kenv0, root)
       }
-      KindEnv.merge(effKenvs :+ argKenv)
+      KindEnv.merge(effKenv, argKenv)
 
     case UnkindedType.Enum(sym, _) =>
       val tyconKind = getEnumKind(root.enums(sym))
@@ -1812,11 +1812,24 @@ object Kinder {
 
     /**
       * Merges the given kind environments.
+      */
+    def merge(kenv1: KindEnv, kenvs: KindEnv*)(implicit sctx: SharedContext): KindEnv = {
+      kenvs.foldLeft(kenv1)(_ ++ _)
+    }
+
+    /**
+      * Merges the given kind environments.
       *
       * The environments must be disjoint.
       */
     def disjointAppend(kenv1: KindEnv, kenv2: KindEnv): KindEnv = {
-      KindEnv(kenv1.map ++ kenv2.map)
+      if (kenv1.map.isEmpty) {
+        kenv2
+      } else if (kenv2.map.isEmpty) {
+        kenv1
+      } else {
+        KindEnv(kenv1.map ++ kenv2.map)
+      }
     }
 
     /**
@@ -1833,14 +1846,17 @@ object Kinder {
     /**
       * Adds the given mapping to the kind environment.
       */
-    def +(pair: (Symbol.UnkindedTypeVarSym, Kind))(implicit sctx: SharedContext): KindEnv = pair match {
-      case (tvar, kind) => map.get(tvar) match {
+    def +(tvar: Symbol.UnkindedTypeVarSym, kind: Kind)(implicit sctx: SharedContext): KindEnv = {
+      map.get(tvar) match {
         case Some(kind0) => unify(kind0, kind) match {
+          // The kind is unchanged: reuse this environment rather than rebuilding the map.
+          case Some(minKind) if minKind == kind0 => this
           case Some(minKind) => KindEnv(map + (tvar -> minKind))
           case None =>
             val e = KindError.MismatchedKinds(kind0, kind, tvar.loc)
             sctx.errors.add(e)
-            KindEnv(map + (tvar -> kind0))
+            // We keep the existing kind0 mapping, so the environment is unchanged.
+            this
         }
         case None => KindEnv(map + (tvar -> kind))
       }
@@ -1849,8 +1865,19 @@ object Kinder {
     /**
       * Merges the given kind environment into this kind environment.
       */
-    def ++(other: KindEnv)(implicit sctx: SharedContext): KindEnv = {
-      other.map.foldLeft(this)(_ + _)
+    def ++(that: KindEnv)(implicit sctx: SharedContext): KindEnv = {
+      if (this.map.isEmpty) {
+        that
+      } else if (that.map.isEmpty) {
+        this
+      } else {
+        // Performance: `foreachEntry` avoids a tuple allocation per binding.
+        var acc = this
+        that.map.foreachEntry {
+          (tvar, kind) => acc = acc.+(tvar, kind)
+        }
+        acc
+      }
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/KindUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/KindUnification.scala
@@ -22,37 +22,43 @@ object KindUnification {
   /**
     * Unifies the kinds, returning the most specific kind if possible.
     */
-  def unify(k1: Kind, k2: Kind): Option[Kind] = (k1, k2) match {
-    // NB:  The order of these cases is determined by coverage analysis.
+  def unify(k1: Kind, k2: Kind): Option[Kind] = {
+    // Fast path: a reference-equality check short-circuits the common case
+    // without allocating the tuple matched on below.
+    if (k1 eq k2) {
+      Some(k1)
+    } else (k1, k2) match {
+      // NB:  The order of these cases is determined by coverage analysis.
 
-    // k ~ k = k
-    case (kind1, kind2) if kind1 == kind2 =>
-      Some(kind1)
+      // k ~ k = k
+      case (kind1, kind2) if kind1 == kind2 =>
+        Some(kind1)
 
-    // (a1 -> b1) ~ (a2 -> b2) = (a1 ~ a2) ~ (b1 -> b2)
-    case (Kind.Arrow(k11, k12), Kind.Arrow(k21, k22)) =>
-      for {
-        kind1 <- unify(k11, k21)
-        kind2 <- unify(k12, k22)
-      } yield Kind.mkArrow(kind1, kind2)
+      // (a1 -> b1) ~ (a2 -> b2) = (a1 ~ a2) ~ (b1 -> b2)
+      case (Kind.Arrow(k11, k12), Kind.Arrow(k21, k22)) =>
+        for {
+          kind1 <- unify(k11, k21)
+          kind2 <- unify(k12, k22)
+        } yield Kind.mkArrow(kind1, kind2)
 
-    // Wild ~ k = k
-    case (Kind.Wild, k) =>
-      Some(k)
-    case (k, Kind.Wild) =>
-      Some(k)
+      // Wild ~ k = k
+      case (Kind.Wild, k) =>
+        Some(k)
+      case (k, Kind.Wild) =>
+        Some(k)
 
-    // WildCaseSet ~ CaseSet(s) = CaseSet(s)
-    case (Kind.WildCaseSet , Kind.CaseSet(sym)) =>
-      Some(Kind.CaseSet(sym))
-    case (Kind.CaseSet(sym), Kind.WildCaseSet) =>
-      Some(Kind.CaseSet(sym))
+      // WildCaseSet ~ CaseSet(s) = CaseSet(s)
+      case (Kind.WildCaseSet , Kind.CaseSet(sym)) =>
+        Some(Kind.CaseSet(sym))
+      case (Kind.CaseSet(sym), Kind.WildCaseSet) =>
+        Some(Kind.CaseSet(sym))
 
-    case (Kind.Error, k) => Some(k)
+      case (Kind.Error, k) => Some(k)
 
-    case (k, Kind.Error) => Some(k)
+      case (k, Kind.Error) => Some(k)
 
-    // else fail
-    case _ => None
+      // else fail
+      case _ => None
+    }
   }
 }


### PR DESCRIPTION
Cuts redundant allocations on the hot kind-environment and kind-unification paths in the `Kinder` phase. No behavior change.

### `KindUnification.unify`
- Add a reference-equality (`eq`) fast path that short-circuits the common case without allocating the `Tuple2` matched on below. The original `==` guard case is kept, so structural equality the `eq` check misses (e.g. non-interned `CaseSet`s) is still handled.

### `KindEnv`
- Short-circuit empty merges in `++` and `disjointAppend` (return the other side directly). `inferType` is full of `acc ++ inferType(...)` folds where the recursive call returns `empty` for leaf types, and `merge` starts every fold from `empty`.
- Add a varargs `merge` overload and drop the `:::` / `:+` / `.toList` churn at the call sites in `inferSpec`, `inferType` (`Arrow`), and `Ascribe`.
- `+` now takes `(tvar, kind)` instead of a pair, and `++` iterates with `foreachEntry` to avoid a tuple allocation per binding (matching the existing pattern in `Substitution`).
- `+` returns `this` when the mapping is unchanged (unify leaves the kind as-is, or the mismatch path which re-inserts the existing kind), avoiding a `Map.updated` + wrapper allocation on the common re-merge path.