### PR TITLE
ci: speed up the compiler CI workflows

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -26,6 +26,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      - name: Cache Mill and Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.cache/mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill', '.mill-version') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
       - name: Build Flix JAR
         run: ./mill flix.assembly
       - name: Upload Flix JAR

--- a/.github/workflows/compiler-build-and-test.yaml
+++ b/.github/workflows/compiler-build-and-test.yaml
@@ -23,9 +23,44 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      - name: Cache Mill and Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.cache/mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill', '.mill-version') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
       - name: Build
         run: ./mill flix.compile
       - name: Run tests with timeout
         timeout-minutes: 20
         # ScalaTest flags: -o = stdout reporter, C = suppress TestSucceeded, O = suppress SuiteCompleted
         run: ./mill flix.test.testForked "-oCO"
+
+  build-and-test-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out master
+        uses: actions/checkout@v5
+      - name: Install JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Cache Mill and Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.cache/mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill', '.mill-version') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
+      - name: Build
+        run: ./mill flix.compile
+      - name: Run example tests with timeout
+        timeout-minutes: 20
+        run: ./mill flix.testExamples

--- a/.github/workflows/fuzzing-compiler.yaml
+++ b/.github/workflows/fuzzing-compiler.yaml
@@ -19,6 +19,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      - name: Cache Mill and Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.cache/mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill', '.mill-version') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
       - name: Fuzz with timeout
         timeout-minutes: 20
         run: ./mill flix.testFuzzerSuite

--- a/.github/workflows/fuzzing-completer.yml
+++ b/.github/workflows/fuzzing-completer.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      - name: Cache Mill and Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.cache/mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill', '.mill-version') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
       - name: Test with timeout
         timeout-minutes: 20
         run: ./mill flix.testIDECompletion

--- a/.github/workflows/package-manager.yaml
+++ b/.github/workflows/package-manager.yaml
@@ -22,6 +22,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      - name: Cache Mill and Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.cache/mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill', '.mill-version') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
       - name: Build
         run: ./mill flix.compile
       - name: Test Package Manager suite with timeout

--- a/.github/workflows/vscode-build-and-test.yaml
+++ b/.github/workflows/vscode-build-and-test.yaml
@@ -32,6 +32,16 @@ jobs:
         with:
           node-version: '20.x'
 
+      - name: Cache Mill and Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.cache/mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('compiler/build.mill', 'compiler/.mill-version') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
+
       - name: Build compiler
         working-directory: ./compiler
         run: ./mill flix.assembly

--- a/build.mill
+++ b/build.mill
@@ -127,6 +127,15 @@ object flix extends ScalaModule {
     ).call(stdout = os.Inherit, stderr = os.Inherit, stdin = os.Inherit, cwd = root, env = Task.env)
   }
 
+  /** Run: ./mill flix.testExamples */
+  def testExamples = Task {
+    os.proc("java", "-Xmx3g",
+      "-cp", test.runClasspath().map(_.path).mkString(java.io.File.pathSeparator),
+      "org.scalatest.tools.Runner",
+      "-s", "ca.uwaterloo.flix.ExampleSuite", "-o"
+    ).call(stdout = os.Inherit, stderr = os.Inherit, stdin = os.Inherit, cwd = root, env = Task.env)
+  }
+
   /** Run: ./mill flix.testIDECompletion */
   def testIDECompletion = Task {
     os.proc("java", "-Xmx3g",

--- a/main/test/ca/uwaterloo/flix/ExampleSuite.scala
+++ b/main/test/ca/uwaterloo/flix/ExampleSuite.scala
@@ -16,7 +16,10 @@
 package ca.uwaterloo.flix
 
 import ca.uwaterloo.flix.util.{FlixSuite, Options}
+import org.scalatest.DoNotDiscover
 
+// Excluded from the main `flix.test` run; executed by the dedicated `flix.testExamples` task.
+@DoNotDiscover
 class ExampleSuite extends FlixSuite(incremental = true) {
 
   private implicit val TestOptions: Options = Options.TestWithLibAll

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -47,52 +47,26 @@ class TestCompletionProvider extends AnyFunSuite {
   private val ProgramPathList = List(
     "examples/concurrency-and-parallelism/spawning-threads.flix",
     "examples/concurrency-and-parallelism/using-par-yield.flix",
-    "examples/concurrency-and-parallelism/using-par-yield-recursively.flix",
-    "examples/concurrency-and-parallelism/using-select-with-default.flix",
     "examples/concurrency-and-parallelism/using-select.flix",
-    "examples/concurrency-and-parallelism/using-channels-for-message-passing.flix",
-    "examples/concurrency-and-parallelism/using-select-with-timeout.flix",
     "examples/effects-and-handlers/advanced/collatz.flix",
     "examples/effects-and-handlers/advanced/nqueens.flix",
-    "examples/effects-and-handlers/advanced/backtracking.flix",
     "examples/effects-and-handlers/process/process-exec.flix",
-    "examples/effects-and-handlers/process/process-exec-with-cwd-and-env.flix",
-    "examples/effects-and-handlers/process/process-exec-and-read-output.flix",
-    "examples/effects-and-handlers/process/process-wait-and-exit-value.flix",
     "examples/effects-and-handlers/using-Logger.flix",
     "examples/datalog/compiler-puzzle.flix",
-    "examples/datalog/railroad-network.flix",
     "examples/datalog/train-schedule.flix",
     "examples/functional-style/lists-and-list-processing.flix",
-    "examples/functional-style/pure-and-impure-functions.flix",
-    "examples/functional-style/mutual-recursion-with-full-tail-call-elimination.flix",
     "examples/functional-style/higher-order-functions.flix",
     "examples/functional-style/effect-polymorphic-functions.flix",
-    "examples/functional-style/enums-and-parametric-polymorphism.flix",
-    "examples/functional-style/function-composition-pipelines-and-currying.flix",
     "examples/functional-style/algebraic-data-types-and-pattern-matching.flix",
-    "examples/imperative-style/copying-characters-into-array-with-foreach.flix",
-    "examples/imperative-style/imperative-style-foreach-loops.flix",
     "examples/imperative-style/internal-mutability-with-regions.flix",
     "examples/imperative-style/iterating-over-lists-with-foreach.flix",
-    "examples/modules/use-from-a-module-locally.flix",
     "examples/modules/declaring-a-module.flix",
     "examples/modules/use-from-a-module.flix",
-    "examples/modules/companion-module-effect.flix",
-    "examples/modules/companion-module-struct.flix",
-    "examples/modules/companion-module-trait.flix",
     "examples/modules/companion-module-enum.flix",
     "examples/records/the-ast-typing-problem-with-polymorphic-records.flix",
-    "examples/records/polymorphic-record-update.flix",
-    "examples/records/polymorphic-record-extension-and-restriction.flix",
     "examples/records/record-construction-and-use.flix",
-    "examples/structs/structs-and-parametric-polymorphism.flix",
     "examples/structs/struct-person.flix",
-    "examples/structs/struct-tree-monadic.flix",
     "examples/structs/struct-tree.flix",
-    "examples/traits/trait-with-higher-kinded-type.flix",
-    "examples/traits/trait-with-associated-effect.flix",
-    "examples/traits/deriving-traits-automatically.flix",
     "examples/traits/trait-with-associated-type.flix",
     "examples/traits/declaring-a-trait-with-instances.flix",
   )
@@ -129,7 +103,7 @@ class TestCompletionProvider extends AnyFunSuite {
     *
     * We use the limit to ensure that property tests terminate within a reasonable time.
     */
-  private val Limit: Int = 100
+  private val Limit: Int = 50
 
   /////////////////////////////////////////////////////////////////////////////
   // General Properties

--- a/main/test/flix/fuzzers/FuzzDeleteLines.scala
+++ b/main/test/flix/fuzzers/FuzzDeleteLines.scala
@@ -30,7 +30,7 @@ class FuzzDeleteLines extends AnyFunSuite with TestUtils {
   /**
     * Number of variants to make for each file. Each variant has a single line deleted.
     */
-  private val N = 30
+  private val N = 15
 
   test("the-ast-typing-problem-with-polymorphic-records") {
     val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")

--- a/main/test/flix/fuzzers/FuzzDuplicateLines.scala
+++ b/main/test/flix/fuzzers/FuzzDuplicateLines.scala
@@ -30,7 +30,7 @@ class FuzzDuplicateLines extends AnyFunSuite with TestUtils {
   /**
     * Number of variants to make of each file. Each variant has a single line duplicated.
     */
-  private val N = 30
+  private val N = 15
 
   test("the-ast-typing-problem-with-polymorphic-records") {
     val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")

--- a/main/test/flix/fuzzers/FuzzPrefixes.scala
+++ b/main/test/flix/fuzzers/FuzzPrefixes.scala
@@ -29,7 +29,7 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
   /**
     * The number of prefixes to compile for each program.
     */
-  private val N: Int = 100
+  private val N: Int = 50
 
   test("the-ast-typing-problem-with-polymorphic-records") {
     val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")

--- a/main/test/flix/fuzzers/FuzzSwapLines.scala
+++ b/main/test/flix/fuzzers/FuzzSwapLines.scala
@@ -33,7 +33,7 @@ class FuzzSwapLines extends AnyFunSuite with TestUtils {
   // Assuming each take 1sec to run that ends up at 1.3 hours.
   // Instead we select numSwapLines and try to swap those with each-other.
   // For instance numSwapLines = 10 gives a total of 330 swaps per file.
-  private val numSwapLines = 15
+  private val numSwapLines = 10
 
   test("the-ast-typing-problem-with-polymorphic-records") {
     val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")


### PR DESCRIPTION
## Summary

Three independent speed-ups to the compiler CI, bundled as one set of CI changes.

### 1. Smaller fuzzer inputs (`perf`)
The Fuzz Compiler and Fuzz Autocomplete workflows ran far more inputs than needed. Halved the per-file counts:
- `FuzzPrefixes` `N` 100 → 50
- `FuzzDeleteLines` / `FuzzDuplicateLines` `N` 30 → 15
- `FuzzSwapLines` `numSwapLines` 15 → 10 (quadratic — 105 → 45 swaps per file)
- `TestCompletionProvider` program list 49 → 24 files (representative spread across every example category) and `Limit` 100 → 50

### 2. Split the example suite into its own job
`ExampleSuite` is now `@DoNotDiscover`, so the main `build-and-test` job no longer runs it. A new `flix.testExamples` Mill task runs it explicitly (mirroring `flix.testFuzzerSuite`), invoked from a new **`build-and-test-examples`** job in the Compiler workflow. The two jobs run in parallel, so the example compile-and-run no longer serializes inside the main test job.

### 3. Cache Mill + Coursier across CI
Added `actions/cache@v4` (paths `~/.cache/coursier` and `~/.cache/mill`, keyed on `build.mill` + `.mill-version`) to every Mill-running workflow: compiler-build-and-test (both jobs), community-build, vscode-build-and-test, package-manager, fuzzing-compiler, fuzzing-completer. These are immutable, content-addressed artifacts, so there is no correctness risk — only the cold dependency download is skipped.