### PR TITLE
fix: reject duplicate def in an instance during resolution

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -273,6 +273,7 @@ object ErrorCode {
   case object E9178 extends ErrorCode
   case object E9245 extends ErrorCode
   case object E9281 extends ErrorCode
+  case object E9290 extends ErrorCode
   case object E9356 extends ErrorCode
   case object E9364 extends ErrorCode
   case object E9394 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -101,6 +101,34 @@ object ResolutionError {
   }
 
   /**
+    * An error raised to indicate a duplicate definition in an instance.
+    *
+    * @param name the name of the duplicated definition.
+    * @param sym  the trait symbol of the instance.
+    * @param loc1 the location of the first definition.
+    * @param loc2 the location of the second definition.
+    */
+  case class DuplicateInstanceDef(name: String, sym: Symbol.TraitSym, loc1: SourceLocation, loc2: SourceLocation) extends ResolutionError {
+    def code: ErrorCode = ErrorCode.E9290
+
+    def summary: String = s"Duplicate definition '$name' in instance of trait '${sym.name}'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Duplicate definition '${red(name)}' in instance of trait '${magenta(sym.name)}'.
+         |
+         |${highlight(loc1, "first occurrence", fmt)}
+         |
+         |${highlight(loc2, "duplicate", fmt)}
+         |
+         |${underline("Explanation:")} An instance can define each member of its trait at most once.
+         |""".stripMargin
+    }
+
+    val loc: SourceLocation = loc1
+  }
+
+  /**
     * An error raised to indicate a duplicate derivation.
     *
     * @param sym  the trait symbol of the duplicate derivation.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -445,7 +445,7 @@ object Resolver {
         case trt =>
           val assocsVal = resolveAssocTypeDefs(assocs0, trt, tpe, scp, taenv, ns0, root, trt0.loc)
           val tconstr = ResolvedAst.TraitConstraint(TraitSymUse(trt.sym, trt0.loc), tpe, trt0.loc)
-          val defs = defs0.map(resolveDef(_, Some(tconstr), scp)(ns0, taenv, sctx, root, flix))
+          val defs = checkDuplicateInstanceDefs(defs0.map(resolveDef(_, Some(tconstr), scp)(ns0, taenv, sctx, root, flix)), trt.sym)
           val tconstrs = optTconstrs.collect { case Some(t) => t }
           mapN(assocsVal) {
             case assocs =>
@@ -453,6 +453,33 @@ object Resolver {
               ResolvedAst.Declaration.Instance(doc, ann, mod, symUse, tparams, tpe, tconstrs, econstrs, assocs, defs, Name.mkUnlocatedNName(ns), loc)
           }
       }
+  }
+
+  /**
+    * Checks for duplicate definitions (by name) within an instance.
+    *
+    * Reports a [[ResolutionError.DuplicateInstanceDef]] for each duplicate and returns the
+    * definitions with later duplicates removed, keeping the first occurrence of each name.
+    * Instance defs are given distinct symbols by the [[Namer]], so duplicates are not caught
+    * by the usual symbol table machinery and must be detected here.
+    */
+  private def checkDuplicateInstanceDefs(defs: List[ResolvedAst.Declaration.Def], traitSym: Symbol.TraitSym)(implicit sctx: SharedContext): List[ResolvedAst.Declaration.Def] = {
+    val seen = mutable.Map.empty[String, ResolvedAst.Declaration.Def]
+    val result = mutable.ArrayBuffer.empty[ResolvedAst.Declaration.Def]
+    for (defn <- defs) {
+      val name = defn.sym.text
+      seen.get(name) match {
+        case None =>
+          seen.put(name, defn)
+          result += defn
+        case Some(firstDefn) =>
+          val loc1 = firstDefn.sym.loc
+          val loc2 = defn.sym.loc
+          sctx.errors.add(ResolutionError.DuplicateInstanceDef(name, traitSym, loc1, loc2))
+          sctx.errors.add(ResolutionError.DuplicateInstanceDef(name, traitSym, loc2, loc1))
+      }
+    }
+    result.toList
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -1650,6 +1650,57 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.DuplicateAssocTypeDef](result)
   }
 
+  test("DuplicateInstanceDef.01") {
+    val input =
+      """
+        |trait C[a] {
+        |    pub def f(x: a): a
+        |}
+        |
+        |instance C[String] {
+        |    pub def f(x: String): String = x
+        |    pub def f(x: String): String = x
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.DuplicateInstanceDef](result)
+  }
+
+  test("DuplicateInstanceDef.02") {
+    val input =
+      """
+        |trait C[a] {
+        |    pub def f(x: a): a
+        |}
+        |
+        |instance C[String] {
+        |    pub def f(x: String): String = x
+        |    pub def f(x: String): String = x
+        |    pub def f(x: String): String = x
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.DuplicateInstanceDef](result)
+  }
+
+  test("DuplicateInstanceDef.03") {
+    // A duplicate def that is not a member of the trait is still reported as a duplicate.
+    val input =
+      """
+        |trait C[a] {
+        |    pub def f(x: a): a
+        |}
+        |
+        |instance C[String] {
+        |    pub def f(x: String): String = x
+        |    pub def g(x: String): String = x
+        |    pub def g(x: String): String = x
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.DuplicateInstanceDef](result)
+  }
+
   test("MissingAssocTypeDef.01") {
     val input =
       """


### PR DESCRIPTION
## Summary

Fixes #12859.

A duplicate `def` inside an `instance` was silently accepted by the front-end and only surfaced during **monomorphization** as an `InternalCompilerException`:

```
Expected at most one matching definition for 'Foo.bar', but found 2 signatures.
```

## Root cause

The `Namer` deliberately gives every instance `def` a fresh symbol id (so that instance defs sharing a namespace stay distinct). As a side effect, two instance defs with the same name get *distinct* symbols, so the usual symbol-table duplicate detection never fires. The duplicate slips through the whole front-end and only blows up in `Specialization.resolveSigSym` — the very guard annotated *"Should have been caught previously."*

## Fix

There was already a precedent: duplicate **associated-type** defs inside an instance are caught in the `Resolver` (`resolveAssocTypeDefs` → `ResolutionError.DuplicateAssocTypeDef`). This mirrors that for regular defs:

- `Resolver.resolveInstance` now calls a new `checkDuplicateInstanceDefs` helper that groups the resolved instance defs by name, reports a duplicate error at both locations, and keeps the first occurrence of each name so the resulting AST is well-formed.
- New `ResolutionError.DuplicateInstanceDef` error (code `E9290`).

The duplicate is now caught regardless of reachability, e.g.:

```
>> Duplicate definition 'bar' in instance of trait 'Foo'.

6 |     pub def bar(): Int32 = 1
                ^^^ first occurrence

7 |     pub def bar(): Int32 = 2
                ^^^ duplicate
```