### PR TITLE
fix: box primitive returns of generic Java anonymous-class methods (#12876)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -84,7 +84,7 @@ object GenAnonymousClasses {
         case Some(jm) => javaClassToBackendType(jm.getReturnType)
         case None => if (m.tpe == SimpleType.Unit) VoidableType.Void else BackendType.toBackendType(m.tpe)
       }
-      cm.mkMethod(m.ann, ClassMaker.InstanceMethod(className, m.ident.name, MethodDescriptor(actualArgs, actualres)), IsPublic, NotFinal, methodIns(abstractClass, cloField, m)(_, root))
+      cm.mkMethod(m.ann, ClassMaker.InstanceMethod(className, m.ident.name, MethodDescriptor(actualArgs, actualres)), IsPublic, NotFinal, methodIns(abstractClass, cloField, actualres, m)(_, root))
     }
 
     // Generate bridge methods for super method calls.
@@ -188,7 +188,7 @@ object GenAnonymousClasses {
   }
 
   /** Creates code to read the arguments, load it into the `cloField` closure, call that function, and returns. */
-  private def methodIns(abstractClass: BackendObjType.AbstractArrow, cloField: ClassMaker.InstanceField, m: JvmMethod)(implicit mv: MethodVisitor, root: Root): Unit = {
+  private def methodIns(abstractClass: BackendObjType.AbstractArrow, cloField: ClassMaker.InstanceField, actualRes: VoidableType, m: JvmMethod)(implicit mv: MethodVisitor, root: Root): Unit = {
     val functionAbstractClass = abstractClass.superClass
     val returnType = BackendType.toBackendType(m.tpe)
 
@@ -204,12 +204,15 @@ object GenAnonymousClasses {
           PUTFIELD(functionAbstractClass.ArgField(i))
         }
     }
-    // Invoke the closure.
+    // Invoke the closure, leaving its result on the stack in the representation of `m.tpe`.
     BackendObjType.Result.unwindSuspensionFreeThunkToType(returnType, s"in anonymous class method ${m.ident.name}", m.loc)
 
-    m.tpe match {
-      case SimpleType.Unit => RETURN()
-      case _ => xReturn(returnType)
+    // Return the value using the method's erased JVM return type (`actualRes`). Any boxing
+    // needed to feed a primitive result into a reference (e.g. `Object`) return has already
+    // been applied in Lowering, so the value on the stack already matches `actualRes`.
+    actualRes match {
+      case VoidableType.Void => RETURN()
+      case res: BackendType => xReturn(res)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -564,7 +564,7 @@ object Lowering {
         val thisTpe = lowerType(thisParam.tpe)
         val thisRef = MonoAst.Expr.Var(thisParam.bnd.sym, thisTpe, loc)
         implicit val lctx: LocalContext = LocalContext(Some(sym), Some(thisRef))
-        lowerJvmMethod(m)
+        lowerJvmMethod(m, clazz)
       }
       val t = lowerType(tpe)
       MonoAst.Expr.NewObject(sym, clazz, t, eff, cs, ms, loc)
@@ -667,13 +667,27 @@ object Lowering {
   /**
     * Lowers the given JvmMethod `method`.
     */
-  private def lowerJvmMethod(method: TypedAst.JvmMethod)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.JvmMethod = method match {
-    case TypedAst.JvmMethod(ann, ident, fparams, exp, retTyp, eff, loc) =>
+  private def lowerJvmMethod(method: TypedAst.JvmMethod, clazz: Class[?])(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.JvmMethod = method match {
+    case TypedAst.JvmMethod(ann, ident, fparams, exp, _, eff, loc) =>
       val fs = fparams.map(lowerFormalParam)
-      val e = lowerExp(exp)
-      val t = lowerType(retTyp)
-      MonoAst.JvmMethod(ann, ident, fs, e, t, eff, loc)
+      val e0 = lowerExp(exp)
+      // If this method overrides a Java method whose erased return type is a reference
+      // (e.g. `Object` for a generic interface method) but the Flix result is a primitive,
+      // box it so the value matches the erased JVM signature. This mirrors the boxing applied
+      // to generic Java method *calls* above (see `boxIfNecessary` in InvokeMethod), and the
+      // call site unboxes the result symmetrically.
+      val e = overriddenJavaReturnType(clazz, ident.name, fparams.tail.length) match {
+        case Some(javaReturnType) => boxIfNecessary(e0, javaReturnType)
+        case None => e0
+      }
+      MonoAst.JvmMethod(ann, ident, fs, e, e.tpe, eff, loc)
   }
+
+  /** Returns the erased return type of the Java method on `clazz` matching `name` and `arity` (excluding the receiver). */
+  private def overriddenJavaReturnType(clazz: Class[?], name: String, arity: Int): Option[Class[?]] =
+    clazz.getMethods.collectFirst {
+      case m if m.getName == name && m.getParameterCount == arity => m.getReturnType
+    }
 
   /**
     * Lowers the given catch rule `rule0`.

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -898,7 +898,12 @@ object Specialization {
     case Expr.NewObject(sym, clazz, tpe, eff, constructors0, methods0, loc) =>
       val constructors = constructors0.map(specializeJvmConstructor(_, env0, subst))
       val methods = methods0.map(specializeJvmMethod(_, env0, subst))
-      Expr.NewObject(sym, clazz, subst(tpe), subst(eff), constructors, methods, loc)
+      // Mint a fresh anonymous class symbol for each specialization. Otherwise distinct
+      // specializations of an enclosing generic def (e.g. `mk[String]` and `mk[Int32]`)
+      // would reuse the same anonymous class name and collide, so one specialization would
+      // run with the other's generated class.
+      val freshSym = Symbol.mkFreshAnonClassSym(sym.loc)
+      Expr.NewObject(freshSym, clazz, subst(tpe), subst(eff), constructors, methods, loc)
 
     case Expr.NewChannel(innerExp, tpe, eff, loc) =>
       val e = specializeExp(innerExp, env0, subst)

--- a/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
@@ -662,6 +662,10 @@ object TypeVerifier {
       case SimpleType.Bool if klazz == classOf[Boolean] => tpe
       case SimpleType.Char if klazz == classOf[Char] => tpe
       case SimpleType.Unit if klazz == classOf[Unit] => tpe
+      // Unit is represented as a reference (the Unit singleton) at runtime, so it is a
+      // subtype of any non-primitive Java type, e.g. the erased `Object` return of a
+      // generic interface method implemented by an anonymous class.
+      case SimpleType.Unit if !klazz.isPrimitive => tpe
       case SimpleType.Null if !klazz.isPrimitive => tpe
 
       case SimpleType.String if klazz.isAssignableFrom(classOf[java.lang.String]) => tpe

--- a/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
@@ -692,6 +692,13 @@ object TypeVerifier {
 
       case SimpleType.AnyType if klazz == classOf[Object] => tpe
 
+      // Every Flix reference type (enums, tuples, structs, records, lazies, lambdas, lists,
+      // BigInt, ...) is represented as a reference (an object) at runtime, so it is a subtype of
+      // `java.lang.Object` -- e.g. the erased `Object` return type of a generic Java interface
+      // method implemented by an anonymous class. `SimpleType.erase` returns `Object` for exactly
+      // the reference-represented types (primitives erase to themselves).
+      case _ if klazz == classOf[Object] && SimpleType.erase(tpe) == SimpleType.Object => tpe
+
       case _ => failMismatchedTypes(tpe, klazz, loc)
     }
   }

--- a/main/test/flix/Test.Exp.Jvm.Generic.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.Generic.NewObject.flix
@@ -395,6 +395,60 @@ mod Test.Exp.Jvm.Generic.NewObject {
         };
         assertEq(expected = (), c.call())
 
+    // --- Generic interface instantiated with a reference type param (list, tuple, enum, record) ---
+    // These are the reference-typed counterparts of the primitive tests above. The overridden
+    // method's erased JVM return type is `Object`; a reference value already matches it, so no
+    // boxing is needed and the value is `areturn`ed directly. They also exercise the internal
+    // TypeVerifier, which must accept any Flix reference type as a subtype of the erased `Object`.
+
+    enum Shape with Eq, ToString {
+        case Circle(Int32)
+        case Square(Int32)
+    }
+
+    @Test
+    def testNewObjectReferenceCallableList(): Unit \ {Assert, IO} =
+        let c = new Callable[List[Int32]] {
+            def call(_this: Callable[List[Int32]]): List[Int32] = 1 :: 2 :: 3 :: Nil
+        };
+        assertEq(expected = 1 :: 2 :: 3 :: Nil, c.call())
+
+    @Test
+    def testNewObjectReferenceCallableListString(): Unit \ {Assert, IO} =
+        let c = new Callable[List[String]] {
+            def call(_this: Callable[List[String]]): List[String] = "a" :: "b" :: Nil
+        };
+        assertEq(expected = "a" :: "b" :: Nil, c.call())
+
+    @Test
+    def testNewObjectReferenceCallableTuple(): Unit \ {Assert, IO} =
+        let c = new Callable[(Int32, String)] {
+            def call(_this: Callable[(Int32, String)]): (Int32, String) = (1, "one")
+        };
+        assertEq(expected = (1, "one"), c.call())
+
+    @Test
+    def testNewObjectReferenceCallableOption(): Unit \ {Assert, IO} =
+        let c = new Callable[Option[Int32]] {
+            def call(_this: Callable[Option[Int32]]): Option[Int32] = Some(42)
+        };
+        assertEq(expected = Some(42), c.call())
+
+    @Test
+    def testNewObjectReferenceCallableEnum(): Unit \ {Assert, IO} =
+        let c = new Callable[Shape] {
+            def call(_this: Callable[Shape]): Shape = Shape.Circle(5)
+        };
+        assertEq(expected = Shape.Circle(5), c.call())
+
+    @Test
+    def testNewObjectReferenceCallableRecord(): Unit \ {Assert, IO} =
+        let c = new Callable[{ x = Int32, y = Int32 }] {
+            def call(_this: Callable[{ x = Int32, y = Int32 }]): { x = Int32, y = Int32 } = { x = 1, y = 2 }
+        };
+        let r = c.call();
+        assertEq(expected = 1, r#x)
+
     // --- A single generic anonymous-class site specialized at multiple types ---
     // Regression tests for the anonymous-class specialization collision. The `new Callable[a]`
     // site below lives in one generic def; monomorphization specializes it once per type. Each
@@ -446,8 +500,26 @@ mod Test.Exp.Jvm.Generic.NewObject {
     def testNewObjectSpecializationString(): Unit \ {Assert, IO} =
         assertEq(expected = "hello", boxedCallable("hello").call())
 
+    @Test
+    def testNewObjectSpecializationList(): Unit \ {Assert, IO} =
+        assertEq(expected = 1 :: 2 :: Nil, boxedCallable(1 :: 2 :: Nil).call())
+
+    @Test
+    def testNewObjectSpecializationTuple(): Unit \ {Assert, IO} =
+        assertEq(expected = (1, "one"), boxedCallable((1, "one")).call())
+
+    @Test
+    def testNewObjectSpecializationOption(): Unit \ {Assert, IO} =
+        assertEq(expected = Some(13), boxedCallable(Some(13)).call())
+
+    @Test
+    def testNewObjectSpecializationEnum(): Unit \ {Assert, IO} =
+        assertEq(expected = Shape.Square(7), boxedCallable(Shape.Square(7)).call())
+
     // Mixes many specializations of the same site in one expression -- this is the exact shape
     // that failed before the fix: the first call would run with a later specialization's class.
+    // Includes reference types (list, tuple, enum) alongside primitives so a collision between a
+    // primitive and a reference representation surfaces as a `VerifyError`/`ClassCastException`.
     @Test
     def testNewObjectSpecializationMixed(): Unit \ {Assert, IO} =
         assertEq(expected = 7i8, boxedCallable(7i8).call());
@@ -459,6 +531,9 @@ mod Test.Exp.Jvm.Generic.NewObject {
         assertEq(expected = false, boxedCallable(false).call());
         assertEq(expected = 'z', boxedCallable('z').call());
         assertEq(expected = (), boxedCallable(()).call());
-        assertEq(expected = "world", boxedCallable("world").call())
+        assertEq(expected = "world", boxedCallable("world").call());
+        assertEq(expected = 14 :: 15 :: Nil, boxedCallable(14 :: 15 :: Nil).call());
+        assertEq(expected = (16, "x"), boxedCallable((16, "x")).call());
+        assertEq(expected = Shape.Circle(17), boxedCallable(Shape.Circle(17)).call())
 
 }

--- a/main/test/flix/Test.Exp.Jvm.Generic.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.Generic.NewObject.flix
@@ -326,4 +326,139 @@ mod Test.Exp.Jvm.Generic.NewObject {
         };
         assertTrue(c.compare("a", "b") < 0)
 
+    // --- Generic interface instantiated with a non-reference (primitive / Unit) type param ---
+    // Regression tests for https://github.com/flix/flix/issues/12876. The overridden method's
+    // erased JVM return type is `Object`, so a primitive result must be boxed (e.g. via
+    // `Integer.valueOf`) and `Unit` returned as its runtime value; otherwise the generated
+    // anonymous class fails JVM verification with a `VerifyError`.
+
+    @Test
+    def testNewObjectPrimitiveCallableInt8(): Unit \ {Assert, IO} =
+        let c = new Callable[Int8] {
+            def call(_this: Callable[Int8]): Int8 = 42i8
+        };
+        assertEq(expected = 42i8, c.call())
+
+    @Test
+    def testNewObjectPrimitiveCallableInt16(): Unit \ {Assert, IO} =
+        let c = new Callable[Int16] {
+            def call(_this: Callable[Int16]): Int16 = 42i16
+        };
+        assertEq(expected = 42i16, c.call())
+
+    @Test
+    def testNewObjectPrimitiveCallableInt32(): Unit \ {Assert, IO} =
+        let c = new Callable[Int32] {
+            def call(_this: Callable[Int32]): Int32 = 42i32
+        };
+        assertEq(expected = 42i32, c.call())
+
+    @Test
+    def testNewObjectPrimitiveCallableInt64(): Unit \ {Assert, IO} =
+        let c = new Callable[Int64] {
+            def call(_this: Callable[Int64]): Int64 = 42i64
+        };
+        assertEq(expected = 42i64, c.call())
+
+    @Test
+    def testNewObjectPrimitiveCallableFloat32(): Unit \ {Assert, IO} =
+        let c = new Callable[Float32] {
+            def call(_this: Callable[Float32]): Float32 = 42.0f32
+        };
+        assertEq(expected = 42.0f32, c.call())
+
+    @Test
+    def testNewObjectPrimitiveCallableFloat64(): Unit \ {Assert, IO} =
+        let c = new Callable[Float64] {
+            def call(_this: Callable[Float64]): Float64 = 42.0f64
+        };
+        assertEq(expected = 42.0f64, c.call())
+
+    @Test
+    def testNewObjectPrimitiveCallableBool(): Unit \ {Assert, IO} =
+        let c = new Callable[Bool] {
+            def call(_this: Callable[Bool]): Bool = true
+        };
+        assertTrue(c.call())
+
+    @Test
+    def testNewObjectPrimitiveCallableChar(): Unit \ {Assert, IO} =
+        let c = new Callable[Char] {
+            def call(_this: Callable[Char]): Char = 'x'
+        };
+        assertEq(expected = 'x', c.call())
+
+    @Test
+    def testNewObjectUnitCallable(): Unit \ {Assert, IO} =
+        let c = new Callable[Unit] {
+            def call(_this: Callable[Unit]): Unit = ()
+        };
+        assertEq(expected = (), c.call())
+
+    // --- A single generic anonymous-class site specialized at multiple types ---
+    // Regression tests for the anonymous-class specialization collision. The `new Callable[a]`
+    // site below lives in one generic def; monomorphization specializes it once per type. Each
+    // specialization must get its own generated anonymous class. Otherwise distinct
+    // specializations (e.g. `boxedCallable[Int32]` vs `boxedCallable[Bool]`) share one class
+    // name and collide, so one specialization runs with another's class -- a `ClassCastException`
+    // (or a `VerifyError` when the colliding representations differ) at runtime.
+
+    def boxedCallable(x: a): Callable[a] \ IO =
+        new Callable[a] { def call(_this: Callable[a]): a = x }
+
+    @Test
+    def testNewObjectSpecializationInt8(): Unit \ {Assert, IO} =
+        assertEq(expected = 1i8, boxedCallable(1i8).call())
+
+    @Test
+    def testNewObjectSpecializationInt16(): Unit \ {Assert, IO} =
+        assertEq(expected = 2i16, boxedCallable(2i16).call())
+
+    @Test
+    def testNewObjectSpecializationInt32(): Unit \ {Assert, IO} =
+        assertEq(expected = 3i32, boxedCallable(3i32).call())
+
+    @Test
+    def testNewObjectSpecializationInt64(): Unit \ {Assert, IO} =
+        assertEq(expected = 4i64, boxedCallable(4i64).call())
+
+    @Test
+    def testNewObjectSpecializationFloat32(): Unit \ {Assert, IO} =
+        assertEq(expected = 5.0f32, boxedCallable(5.0f32).call())
+
+    @Test
+    def testNewObjectSpecializationFloat64(): Unit \ {Assert, IO} =
+        assertEq(expected = 6.0f64, boxedCallable(6.0f64).call())
+
+    @Test
+    def testNewObjectSpecializationBool(): Unit \ {Assert, IO} =
+        assertEq(expected = true, boxedCallable(true).call())
+
+    @Test
+    def testNewObjectSpecializationChar(): Unit \ {Assert, IO} =
+        assertEq(expected = 'q', boxedCallable('q').call())
+
+    @Test
+    def testNewObjectSpecializationUnit(): Unit \ {Assert, IO} =
+        assertEq(expected = (), boxedCallable(()).call())
+
+    @Test
+    def testNewObjectSpecializationString(): Unit \ {Assert, IO} =
+        assertEq(expected = "hello", boxedCallable("hello").call())
+
+    // Mixes many specializations of the same site in one expression -- this is the exact shape
+    // that failed before the fix: the first call would run with a later specialization's class.
+    @Test
+    def testNewObjectSpecializationMixed(): Unit \ {Assert, IO} =
+        assertEq(expected = 7i8, boxedCallable(7i8).call());
+        assertEq(expected = 8i16, boxedCallable(8i16).call());
+        assertEq(expected = 9i32, boxedCallable(9i32).call());
+        assertEq(expected = 10i64, boxedCallable(10i64).call());
+        assertEq(expected = 11.0f32, boxedCallable(11.0f32).call());
+        assertEq(expected = 12.0f64, boxedCallable(12.0f64).call());
+        assertEq(expected = false, boxedCallable(false).call());
+        assertEq(expected = 'z', boxedCallable('z').call());
+        assertEq(expected = (), boxedCallable(()).call());
+        assertEq(expected = "world", boxedCallable("world").call())
+
 }


### PR DESCRIPTION
## Summary

Fixes #12876 and a closely-related anonymous-class bug found while investigating it.

### Bug 1 — `VerifyError` for non-reference type params (#12876)

Implementing a generic Java interface with an anonymous class (e.g. `new Future[a] { ... }`) crashed with a `java.lang.VerifyError` when the type parameter `a` had a **non-reference** JVM representation (any primitive — `Int8`…`Float64`, `Bool`, `Char` — or `Unit`). The overridden method's erased JVM return type is `Object`, but the generated bytecode returned the value natively (`ireturn`/`lreturn`/… for primitives, or a value-less `return` for `Unit`). Reference types (`String`, `List`, tuples, `BigInt`, …) already worked.

Fix:
- **`Lowering`** boxes a primitive method result into its `java.lang.*` wrapper (`Integer.valueOf`, …) when the overridden Java method's erased return type is a reference, reusing the existing `boxIfNecessary` — symmetric with how generic Java method *calls* are boxed/unboxed, and the call site unboxes the result via `intValue()`/etc.
- **`GenAnonymousClasses`** now returns according to the erased descriptor return type (`actualRes`) rather than the Flix type, so `Unit` is `areturn`ed as its runtime value instead of a value-less `return`.
- **`TypeVerifier`** accepts `Unit` and any other Flix reference type (enums, tuples, records, lists, …) as a subtype of the erased `Object` return, since they are all reference-represented at runtime (`SimpleType.erase(tpe) == Object`).

### Bug 2 — anonymous-class specialization collision

A single generic def containing one `new Interface[a] { ... }` site, called at multiple types in one program, cross-wired the generated anonymous classes:

```flix
def mk(a: a): Callable[a] \ IO = new Callable[a] { def call(_this: Callable[a]): a = a }

def main(): Unit \ IO =
    println(mk("hello").call());        // ran with the List specialization's class -> ClassCastException
    println(mk(1 :: 2 :: Nil).call())
```

Monomorphization reused a single `AnonClassSym` across all specializations of the enclosing generic def, so `mk[String]` and `mk[List[Int32]]` collided on one generated class name and one specialization ran with the other's class. This reproduced on `master` for reference types too, so it is independent of Bug 1.

Fix: `Specialization` now mints a fresh `AnonClassSym` for each specialization.

### Tests

Adds systematic regression tests in `Test.Exp.Jvm.Generic.NewObject.flix` covering **all primitive types, `Unit`, and reference types (lists, tuples, options, enums, records)** for both shapes:
- **Inline anonymous-class sites** (`new Callable[T] { ... }`) — exercises the boxing / `VerifyError` fix (primitives/`Unit`) and the direct `areturn` of reference values.
- **A single shared generic def specialized at each type** — exercises the specialization-collision fix, plus a combined test mixing many specializations (primitive and reference) in one expression (the exact original failing shape).

## Known problems / not addressed in this PR

- Boxing/unboxing at this Java-generic boundary relies on matching the overridden method by **name + parameter count** (consistent with the existing descriptor computation in `GenAnonymousClasses`). Overloads with the same arity but differing parameter types are not disambiguated; this matches pre-existing behavior and was not changed.
