### PR TITLE
chore: add module preambles to grouping library modules

### DIFF
--- a/main/src/library/Math.flix
+++ b/main/src/library/Math.flix
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+///
+/// The `Math` module is a collection of mathematical utility submodules,
+/// each offering a self-contained piece of functionality:
+///
+/// - `Math.Random` generates pseudorandom numbers.
+/// - `Math.Shuffle` produces random permutations of collections.
+///
 pub mod Math {
     /* empty */
 }

--- a/main/src/library/Net.flix
+++ b/main/src/library/Net.flix
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
+///
+/// The `Net` module is a collection of networking utility submodules,
+/// each offering a self-contained piece of functionality:
+///
+/// - `Http` and `Https` perform web requests.
+/// - `HttpRequest` and `HttpResponse` represent the messages exchanged.
+/// - `Method` represents an HTTP method and `Body` an HTTP message body.
+/// - `Retry` configures how failed requests are retried.
+/// - `Dns` resolves host names and `Ping` checks host reachability.
+/// - `TcpConnect`, `TcpBind`, and `TcpAccept` open and accept TCP connections.
+/// - `TcpServer` and `TcpSocket` represent a listening server and a connection.
+/// - `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` represent IP addresses.
+/// - `SocketAddr` represents a socket address (an IP address and a port).
+///
 pub mod Net {
     /* empty */
 }

--- a/main/src/library/Sys.flix
+++ b/main/src/library/Sys.flix
@@ -14,6 +14,16 @@
  *  limitations under the License.
  */
 
+///
+/// The `Sys` module is a collection of operating-system utility submodules,
+/// each offering a self-contained piece of functionality:
+///
+/// - `Sys.Console` reads from and writes to the console.
+/// - `Sys.Env` accesses environment variables, command-line arguments, and system properties.
+/// - `Sys.Exit` terminates the running JVM.
+/// - `Sys.Process` starts and manages external processes, with `Sys.ProcessHandle`
+///   and the `Sys.StdIn`, `Sys.StdOut`, and `Sys.StdErr` stream wrappers.
+///
 pub mod Sys {
     /* empty */
 }

--- a/main/src/library/Time.flix
+++ b/main/src/library/Time.flix
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+///
+/// The `Time` module is a collection of time-related utility submodules,
+/// each offering a self-contained piece of functionality:
+///
+/// - `Time.Clock` accesses the current (real-world) time.
+/// - `Time.Duration` represents a span of time.
+/// - `Time.Sleep` suspends the current thread for a given duration.
+/// - `Time.TimeUnit` represents units of time, such as seconds and minutes.
+///
 pub mod Time {
     /* empty */
 }

--- a/main/src/library/Util.flix
+++ b/main/src/library/Util.flix
@@ -14,4 +14,13 @@
  * limitations under the License.
  */
 
+///
+/// The `Util` module is a collection of general-purpose utility submodules,
+/// each offering a self-contained piece of functionality:
+///
+/// - `Util.Checksum` computes cryptographic digests, such as SHA-256.
+/// - `Util.Codec` encodes and decodes data, such as Base64.
+/// - `Util.GetOpt` parses command-line options and arguments.
+/// - `Util.Json` parses, builds, and serializes JSON values.
+///
 pub mod Util {}


### PR DESCRIPTION
Adds short doc-comment preambles to the namespace-parent library modules that group several submodules but previously had an empty body.

Each preamble explains that the module is a collection of submodules and briefly summarizes the functionality each offers:

- `Util` — checksums, codecs, command-line option parsing, and JSON.
- `Math` — pseudorandom numbers and shuffling.
- `Time` — clock access, durations, sleeping, and time units.
- `Sys` — console, environment, exit, and process handling.
- `Net` — HTTP/HTTPS, TCP, IP/socket addressing, DNS, and ping.

`Concurrent` was intentionally left unchanged.