### PR TITLE
feat: move FsLayer.bytesToHex to Util.Codec.encodeHex

### DIFF
--- a/main/src/library/Fs/FileRead.flix
+++ b/main/src/library/Fs/FileRead.flix
@@ -226,7 +226,7 @@ pub mod Fs.FileRead {
         sidecar: String,
         f: Unit -> a \ ef
     ): a \ (ef - FileRead) + FileRead =
-        let computeHex = bytes -> Fs.FsLayer.bytesToHex(hash(bytes));
+        let computeHex = bytes -> Util.Codec.encodeHex(hash(bytes));
         let doReadBytes = file -> FileRead.readBytes(file);
         let doReadSidecar = file -> FileRead.read(file);
         run { f() } with handler FileRead {

--- a/main/src/library/Fs/FileSystem.flix
+++ b/main/src/library/Fs/FileSystem.flix
@@ -1455,7 +1455,7 @@ pub mod Fs.FileSystem {
         sidecar: String,
         f: Unit -> a \ ef
     ): a \ (ef - FileSystem) + FileSystem =
-        let computeHex = bytes -> Fs.FsLayer.bytesToHex(hash(bytes));
+        let computeHex = bytes -> Util.Codec.encodeHex(hash(bytes));
         let doReadBytes = file -> FileSystem.readBytes(file);
         let doReadSidecar = file -> FileSystem.read(file);
         let updateSidecar = file -> Fs.FsLayer.updateSidecar(file, sidecar, computeHex, doReadBytes, (str, f1) -> FileSystem.write(str = str, f1));

--- a/main/src/library/Fs/FileWrite.flix
+++ b/main/src/library/Fs/FileWrite.flix
@@ -770,7 +770,7 @@ pub mod Fs.FileWrite {
         sidecar: String,
         f: Unit -> a \ ef
     ): a \ (ef - FileWrite) + { FileWrite, FileRead } =
-        let computeHex = bytes -> Fs.FsLayer.bytesToHex(hash(bytes));
+        let computeHex = bytes -> Util.Codec.encodeHex(hash(bytes));
         let updateSidecar = file -> Fs.FsLayer.updateSidecar(file, sidecar, computeHex, f1 -> FileRead.readBytes(f1), (str, f1) -> FileWrite.write(str = str, f1));
         let afterWrite = (file, doWrite) -> Fs.FsLayer.checksumAfterWrite(file, doWrite, updateSidecar);
         let doMoveSidecar = (s, d) -> FileWrite.moveWith(src = s, d, Set#{Fs.MoveOption.ReplaceExisting});

--- a/main/src/library/Fs/FsLayer.flix
+++ b/main/src/library/Fs/FsLayer.flix
@@ -43,7 +43,6 @@ mod Fs.FsLayer {
     import java.nio.file.PathMatcher
     import java.nio.file.StandardOpenOption
     import java.util.stream.BaseStream
-    import java.util.HexFormat
     import java.util.UUID
     import java.util.stream.Stream
 
@@ -853,14 +852,6 @@ mod Fs.FsLayer {
         }
 
     // ─── Checksum helpers ──────────────────────────────────────────────
-
-    ///
-    /// Converts a vector of bytes to a lowercase hex string.
-    ///
-    pub def bytesToHex(v: Vector[Int8]): String = region rc {
-        let arr = Vector.toArray(rc, v);
-        unsafe IO { HexFormat.of().formatHex(arr) }
-    }
 
     ///
     /// Verifies `actual` (a hex digest string) against the checksum stored in

--- a/main/src/library/Util/Codec.flix
+++ b/main/src/library/Util/Codec.flix
@@ -18,6 +18,7 @@ pub mod Util.Codec {
 
     import java.lang.IllegalArgumentException
     import java.util.{Base64 => JBase64}
+    import java.util.HexFormat
 
     ///
     /// Encodes the given bytes `v` as a Base64 string.
@@ -56,5 +57,39 @@ pub mod Util.Codec {
     ///
     pub def decodeBase64String(s: String): Result[String, String] =
         Result.map(String.fromBytes, decodeBase64(s))
+
+    ///
+    /// Encodes the given bytes `v` as a lowercase hex string.
+    ///
+    pub def encodeHex(v: Vector[Int8]): String =
+        unsafe IO { HexFormat.of().formatHex(v) }
+
+    ///
+    /// Decodes the given hex string `s` to bytes.
+    ///
+    /// Returns `Err` if `s` is not a valid hex string.
+    ///
+    pub def decodeHex(s: String): Result[String, Vector[Int8]] =
+        try {
+            unsafe IO {
+                Ok(Array.toVector(HexFormat.of().parseHex(s)))
+            }
+        } catch {
+            case _: IllegalArgumentException => Err("Codec.decodeHex")
+        }
+
+    ///
+    /// Encodes the given string `s` (as UTF-8 bytes) as a lowercase hex string.
+    ///
+    pub def encodeHexString(s: String): String =
+        encodeHex(String.toBytes(s))
+
+    ///
+    /// Decodes the given hex string `s` to a UTF-8 string.
+    ///
+    /// Returns `Err` if `s` is not a valid hex string.
+    ///
+    pub def decodeHexString(s: String): Result[String, String] =
+        Result.map(String.fromBytes, decodeHex(s))
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestCodec.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestCodec.flix
@@ -109,4 +109,102 @@ mod TestCodec {
         assertEq(expected = Ok(String.toBytes("foobar")),
             Codec.decodeBase64(Codec.encodeBase64(String.toBytes("foobar"))))
 
+    /////////////////////////////////////////////////////////////////////////////
+    // encodeHex                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def encodeHex01(): Unit \ Assert =
+        assertEq(expected = "", Codec.encodeHex(String.toBytes("")))
+
+    @Test
+    def encodeHex02(): Unit \ Assert =
+        assertEq(expected = "66", Codec.encodeHex(String.toBytes("f")))
+
+    @Test
+    def encodeHex03(): Unit \ Assert =
+        assertEq(expected = "666f6f", Codec.encodeHex(String.toBytes("foo")))
+
+    @Test
+    def encodeHex04(): Unit \ Assert =
+        assertEq(expected = "666f6f626172", Codec.encodeHex(String.toBytes("foobar")))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // decodeHex                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def decodeHex01(): Unit \ Assert =
+        assertEq(expected = Ok(String.toBytes("")), Codec.decodeHex(""))
+
+    @Test
+    def decodeHex02(): Unit \ Assert =
+        assertEq(expected = Ok(String.toBytes("f")), Codec.decodeHex("66"))
+
+    @Test
+    def decodeHex03(): Unit \ Assert =
+        assertEq(expected = Ok(String.toBytes("foobar")), Codec.decodeHex("666f6f626172"))
+
+    @Test
+    def decodeHex04(): Unit \ Assert =
+        assertErr(Codec.decodeHex("zz"))
+
+    @Test
+    def decodeHex05(): Unit \ Assert =
+        assertErr(Codec.decodeHex("abc"))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // encodeHexString                                                         //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def encodeHexString01(): Unit \ Assert =
+        assertEq(expected = "", Codec.encodeHexString(""))
+
+    @Test
+    def encodeHexString02(): Unit \ Assert =
+        assertEq(expected = "466c6978", Codec.encodeHexString("Flix"))
+
+    @Test
+    def encodeHexString03(): Unit \ Assert =
+        assertEq(expected = "48656c6c6f2c20576f726c6421", Codec.encodeHexString("Hello, World!"))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // decodeHexString                                                         //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def decodeHexString01(): Unit \ Assert =
+        assertEq(expected = Ok(""), Codec.decodeHexString(""))
+
+    @Test
+    def decodeHexString02(): Unit \ Assert =
+        assertEq(expected = Ok("Flix"), Codec.decodeHexString("466c6978"))
+
+    @Test
+    def decodeHexString03(): Unit \ Assert =
+        assertEq(expected = Ok("Hello, World!"), Codec.decodeHexString("48656c6c6f2c20576f726c6421"))
+
+    @Test
+    def decodeHexString04(): Unit \ Assert =
+        assertErr(Codec.decodeHexString("zz"))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // hex roundtrip                                                           //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def hexRoundtrip01(): Unit \ Assert =
+        assertEq(expected = Ok(""), Codec.decodeHexString(Codec.encodeHexString("")))
+
+    @Test
+    def hexRoundtrip02(): Unit \ Assert =
+        assertEq(expected = Ok("The quick brown fox jumps over the lazy dog"),
+            Codec.decodeHexString(Codec.encodeHexString("The quick brown fox jumps over the lazy dog")))
+
+    @Test
+    def hexRoundtrip03(): Unit \ Assert =
+        assertEq(expected = Ok(String.toBytes("foobar")),
+            Codec.decodeHex(Codec.encodeHex(String.toBytes("foobar"))))
+
 }


### PR DESCRIPTION
Resolves #12501.

`Fs.FsLayer.bytesToHex` was a general-purpose `Vector[Int8] -> String` hex helper living inside the filesystem layer, used only for checksum/digest formatting. This moves it to `Util.Codec`, where it sits next to the existing Base64 codec and follows the same `encode*`/`decode*` naming.

### Changes

**`Util.Codec`** — adds four functions mirroring the Base64 API:

| Function | Signature |
|---|---|
| `encodeHex` | `Vector[Int8] -> String` (was `FsLayer.bytesToHex`) |
| `decodeHex` | `String -> Result[String, Vector[Int8]]` (new inverse, via `HexFormat.parseHex`) |
| `encodeHexString` | `String -> String` |
| `decodeHexString` | `String -> Result[String, String]` |

**`Fs.FsLayer`** — removes `bytesToHex` and its now-unused `java.util.HexFormat` import.

**Call sites** — `Fs.FsLayer.bytesToHex` → `Util.Codec.encodeHex` in `FileRead`, `FileWrite`, and `FileSystem`.

**`TestCodec`** — 19 new tests: `encodeHex` (4), `decodeHex` (5, incl. non-hex and odd-length error cases), `encodeHexString` (3), `decodeHexString` (4), and 3 hex round-trips.

Hex digits are lowercase (`HexFormat.of()` default), preserving the previous `bytesToHex` behavior.