### PR TITLE
fix: report empty interpolation mixed with non-empty (`"${x}${}"`)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -3284,10 +3284,20 @@ object Parser2 {
         case _ => None
       }
 
+      // A `}${` token both closes the current interpolation and opens the next one (e.g. between the two
+      // interpolations in `"${x}${y}"`). When such a token appears right after an opener, the current
+      // interpolation is empty (e.g. the first `${}` in `"${}${x}"`). It is distinguished from a nested string
+      // opener `"${` (e.g. in `"${ "${x}" }"`) by its leading `}`.
+      def atEmptyInterpolation: Boolean =
+        at(TokenKind.LiteralStringInterpolationL) && nthToken(0).exists(_.text.startsWith("}"))
+
       var lastOpener = getOpener
       while (lastOpener.isDefined && !eof()) {
         if (atTerminator(lastOpener)) {
           lastOpener = None // Terminate the loop.
+        } else if (atEmptyInterpolation) {
+          // Skip the empty interpolation, leaving the openers adjacent in the tree so the Weeder reports it.
+          lastOpener = getOpener
         } else {
           expression()
           lastOpener = getOpener // Try to get nested interpolation.

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -874,11 +874,12 @@ object Weeder2 {
     private def visitStringInterpolationExpr(tree: Tree)(implicit sctx: SharedContext): Expr = {
       expect(tree, TreeKind.Expr.StringInterpolation)
       val init = WeededAst.Expr.Cst(Constant.Str(""), tree.loc)
-      // Check for empty interpolation
-      if (tryPick(TreeKind.Expr.Expr, tree).isEmpty) {
-        val error = EmptyInterpolatedExpression(tree.loc)
-        sctx.errors.add(error)
-        return Expr.Error(error)
+
+      // Check for empty interpolated expressions, e.g. `"${}"` or `"${x}${}"`.
+      val emptyInterpolations = findEmptyInterpolations(tree)
+      if (emptyInterpolations.nonEmpty) {
+        emptyInterpolations.foreach(sctx.errors.add)
+        return Expr.Error(emptyInterpolations.head)
       }
 
       tree.children.foldLeft(init: WeededAst.Expr) {
@@ -905,6 +906,31 @@ object Weeder2 {
         // Skip anything else (Parser will have produced an error.)
         case (acc, _) => acc
       }
+    }
+
+    /**
+      * Returns an [[EmptyInterpolatedExpression]] error for each empty interpolation (e.g. `${}`) in `tree`.
+      *
+      * Each interpolation is opened by a [[TokenKind.LiteralStringInterpolationL]] token (`"${` or `}${`) and must be
+      * followed by an expression. If the opener is instead followed by another opener or the closing `}"` then the
+      * interpolation is empty. This catches both fully-empty strings (`"${}"`) and empty interpolations mixed with
+      * non-empty ones (`"${x}${}"`).
+      */
+    private def findEmptyInterpolations(tree: Tree): List[EmptyInterpolatedExpression] = {
+      def isExpr(child: SyntaxTree.Child): Boolean = child match {
+        case t: Tree => t.kind == TreeKind.Expr.Expr
+        case _ => false
+      }
+      // Ignore comment tokens so they cannot sit between an opener and its expression.
+      val children = tree.children.filterNot {
+        case token@Token(_, _, _, _, _, _) => token.kind.isComment
+        case _ => false
+      }
+      children.sliding(2).collect {
+        case Array(opener@Token(_, _, _, _, _, _), next)
+          if opener.kind == TokenKind.LiteralStringInterpolationL && !isExpr(next) =>
+          EmptyInterpolatedExpression(opener.mkSourceLocation())
+      }.toList
     }
 
     private def visitOpenVariantExpr(tree: Tree)(implicit sctx: SharedContext): Expr = {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -196,6 +196,30 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.EmptyInterpolatedExpression](result)
   }
 
+  test("EmptyInterpolatedExpression.07") {
+    val input = "def f(x: String): String = \"${x}${}\""
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.EmptyInterpolatedExpression](result)
+  }
+
+  test("EmptyInterpolatedExpression.08") {
+    val input = "def f(x: String): String = \"${}${x}\""
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.EmptyInterpolatedExpression](result)
+  }
+
+  test("EmptyInterpolatedExpression.09") {
+    val input = "def f(x: String, y: String): String = \"${x}${}${y}\""
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.EmptyInterpolatedExpression](result)
+  }
+
+  test("EmptyInterpolatedExpression.10") {
+    val input = "def f(y: String): String = \"${}abc${y}\""
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.EmptyInterpolatedExpression](result)
+  }
+
   test("EmptyRecordExtensionPattern.01") {
     val input =
       """


### PR DESCRIPTION
Fixes #12628.

A string like `"${s}${}"` compiled successfully and silently dropped the empty `${}` interpolation, even though `"${}"` correctly raised `EmptyInterpolatedExpression`.

## Root cause

Two problems, both needed for a complete fix:

1. **Weeder** — the empty-interpolation check (`tryPick(Expr.Expr).isEmpty`) only fired when the string had *no* interpolated expressions at all. With `"${s}${}"`, the `s` expression made the check pass, so the empty slot went unreported.

2. **Parser** — for an empty interpolation *followed by another* (e.g. `"${}${x}"`, `"${x}${}${y}"`), the lexer emits a single `}${` token that both closes the empty interpolation and opens the next one. This token was passed to `expression()`, which mis-parsed `}${...}` as a *nested* string literal — so the weeder couldn't see the real structure.

## Fix

- **Parser** (`Parser2.scala`): added an `atEmptyInterpolation` check. When a `}${` continuation opener appears where an expression is expected, the interpolation is empty — skip it (leaving the openers adjacent in the tree) instead of mis-parsing. It is distinguished from a genuine nested-string opener `"${` by its leading `}`.
- **Weeder** (`Weeder2.scala`): replaced the all-or-nothing check with `findEmptyInterpolations`, which flags any `${` opener not followed by an expression, reusing the existing `EmptyInterpolatedExpression` error with a precise per-slot source location.

## Result

```
3 |     let s1 = "${s}${}";
                     ^^^
                     missing expression
```

Valid interpolations (adjacent `"${x}${y}"`, nested `"${ "${x}" }"`, literals `"a${x}b${y}c"`) are unaffected. Empty interpolations at the start, middle, end, consecutive, nested, and with surrounding literals all now report the error.