### PR TITLE
fix: use "arguments" terminology in MismatchedOpArity error

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -613,11 +613,12 @@ object ResolutionError {
   }
 
   /**
-    * An error indicating the number of effect operation parameters does not match the expected number.
+    * An error indicating that the number of arguments given to an effect operation
+    * does not match the number of formal parameters it declares.
     *
     * @param op       the effect operation symbol.
-    * @param expected the expected number of parameters.
-    * @param actual   the actual number of parameters.
+    * @param expected the expected number of arguments (the operation's declared arity).
+    * @param actual   the actual number of arguments given.
     * @param loc      the location where the error occurred.
     */
   case class MismatchedOpArity(op: Symbol.OpSym, expected: Int, actual: Int, loc: SourceLocation) extends ResolutionError {
@@ -629,9 +630,9 @@ object ResolutionError {
       import fmt.*
       s""">> Mismatched arity for operation '${red(op.name)}'.
          |
-         |Expected ${Grammar.n_things(expected, "parameter")} but found $actual.
+         |Expected ${Grammar.n_things(expected, "argument")} but found $actual.
          |
-         |${highlight(loc, s"expected $expected parameters", fmt)}
+         |${highlight(loc, s"expected $expected arguments", fmt)}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -1017,9 +1017,9 @@ object WeederError {
   }
 
   /**
-    * An error raised to indicate that an argument list is missing a kind.
+    * An error raised to indicate that a constructor invocation is missing its argument list.
     *
-    * @param loc the location of the argument list.
+    * @param loc the location of the constructor invocation.
     */
   case class MissingArgumentList(loc: SourceLocation) extends WeederError {
     def code: ErrorCode = ErrorCode.E2781


### PR DESCRIPTION
Closes #12295.

The `MismatchedOpArity` error is raised at an effect-operation **call site** (`Resolver.checkOpArity`), where `expected` is the operation's declared arity and `actual` is the number of arguments supplied. Its message described the supplied count as *parameters*:

> Expected N parameters but found M

This contradicts the structurally identical `MismatchedTagPatternArity` error (also a use site), which correctly says *arguments*. At a call site the supplied values are arguments, not formal parameters.

This PR:

- Changes the `MismatchedOpArity` message and source highlight from "parameters" to "arguments", making it consistent with `MismatchedTagPatternArity`.
- Corrects the `MismatchedOpArity` doc-comment, which previously labelled both `expected` and `actual` as "number of parameters" even though `actual` is the argument count.
- Fixes a copy-paste doc-comment on `MissingArgumentList` ("an argument list is missing a kind" → "a constructor invocation is missing its argument list").

An audit of the remaining `argument`/`parameter`/`arity` strings across the error files found the terminology otherwise used correctly (declaration sites say "formal parameter", call/use sites say "argument"), so no other changes were needed.