### PR TITLE
fix: prevent playground hang on runtime FlixError

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
@@ -216,7 +216,12 @@ class SocketServer(port: Int) extends WebSocketServer(new InetSocketAddress(port
           Err(CompilationMessage.formatAll(errors.toList)(flix.getFormatter, None))
       }
     } catch {
-      case ex: RuntimeException => Err(ex.getMessage)
+      // Catch `Throwable` (not just `RuntimeException`): a successfully compiled
+      // program can crash at runtime by throwing a `FlixError` (e.g. `HoleError`,
+      // `MatchError`, `CastError`), which extends `java.lang.Error`, not
+      // `RuntimeException`. If such an error escaped, no response would be sent
+      // and the client (play.flix.dev) would hang. See issue #11540.
+      case ex: Throwable => Err(Option(ex.getMessage).getOrElse(ex.toString))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/util/SafeExec.scala
+++ b/main/src/ca/uwaterloo/flix/util/SafeExec.scala
@@ -40,18 +40,20 @@ object SafeExec {
     System.setOut(new PrintStream(newOut, true, UTF8))
     System.setErr(new PrintStream(newErr, true, UTF8))
 
-    // Execute the function f.
-    val result = f()
+    try {
+      // Execute the function f.
+      val result = f()
 
-    // Restore the original out and err streams.
-    System.setOut(originalOut)
-    System.setErr(originalErr)
+      // Return a triple of the result and the two captured streams as strings.
+      val capturedOut = newOut.toString(UTF8)
+      val capturedErr = newErr.toString(UTF8)
 
-    // Return a triple of the result and the two captured streams as strings.
-    val capturedOut = newOut.toString(UTF8)
-    val capturedErr = newErr.toString(UTF8)
-
-    (result, capturedOut, capturedErr)
+      (result, capturedOut, capturedErr)
+    } finally {
+      // Restore the original out and err streams, even if `f` throws.
+      System.setOut(originalOut)
+      System.setErr(originalErr)
+    }
   }
 
 }


### PR DESCRIPTION
## Problem

Entering a program containing a hole (`???` or `?name`) into [play.flix.dev](https://play.flix.dev) results in an endless loading animation (issue #11540).

A hole is not a compile error — it typechecks and is lowered to a runtime throw. When `main` runs and reaches the hole, it throws `HoleError`, which extends `dev.flix.runtime.FlixError`, which extends **`java.lang.Error`** (not `RuntimeException`).

The playground backend, `SocketServer.eval`, ran the compiled `main` but only caught `case ex: RuntimeException`. Since `HoleError` is an `Error`, it escaped the handler, so `ws.send(...)` was never reached and the client never received a response — hence the endless spinner.

This affects every runtime `FlixError`, not just holes: `MatchError` (non-exhaustive match) and `CastError` (failed cast) hang the playground identically.

## Fix

- **`SocketServer.scala`**: catch `Throwable` instead of `RuntimeException` in the run path, so a crashing program is reported as a `failure` result. This matches how `Shell`, `Tester`, `Flix`, and the LSP servers already handle program execution. A `null`-message guard is added to avoid a secondary JSON-rendering failure.
- **`SafeExec.scala`**: wrap the body in `try/finally` so `System.out`/`System.err` are restored even when the executed program throws (previously they were left pointing at the abandoned capture buffers).

Fixes #11540