### PR TITLE
feat: special-case type errors between arrows and non-arrows

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -222,6 +222,7 @@ object ErrorCode {
   case object E6805 extends ErrorCode
   case object E6843 extends ErrorCode
   case object E6916 extends ErrorCode
+  case object E6925 extends ErrorCode
   case object E6956 extends ErrorCode
   case object E7027 extends ErrorCode
   case object E7067 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -576,6 +576,40 @@ object TypeError {
   }
 
   /**
+    * A mismatch between a function (arrow) type and a non-function type.
+    *
+    * This is a special case of [[MismatchedTypes]]: a function and a non-function can never be
+    * unified, regardless of effects.
+    *
+    * @param arrowType    the function (arrow) type.
+    * @param nonArrowType the non-function type.
+    * @param fullType1    the first full type.
+    * @param fullType2    the second full type.
+    * @param renv         the rigidity environment.
+    * @param loc          the location where the error occurred.
+    */
+  case class MismatchedArrowAndNonArrow(arrowType: Type, nonArrowType: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+    def code: ErrorCode = ErrorCode.E6925
+
+    def amb: SymbolSet = SymbolSet.ambiguous(SymbolSet.symbolsOf(fullType1), SymbolSet.symbolsOf(fullType2))
+
+    def summary: String = s"Unable to unify the function type '${formatType(arrowType, Some(renv), minimizeEffs = true, amb = amb)}' with the non-function type '${formatType(nonArrowType, Some(renv), minimizeEffs = true, amb = amb)}'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Unable to unify the ${magenta("function")} type '${red(formatType(arrowType, Some(renv), minimizeEffs = true, amb = amb))}' with the non-function type '${red(formatType(nonArrowType, Some(renv), minimizeEffs = true, amb = amb))}'.
+         |
+         |${highlight(loc, "mismatched types.", fmt)}
+         |
+         |Type One: ${cyan(formatType(fullType1, Some(renv), minimizeEffs = true, amb = amb))}
+         |Type Two: ${magenta(formatType(fullType2, Some(renv), minimizeEffs = true, amb = amb))}
+         |
+         |${underline("Explanation:")} A ${magenta("function")} type can never be equal to a non-function type, regardless of effects.
+         |""".stripMargin
+    }
+  }
+
+  /**
     * Missing trait instance.
     *
     * @param trt  the trait of the instance.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -191,7 +191,7 @@ object ConstraintSolverInterface {
     case TypeConstraint.Equality(baseType1, baseType2, Provenance.Match(fullType1, fullType2, loc)) =>
       val default = List(mkMismatchedTypesOrEffects(subst(baseType1), subst(baseType2), subst(fullType1), subst(fullType2), renv, loc))
 
-      (fullType1.typeConstructor, fullType1.typeConstructor) match {
+      (fullType1.typeConstructor, fullType2.typeConstructor) match {
         case (Some(TypeConstructor.SchemaRowExtend(pred1)), Some(TypeConstructor.SchemaRowExtend(pred2))) if pred1 == pred2 =>
           (baseType1.typeConstructor, baseType2.typeConstructor) match {
             case (Some(TypeConstructor.Relation(arity1)), Some(TypeConstructor.Relation(arity2))) if arity1 != arity2 =>
@@ -259,15 +259,47 @@ object ConstraintSolverInterface {
   }
 
   /**
-    * Create either the MismatchedTypes or MismatchedEffects error based on the kind of the type.
+    * Create the most specific mismatch error for the two conflicting types.
+    *
+    * If one type is a function (arrow) and the other is a concrete non-function, we emit the
+    * specialized [[TypeError.MismatchedArrowAndNonArrow]] error, since the two can never be unified
+    * regardless of effects. Otherwise, we create either the MismatchedTypes or MismatchedEffects
+    * error based on the kind of the type.
     */
   private def mkMismatchedTypesOrEffects(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix): TypeError = {
-    baseType1.kind match {
-      case Kind.Eff =>
-        TypeError.MismatchedEffects(baseType1, baseType2, fullType1, fullType2, renv, loc)
+    (isArrowType(baseType1), isArrowType(baseType2)) match {
+      case (true, _) if isConcreteNonArrowType(baseType2) =>
+        TypeError.MismatchedArrowAndNonArrow(baseType1, baseType2, fullType1, fullType2, renv, loc)
+      case (_, true) if isConcreteNonArrowType(baseType1) =>
+        TypeError.MismatchedArrowAndNonArrow(baseType2, baseType1, fullType1, fullType2, renv, loc)
       case _ =>
-        TypeError.MismatchedTypes(baseType1, baseType2, fullType1, fullType2, renv, loc)
+        baseType1.kind match {
+          case Kind.Eff =>
+            TypeError.MismatchedEffects(baseType1, baseType2, fullType1, fullType2, renv, loc)
+          case _ =>
+            TypeError.MismatchedTypes(baseType1, baseType2, fullType1, fullType2, renv, loc)
+        }
     }
+  }
+
+  /**
+    * Returns `true` if `tpe` is a function (arrow) type, with or without an effect.
+    */
+  private def isArrowType(tpe: Type): Boolean = tpe.typeConstructor match {
+    case Some(TypeConstructor.Arrow(_)) | Some(TypeConstructor.ArrowWithoutEffect(_)) => true
+    case _ => false
+  }
+
+  /**
+    * Returns `true` if `tpe` has a concrete (non-arrow) type constructor.
+    *
+    * Returns `false` for type variables and associated types, since those could still unify with a
+    * function type.
+    */
+  private def isConcreteNonArrowType(tpe: Type): Boolean = tpe.typeConstructor match {
+    case Some(TypeConstructor.Arrow(_)) | Some(TypeConstructor.ArrowWithoutEffect(_)) => false
+    case Some(_) => true
+    case None => false
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -189,7 +189,11 @@ object ConstraintSolverInterface {
       List(TypeError.NonUnitStatement(subst(actual), loc))
 
     case TypeConstraint.Equality(baseType1, baseType2, Provenance.Match(fullType1, fullType2, loc)) =>
-      val default = List(mkMismatchedTypesOrEffects(subst(baseType1), subst(baseType2), subst(fullType1), subst(fullType2), renv, loc))
+      val baseTpe1 = subst(baseType1)
+      val baseTpe2 = subst(baseType2)
+      val fullTpe1 = subst(fullType1)
+      val fullTpe2 = subst(fullType2)
+      val default = List(mkMismatchedTypesOrEffects(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc))
 
       (fullType1.typeConstructor, fullType2.typeConstructor) match {
         case (Some(TypeConstructor.SchemaRowExtend(pred1)), Some(TypeConstructor.SchemaRowExtend(pred2))) if pred1 == pred2 =>
@@ -208,6 +212,13 @@ object ConstraintSolverInterface {
 
             case _ => default
           }
+
+        // A function type and a concrete non-function type can never be unified, regardless of effects.
+        case _ if isArrowType(baseTpe1) && isConcreteNonArrowType(baseTpe2) =>
+          List(TypeError.MismatchedArrowAndNonArrow(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc))
+
+        case _ if isArrowType(baseTpe2) && isConcreteNonArrowType(baseTpe1) =>
+          List(TypeError.MismatchedArrowAndNonArrow(baseTpe2, baseTpe1, fullTpe1, fullTpe2, renv, loc))
 
         case _ => default
       }
@@ -259,21 +270,14 @@ object ConstraintSolverInterface {
   }
 
   /**
-    * Create the most specific mismatch error for the two conflicting types.
+    * Create either the MismatchedTypes or MismatchedEffects error based on the kind of the type.
     */
   private def mkMismatchedTypesOrEffects(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix): TypeError = {
-    (isArrowType(baseType1), isArrowType(baseType2)) match {
-      case (true, _) if isConcreteNonArrowType(baseType2) =>
-        TypeError.MismatchedArrowAndNonArrow(baseType1, baseType2, fullType1, fullType2, renv, loc)
-      case (_, true) if isConcreteNonArrowType(baseType1) =>
-        TypeError.MismatchedArrowAndNonArrow(baseType2, baseType1, fullType1, fullType2, renv, loc)
+    baseType1.kind match {
+      case Kind.Eff =>
+        TypeError.MismatchedEffects(baseType1, baseType2, fullType1, fullType2, renv, loc)
       case _ =>
-        baseType1.kind match {
-          case Kind.Eff =>
-            TypeError.MismatchedEffects(baseType1, baseType2, fullType1, fullType2, renv, loc)
-          case _ =>
-            TypeError.MismatchedTypes(baseType1, baseType2, fullType1, fullType2, renv, loc)
-        }
+        TypeError.MismatchedTypes(baseType1, baseType2, fullType1, fullType2, renv, loc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -260,11 +260,6 @@ object ConstraintSolverInterface {
 
   /**
     * Create the most specific mismatch error for the two conflicting types.
-    *
-    * If one type is a function (arrow) and the other is a concrete non-function, we emit the
-    * specialized [[TypeError.MismatchedArrowAndNonArrow]] error, since the two can never be unified
-    * regardless of effects. Otherwise, we create either the MismatchedTypes or MismatchedEffects
-    * error based on the kind of the type.
     */
   private def mkMismatchedTypesOrEffects(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix): TypeError = {
     (isArrowType(baseType1), isArrowType(baseType2)) match {
@@ -286,7 +281,8 @@ object ConstraintSolverInterface {
     * Returns `true` if `tpe` is a function (arrow) type, with or without an effect.
     */
   private def isArrowType(tpe: Type): Boolean = tpe.typeConstructor match {
-    case Some(TypeConstructor.Arrow(_)) | Some(TypeConstructor.ArrowWithoutEffect(_)) => true
+    case Some(TypeConstructor.Arrow(_)) => true
+    case Some(TypeConstructor.ArrowWithoutEffect(_)) => true
     case _ => false
   }
 
@@ -297,7 +293,8 @@ object ConstraintSolverInterface {
     * function type.
     */
   private def isConcreteNonArrowType(tpe: Type): Boolean = tpe.typeConstructor match {
-    case Some(TypeConstructor.Arrow(_)) | Some(TypeConstructor.ArrowWithoutEffect(_)) => false
+    case Some(TypeConstructor.Arrow(_)) => false
+    case Some(TypeConstructor.ArrowWithoutEffect(_)) => false
     case Some(_) => true
     case None => false
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -174,6 +174,18 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[MismatchedTypes](result)
   }
 
+  test("MismatchedArrowAndNonArrow.01") {
+    val input = "def foo(): a = solve (x -> x)"
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedArrowAndNonArrow](result)
+  }
+
+  test("MismatchedArrowAndNonArrow.02") {
+    val input = "def foo(): a = if (true) (x -> x) else 1"
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedArrowAndNonArrow](result)
+  }
+
   test("MismatchedTypes.06") {
     val input =
       """


### PR DESCRIPTION
Closes #12364.

When type unification fails between a function (arrow) type and a concrete non-function type, the compiler previously emitted the generic `MismatchedTypes` error, whose effect-laden output obscured the real problem. As noted in the issue, *a `String` is just not a function (no matter the effects!)*.

This PR special-cases that situation:

- **New `MismatchedArrowAndNonArrow` error** (`E6925`) raised from `mkMismatchedTypesOrEffects` when exactly one side is a function (`Arrow` / `ArrowWithoutEffect`) and the other is a concrete non-function. The message names the function type explicitly and explains that a function and a non-function can never be equal, regardless of effects.
- Type variables and associated types (whose `typeConstructor` is `None`) are deliberately excluded, since they could still unify with a function type — those fall through to the existing `MismatchedTypes` / `MismatchedEffects`.

On the issue's example this now reports:

```
>> Unable to unify the function type 'Unit -> Unit \ Logger' with the non-function type 'String'.

   Explanation: A function type can never be equal to a non-function type, regardless of effects.
```

Also bundles a small **fix**: the schema-predicate mismatch special-casing in `ConstraintSolverInterface` matched on `fullType1.typeConstructor` twice instead of `fullType1` and `fullType2`. The corrected condition now requires both sides to be schema rows for the same predicate (the existing `MismatchedPredicateArity` / `MismatchedPredicateDenotation` behavior is preserved).