### PR TITLE
refactor: move Order.thenCompare into sequences.flix example

### DIFF
--- a/examples/unsorted/restrictable-variants/sequences.flix
+++ b/examples/unsorted/restrictable-variants/sequences.flix
@@ -857,7 +857,7 @@ instance Order[Seq.Seq[s][a]] with Order[a] {
     ///
     pub def compare(l1: Seq.Seq[s][a], l2: Seq.Seq[s][a]): Comparison = {
         let l = Seq.zip(l1, l2);
-        compareHelper(l) `Order.thenCompare` lazy (Seq.length(l1) <=> Seq.length(l2))
+        compareHelper(l) `thenCompare` lazy (Seq.length(l1) <=> Seq.length(l2))
     }
 
 }
@@ -865,7 +865,7 @@ instance Order[Seq.Seq[s][a]] with Order[a] {
 def compareHelper(l: Seq.Seq[s][(a, a)]): Comparison with Order[a] = choose l {
     case Seq.Seq.Nil         => Comparison.EqualTo
     case Seq.Seq.One(x)      => fst(x) <=> snd(x)
-    case Seq.Seq.Cons(x, xs) => (fst(x) <=> snd(x)) `Order.thenCompare` lazy compareHelper(xs)
+    case Seq.Seq.Cons(x, xs) => (fst(x) <=> snd(x)) `thenCompare` lazy compareHelper(xs)
 }
 
 instance Functor[Seq.Seq[s]] {
@@ -886,3 +886,11 @@ instance ForEach[Seq.Seq[s][a]] {
     type Elm = a
     pub def forEach(f: a -> Unit \ ef, t: Seq.Seq[s][a]): Unit \ ef = Seq.forEach(f, t)
 }
+
+///
+/// Lazily combines two comparisons.
+///
+/// If `c1` is either `Comparison.LessThan` or `Comparison.GreaterThan` then `c2` is never evaluated.
+///
+def thenCompare(c1: Comparison, c2: Lazy[Comparison]): Comparison =
+    if (c1 != Comparison.EqualTo) c1 else force c2

--- a/main/src/library/Order.flix
+++ b/main/src/library/Order.flix
@@ -142,14 +142,6 @@ pub mod Order {
     pub def maxBy(cmp: (a, a) -> Comparison, x: a, y: a): a =
         if (cmp(x, y) == Comparison.LessThan) y else x
 
-    ///
-    /// Lazily combines two comparisons.
-    ///
-    /// If `c1` is either `Comparison.LessThan` or `Comparison.GreaterThan` then `c2` is never evaluated.
-    ///
-    pub def thenCompare(c1: Comparison, c2: Lazy[Comparison]): Comparison =
-        if (c1 != Comparison.EqualTo) c1 else force c2
-
     instance Order[Unit] {
 
         pub def compare(_: Unit, _: Unit): Comparison = Comparison.EqualTo


### PR DESCRIPTION
## Summary

`Order.thenCompare` was a public standard-library combinator that lazily combines two `Comparison` values. Its only call sites in the entire codebase were in the restrictable-variants `sequences.flix` example.

Its behavior is equivalent to a nested `match` on `Comparison` (return early unless the first comparison is `EqualTo`), which is the pattern the rest of `Order.flix` (the tuple instances) and the `Deriver` already use directly.

This PR removes `thenCompare` from `Order.flix` and relocates it as a file-local helper at the bottom of `sequences.flix`, leaving the example's lazy comparison code unchanged. As a side effect, this removes `Order.flix`'s only remaining use of `Lazy`/`force`.

## Changes

- **`main/src/library/Order.flix`** — remove the `pub def thenCompare` definition.
- **`examples/unsorted/restrictable-variants/sequences.flix`** — add a file-local `def thenCompare`; the two call sites now reference it as `` `thenCompare` `` instead of `` `Order.thenCompare` ``.

No behavior change.