### PR TITLE
fix: terminate associated type reduction (#11213)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -49,11 +49,11 @@ object TypeReduction2 {
 
     case Type.Alias(_, _, tpe, _) => (tpe, Nil)
 
-    case Type.AssocType(AssocTypeSymUse(sym, _), tpe, _, _) =>
+    case Type.AssocType(symUse, tpe, kind, loc) =>
       val (t, cs) = reduce(tpe)
 
       // Get all the associated types from the context
-      val assocOpt = eqenv.getAssocDef(sym, t)
+      val assocOpt = eqenv.getAssocDef(symUse.sym, t)
 
       // Find the instance that matches
       val matches = assocOpt.flatMap {
@@ -82,8 +82,17 @@ object TypeReduction2 {
       }
 
       matches match {
-        // Case 1: No match. Can't reduce the type.
-        case None => (tpe0, cs)
+        // Case 1: No match. We cannot reduce the head, but the argument may have
+        // been reduced. We must reflect that in the returned type: reducing the
+        // argument calls `progress.markProgress()`, so returning the original
+        // `tpe0` here would signal progress without changing the type, causing
+        // the constraint solver to loop forever (see issue #11213).
+        // Performance: Reuse `tpe0` if the argument was unchanged.
+        case None =>
+          if (t eq tpe)
+            (tpe0, cs)
+          else
+            (Type.AssocType(symUse, t, kind, loc), cs)
 
         // Case 2: One match. Use it.
         case Some(newTpe) =>

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1199,6 +1199,180 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
+  test("TestAssocType.05") {
+    // Regression test. See https://github.com/flix/flix/issues/11213
+    // The associated effect of the `Vec` instance is declared as `OutInt32`, but the body
+    // `Container.forEach(Runner.exec, x)` has effect `Runner.E[Container.Elm[Vec[a]]]`.
+    // Reducing this nested associated type must terminate and report the mismatch.
+    val input =
+      """
+        |trait Container[t] {
+        |    type Elm: Type
+        |    pub def forEach(f: Container.Elm[t] -> Unit \ ef, t: t): Unit \ ef
+        |}
+        |
+        |enum Vec[a](a)
+        |
+        |instance Container[Vec[a]] {
+        |    type Elm = a
+        |    pub def forEach(f: a -> Unit \ ef, v: Vec[a]): Unit \ ef =
+        |        let Vec.Vec(x) = v;
+        |        f(x)
+        |}
+        |
+        |eff OutInt32 {
+        |    def toStream(x: Int32): Unit
+        |}
+        |
+        |trait Runner[a] {
+        |    type E: Eff
+        |    pub def exec(x: a): Unit \ Runner.E[a]
+        |}
+        |
+        |instance Runner[Int32] {
+        |    type E = OutInt32
+        |    pub def exec(x: Int32): Unit \ OutInt32 = OutInt32.toStream(x)
+        |}
+        |
+        |instance Runner[Vec[a]] with Runner[a] {
+        |    type E = OutInt32
+        |    pub def exec(x: Vec[a]): Unit \ OutInt32 =
+        |        Container.forEach(Runner.exec, x)
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError](result)
+  }
+
+  test("TestAssocType.06") {
+    // Regression test. See https://github.com/flix/flix/issues/11213
+    // The `Vec` instance is missing the `with Runner[a]` constraint, so `Runner.exec` on the
+    // element type is unresolvable. Reducing the nested associated type must terminate.
+    val input =
+      """
+        |trait Container[t] {
+        |    type Elm: Type
+        |    pub def forEach(f: Container.Elm[t] -> Unit \ ef, t: t): Unit \ ef
+        |}
+        |
+        |enum Vec[a](a)
+        |
+        |instance Container[Vec[a]] {
+        |    type Elm = a
+        |    pub def forEach(f: a -> Unit \ ef, v: Vec[a]): Unit \ ef =
+        |        let Vec.Vec(x) = v;
+        |        f(x)
+        |}
+        |
+        |eff OutInt32 {
+        |    def toStream(x: Int32): Unit
+        |}
+        |
+        |trait Runner[a] {
+        |    type E: Eff
+        |    pub def exec(x: a): Unit \ Runner.E[a]
+        |}
+        |
+        |instance Runner[Int32] {
+        |    type E = OutInt32
+        |    pub def exec(x: Int32): Unit \ OutInt32 = OutInt32.toStream(x)
+        |}
+        |
+        |instance Runner[Vec[a]] {
+        |    type E = Runner.E[a]
+        |    pub def exec(x: Vec[a]): Unit \ Runner.E[a] =
+        |        Container.forEach(Runner.exec, x)
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError](result)
+  }
+
+  test("TestAssocType.07") {
+    // Regression test. See https://github.com/flix/flix/issues/11213
+    // The body performs an extra `OutInt32` effect on top of the nested associated effect, so
+    // its effect is `Runner.E[a] + OutInt32`, which does not match the declared `Runner.E[a]`.
+    val input =
+      """
+        |trait Container[t] {
+        |    type Elm: Type
+        |    pub def forEach(f: Container.Elm[t] -> Unit \ ef, t: t): Unit \ ef
+        |}
+        |
+        |enum Vec[a](a)
+        |
+        |instance Container[Vec[a]] {
+        |    type Elm = a
+        |    pub def forEach(f: a -> Unit \ ef, v: Vec[a]): Unit \ ef =
+        |        let Vec.Vec(x) = v;
+        |        f(x)
+        |}
+        |
+        |eff OutInt32 {
+        |    def toStream(x: Int32): Unit
+        |}
+        |
+        |trait Runner[a] {
+        |    type E: Eff
+        |    pub def exec(x: a): Unit \ Runner.E[a]
+        |}
+        |
+        |instance Runner[Int32] {
+        |    type E = OutInt32
+        |    pub def exec(x: Int32): Unit \ OutInt32 = OutInt32.toStream(x)
+        |}
+        |
+        |instance Runner[Vec[a]] with Runner[a] {
+        |    type E = Runner.E[a]
+        |    pub def exec(x: Vec[a]): Unit \ Runner.E[a] =
+        |        Container.forEach(Runner.exec, x);
+        |        OutInt32.toStream(42)
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError](result)
+  }
+
+  test("TestAssocType.08") {
+    // Regression test. See https://github.com/flix/flix/issues/11213
+    // `Runner.exec` on a `Vec[Int32]` has effect `Runner.E[Vec[Int32]]`, which reduces through
+    // the instances to `OutInt32`. The declared `OutString` must not match, and the concrete
+    // reduction chain must terminate.
+    val input =
+      """
+        |enum Vec[a](a)
+        |
+        |eff OutInt32 {
+        |    def toStream(x: Int32): Unit
+        |}
+        |
+        |eff OutString {
+        |    def toStream(x: String): Unit
+        |}
+        |
+        |trait Runner[a] {
+        |    type E: Eff
+        |    pub def exec(x: a): Unit \ Runner.E[a]
+        |}
+        |
+        |instance Runner[Int32] {
+        |    type E = OutInt32
+        |    pub def exec(x: Int32): Unit \ OutInt32 = OutInt32.toStream(x)
+        |}
+        |
+        |instance Runner[Vec[a]] with Runner[a] {
+        |    type E = Runner.E[a]
+        |    pub def exec(x: Vec[a]): Unit \ Runner.E[a] =
+        |        let Vec.Vec(y) = x;
+        |        Runner.exec(y)
+        |}
+        |
+        |def runMismatch(x: Vec[Int32]): Unit \ OutString = Runner.exec(x)
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError](result)
+  }
+
   test("TestRecordPattern.01") {
     val input =
       """

--- a/main/test/flix/Test.Dec.Assoc.Type.Eff.flix
+++ b/main/test/flix/Test.Dec.Assoc.Type.Eff.flix
@@ -34,8 +34,7 @@ mod Test.Dec.Assoc.Type.Eff {
     instance Runner[Vector[a]] with Runner[a] {
         pub type E = Runner.E[a]
         pub def exec(x: Vector[a]): Unit \ Runner.E[a] =
-            let f: a -> Unit \ Runner.E[a] = Runner.exec;
-            foreach(a <- x) f(a)
+            foreach(a <- x) Runner.exec(a)
     }
 
     ////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes #11213.

## Problem

Calling a trait method with an associated effect directly inside a `foreach` (rather than via a type-annotated local binding) caused the compiler to loop forever. The minimal trigger is the `Runner[Vector[a]]` instance in `Test.Dec.Assoc.Type.Eff.flix`:

```flix
instance Runner[Vector[a]] with Runner[a] {
    pub type E = Runner.E[a]
    pub def exec(x: Vector[a]): Unit \ Runner.E[a] =
        foreach(a <- x) Runner.exec(a)   // hangs without the `let f: a -> Unit \ Runner.E[a] = Runner.exec` workaround
}
```

## Root cause

`foreach` desugars to `ForEach.forEach`, which makes the solver form the constraint `e ~ Runner.E[ForEach.Elm[Vector[t]]]`. In `TypeReduction2.reduce`, the `Type.AssocType` no-match branch returned the original `tpe0` even though the recursive reduction of the argument had already called `progress.markProgress()`:

- the inner `ForEach.Elm[Vector[t]]` reduces to `t` and marks progress,
- the outer `Runner.E[t]` cannot reduce (`t` is a flexible variable, no instance head),
- so `reduce` returned the unchanged original type while signaling progress.

`ConstraintSolver2`'s `exhaustively` loop trusts "progress implies a changed type", so it re-reduced the same constraint indefinitely.

## Fix

In the no-match branch, return the associated type rebuilt with the reduced argument, reusing `tpe0` only when the argument is unchanged (`t eq tpe`). This restores the invariant that marking progress reflects a genuinely changed type, so the solver converges.

The change also:
- removes the now-unnecessary type-annotation workaround from `Test.Dec.Assoc.Type.Eff.flix`, and
- adds negative regression tests in `TestTyper` that exercise the nested associated-type reduction path.