### PR TITLE
refactor: use ForEach in RichString.joinWith

### DIFF
--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -39,8 +39,8 @@ pub mod Map {
         type Aef = Formattable.Aef[k] + Formattable.Aef[v]
 
         pub def format(x: Map[k, v]): RichString \ (Formattable.Aef[k] + Formattable.Aef[v]) =
-            let pairs = Map.toList(x) |> List.map(match (k, v) -> Formattable.format(k) + RichString.fromString(" => ") + Formattable.format(v));
-            RichString.fromString("Map#{") + RichString.joinWith(identity, RichString.fromString(", "), pairs) + RichString.fromString("}")
+            let fmtKeyValue = match (k, v) -> Formattable.format(k) + RichString.fromString(" => ") + Formattable.format(v);
+            RichString.fromString("Map#{") + RichString.joinWith(fmtKeyValue, RichString.fromString(", "), x) + RichString.fromString("}")
     }
 
     instance ToString[Map[k, v]] with ToString[k], ToString[v] {

--- a/main/src/library/MultiMap.flix
+++ b/main/src/library/MultiMap.flix
@@ -36,8 +36,8 @@ pub mod MultiMap {
         type Aef = Formattable.Aef[k] + Formattable.Aef[v]
 
         pub def format(x: MultiMap[k, v]): RichString \ Formattable.Aef[k] + Formattable.Aef[v] =
-            let kvs = MultiMap.toMap(x) |> Map.toList |> List.map(match (k, vs) -> Formattable.format(k) + RichString.fromString(" => ") + Formattable.format(vs));
-            RichString.fromString("MultiMap#{") + RichString.joinWith(identity, RichString.fromString(", "), kvs) + RichString.fromString("}")
+            let fmtKeyValue = match (k, vs) -> Formattable.format(k) + RichString.fromString(" => ") + Formattable.format(vs);
+            RichString.fromString("MultiMap#{") + RichString.joinWith(fmtKeyValue, RichString.fromString(", "), MultiMap.toMap(x)) + RichString.fromString("}")
     }
 
     instance Hash[MultiMap[k, v]] with Hash[k], Hash[v] {

--- a/main/src/library/RichString.flix
+++ b/main/src/library/RichString.flix
@@ -302,20 +302,25 @@ pub mod RichString {
     ///
     /// Uses the Formattable trait to format each element.
     ///
-    pub def join(sep: RichString, xs: t[a]): RichString \ (Formattable.Aef[a] + Foldable.Aef[t]) with Formattable[a], Foldable[t] =
+    pub def join(sep: RichString, xs: t): RichString \ (Formattable.Aef[a] + ForEach.Aef[t]) with ForEach[t], Formattable[a] where ForEach.Elm[t] ~ a =
         joinWith(Formattable.format, sep, xs)
 
     ///
     /// Returns the concatenation of elements in `xs` according to `f` with RichString `sep` inserted between each.
     ///
-    pub def joinWith(f: a -> RichString \ ef, sep: RichString, xs: t[a]): RichString \ (ef + Foldable.Aef[t]) with Foldable[t] =
-        let l = Foldable.toList(xs);
-        match l {
-            case Nil => empty()
-            case x :: Nil => f(x)
-            case x :: rest =>
-                List.foldLeft((acc, elem) -> acc + sep + f(elem), f(x), rest)
-        }
+    pub def joinWith(f: ForEach.Elm[t] -> RichString \ ef, sep: RichString, xs: t): RichString \ (ef + ForEach.Aef[t]) with ForEach[t] = region rc {
+        let acc = Ref.fresh(rc, empty());
+        let first = Ref.fresh(rc, true);
+        foreach (x <- xs) {
+            if (Ref.get(first)) {
+                Ref.put(f(x), acc);
+                Ref.put(false, first)
+            } else {
+                Ref.put(Ref.get(acc) + sep + f(x), acc)
+            }
+        };
+        Ref.get(acc)
+    }
 
     ///
     /// Returns the concatenation of `rs1` and `rs2`.

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -45,7 +45,7 @@ pub mod Set {
         type Aef = Formattable.Aef[a]
 
         pub def format(x: Set[a]): RichString \ Formattable.Aef[a] =
-            RichString.fromString("Set#{") + RichString.joinWith(Formattable.format, RichString.fromString(", "), Set.toList(x)) + RichString.fromString("}")
+            RichString.fromString("Set#{") + RichString.joinWith(Formattable.format, RichString.fromString(", "), x) + RichString.fromString("}")
     }
 
     instance ToString[Set[a]] with ToString[a] {


### PR DESCRIPTION
Fixes #12060.

## Summary

- Change the signature of `RichString.join` / `RichString.joinWith` to require `ForEach[t]` instead of `Foldable[t]`.
- Reimplement `joinWith` with a `foreach` loop over the input rather than materializing it with `Foldable.toList`.
- Refactor the `Formattable` instances for `Set`, `Map`, and `MultiMap` to pass their containers directly to `join` / `joinWith` instead of routing through `toList` (and an intermediate `List.map`).

The observable output is unchanged; `Map`/`MultiMap` iterate in ascending key order via their `ForEach` instances, matching the previous `toList`-based order.