### PR TITLE
refactor: require main to return Unit

### DIFF
--- a/examples/effects-and-handlers/advanced/backtracking.flix
+++ b/examples/effects-and-handlers/advanced/backtracking.flix
@@ -27,9 +27,9 @@ def search(k: Int32): Int32 \ { Rewind, NonDet, IO } = {
         guess
 }
 
-pub def main(): Int32 \ { NonDet, IO } = region rc {
+pub def main(): Unit \ { NonDet, IO } = region rc {
     let checkpoints = MutMap.empty(rc);
-    run search(10) with handler Rewind {
+    let result = run search(10) with handler Rewind {
         def save(label, k) = {
             MutMap.put(label, k, checkpoints);
             k()
@@ -38,5 +38,6 @@ pub def main(): Int32 \ { NonDet, IO } = region rc {
             case Some(k) => k()
             case None    => -1
         }
-    }
+    };
+    println("Found: ${result}")
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/EntryPointError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/EntryPointError.scala
@@ -204,8 +204,6 @@ object EntryPointError {
          |${highlight(loc, "the result type must be Unit", fmt)}
          |
          |${underline("Explanation:")} The main function must return Unit.
-         |
-         |To fix this, change the return type to Unit.
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/EntryPointError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/EntryPointError.scala
@@ -201,16 +201,11 @@ object EntryPointError {
       import fmt.*
       s""">> Unexpected result type '${red(FormatType.formatType(tpe))}' for main.
          |
-         |${highlight(loc, "type has no ToString instance", fmt)}
+         |${highlight(loc, "the result type must be Unit", fmt)}
          |
-         |${underline("Explanation:")} The main function must return Unit or a type with a
-         |ToString instance so the result can be printed.
+         |${underline("Explanation:")} The main function must return Unit.
          |
-         |To fix this, either:
-         |
-         |  (a) Change the return type to Unit,
-         |  (b) Define an instance of ToString for '${magenta(FormatType.formatType(tpe))}', or
-         |  (c) Derive an instance of ToString for '${magenta(FormatType.formatType(tpe))}'.
+         |To fix this, change the return type to Unit.
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/EntryPointError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/EntryPointError.scala
@@ -187,28 +187,6 @@ object EntryPointError {
   }
 
   /**
-    * Error indicating an unexpected result type for the main entry point function.
-    *
-    * @param tpe the result type.
-    * @param loc the location where the error occurred.
-    */
-  case class IllegalMainEntryPointResult(tpe: Type, loc: SourceLocation)(implicit flix: Flix) extends EntryPointError {
-    def code: ErrorCode = ErrorCode.E1403
-
-    def summary: String = s"Unexpected result type for main: '${FormatType.formatType(tpe)}'."
-
-    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
-      import fmt.*
-      s""">> Unexpected result type '${red(FormatType.formatType(tpe))}' for main.
-         |
-         |${highlight(loc, "the result type must be Unit", fmt)}
-         |
-         |${underline("Explanation:")} The main function must return Unit.
-         |""".stripMargin
-    }
-  }
-
-  /**
     * Error indicating an unexpected formal parameter in a runnable (test or main) entry point function.
     *
     * @param loc the location where the error occurred.
@@ -235,6 +213,28 @@ object EntryPointError {
          |
          |  @Test
          |  def testFoo(): Unit = ...
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * Error indicating that the main entry point function has a non-Unit return type.
+    *
+    * @param tpe the actual (non-Unit) result type.
+    * @param loc the location where the error occurred.
+    */
+  case class MainNonUnitReturnType(tpe: Type, loc: SourceLocation)(implicit flix: Flix) extends EntryPointError {
+    def code: ErrorCode = ErrorCode.E1403
+
+    def summary: String = s"Unexpected result type for main: '${FormatType.formatType(tpe)}'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Unexpected result type '${red(FormatType.formatType(tpe))}' for main.
+         |
+         |${highlight(loc, "the result type must be Unit", fmt)}
+         |
+         |${underline("Explanation:")} The main function must return Unit.
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -17,13 +17,10 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
-import ca.uwaterloo.flix.language.ast.TypedAst.ApplyPosition
 import ca.uwaterloo.flix.language.ast.shared.*
-import ca.uwaterloo.flix.language.ast.shared.SymUse.DefSymUse
-import ca.uwaterloo.flix.language.ast.{RigidityEnv, Scheme, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.EntryPointError
-import ca.uwaterloo.flix.language.phase.typer.{ConstraintSolver2, SubstitutionTree, TypeConstraint}
 import ca.uwaterloo.flix.runtime.shell.Shell
 import ca.uwaterloo.flix.util.collection.CofiniteSet
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Result}
@@ -48,10 +45,9 @@ import scala.jdk.CollectionConverters.*
   *   - Check that all entry points have valid signatures, where rules differ from main, tests, and
   *     exports. If an entrypoint does not have a valid signature, its related annotation is
   *     removed to allow further compilation to continue with valid assumptions.
-  *   - Wrap entry points with default effect handlers
-  *   - Replace the existing main function by a new main function that prints the returned value if
-  *     its return type is not Unit.
   *   - Compute the set of all entry points and store it in Root.
+  *
+  * (Wrapping entry points with their default effect handlers happens later, in `Lowering`.)
   */
 object EntryPoints {
 
@@ -63,12 +59,8 @@ object EntryPoints {
   def run(root: TypedAst.Root)(implicit flix: Flix): (TypedAst.Root, List[EntryPointError]) = flix.phaseNew("EntryPoints") {
     val (root1, errs1) = resolveMain(root)
     val (root2, errs2) = checkEntryPoints(root1)
-    // WrapTest and WrapMain assumes sensible tests, so CheckEntryPoints must run first.
-    // Notice that a main function with test annotation will be wrapped twice.
-    val root3 = wrapMain(root2)
-    // WrapMain might change main, so findEntryPoints must be after.
-    val root4 = findEntryPoints(root3)
-    (root4, errs1 ++ errs2)
+    val root3 = findEntryPoints(root2)
+    (root3, errs1 ++ errs2)
   }
 
   /**
@@ -203,8 +195,7 @@ object EntryPoints {
     *   - No type variables.
     *   - One parameter of type Unit.
     *   - An effect that is a subset of the primitive effects.
-    *   - Return type Unit or return type `t` where `ToString[t]` exists
-    *     (This is split into two cases to allow compilation without the standard library).
+    *   - Return type Unit.
     */
   private def checkMain(defn: TypedAst.Def)(implicit sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     val errs = checkNoTypeVariables(defn) match {
@@ -213,9 +204,9 @@ object EntryPoints {
         // Only run these on functions without type variables.
         // A main function should have:
         //  - A single Unit argument
-        //  - An String or Unit return value
+        //  - A Unit return value
         //  - An effect set containing only primitive effects or effects that have default handlers
-        checkUnitArg(defn) ++ checkToStringOrUnitResult(defn) ++ checkEffects(defn, Symbol.PrimitiveEffs ++ root.defaultHandlers.map(_.handledSym))
+        checkUnitArg(defn) ++ checkUnitResult(defn) ++ checkEffects(defn, Symbol.PrimitiveEffs ++ root.defaultHandlers.map(_.handledSym))
     }
     if (errs.nonEmpty) {
       // Invalidate main and add errors.
@@ -353,29 +344,19 @@ object EntryPoints {
   }
 
   /**
-    * Returns `None` if `defn` has return type Unit or has a return type with `ToString` defined.
-    * Returns an error otherwise.
+    * Returns `None` if `defn` has return type Unit. Returns an error otherwise.
     *
-    * In order to support compilation without the standard library, Unit is checked first even
-    * though it has `ToString` defined.
+    * The main function must return Unit. Tools that want to run-and-print an arbitrary function
+    * (e.g. the shell's `:eval` or the editor's run button) are responsible for wrapping the call
+    * in `println(...)` themselves, so the compiler does not need to special-case ToString here.
     */
-  private def checkToStringOrUnitResult(defn: TypedAst.Def)(implicit root: TypedAst.Root, flix: Flix): Option[EntryPointError] = {
+  private def checkUnitResult(defn: TypedAst.Def)(implicit flix: Flix): Option[EntryPointError] = {
     val resultType = defn.spec.retTpe
     isUnitType(resultType) match {
       case Result.Ok(true) =>
         None
       case Result.Ok(false) =>
-        val unknownTraitSym = new Symbol.TraitSym(Nil, "ToString", SourceLocation.Unknown)
-        val traitSym = root.traits.getOrElse(unknownTraitSym, throw InternalCompilerException(s"'$unknownTraitSym' trait not found", defn.sym.loc)).sym
-        val constraint = TypeConstraint.Trait(traitSym, resultType, SourceLocation.Unknown)
-        val hasToString = ConstraintSolver2.solveAll(List(constraint), SubstitutionTree.empty)(RegionScope.Top, RigidityEnv.empty, root.traitEnv, root.eqEnv, flix) match {
-          // If we could reduce all the way, it has ToString.
-          case (Nil, _) => true
-          // If not, there is no ToString instance.
-          case (_ :: _, _) => false
-        }
-        if (hasToString) None
-        else Some(EntryPointError.IllegalMainEntryPointResult(resultType, resultType.loc))
+        Some(EntryPointError.IllegalMainEntryPointResult(resultType, resultType.loc))
       case Result.Err(ErrorOrMalformed) =>
         // Do not report an error, since previous phases should have done already.
         None
@@ -485,103 +466,6 @@ object EntryPoints {
       case Type.JvmToEff(_, _) => Result.Err(ErrorOrMalformed)
       case Type.UnresolvedJvmType(_, _) => Result.Err(ErrorOrMalformed)
     }
-  }
-
-  /**
-    * WrapMain takes the main function (if it exists) and creates a new main function that prints
-    * the value of the existing main function (unless it returns unit).
-    *
-    * From previous phases we know that the main function:
-    *   - Exists if root.mainEntryPoint is Some.
-    *   - Returns Unit or has a return type with ToString defined
-    *   - Has a valid signature (without type variables, etc.)
-    */
-  def wrapMain(root: TypedAst.Root)(implicit flix: Flix): TypedAst.Root = {
-    root.mainEntryPoint.map(root.defs(_)) match {
-      case Some(main0: TypedAst.Def) =>
-        isUnitType(main0.spec.retTpe) match {
-          case Result.Ok(true) =>
-            // main doesn't need a wrapper.
-            root
-          case Result.Ok(false) =>
-            // main needs a wrapper.
-            val main = mkEntryPoint(main0, root)
-            val root1 = root.copy(
-              defs = root.defs + (main.sym -> main),
-              mainEntryPoint = Some(main.sym)
-            )
-            root1
-          case Result.Err(ErrorOrMalformed) =>
-            // Do not report an error, since previous phases should have done already.
-            root
-        }
-
-      case Some(_) | None =>
-        // Main doesn't need a wrapper or no main exists.
-        root
-    }
-  }
-
-  /**
-    * Returns a new function that calls the main function and prints its value
-    * (`mainFunc` in the example below).
-    *
-    * {{{
-    *   def mainFunc(): tpe \ ef = exp
-    *
-    *   def main$(): Unit \ ef + IO = println(main())
-    * }}}
-    */
-  private def mkEntryPoint(oldEntryPoint: TypedAst.Def, root: TypedAst.Root)(implicit flix: Flix): TypedAst.Def = {
-    val argSym = Symbol.freshVarSym("_unit", BoundBy.FormalParam, SourceLocation.Unknown)
-
-    // The new type is `Unit -> Unit \ IO + eff` where `eff` is the effect of the old main.
-    val argType = Type.Unit
-    val retType = Type.Unit
-    val eff = Type.mkUnion(Type.IO, oldEntryPoint.spec.eff, SourceLocation.Unknown)
-
-    val tpe = Type.mkArrowWithEffect(argType, eff, retType, SourceLocation.Unknown)
-    val spec = TypedAst.Spec(
-      doc = Doc(Nil, SourceLocation.Unknown),
-      ann = Annotations.Empty,
-      mod = Modifiers.Empty,
-      tparams = Nil,
-      fparams = List(TypedAst.FormalParam(
-        TypedAst.Binder(argSym, argType),
-        argType,
-        TypeSource.Ascribed,
-        Decreasing.NonDecreasing,
-        SourceLocation.Unknown)
-      ),
-      declaredScheme = Scheme(Nil, Nil, Nil, tpe),
-      retTpe = retType,
-      eff = eff,
-      tconstrs = Nil,
-      econstrs = Nil,
-    )
-
-    val mainArrowType = oldEntryPoint.spec.declaredScheme.base
-    val mainSym = DefSymUse(oldEntryPoint.sym, SourceLocation.Unknown)
-    val mainArgType = Type.Unit
-    val mainArg = TypedAst.Expr.Cst(Constant.Unit, mainArgType, SourceLocation.Unknown)
-    val mainReturnType = mainArrowType.arrowResultType
-    val mainEffect = mainArrowType.arrowEffectType
-    // `mainFunc()`.
-    val mainCall = TypedAst.Expr.ApplyDef(mainSym, List(mainArg), List.empty, mainArrowType, mainReturnType, mainEffect, ApplyPosition.NonTail, SourceLocation.Unknown)
-
-    // `println(mainFunc())`.
-    val printSym = DefSymUse(root.defs(new Symbol.DefnSym(None, Nil, "println", SourceLocation.Unknown)).sym, SourceLocation.Unknown)
-    val printArg = mainCall
-    val printArgType = mainCall.tpe
-    val printReturnType = Type.Unit
-    val printEffect = Type.IO
-    val printArrowType = Type.mkArrowWithEffect(printArgType, printEffect, printReturnType, SourceLocation.Unknown)
-    val printCallEffect = Type.mkUnion(printEffect, printArg.eff, SourceLocation.Unknown)
-    val printCall = TypedAst.Expr.ApplyDef(printSym, List(printArg), List(printArgType), printArrowType, printReturnType, printCallEffect, ApplyPosition.NonTail, SourceLocation.Unknown)
-
-    val sym = new Symbol.DefnSym(None, Nil, "main" + Flix.Delimiter, SourceLocation.Unknown)
-
-    TypedAst.Def(sym, spec, printCall, SourceLocation.Unknown)
   }
 
   /** Returns a new root where [[TypedAst.Root.entryPoints]] contains all entry points (main/test/export). */

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -356,7 +356,7 @@ object EntryPoints {
       case Result.Ok(true) =>
         None
       case Result.Ok(false) =>
-        Some(EntryPointError.IllegalMainEntryPointResult(resultType, resultType.loc))
+        Some(EntryPointError.MainNonUnitReturnType(resultType, resultType.loc))
       case Result.Err(ErrorOrMalformed) =>
         // Do not report an error, since previous phases should have done already.
         None

--- a/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoints.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoints.scala
@@ -297,7 +297,7 @@ class TestEntryPoints extends AnyFunSuite with TestUtils {
     expectError[EntryPointError.IllegalEntryPointEffect](result)
   }
 
-  test("Test.IllegalMainEntryPointResult.Main.01") {
+  test("Test.MainNonUnitReturnType.Main.01") {
     val input =
       """
         |def main(): a \ IO = checked_ecast(???)
@@ -306,53 +306,53 @@ class TestEntryPoints extends AnyFunSuite with TestUtils {
     expectError[EntryPointError.IllegalEntryPointTypeVariables](result)
   }
 
-  test("Test.IllegalMainEntryPointResult.Main.02") {
+  test("Test.MainNonUnitReturnType.Main.02") {
     val input =
       """
         |enum E
         |def main(): E = ???
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
-    expectError[EntryPointError.IllegalMainEntryPointResult](result)
+    expectError[EntryPointError.MainNonUnitReturnType](result)
   }
 
-  test("Test.IllegalMainEntryPointResult.Main.03") {
+  test("Test.MainNonUnitReturnType.Main.03") {
     // A non-Unit return type is rejected even when it has a ToString instance.
     val input =
       """
         |def main(): Int64 \ IO = checked_ecast(42i64)
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
-    expectError[EntryPointError.IllegalMainEntryPointResult](result)
+    expectError[EntryPointError.MainNonUnitReturnType](result)
   }
 
-  test("Test.IllegalMainEntryPointResult.Main.04") {
+  test("Test.MainNonUnitReturnType.Main.04") {
     val input =
       """
         |def main(): String = ???
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
-    expectError[EntryPointError.IllegalMainEntryPointResult](result)
+    expectError[EntryPointError.MainNonUnitReturnType](result)
   }
 
-  test("Test.IllegalMainEntryPointResult.Other.01") {
+  test("Test.MainNonUnitReturnType.Other.01") {
     val input =
       """
         |enum E
         |def f(): E = ???
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin.copy(entryPoint = Some(Symbol.mkDefnSym("f"))))
-    expectError[EntryPointError.IllegalMainEntryPointResult](result)
+    expectError[EntryPointError.MainNonUnitReturnType](result)
   }
 
-  test("Test.IllegalMainEntryPointResult.Other.02") {
+  test("Test.MainNonUnitReturnType.Other.02") {
     // A non-Unit return type with a ToString instance is rejected for an explicit entry point too.
     val input =
       """
         |def f(): Int64 \ IO = checked_ecast(42i64)
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin.copy(entryPoint = Some(Symbol.mkDefnSym("f"))))
-    expectError[EntryPointError.IllegalMainEntryPointResult](result)
+    expectError[EntryPointError.MainNonUnitReturnType](result)
   }
 
   test("Test.IllegalSignature.Main.01") {
@@ -366,7 +366,7 @@ class TestEntryPoints extends AnyFunSuite with TestUtils {
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[EntryPointError.IllegalRunnableEntryPointArgs](result)
-    expectError[EntryPointError.IllegalMainEntryPointResult](result)
+    expectError[EntryPointError.MainNonUnitReturnType](result)
     expectError[EntryPointError.IllegalEntryPointEffect](result)
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoints.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoints.scala
@@ -316,11 +316,40 @@ class TestEntryPoints extends AnyFunSuite with TestUtils {
     expectError[EntryPointError.IllegalMainEntryPointResult](result)
   }
 
+  test("Test.IllegalMainEntryPointResult.Main.03") {
+    // A non-Unit return type is rejected even when it has a ToString instance.
+    val input =
+      """
+        |def main(): Int64 \ IO = checked_ecast(42i64)
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[EntryPointError.IllegalMainEntryPointResult](result)
+  }
+
+  test("Test.IllegalMainEntryPointResult.Main.04") {
+    val input =
+      """
+        |def main(): String = ???
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[EntryPointError.IllegalMainEntryPointResult](result)
+  }
+
   test("Test.IllegalMainEntryPointResult.Other.01") {
     val input =
       """
         |enum E
         |def f(): E = ???
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin.copy(entryPoint = Some(Symbol.mkDefnSym("f"))))
+    expectError[EntryPointError.IllegalMainEntryPointResult](result)
+  }
+
+  test("Test.IllegalMainEntryPointResult.Other.02") {
+    // A non-Unit return type with a ToString instance is rejected for an explicit entry point too.
+    val input =
+      """
+        |def f(): Int64 \ IO = checked_ecast(42i64)
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin.copy(entryPoint = Some(Symbol.mkDefnSym("f"))))
     expectError[EntryPointError.IllegalMainEntryPointResult](result)
@@ -371,7 +400,7 @@ class TestEntryPoints extends AnyFunSuite with TestUtils {
   test("Test.ValidEntryPoint.Main.02") {
     val input =
       """
-        |def main(): Int64 \ IO = checked_ecast(42i64)
+        |def main(): Unit \ IO = checked_ecast(())
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectSuccess(result)
@@ -380,7 +409,7 @@ class TestEntryPoints extends AnyFunSuite with TestUtils {
   test("Test.ValidEntryPoint.Main.03") {
     val input =
       """
-        |def main(): Int64 \ NonDet = checked_ecast(42i64)
+        |def main(): Unit \ NonDet = checked_ecast(())
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectSuccess(result)
@@ -389,7 +418,7 @@ class TestEntryPoints extends AnyFunSuite with TestUtils {
   test("Test.ValidEntryPoint.Main.04") {
     val input =
       """
-        |def main(): Int64 \ {NonDet, IO} = checked_ecast(42i64)
+        |def main(): Unit \ {NonDet, IO} = checked_ecast(())
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectSuccess(result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParserRecovery.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParserRecovery.scala
@@ -422,7 +422,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
         |    /// This is not quite finished
         |    pub def
         |}
-        |def main(): Int32 = Bar.foo()
+        |def main(): Unit = ()
         |
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
@@ -790,7 +790,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     val input =
       """
         |def map(t: Int32): Int32 = match t
-        |def main(): Int32 = 123
+        |def main(): Unit = ()
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[ParseError](result)
@@ -804,7 +804,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
         |    ParentOf("Pompey", "Strabo").,
         |    ParentOf("Sextus", "Pompey").
         |}
-        |def main(): Int32 = 123
+        |def main(): Unit = ()
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[ParseError](result)
@@ -941,7 +941,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
       """
         |def foo(): Unit \ IO =
         |    def bar(): Int32 = 123
-        |def main(): Int32 = 456
+        |def main(): Unit = ()
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[ParseError](result)
@@ -957,7 +957,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
         |    } with handler AskTell ;
         |    true
         |
-        |def main(): Int32 = 123
+        |def main(): Unit = ()
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[ParseError](result)
@@ -969,7 +969,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
       """
         |def foo(): Bool =
         |    try { true } catch
-        |def main(): Int32 = 123
+        |def main(): Unit = ()
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[ParseError](result)
@@ -979,7 +979,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
   test("MissingRecordOperation.01") {
     val input =
       """
-        |def main(): Int32 =
+        |def main(): Unit =
         |    let _ = { | {} };
         |    2
         |""".stripMargin
@@ -993,7 +993,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
       """
         |def foo(): Bool =
         |    run { true }
-        |def main(): Int32 = 123
+        |def main(): Unit = ()
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[ParseError](result)
@@ -1005,7 +1005,7 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
       """
         |def foo(): Bool =
         |    try { true }
-        |def main(): Int32 = 123
+        |def main(): Unit = ()
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[ParseError](result)


### PR DESCRIPTION
Closes #12293.

Previously `main` could return `Unit` *or* any type with a `ToString` instance, and the compiler synthesized a wrapper (`wrapMain`/`mkEntryPoint`) that did `println(main())`. This special-casing is unnecessary: tools that run-and-print an arbitrary function — the shell's `:eval` and the editor's ▶ Run button — already wrap the call in `println(...)` themselves and produce a `Unit`-returning entry point.

This makes `main` (and any explicitly selected entry point) require a `Unit` return type:

- Replace `checkToStringOrUnitResult` with `checkUnitResult` (drops the `ToString` constraint solve).
- Delete the now-dead `wrapMain` / `mkEntryPoint` result-printing machinery.
- Simplify the `IllegalMainEntryPointResult` error message accordingly.

The only user-visible change: directly running a non-`Unit` entry point (e.g. `flix run --entrypoint f`, or `def main(): Int32`) now reports `[E1403]` instead of auto-printing its result. The editor ▶ Run button is unaffected, since it routes through the REPL's `:eval`, which wraps in `println`.

The one bundled example with a non-`Unit` main (`backtracking.flix`) now prints its result explicitly.
