### PR TITLE
feat: allow null to be passed directly to Java calls (#10969)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -277,6 +277,13 @@ object TypeReduction2 {
     case Type.Cst(TypeConstructor.Regex, _) => classOf[java.util.regex.Pattern]
     case Type.Cst(TypeConstructor.Native(clazz), _) => clazz
 
+    // The Null type has no Java class; `null` is a valid value of any reference
+    // type. Apache Commons treats a `null` element in the parameter-type array
+    // as assignable to any non-primitive parameter (and not to primitives), so
+    // returning `null` lets `null` arguments resolve against specific reference
+    // parameters (e.g. `String`), not just `Object`.
+    case Type.Cst(TypeConstructor.Null, _) => null
+
     // Parameterized Java types (e.g. ArrayList[String])
     case Type.Apply(_, _, _) if isNativeBase(tpe) =>
       tpe.baseType match {
@@ -286,13 +293,11 @@ object TypeReduction2 {
 
     // Arrays
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Array, _), elmType, _), _, _) =>
-      val t = getJavaType(elmType)
-      t.arrayType()
+      getJavaArrayType(elmType)
 
     // Vectors
     case Type.Apply(Type.Cst(TypeConstructor.Vector, _), elmType, _) =>
-      val t = getJavaType(elmType)
-      t.arrayType()
+      getJavaArrayType(elmType)
 
     // Functions: map Flix Arrow types to Java functional interfaces.
     case Type.Apply(Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Arrow(2), _), _, _), varArg, _), varRet, _) =>
@@ -301,6 +306,18 @@ object TypeReduction2 {
         case None => classOf[Object]
       }
     case _ => classOf[Object] // default
+  }
+
+  /**
+    * Returns the Java array class for an array/vector with the given element type.
+    *
+    * A `Null` element type has no Java class (see [[getJavaType]]), so we fall
+    * back to `Object[]` (e.g. `Array#{null, null}` becomes `Object[]`).
+    */
+  private def getJavaArrayType(elmType: Type): Class[?] = {
+    val t = getJavaType(elmType)
+    val elmClass: Class[?] = if (t == null) classOf[Object] else t
+    elmClass.arrayType()
   }
 
   /** Tries to find a field of `thisObj` with the name `fieldName`. */
@@ -570,26 +587,32 @@ object TypeReduction2 {
     val substMap = buildTypeVarSubstitution(method, typeArgs)
     val genericParamTypes = method.getGenericParameterTypes
     argTypes.zip(genericParamTypes).flatMap { case (argType, genericParamType) =>
-      genericParamType match {
-        case tv: TypeVariable[_] =>
-          substMap.get(tv.getName).map { expectedType =>
-            TypeConstraint.Equality(expectedType, argType,
-              TypeConstraint.Provenance.Match(expectedType, argType, loc))
-          }
-        case pt: ParameterizedType =>
-          mkParamTypeConstraints(pt, argType, substMap, loc)
-        case gat: GenericArrayType =>
-          // For varargs/array params (e.g., T[] in Stream.of(T...)), emit a constraint
-          // linking the component type variable to the Flix array/vector element type.
-          (gat.getGenericComponentType, argType.typeArguments) match {
-            case (tv: TypeVariable[_], elmType :: _) =>
-              substMap.get(tv.getName).map { expectedType =>
-                TypeConstraint.Equality(expectedType, elmType,
-                  TypeConstraint.Provenance.Match(expectedType, elmType, loc))
-              }.toList
-            case _ => Nil
-          }
-        case _ => None
+      argType match {
+        // `null` is a valid value of any reference type, so it must not constrain
+        // the parameter's type variable. Emit no constraint and let the receiver
+        // or surrounding context determine the type variable.
+        case Type.Cst(TypeConstructor.Null, _) => None
+        case _ => genericParamType match {
+          case tv: TypeVariable[_] =>
+            substMap.get(tv.getName).map { expectedType =>
+              TypeConstraint.Equality(expectedType, argType,
+                TypeConstraint.Provenance.Match(expectedType, argType, loc))
+            }
+          case pt: ParameterizedType =>
+            mkParamTypeConstraints(pt, argType, substMap, loc)
+          case gat: GenericArrayType =>
+            // For varargs/array params (e.g., T[] in Stream.of(T...)), emit a constraint
+            // linking the component type variable to the Flix array/vector element type.
+            (gat.getGenericComponentType, argType.typeArguments) match {
+              case (tv: TypeVariable[_], elmType :: _) =>
+                substMap.get(tv.getName).map { expectedType =>
+                  TypeConstraint.Equality(expectedType, elmType,
+                    TypeConstraint.Provenance.Match(expectedType, elmType, loc))
+                }.toList
+              case _ => Nil
+            }
+          case _ => None
+        }
       }
     }
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -807,6 +807,22 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
+  test("UndefinedJvmMethod.08") {
+    // `null` is not assignable to a primitive parameter (`charAt(int)`),
+    // so the method must not resolve.
+    val input =
+      raw"""
+           |import java.lang.String
+           |
+           |def foo(): Unit =
+           |    let o = new String();
+           |    let _ = o.charAt(null);
+           |    ()
+       """.stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MethodNotFound](result)
+  }
+
   test("UndefinedJvmField.01") {
     val input =
       """

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod.Overload.Null.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod.Overload.Null.flix
@@ -5,6 +5,9 @@ mod Test.Exp.Jvm.InvokeMethod.Overload.Null {
     import java.lang.Object
     import java.lang.StringBuilder
     import java.lang.{String => JString}
+    import java.util.ArrayList
+    import java.util.Collections
+    import java.util.List
     import java.util.Objects
     import java.util.Optional
 
@@ -50,5 +53,27 @@ mod Test.Exp.Jvm.InvokeMethod.Overload.Null {
     def testInvokeMethod_09(): Unit \ Assert + IO =
         let opt = Optional.ofNullable((checked_cast(null): Object));
         assertFalse(opt.isPresent())
+
+    // Bare `null` (no cast) passed to a method with a specific reference parameter.
+    // `equalsIgnoreCase(String)` is the unique overload and is null-safe at runtime.
+    @Test
+    def testInvokeMethod_10(): Unit \ Assert + IO =
+        let obj = "hello";
+        assertFalse(obj.equalsIgnoreCase(null))
+
+    // Bare `null` passed to a generic instance method: `List<E>.add(E)` with `E = String`.
+    @Test
+    def testInvokeMethod_11(): Unit \ Assert + IO =
+        let list: ArrayList[String] = new ArrayList();
+        discard list.add(null);
+        discard list.add("x");
+        assertEq(expected = 2, list.size())
+
+    // Bare `null` passed to a generic static method: `Collections.singletonList(T)`,
+    // with the return-type annotation fixing `T = String`.
+    @Test
+    def testInvokeMethod_12(): Unit \ Assert + IO =
+        let single: List[String] = Collections.singletonList(null);
+        assertEq(expected = 1, single.size())
 
 }


### PR DESCRIPTION
Fixes #10969.

A bare `null` could not be passed to a Java method/constructor whose parameter is a *specific* reference type:

```flix
"hello".equalsIgnoreCase(null)   // before: Method not found ... with arguments (Null)
```

It only worked when the parameter was `Object` (e.g. `"hello".equals(null)`) or with an explicit cast (`checked_cast(null): String`). `null` is a valid value of every Java reference type, so the cast was pure boilerplate.

## Cause

In `TypeReduction2.getJavaType`, the Flix `Null` type fell through to the default case and was mapped to `classOf[Object]`. The reflective overload lookup (`MethodUtils.getMatchingAccessibleMethod` / `ConstructorUtils.getMatchingAccessibleConstructor`) was then asked for, e.g., `equalsIgnoreCase(Object)`, which does not exist — so resolution failed. The backend was already correct (it carries the resolved `Method`/`Constructor` and emits `ACONST_NULL` + `CHECKCAST` to the real parameter type), so no backend change was needed.

## Changes (all in `TypeReduction2.scala`)

- **`getJavaType`**: map `Null` to the `null` class. Apache Commons (`ClassUtils.isAssignable(null, toClass)` ⇒ `!toClass.isPrimitive()`) treats a `null` parameter-type as assignable to any non-primitive parameter, and correctly *not* to primitives. This matches the existing notion that `Null` is a subtype of every non-primitive (`Safety.scala` checked-cast cases, `TypeVerifier.isJavaSubtype`).
- **`mkArgConstraints`**: skip the equality constraint for a `null` argument, so generic parameters work too (e.g. `List[String].add(null)`, `Collections.singletonList(null)`) without forcing the type variable to `Null`.
- **`getJavaArrayType` helper**: array/vector element types of `Null` fall back to `Object[]` (e.g. `Array#{null, null}`) instead of NPE-ing on `null.arrayType()`.

## Behavior

- `"hello".equalsIgnoreCase(null)` now type-checks (⇒ `false`).
- `null` to a **primitive** parameter still fails with `MethodNotFound`.
- `Array#{null, null}` resolves to `Object[]`.

## Known limitations (out of scope)

- **Overload ambiguity**: with a bare `null`, the reflective lookup picks an overload even where Java would report ambiguity (e.g. `new StringBuilder(null)` resolves to `StringBuilder(CharSequence)`). Cast to disambiguate.
- **Arrays/vectors of `null`** used where e.g. `String[]` is expected still require explicit element typing — `Array#{null}` is the honest `Object[]`.