### PR TITLE
feat: add Discrete instances and adjacent (#11047)

### DIFF
--- a/main/src/library/Discrete.flix
+++ b/main/src/library/Discrete.flix
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Magnus Madsen
+ * Copyright 2026 Flix Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,20 @@
 
 mod Discrete {
 
+    ///
+    /// A trait for types whose values form a discrete sequence, i.e. where every
+    /// value has an immediate successor and predecessor.
+    ///
+    /// The successor and predecessor functions must satisfy the following laws:
+    ///
+    ///   - `prev(succ(x)) == x`
+    ///   - `succ(prev(x)) == x`
+    ///   - `succ(x) > x`, except at the maximum value of a bounded type (see below).
+    ///
+    /// For bounded types (e.g. `Int8`, `Int16`, `Int32`, `Int64`), `succ` wraps
+    /// around from the maximum value to the minimum value, and `prev` wraps around
+    /// from the minimum value to the maximum value. The unbounded `BigInt` never wraps.
+    ///
     trait Discrete[t] with Order[t] {
         ///
         /// Returns the successor of the given `x`.
@@ -28,9 +42,35 @@ mod Discrete {
         pub def prev(x: t): t
     }
 
+    instance Discrete[Int8] {
+        pub def succ(x: Int8): Int8 = x + 1i8
+        pub def prev(x: Int8): Int8 = x - 1i8
+    }
+
+    instance Discrete[Int16] {
+        pub def succ(x: Int16): Int16 = x + 1i16
+        pub def prev(x: Int16): Int16 = x - 1i16
+    }
+
     instance Discrete[Int32] {
         pub def succ(x: Int32): Int32 = x + 1
         pub def prev(x: Int32): Int32 = x - 1
     }
+
+    instance Discrete[Int64] {
+        pub def succ(x: Int64): Int64 = x + 1i64
+        pub def prev(x: Int64): Int64 = x - 1i64
+    }
+
+    instance Discrete[BigInt] {
+        pub def succ(x: BigInt): BigInt = x + 1ii
+        pub def prev(x: BigInt): BigInt = x - 1ii
+    }
+
+    ///
+    /// Returns `true` if `x` and `y` are adjacent, i.e. if one is the successor of the other.
+    ///
+    pub def adjacent(x: t, y: t): Bool with Discrete[t] =
+        Discrete.succ(x) == y or Discrete.succ(y) == x
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestDiscrete.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestDiscrete.flix
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod TestDiscrete {
+
+    use Assert.{assertEq, assertTrue, assertFalse}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // succ                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def succInt8_01(): Unit \ Assert = assertEq(expected = 6i8, Discrete.succ(5i8))
+
+    @Test
+    def succInt8_02(): Unit \ Assert = assertEq(expected = 0i8, Discrete.succ(-1i8))
+
+    @Test
+    def succInt16_01(): Unit \ Assert = assertEq(expected = 6i16, Discrete.succ(5i16))
+
+    @Test
+    def succInt16_02(): Unit \ Assert = assertEq(expected = 0i16, Discrete.succ(-1i16))
+
+    @Test
+    def succInt32_01(): Unit \ Assert = assertEq(expected = 6, Discrete.succ(5))
+
+    @Test
+    def succInt32_02(): Unit \ Assert = assertEq(expected = 0, Discrete.succ(-1))
+
+    @Test
+    def succInt64_01(): Unit \ Assert = assertEq(expected = 6i64, Discrete.succ(5i64))
+
+    @Test
+    def succInt64_02(): Unit \ Assert = assertEq(expected = 0i64, Discrete.succ(-1i64))
+
+    @Test
+    def succBigInt_01(): Unit \ Assert = assertEq(expected = 6ii, Discrete.succ(5ii))
+
+    @Test
+    def succBigInt_02(): Unit \ Assert = assertEq(expected = 0ii, Discrete.succ(-1ii))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // prev                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def prevInt8_01(): Unit \ Assert = assertEq(expected = 4i8, Discrete.prev(5i8))
+
+    @Test
+    def prevInt8_02(): Unit \ Assert = assertEq(expected = -1i8, Discrete.prev(0i8))
+
+    @Test
+    def prevInt16_01(): Unit \ Assert = assertEq(expected = 4i16, Discrete.prev(5i16))
+
+    @Test
+    def prevInt16_02(): Unit \ Assert = assertEq(expected = -1i16, Discrete.prev(0i16))
+
+    @Test
+    def prevInt32_01(): Unit \ Assert = assertEq(expected = 4, Discrete.prev(5))
+
+    @Test
+    def prevInt32_02(): Unit \ Assert = assertEq(expected = -1, Discrete.prev(0))
+
+    @Test
+    def prevInt64_01(): Unit \ Assert = assertEq(expected = 4i64, Discrete.prev(5i64))
+
+    @Test
+    def prevInt64_02(): Unit \ Assert = assertEq(expected = -1i64, Discrete.prev(0i64))
+
+    @Test
+    def prevBigInt_01(): Unit \ Assert = assertEq(expected = 4ii, Discrete.prev(5ii))
+
+    @Test
+    def prevBigInt_02(): Unit \ Assert = assertEq(expected = -1ii, Discrete.prev(0ii))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // prev(succ(x)) == x                                                      //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def roundtripInt8_01(): Unit \ Assert = assertEq(expected = 42i8, Discrete.prev(Discrete.succ(42i8)))
+
+    @Test
+    def roundtripInt16_01(): Unit \ Assert = assertEq(expected = 42i16, Discrete.prev(Discrete.succ(42i16)))
+
+    @Test
+    def roundtripInt32_01(): Unit \ Assert = assertEq(expected = 42, Discrete.prev(Discrete.succ(42)))
+
+    @Test
+    def roundtripInt64_01(): Unit \ Assert = assertEq(expected = 42i64, Discrete.prev(Discrete.succ(42i64)))
+
+    @Test
+    def roundtripBigInt_01(): Unit \ Assert = assertEq(expected = 42ii, Discrete.prev(Discrete.succ(42ii)))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // wraparound (bounded types)                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def wraparoundInt8_01(): Unit \ Assert = assertEq(expected = Int8.minValue(), Discrete.succ(Int8.maxValue()))
+
+    @Test
+    def wraparoundInt8_02(): Unit \ Assert = assertEq(expected = Int8.maxValue(), Discrete.prev(Int8.minValue()))
+
+    @Test
+    def wraparoundInt16_01(): Unit \ Assert = assertEq(expected = Int16.minValue(), Discrete.succ(Int16.maxValue()))
+
+    @Test
+    def wraparoundInt16_02(): Unit \ Assert = assertEq(expected = Int16.maxValue(), Discrete.prev(Int16.minValue()))
+
+    @Test
+    def wraparoundInt32_01(): Unit \ Assert = assertEq(expected = Int32.minValue(), Discrete.succ(Int32.maxValue()))
+
+    @Test
+    def wraparoundInt32_02(): Unit \ Assert = assertEq(expected = Int32.maxValue(), Discrete.prev(Int32.minValue()))
+
+    @Test
+    def wraparoundInt64_01(): Unit \ Assert = assertEq(expected = Int64.minValue(), Discrete.succ(Int64.maxValue()))
+
+    @Test
+    def wraparoundInt64_02(): Unit \ Assert = assertEq(expected = Int64.maxValue(), Discrete.prev(Int64.minValue()))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // adjacent                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def adjacent01(): Unit \ Assert = assertTrue(Discrete.adjacent(1, 2))
+
+    @Test
+    def adjacent02(): Unit \ Assert = assertTrue(Discrete.adjacent(2, 1))
+
+    @Test
+    def adjacent03(): Unit \ Assert = assertFalse(Discrete.adjacent(1, 3))
+
+    @Test
+    def adjacent04(): Unit \ Assert = assertFalse(Discrete.adjacent(1, 1))
+
+    @Test
+    def adjacent05(): Unit \ Assert = assertTrue(Discrete.adjacent(-1, 0))
+
+    @Test
+    def adjacent06(): Unit \ Assert = assertTrue(Discrete.adjacent(5i8, 6i8))
+
+    @Test
+    def adjacent07(): Unit \ Assert = assertFalse(Discrete.adjacent(5i8, 5i8))
+
+    @Test
+    def adjacent08(): Unit \ Assert = assertTrue(Discrete.adjacent(100ii, 99ii))
+
+    @Test
+    def adjacent09(): Unit \ Assert = assertFalse(Discrete.adjacent(100ii, 102ii))
+
+}


### PR DESCRIPTION
Extends the `Discrete` trait, addressing the `Discrete` part of #11047.

## Changes

- Add `Discrete` instances for `Int8`, `Int16`, `Int64`, and `BigInt` (inserted in width order, matching `Order`).
- Add `Discrete.adjacent(x, y)`, which returns `true` if one of `x` and `y` is the successor of the other.
- Document the trait laws (`prev(succ(x)) == x`, `succ(prev(x)) == x`, `succ(x) > x` except at the maximum) and the wraparound behaviour of `succ`/`prev` at the bounds of bounded types. `BigInt` is unbounded and never wraps.
- Add `TestDiscrete` covering `succ`/`prev` for every instance, the `prev(succ(x)) == x` round-trip, boundary wraparound, and `adjacent`.

## Notes / out of scope

- `Char` is deferred: Flix `Char` is a 16-bit UTF-16 unit with no clean `Int32 -> Char` conversion (only `unchecked_cast`), so it wants a small helper first.
- No `Option`-returning `succSafe`/`prevSafe` variants; `succ`/`prev` wrap at the bounds as documented.
- The `Range` part of #11047 (`isEmpty`, `memberOf`, `overlaps`, conversions, `Iterable`) will follow in a separate PR.