### PR TITLE
feat: relativize absolute source paths in error messages

### DIFF
--- a/main/src/ca/uwaterloo/flix/util/Formatter.scala
+++ b/main/src/ca/uwaterloo/flix/util/Formatter.scala
@@ -6,6 +6,7 @@ import ca.uwaterloo.flix.language.ast.shared.Source
 import ca.uwaterloo.flix.language.errors.ErrorCode
 import ca.uwaterloo.flix.util.collection.ListOps
 
+import java.nio.file.{Path, Paths}
 import scala.collection.mutable
 
 trait Formatter {
@@ -15,7 +16,7 @@ trait Formatter {
     val fixedChars = 8
     val k = kind.toString
     val c = code.toString
-    val s = source.name
+    val s = Formatter.relativizeForDisplay(source.name)
     val numberOfDashes = Math.max(3, minWidth - fixedChars - k.length - c.length - s.length)
     val dashes = "-" * numberOfDashes
     s"-- ${blue(k)} ${blue(s"[$c]")} $dashes ${blue(s)}${System.lineSeparator()}"
@@ -147,6 +148,33 @@ trait Formatter {
 }
 
 object Formatter {
+
+  /**
+    * The current working directory, used to relativize absolute source paths for display.
+    */
+  private lazy val WorkingDirectory: Path = Paths.get("").toAbsolutePath
+
+  /**
+    * Returns the source `name` relativized to the current working directory for display.
+    *
+    * An absolute path is made relative to the working directory when that yields a shorter
+    * string (e.g. a long absolute project path becomes `src/Main.flix`). Relative paths are
+    * returned unchanged, as is any path that cannot be relativized (e.g. a different filesystem
+    * root on Windows).
+    */
+  def relativizeForDisplay(name: String): String = {
+    try {
+      val path = Paths.get(name)
+      if (!path.isAbsolute) {
+        name
+      } else {
+        val relative = WorkingDirectory.relativize(path).toString.replace('\\', '/')
+        if (relative.length < name.length) relative else name
+      }
+    } catch {
+      case _: IllegalArgumentException => name
+    }
+  }
 
   /**
     * A formatter that does not apply any color styling.


### PR DESCRIPTION
Fixes #4703.

## Problem

Error headers render the source path exactly as it entered the compiler. In project mode the build walks sources from the absolute working directory, so the path is absolute — and a long absolute path overflows the 80-column header rule:

```
-- Type Error [E7796] --- /Users/au216465/Work/GitHub/flix/flix3/out/example.flix
```

## Change

Route the header's source name through a new `Formatter.relativizeForDisplay`, which:

- relativizes an **absolute** path to the current working directory when that yields a shorter string;
- returns **relative** paths unchanged;
- falls back to the original on `IllegalArgumentException` (e.g. a different filesystem root on Windows).

```
-- Type Error [E7796] ----------------------------------------- out/example.flix
```

The relativized path is still valid and clickable. Machine-facing consumers (LSP document URIs via `Location.from`, the JVM `SourceFile` attribute via `visitSource`) read `source.name` directly and are unaffected.

## Scope

Only the error-message header is wired up here. Other human-facing sites still show the raw path and can be routed through the same helper in a follow-up if desired: the compiler-top TUI (`Formatting.scala`), test output (`Tester.scala`), `Summary.scala`, and `SourceLocation.format`.