### PR TITLE
feat: extend Range with queries, conversions, and Iterable (#11047)

### DIFF
--- a/main/src/library/Range.flix
+++ b/main/src/library/Range.flix
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Magnus Madsen
+ * Copyright 2026 Flix Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,41 @@ pub mod Range {
         pub def forEach(f: t -> Unit \ ef, t: Range[t]): Unit \ ef = Range.forEach(f, t)
     }
 
+    instance Iterable[Range[t]] with Discrete[t] {
+        type Elm = t
+        pub def iterator(rc: Region[r], rng: Range[t]): Iterator[t, r, r] \ r = Range.iterator(rc, rng)
+    }
+
+    ///
+    /// Returns `true` if and only if the range `r` is empty, i.e. it contains no elements.
+    ///
+    pub def isEmpty(r: Range[t]): Bool with Order[t] =
+        let Range(b, e) = r;
+        not (b < e)
+
+    ///
+    /// Returns `true` if and only if `x` is a member of the range `r`.
+    ///
+    pub def memberOf(x: t, r: Range[t]): Bool with Order[t] =
+        let Range(b, e) = r;
+        b <= x and x < e
+
+    ///
+    /// Returns `true` if and only if the ranges `r1` and `r2` overlap, i.e. they share at least one element.
+    ///
+    pub def overlaps(r1: Range[t], r2: Range[t]): Bool with Order[t] =
+        not isEmpty(intersection(r1, r2))
+
+    ///
+    /// Returns the intersection of the ranges `r1` and `r2`.
+    ///
+    /// The result is empty if `r1` and `r2` do not overlap.
+    ///
+    pub def intersection(r1: Range[t], r2: Range[t]): Range[t] with Order[t] =
+        let Range(b1, e1) = r1;
+        let Range(b2, e2) = r2;
+        Range(Order.max(b1, b2), Order.min(e1, e2))
+
     ///
     /// Applies `f` to every element of `r`.
     ///
@@ -38,5 +73,33 @@ pub mod Range {
                 f(i); loop(Discrete.succ(i))
             };
         loop(b)
+
+    ///
+    /// Returns an iterator over the elements of `r`.
+    ///
+    pub def iterator(rc: Region[r], rng: Range[t]): Iterator[t, r, r] \ r with Discrete[t] =
+        let Range(b, e) = rng;
+        Iterator.unfold(rc, i -> if (i < e) Some((i, Discrete.succ(i))) else None, b)
+
+    ///
+    /// Returns the elements of `r` as a list.
+    ///
+    pub def toList(r: Range[t]): List[t] with Discrete[t] = region rc {
+        Range.iterator(rc, r) |> Iterator.toList
+    }
+
+    ///
+    /// Returns the elements of `r` as a set.
+    ///
+    pub def toSet(r: Range[t]): Set[t] with Discrete[t] = region rc {
+        Range.iterator(rc, r) |> Iterator.toSet
+    }
+
+    ///
+    /// Returns the elements of `r` as a vector.
+    ///
+    pub def toVector(r: Range[t]): Vector[t] with Discrete[t] = region rc {
+        Range.iterator(rc, r) |> Iterator.toVector
+    }
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestRange.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRange.flix
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod TestRange {
+
+    use Range.Range
+    use Assert.{assertEq, assertTrue, assertFalse}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // isEmpty                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def isEmpty01(): Unit \ Assert = assertTrue(Range.isEmpty(Range(0, 0)))
+
+    @Test
+    def isEmpty02(): Unit \ Assert = assertTrue(Range.isEmpty(Range(5, 5)))
+
+    @Test
+    def isEmpty03(): Unit \ Assert = assertFalse(Range.isEmpty(Range(0, 3)))
+
+    @Test
+    def isEmpty04(): Unit \ Assert = assertFalse(Range.isEmpty(Range(-3, 0)))
+
+    @Test
+    def isEmpty05(): Unit \ Assert = assertTrue(Range.isEmpty(Range(3, 0)))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // memberOf                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def memberOf01(): Unit \ Assert = assertTrue(Range.memberOf(0, Range(0, 3)))
+
+    @Test
+    def memberOf02(): Unit \ Assert = assertTrue(Range.memberOf(2, Range(0, 3)))
+
+    @Test
+    def memberOf03(): Unit \ Assert = assertFalse(Range.memberOf(3, Range(0, 3)))
+
+    @Test
+    def memberOf04(): Unit \ Assert = assertFalse(Range.memberOf(-1, Range(0, 3)))
+
+    @Test
+    def memberOf05(): Unit \ Assert = assertFalse(Range.memberOf(0, Range(0, 0)))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // overlaps                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def overlaps01(): Unit \ Assert = assertTrue(Range.overlaps(Range(0, 3), Range(2, 5)))
+
+    @Test
+    def overlaps02(): Unit \ Assert = assertTrue(Range.overlaps(Range(2, 5), Range(0, 3)))
+
+    @Test
+    def overlaps03(): Unit \ Assert = assertFalse(Range.overlaps(Range(0, 3), Range(3, 5)))
+
+    @Test
+    def overlaps04(): Unit \ Assert = assertFalse(Range.overlaps(Range(0, 3), Range(5, 8)))
+
+    @Test
+    def overlaps05(): Unit \ Assert = assertTrue(Range.overlaps(Range(0, 10), Range(3, 5)))
+
+    @Test
+    def overlaps06(): Unit \ Assert = assertFalse(Range.overlaps(Range(0, 3), Range(1, 1)))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // intersection                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def intersection01(): Unit \ Assert = assertEq(expected = Range(3, 5), Range.intersection(Range(0, 5), Range(3, 8)))
+
+    @Test
+    def intersection02(): Unit \ Assert = assertEq(expected = Range(2, 5), Range.intersection(Range(0, 10), Range(2, 5)))
+
+    @Test
+    def intersection03(): Unit \ Assert = assertTrue(Range.isEmpty(Range.intersection(Range(0, 3), Range(5, 8))))
+
+    @Test
+    def intersection04(): Unit \ Assert = assertEq(expected = Range(0, 5), Range.intersection(Range(0, 5), Range(0, 5)))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // forEach                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def forEach01(): Unit \ Assert = region rc {
+        let sum = Ref.fresh(rc, 0);
+        Range.forEach(x -> Ref.put(Ref.get(sum) + x, sum), Range(0, 5));
+        assertEq(expected = 10, Ref.get(sum))
+    }
+
+    @Test
+    def forEach02(): Unit \ Assert = region rc {
+        let sum = Ref.fresh(rc, 0);
+        Range.forEach(x -> Ref.put(Ref.get(sum) + x, sum), Range(0, 0));
+        assertEq(expected = 0, Ref.get(sum))
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // iterator                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def iterator01(): Unit \ Assert = region rc {
+        assertEq(expected = 0 :: 1 :: 2 :: Nil, Range.iterator(rc, Range(0, 3)) |> Iterator.toList)
+    }
+
+    @Test
+    def iterator02(): Unit \ Assert = region rc {
+        assertEq(expected = Nil, Range.iterator(rc, Range(0, 0)) |> Iterator.toList)
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toList                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def toList01(): Unit \ Assert = assertEq(expected = 0 :: 1 :: 2 :: Nil, Range.toList(Range(0, 3)))
+
+    @Test
+    def toList02(): Unit \ Assert = assertEq(expected = 2 :: 3 :: 4 :: Nil, Range.toList(Range(2, 5)))
+
+    @Test
+    def toList03(): Unit \ Assert = assertEq(expected = Nil, Range.toList(Range(0, 0)))
+
+    @Test
+    def toList04(): Unit \ Assert = assertEq(expected = Nil, Range.toList(Range(3, 0)))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toSet                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def toSet01(): Unit \ Assert = assertEq(expected = Set#{0, 1, 2}, Range.toSet(Range(0, 3)))
+
+    @Test
+    def toSet02(): Unit \ Assert = assertEq(expected = Set#{}, Range.toSet(Range(0, 0)))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toVector                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def toVector01(): Unit \ Assert = assertEq(expected = Vector#{0, 1, 2}, Range.toVector(Range(0, 3)))
+
+    @Test
+    def toVector02(): Unit \ Assert = assertEq(expected = Vector#{}, Range.toVector(Range(0, 0)))
+
+}


### PR DESCRIPTION
Extends the `Range` module. Together with #12901 (the `Discrete` part), this completes #11047.

Closes #11047

## Changes

- **Queries** (all `Order`-only): `isEmpty`, `memberOf`, `overlaps`, and `intersection`. `overlaps` is derived as `not isEmpty(intersection(r1, r2))`, so empty and non-overlapping ranges are handled without special cases.
- **Iteration**: an `iterator` function (built on `Iterator.unfold`, so empty ranges yield nothing) and a matching `Iterable[Range[t]]` instance that delegates to it.
- **Conversions** (`Discrete`): `toList`, `toSet`, and `toVector`, routed through `Range.iterator`.
- Add `TestRange` covering the half-open boundary behaviour (inclusive lower, exclusive upper, adjacent-but-not-overlapping ranges), empty and reversed ranges, and empty conversion results.

## Notes / out of scope

- `length`/`size` is deferred: it is O(n) over `succ`, and the element count can exceed `Int32` for large `Int64`/`BigInt` ranges. It is better added once `Discrete` gains a `distance`-style method.
- `clamp` is omitted: clamping into a half-open range needs `Discrete.prev` (the last element is `prev(e)`), so it does not belong with the `Order`-only queries.