### PR TITLE
refactor: split MismatchedOpArity into OverAppliedOp and UnderAppliedOp errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -46,6 +46,7 @@ object ErrorCode {
   case object E0895 extends ErrorCode
   case object E0905 extends ErrorCode
   case object E0912 extends ErrorCode
+  case object E0913 extends ErrorCode
   case object E0958 extends ErrorCode
   case object E1016 extends ErrorCode
   case object E1023 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -613,22 +613,47 @@ object ResolutionError {
   }
 
   /**
-    * An error indicating that the number of arguments given to an effect operation
-    * does not match the number of formal parameters it declares.
+    * An error indicating that an effect operation is given too many arguments,
+    * i.e. more arguments than the number of formal parameters it declares.
     *
     * @param op       the effect operation symbol.
     * @param expected the expected number of arguments (the operation's declared arity).
     * @param actual   the actual number of arguments given.
     * @param loc      the location where the error occurred.
     */
-  case class MismatchedOpArity(op: Symbol.OpSym, expected: Int, actual: Int, loc: SourceLocation) extends ResolutionError {
+  case class OverAppliedOp(op: Symbol.OpSym, expected: Int, actual: Int, loc: SourceLocation) extends ResolutionError {
     def code: ErrorCode = ErrorCode.E0912
 
-    def summary: String = s"Mismatched arity for operation '${op.name}'."
+    def summary: String = s"Too many arguments for operation '${op.name}'."
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Mismatched arity for operation '${red(op.name)}'.
+      s""">> Too many arguments for operation '${red(op.name)}'.
+         |
+         |Expected ${Grammar.n_things(expected, "argument")} but found $actual.
+         |
+         |${highlight(loc, s"expected $expected arguments", fmt)}
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * An error indicating that an effect operation is given too few arguments,
+    * i.e. fewer arguments than the number of formal parameters it declares.
+    *
+    * @param op       the effect operation symbol.
+    * @param expected the expected number of arguments (the operation's declared arity).
+    * @param actual   the actual number of arguments given.
+    * @param loc      the location where the error occurred.
+    */
+  case class UnderAppliedOp(op: Symbol.OpSym, expected: Int, actual: Int, loc: SourceLocation) extends ResolutionError {
+    def code: ErrorCode = ErrorCode.E0913
+
+    def summary: String = s"Too few arguments for operation '${op.name}'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Too few arguments for operation '${red(op.name)}'.
          |
          |Expected ${Grammar.n_things(expected, "argument")} but found $actual.
          |

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3491,11 +3491,16 @@ object Resolver {
 
   /**
     * Checks that the operator's arity matches the number of arguments given.
+    *
+    * Reports [[ResolutionError.OverAppliedOp]] if too many arguments are given and
+    * [[ResolutionError.UnderAppliedOp]] if too few arguments are given.
     */
   private def checkOpArity(op: Declaration.Op, numArgs: Int, loc: SourceLocation)(implicit sctx: SharedContext): Unit = {
-    if (op.spec.fparams.length != numArgs) {
-      val error = ResolutionError.MismatchedOpArity(op.sym, op.spec.fparams.length, numArgs, loc)
-      sctx.errors.add(error)
+    val expected = op.spec.fparams.length
+    if (numArgs > expected) {
+      sctx.errors.add(ResolutionError.OverAppliedOp(op.sym, expected, numArgs, loc))
+    } else if (numArgs < expected) {
+      sctx.errors.add(ResolutionError.UnderAppliedOp(op.sym, expected, numArgs, loc))
     }
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -1777,7 +1777,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.IllegalAssocTypeApplication](result)
   }
 
-  test("Test.MismatchedOpArity.Handler.01") {
+  test("Test.OverAppliedOp.Handler.01") {
     val input =
       """
         |eff E {
@@ -1791,10 +1791,44 @@ class TestResolver extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
-    expectError[ResolutionError.MismatchedOpArity](result)
+    expectError[ResolutionError.OverAppliedOp](result)
   }
 
-  test("Test.MismatchedOpArity.Handler.02") {
+  test("Test.OverAppliedOp.Handler.02") {
+    val input =
+      """
+        |eff E {
+        |    def op(x: String, y: Int32): Unit
+        |}
+        |
+        |def foo(): Unit = {
+        |    run checked_ecast(()) with handler E {
+        |        def op(x, y, z, cont) = ()
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.OverAppliedOp](result)
+  }
+
+  test("Test.OverAppliedOp.Handler.03") {
+    val input =
+      """
+        |eff E {
+        |    def op(x: String): Unit
+        |}
+        |
+        |def foo(): Unit = {
+        |    run checked_ecast(()) with handler E {
+        |        def op(a, b, c, cont) = ()
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.OverAppliedOp](result)
+  }
+
+  test("Test.UnderAppliedOp.Handler.01") {
     val input =
       """
         |eff E {
@@ -1808,7 +1842,41 @@ class TestResolver extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
-    expectError[ResolutionError.MismatchedOpArity](result)
+    expectError[ResolutionError.UnderAppliedOp](result)
+  }
+
+  test("Test.UnderAppliedOp.Handler.02") {
+    val input =
+      """
+        |eff E {
+        |    def op(x: String, y: Int32, z: Bool): Unit
+        |}
+        |
+        |def foo(): Unit = {
+        |    run checked_ecast(()) with handler E {
+        |        def op(cont) = ()
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UnderAppliedOp](result)
+  }
+
+  test("Test.UnderAppliedOp.Handler.03") {
+    val input =
+      """
+        |eff E {
+        |    def op(x: String, y: Int32, z: Bool): Unit
+        |}
+        |
+        |def foo(): Unit = {
+        |    run checked_ecast(()) with handler E {
+        |        def op(x, cont) = ()
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UnderAppliedOp](result)
   }
 
   test("Test.MismatchedTagPatternArity.01") {


### PR DESCRIPTION
Closes #6742.

Splits the single `ResolutionError.MismatchedOpArity` error into two distinct errors so the message can state *which way* an effect operation handler's arity is wrong:

- `OverAppliedOp` (`E0912`) — `Too many arguments for operation '...'.`
- `UnderAppliedOp` (`E0913`) — `Too few arguments for operation '...'.`

`Resolver.checkOpArity` now dispatches on the direction of the mismatch instead of a single equality check. The set of inputs that produce an error is unchanged; only the reported error type and message differ.

Note: the original error lived under `ResolutionError`, not `TypeError` as the issue title suggests — it appears to have been relocated since the issue was filed.