### PR TITLE
feat: add LSP folding ranges for comments (#8799)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/FoldingRange.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/FoldingRange.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp
+
+import org.eclipse.lsp4j
+import org.json4s.*
+import org.json4s.JsonDSL.*
+
+/**
+  * Represents a `FoldingRange` in LSP.
+  *
+  * A folding range identifies a region of text that an editor may collapse (fold) into a single line.
+  *
+  * We only provide line-based folding ranges, i.e. the start and end characters are left unspecified so
+  * that the whole lines from [[startLine]] to [[endLine]] (inclusive) are folded.
+  *
+  * @param startLine The (one-indexed) line where the folded range starts.
+  * @param endLine   The (one-indexed) line where the folded range ends.
+  * @param kind      The kind of the folding range.
+  */
+case class FoldingRange(startLine: Int, endLine: Int, kind: FoldingRangeKind) {
+  // NB: LSP line numbers are zero-indexed, but Flix uses one-indexed numbers internally.
+  def toJSON: JValue =
+    ("startLine" -> (startLine - 1)) ~
+      ("endLine" -> (endLine - 1)) ~
+      ("kind" -> kind.toJSON)
+
+  // NB: LSP line numbers are zero-indexed, but Flix uses one-indexed numbers internally.
+  def toLsp4j: lsp4j.FoldingRange = {
+    val foldingRange = new lsp4j.FoldingRange(startLine - 1, endLine - 1)
+    foldingRange.setKind(kind.toLsp4j)
+    foldingRange
+  }
+}

--- a/main/src/ca/uwaterloo/flix/api/lsp/FoldingRange.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/FoldingRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Magnus Madsen
+ * Copyright 2026 Flix Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/ca/uwaterloo/flix/api/lsp/FoldingRangeKind.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/FoldingRangeKind.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp
+
+import org.eclipse.lsp4j
+import org.json4s.*
+import org.json4s.JsonDSL.*
+
+/**
+  * Represents a `FoldingRangeKind` in LSP.
+  *
+  * A set of predefined kinds that describe the meaning of a [[FoldingRange]].
+  */
+sealed trait FoldingRangeKind {
+  def toJSON: JValue = this match {
+    case FoldingRangeKind.Comment => "comment"
+    case FoldingRangeKind.Imports => "imports"
+    case FoldingRangeKind.Region => "region"
+  }
+
+  def toLsp4j: String = this match {
+    case FoldingRangeKind.Comment => lsp4j.FoldingRangeKind.Comment
+    case FoldingRangeKind.Imports => lsp4j.FoldingRangeKind.Imports
+    case FoldingRangeKind.Region => lsp4j.FoldingRangeKind.Region
+  }
+}
+
+object FoldingRangeKind {
+
+  /**
+    * A folding range for a comment.
+    */
+  case object Comment extends FoldingRangeKind
+
+  /**
+    * A folding range for imports or includes.
+    */
+  case object Imports extends FoldingRangeKind
+
+  /**
+    * A folding range for a region (e.g. `#region`).
+    */
+  case object Region extends FoldingRangeKind
+
+}

--- a/main/src/ca/uwaterloo/flix/api/lsp/FoldingRangeKind.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/FoldingRangeKind.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Magnus Madsen
+ * Copyright 2026 Flix Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -199,6 +199,7 @@ object LspServer {
       serverCapabilities.setWorkspaceSymbolProvider(true)
       serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Full)// TODO: make it incremental
       serverCapabilities.setDocumentFormattingProvider(true)
+      serverCapabilities.setFoldingRangeProvider(true)
 
       serverCapabilities
     }
@@ -426,6 +427,12 @@ object LspServer {
       val uri = params.getTextDocument.getUri
       val symbols = SymbolProvider.processDocumentSymbols(uri)(flixLanguageServer.root)
       CompletableFuture.completedFuture(symbols.map(_.toLsp4j).map(messages.Either.forRight[SymbolInformation, DocumentSymbol]).asJava)
+    }
+
+    override def foldingRange(params: FoldingRangeRequestParams): CompletableFuture[util.List[FoldingRange]] = {
+      val uri = params.getTextDocument.getUri
+      val foldingRanges = FoldingRangeProvider.getFoldingRanges(uri)(flixLanguageServer.root).map(_.toLsp4j).asJava
+      CompletableFuture.completedFuture(foldingRanges)
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/Request.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Request.scala
@@ -167,6 +167,11 @@ object Request {
   case class Formatting(requestId: String, uri: String, options: FormattingOptions) extends Request
 
   /**
+    * A request to get the folding ranges for a file.
+    */
+  case class FoldingRange(requestId: String, uri: String) extends Request
+
+  /**
     * Tries to parse the given `json` value as a [[AddUri]] request.
     */
   def parseAddUri(json: json4s.JValue): Result[Request, String] = {
@@ -491,6 +496,16 @@ object Request {
       uri <- parseUri(json)
       options = FormattingOptions.parse(json \ "options")
     } yield Request.Formatting(id, uri, options)
+  }
+
+  /**
+    * Tries to parse the given `json` value as a [[FoldingRange]] request.
+    */
+  def parseFoldingRange(json: json4s.JValue): Result[Request, String] = {
+    for {
+      id <- parseId(json)
+      uri <- parseUri(json)
+    } yield Request.FoldingRange(id, uri)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
@@ -187,6 +187,7 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
       case JString("lsp/showAst") => Request.parseShowAst(json)
       case JString("lsp/codeAction") => Request.parseCodeAction(json)
       case JString("lsp/formatting") => Request.parseFormatting(json)
+      case JString("lsp/foldingRange") => Request.parseFoldingRange(json)
 
       case _ => Err(s"Unsupported request: '$s'.")
     }
@@ -336,6 +337,9 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
     case Request.Formatting(id, uri, options) =>
       val edits = FormattingProvider.formatDocument(uri, options)(flix).map(_.toJSON)
       ("id" -> id) ~ ("uri" -> uri) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> JArray(edits))
+
+    case Request.FoldingRange(id, uri) =>
+      ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> JArray(FoldingRangeProvider.getFoldingRanges(uri)(root).map(_.toJSON)))
 
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FoldingRangeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FoldingRangeProvider.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp.provider
+
+import ca.uwaterloo.flix.api.lsp.{FoldingRange, FoldingRangeKind}
+import ca.uwaterloo.flix.language.ast.TypedAst.Root
+import ca.uwaterloo.flix.language.ast.{Token, TokenKind}
+
+import scala.collection.mutable
+
+/**
+  * Provides the means to handle an LSP folding range request.
+  *
+  * We compute folding ranges for multi-line comments so that they can be collapsed (folded) in an editor:
+  *   - A run of consecutive line comments (`//`) on adjacent lines.
+  *   - A run of consecutive doc comments (`///`) on adjacent lines.
+  *   - A single block comment (`/* ... */`) spanning multiple lines.
+  */
+object FoldingRangeProvider {
+
+  /**
+    * Returns the folding ranges for the file at the given `uri`.
+    */
+  def getFoldingRanges(uri: String)(implicit root: Root): List[FoldingRange] = {
+    root.tokens.keys.find(_.name == uri) match {
+      case None => Nil
+      case Some(source) =>
+        val comments = root.tokens(source).iterator.filter(_.kind.isComment).toList
+        foldComments(comments).sortBy(r => (r.startLine, r.endLine))
+    }
+  }
+
+  /**
+    * Returns a folding range for each foldable comment in the given list of `comments`.
+    *
+    * The `comments` must be given in source order.
+    */
+  private def foldComments(comments: List[Token]): List[FoldingRange] = {
+    // Each block comment that spans more than one line forms its own folding range.
+    val blockRanges = comments.collect {
+      case tok if tok.kind == TokenKind.CommentBlock && tok.start.lineOneIndexed < tok.end.lineOneIndexed =>
+        FoldingRange(tok.start.lineOneIndexed, tok.end.lineOneIndexed, FoldingRangeKind.Comment)
+    }
+
+    // A run of adjacent line comments (and likewise doc comments) forms a folding range.
+    // Line and doc comments are folded separately so that the two kinds are not merged into one range.
+    val lineRanges = foldRuns(comments.filter(_.kind == TokenKind.CommentLine))
+    val docRanges = foldRuns(comments.filter(_.kind == TokenKind.CommentDoc))
+
+    blockRanges ::: lineRanges ::: docRanges
+  }
+
+  /**
+    * Returns a folding range for each maximal run of line-adjacent tokens in `comments` that spans at least two lines.
+    *
+    * The `comments` must be single-line tokens of the same kind, given in source order.
+    */
+  private def foldRuns(comments: List[Token]): List[FoldingRange] = {
+    val ranges = mutable.ListBuffer.empty[FoldingRange]
+
+    // The first and last token of the run that is currently being accumulated.
+    var runStart: Option[Token] = None
+    var runEnd: Option[Token] = None
+
+    // Emits a folding range for the current run if it spans at least two lines.
+    def closeRun(): Unit = (runStart, runEnd) match {
+      case (Some(start), Some(end)) if start.start.lineOneIndexed < end.end.lineOneIndexed =>
+        ranges += FoldingRange(start.start.lineOneIndexed, end.end.lineOneIndexed, FoldingRangeKind.Comment)
+      case _ => // A run of a single line cannot be folded.
+    }
+
+    for (tok <- comments) {
+      runEnd match {
+        case Some(prev) if tok.start.lineOneIndexed == prev.end.lineOneIndexed + 1 =>
+          // The token is on the line right after the previous one, so it continues the current run.
+          runEnd = Some(tok)
+        case _ =>
+          // The token is not adjacent to the previous one, so it starts a new run.
+          closeRun()
+          runStart = Some(tok)
+          runEnd = Some(tok)
+      }
+    }
+    closeRun()
+
+    ranges.toList
+  }
+}

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FoldingRangeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FoldingRangeProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Magnus Madsen
+ * Copyright 2026 Flix Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestFoldingRangeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestFoldingRangeProvider.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp
+
+import ca.uwaterloo.flix.api.lsp.provider.FoldingRangeProvider
+import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
+import ca.uwaterloo.flix.language.ast.shared.SecurityContext
+import ca.uwaterloo.flix.util.Options
+import org.scalatest.funsuite.AnyFunSuite
+
+class TestFoldingRangeProvider extends AnyFunSuite {
+
+  /**
+    * The Flix object used across all the tests.
+    *
+    * We first compile the stdlib so that every further compilation will be incremental.
+    */
+  private val Flix: Flix = {
+    val flix = new Flix().setOptions(Options.Default)
+    flix.check()
+    flix
+  }
+
+  /**
+    * The uri of the test source.
+    *
+    * Every test uses the same uri so that adding a new source with this uri replaces the old one.
+    */
+  private val Uri = CompilerConstants.VirtualTestFile.toString
+
+  /**
+    * Returns the folding ranges for the given `program`.
+    */
+  private def foldingRanges(program: String): List[FoldingRange] = {
+    implicit val sctx: SecurityContext = SecurityContext.Unrestricted
+    Flix.addVirtualPath(CompilerConstants.VirtualTestFile, program)
+    Flix.check() match {
+      case (Some(root), _) => FoldingRangeProvider.getFoldingRanges(Uri)(root)
+      case (None, _) => fail("Compilation failed: a root is expected.")
+    }
+  }
+
+  test("FoldingRange.DocComment.Multi") {
+    val program =
+      """/// Hello
+        |/// Doc
+        |/// Comment
+        |pub def f(): Int32 = 1
+        |""".stripMargin
+    assertResult(List(FoldingRange(1, 3, FoldingRangeKind.Comment)))(foldingRanges(program))
+  }
+
+  test("FoldingRange.DocComment.Single") {
+    val program =
+      """/// Hello
+        |pub def f(): Int32 = 1
+        |""".stripMargin
+    assertResult(Nil)(foldingRanges(program))
+  }
+
+  test("FoldingRange.LineComment.Multi") {
+    val program =
+      """// one
+        |// two
+        |// three
+        |pub def f(): Int32 = 1
+        |""".stripMargin
+    assertResult(List(FoldingRange(1, 3, FoldingRangeKind.Comment)))(foldingRanges(program))
+  }
+
+  test("FoldingRange.LineComment.Single") {
+    val program =
+      """// one
+        |pub def f(): Int32 = 1
+        |""".stripMargin
+    assertResult(Nil)(foldingRanges(program))
+  }
+
+  test("FoldingRange.LineComment.NonAdjacent") {
+    val program =
+      """// one
+        |pub def f(): Int32 = 1
+        |// two
+        |pub def g(): Int32 = 2
+        |""".stripMargin
+    assertResult(Nil)(foldingRanges(program))
+  }
+
+  test("FoldingRange.BlockComment.Multi") {
+    val program =
+      """/* one
+        |   two
+        |   three */
+        |pub def f(): Int32 = 1
+        |""".stripMargin
+    assertResult(List(FoldingRange(1, 3, FoldingRangeKind.Comment)))(foldingRanges(program))
+  }
+
+  test("FoldingRange.BlockComment.Single") {
+    val program =
+      """/* one line */
+        |pub def f(): Int32 = 1
+        |""".stripMargin
+    assertResult(Nil)(foldingRanges(program))
+  }
+
+  test("FoldingRange.DocComment.TwoBlocks") {
+    val program =
+      """/// a
+        |/// b
+        |pub def f(): Int32 = 1
+        |
+        |/// c
+        |/// d
+        |pub def g(): Int32 = 2
+        |""".stripMargin
+    assertResult(List(FoldingRange(1, 2, FoldingRangeKind.Comment), FoldingRange(5, 6, FoldingRangeKind.Comment)))(foldingRanges(program))
+  }
+
+  test("FoldingRange.DocAndLineComment.NotMerged") {
+    // A doc comment immediately followed by a line comment must not be merged into a single range.
+    val program =
+      """/// doc
+        |// line
+        |pub def f(): Int32 = 1
+        |""".stripMargin
+    assertResult(Nil)(foldingRanges(program))
+  }
+
+  test("FoldingRange.DocAndLineComment.Separate") {
+    // A run of doc comments and an adjacent run of line comments fold into two separate ranges.
+    val program =
+      """/// a
+        |/// b
+        |// c
+        |// d
+        |pub def f(): Int32 = 1
+        |""".stripMargin
+    assertResult(List(FoldingRange(1, 2, FoldingRangeKind.Comment), FoldingRange(3, 4, FoldingRangeKind.Comment)))(foldingRanges(program))
+  }
+
+}

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestFoldingRangeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestFoldingRangeProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Magnus Madsen
+ * Copyright 2026 Flix Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes #8799.

Adds support for collapsible comments via the LSP folding range request, so multi-line comments — for example doc comments:

```
/// Hello
/// Doc
/// Comment
```

can be folded into a single line, just like modules and function definitions.

## Implementation

Comment tokens are retained in `root.tokens` (the lexer keeps them, since `TokenKind.isComment` is part of `isSemantic`). Each `//`/`///` line is its own single-line token and a `/* ... */` block is a single multi-line token, so folding ranges can be derived directly from the tokens without involving the parser.

A new `FoldingRangeProvider` computes the ranges:

- a run of adjacent line comments (`//`) on consecutive lines,
- a run of adjacent doc comments (`///`) on consecutive lines,
- a block comment (`/* ... */`) spanning multiple lines.

Line and doc comments are folded into separate ranges so the two kinds are never merged. Single-line comments and non-adjacent runs are not folded.

## Wiring

- `LspServer` (lsp4j): registers the `foldingRangeProvider` capability and implements the `textDocument/foldingRange` handler.
- `VSCodeLspServer` (WebSocket): adds the `lsp/foldingRange` request, its parser, and its handler.

New data types `FoldingRange` and `FoldingRangeKind` mirror the existing LSP wrapper types and provide both `toLsp4j` and `toJSON`.