### PR TITLE
feat: add bool logic to monomorpher (#8768)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -84,6 +84,7 @@ import scala.collection.mutable
   *   - Schema fields are in alphabetical order
   *   - Effect formulas are flat unions of effects in alphabetical order or a complement thereof.
   *   - Case set formulas are a single CaseSet literal or a complement thererof.
+  *   - Bool formulas are a single Boolean constant (`True` or `False`).
   *
   * At a high level the relation between specialization and lowering is as follows
   *
@@ -1375,6 +1376,13 @@ object Specialization {
       case (Type.Apply(Type.Cst(TypeConstructor.Difference, _), x, _), y) => Type.mkDifference(x, y, loc)
       case (Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y) => Type.mkSymmetricDiff(x, y, loc)
 
+      // Simplify bool equations.
+      // Unlike effects, no separate canonicalization is needed: the smart constructors below fully
+      // reduce a ground formula to a single `True` or `False` constant.
+      case (Type.Cst(TypeConstructor.Not, _), y) => Type.mkNot(y, loc)
+      case (Type.Apply(Type.Cst(TypeConstructor.And, _), x, _), y) => Type.mkAnd(x, y, loc)
+      case (Type.Apply(Type.Cst(TypeConstructor.Or, _), x, _), y) => Type.mkOr(x, y, loc)
+
       // Simplify case equations.
       case (Type.Cst(TypeConstructor.CaseComplement(sym), _), y) => Type.mkCaseComplement(y, sym, loc)
       case (Type.Apply(Type.Cst(TypeConstructor.CaseIntersection(sym), _), x, _), y) => Type.mkCaseIntersection(x, y, sym, loc)
@@ -1442,7 +1450,10 @@ object Specialization {
     case Kind.WildCaseSet => Type.mkAnyType(tpe0.loc)
     case Kind.Star => Type.mkAnyType(tpe0.loc)
     case Kind.Eff => Type.Pure
-    case Kind.Bool => Type.mkAnyType(tpe0.loc)
+    // Design choice: free/unconstrained bool type variables are monomorphized to `False`.
+    // `Bool` is a phantom kind that is erased to `Unit` in the backend, so any choice yields a
+    // well-typed program with identical runtime behavior; we fix on `False` for determinism.
+    case Kind.Bool => Type.False
     case Kind.RecordRow => Type.RecordRowEmpty
     case Kind.SchemaRow => Type.SchemaRowEmpty
     case Kind.Predicate => Type.mkAnyType(tpe0.loc)


### PR DESCRIPTION
Closes #8768.

Previously the monomorpher erased free `Bool`-kinded type variables to `AnyType` and left ground bool formulas (`And`/`Or`/`Not`) unreduced — mirroring neither the effect nor the case-set handling that lives right next to it in `normalizeApply`.

This makes `Bool` symmetric with effects:

- **Design choice: free/unconstrained bool type variables are monomorphized to `False`** (instead of being erased to `AnyType`), so the formulas reaching the backend are ground (`default`). `Bool` is a phantom kind, so the choice is semantically arbitrary; we fix on `False` for determinism and document it as a deliberate design decision.
- **`normalizeApply` folds `And`/`Or`/`Not` applications** via the existing `Type.mkAnd`/`mkOr`/`mkNot` smart constructors. Unlike effects, no separate `CofiniteSet`-style canonicalization is needed: those smart constructors already reduce a ground formula to a single `True`/`False` constant.

`Bool` is a phantom kind — `Simplifier` erases `True`/`False`/`Not`/`And`/`Or` (and `AnyType`) all to `Unit` — so there is **no runtime behavior change**. The benefit is internal: ground, canonical bool types in `MonoAst`, improved specialization deduplication (`True and True` now equals `True`), and removal of the `AnyType` special case the issue flagged as a "pothole for some future programmer."

The change is confined to `Specialization.scala` and follows the structure of the adjacent effect/case-set folding cases.
