### PR TITLE
refactor: use Nel for catch rules in TryCatch

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/effectlock/UseGraph.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/UseGraph.scala
@@ -192,7 +192,7 @@ object UseGraph {
 
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
-      visitExp(exp) ++ visitExps(rules.map(_.exp))
+      visitExp(exp) ++ visitExps(rules.map(_.exp).toList)
 
     case Expr.Throw(exp, _, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -159,7 +159,7 @@ object DesugaredAst {
     case class Unsafe(exp: Expr, eff: Type, asEff: Option[Type], loc: SourceLocation) extends Expr
 
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], loc: SourceLocation) extends Expr
 
     case class Throw(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.ast
 import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
 import ca.uwaterloo.flix.language.ast.shared.*
+import ca.uwaterloo.flix.util.collection.Nel
 
 object ErasedAst {
 
@@ -99,7 +100,7 @@ object ErasedAst {
 
     case class Region(sym: Symbol.VarSym, exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.ast
 import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
+import ca.uwaterloo.flix.util.collection.Nel
 
 object JvmAst {
 
@@ -105,7 +106,7 @@ object JvmAst {
 
     case class Region(sym: Symbol.VarSym, offset: Int, exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -169,7 +169,7 @@ object KindedAst {
     case class Unsafe(exp: Expr, eff: Type, asEff: Option[Type], loc: SourceLocation) extends Expr
 
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], loc: SourceLocation) extends Expr
 
     case class Throw(exp: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.ast
 import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
 import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, JvmAnnotation, Modifiers, Source}
+import ca.uwaterloo.flix.util.collection.Nel
 
 object LiftedAst {
 
@@ -82,7 +83,7 @@ object LiftedAst {
 
     case class Region(sym: Symbol.VarSym, exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -97,7 +97,7 @@ object MonoAst {
 
     case class Cast(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -174,7 +174,7 @@ object NamedAst {
     case class Unsafe(exp: Expr, eff: Type, asEff: Option[Type], loc: SourceLocation) extends Expr
 
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], loc: SourceLocation) extends Expr
 
     case class Throw(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -22,6 +22,8 @@ import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, ExpPosition
 
 import java.lang.reflect.Method
 
+import ca.uwaterloo.flix.util.collection.Nel
+
 object ReducedAst {
 
   case class Root(defs: Map[Symbol.DefnSym, Def],
@@ -96,7 +98,7 @@ object ReducedAst {
 
     case class Region(sym: Symbol.VarSym, exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], ct: ExpPosition, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -183,7 +183,7 @@ object ResolvedAst {
     case class Unsafe(exp: Expr, eff: UnkindedType, asEff: Option[UnkindedType], loc: SourceLocation) extends Expr
 
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], loc: SourceLocation) extends Expr
 
     case class Throw(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.language.ast.shared.ScalaAnnotations.IntroducedBy
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
 import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, JvmAnnotation, Modifiers, Source}
 import ca.uwaterloo.flix.language.phase.ClosureConv
+import ca.uwaterloo.flix.util.collection.Nel
 
 object SimplifiedAst {
 
@@ -98,7 +99,7 @@ object SimplifiedAst {
 
     case class Region(sym: Symbol.VarSym, exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 
     case class RunWith(exp: Expr, effUse: EffSymUse, rules: List[HandlerRule], tpe: SimpleType, purity: Purity, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -216,7 +216,7 @@ object TypedAst {
     case class Unsafe(exp: Expr, runEff: Type, asEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
 
-    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: Nel[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class Throw(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -179,7 +179,7 @@ object WeededAst {
     case class Unsafe(exp: Expr, eff: Type, asEff: Option[Type], loc: SourceLocation) extends Expr
 
 
-    case class TryCatch(exp: Expr, handlers: List[CatchRule], loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, handlers: Nel[CatchRule], loc: SourceLocation) extends Expr
 
     case class Throw(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
@@ -61,7 +61,7 @@ object JvmAstPrinter {
     case Expr.Region(sym, _, exp, _, _, _) => DocAst.Expr.Region(printVarSym(sym), print(exp))
     case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
       case JvmAst.CatchRule(sym, _, clazz, body) => (sym, clazz, print(body))
-    })
+    }.toList)
     case Expr.RunWith(exp, effUse, rules, _, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map {
       case JvmAst.HandlerRule(op, fparams, body) =>
         (op.sym, fparams.map(printFormalParam), print(body))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -64,7 +64,7 @@ object LiftedAstPrinter {
     case Region(sym, exp, _, _, _) => DocAst.Expr.Region(printVarSym(sym), print(exp))
     case TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
       case LiftedAst.CatchRule(sym, clazz, rexp) => (sym, clazz, print(rexp))
-    })
+    }.toList)
     case RunWith(exp, effUse, rules, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map {
       case LiftedAst.HandlerRule(symUse, fparams, body) =>
         (symUse.sym, fparams.map(printFormalParam), print(body))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -41,7 +41,7 @@ object MonoAstPrinter {
     case Expr.Match(exp, rules, _, _, _) => DocAst.Expr.Match(print(exp), rules.map(printMatchRule))
     case Expr.ExtMatch(exp, rules, _, _, _) => DocAst.Expr.ExtMatch(print(exp), rules.map(printExtMatchRule))
     case Expr.Cast(exp, tpe, eff, _) => DocAst.Expr.UncheckedCast(print(exp), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)))
-    case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule))
+    case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule).toList)
     case Expr.RunWith(exp, effUse, rules, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map(printHandlerRule))
     case Expr.NewObject(sym, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(sym, clazz, TypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -65,7 +65,7 @@ object ReducedAstPrinter {
     case Expr.Region(sym, exp, _, _, _) => DocAst.Expr.Region(printVarSym(sym), print(exp))
     case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
       case ReducedAst.CatchRule(sym, clazz, body) => (sym, clazz, print(body))
-    })
+    }.toList)
     case Expr.RunWith(exp, effUse, rules, _, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map {
       case ReducedAst.HandlerRule(op, fparams, body) =>
         (op.sym, fparams.map(printFormalParam), print(body))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -97,7 +97,7 @@ object ResolvedAstPrinter {
 
     case Expr.TryCatch(exp, rules, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
       case ResolvedAst.CatchRule(sym, clazz, body, _) => (sym, clazz, print(body))
-    })
+    }.toList)
     case Expr.Throw(exp, _) => DocAst.Expr.Throw(print(exp))
     case Expr.Handler(symUse, rules, _) => DocAst.Expr.Handler(symUse.sym, rules.map {
       case ResolvedAst.HandlerRule(opSymUse, fparams, exp, _) => (opSymUse.sym, fparams.map(printFormalParam), print(exp))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -69,7 +69,7 @@ object SimplifiedAstPrinter {
     case TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
       case SimplifiedAst.CatchRule(sym, clazz, body) =>
         (sym, clazz, print(body))
-    })
+    }.toList)
     case RunWith(exp, effUse, rules, _, _, _) => DocAst.Expr.RunWithHandler(print(exp), effUse.sym, rules.map {
       case SimplifiedAst.HandlerRule(op, fparams, body) =>
         (op.sym, fparams.map(printFormalParam), print(body))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -74,7 +74,7 @@ object TypedAstPrinter {
     case Expr.UncheckedCast(_, _, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.Unsafe(exp, runEff, asEff, _, _, _) => DocAst.Expr.Unsafe(print(exp), TypePrinter.print(runEff), asEff.map(TypePrinter.print))
 
-    case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule))
+    case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expr.TryCatch(print(exp), rules.map(printCatchRule).toList)
     case Expr.Throw(exp, _, _, _) => DocAst.Expr.Throw(print(exp))
     case Expr.Handler(symUse, rules, _, _, _, _, _) => DocAst.Expr.Handler(symUse.sym, rules.map(printHandlerRule))
     case Expr.RunWith(exp1, exp2, _, _, _) => DocAst.Expr.RunWith(print(exp1), print(exp2))

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
@@ -785,7 +785,7 @@ object PatMatch2 {
       case Expr.TryCatch(exp, rules, _, _, _) =>
         visitExp(exp)
         rules.foreach(r => visitExp(r.exp))
-        checkCatchRules(rules)
+        checkCatchRules(rules.toList)
 
       case TypedAst.Expr.Throw(exp, _, _, _) => visitExp(exp)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
@@ -215,7 +215,7 @@ object TreeShaker1 {
 
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
-      visitExp(exp) ++ visitExps(rules.map(_.exp))
+      visitExp(exp) ++ visitExps(rules.map(_.exp).toList)
 
     case Expr.Throw(exp, _, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker2.scala
@@ -95,7 +95,7 @@ object TreeShaker2 {
       visitExp(exp)
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
-      visitExp(exp) ++ visitExps(rules.map(_.exp))
+      visitExp(exp) ++ visitExps(rules.map(_.exp).toList)
 
     case Expr.RunWith(exp, _, rules, _, _, _) =>
       visitExp(exp) ++ visitExps(rules.map(_.exp))

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -399,7 +399,7 @@ object TypeReconstruction {
           TypedAst.CatchRule(bnd, clazz, b, ruleLoc)
       }
       val tpe = rs.head.exp.tpe
-      val eff = Type.mkUnion(e.eff :: rs.map(_.exp.eff), loc)
+      val eff = Type.mkUnion(e.eff :: rs.map(_.exp.eff).toList, loc)
       TypedAst.Expr.TryCatch(e, rs, tpe, eff, loc)
 
     case KindedAst.Expr.Throw(exp, tvar, evar, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1793,15 +1793,15 @@ object Weeder2 {
       expect(tree, TreeKind.Expr.Try)
       val maybeCatch = pickAll(TreeKind.Expr.TryCatchBodyFragment, tree)
       val expr = pickExpr(tree)
-      maybeCatch.map(visitTryCatchBody) match {
-        // Bad case: try expr
-        case Nil | Nil :: Nil =>
+      maybeCatch.flatMap(visitTryCatchBody) match {
+        // Bad case: try expr (no catch rules)
+        case Nil =>
           // Fall back on Expr.Error
           val error = NeedAtleastOne(NamedTokenSet.CatchRule, SyntacticContext.Expr.OtherExpr, None, tree.loc)
           sctx.errors.add(error)
           Expr.Error(error)
         // Case: try expr catch { rules... }
-        case catches => Expr.TryCatch(expr, catches.flatten, tree.loc)
+        case r :: rs => Expr.TryCatch(expr, Nel(r, rs), tree.loc)
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -224,7 +224,7 @@ object OccurrenceAnalyzer {
         val (rs, ctxs) = rules.map(visitCatchRule).unzip
         val ctx2 = ctxs.foldLeft(ExprContext.Empty)(combineBranch)
         val ctx3 = combineSeq(ctx1, ctx2)
-        if ((e eq exp) && ListOps.zip(rules, rs).forall { case (r1, r2) => r1 eq r2 }) {
+        if ((e eq exp) && ListOps.zip(rules.toList, rs.toList).forall { case (r1, r2) => r1 eq r2 }) {
           (exp0, ctx3) // Reuse exp0.
         } else {
           (Expr.TryCatch(e, rs, tpe, eff, loc), ctx3)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -863,11 +863,11 @@ object ConstraintGen {
       case Expr.TryCatch(exp, rules, loc) =>
         val (tpe, eff) = visitExp(exp)
         val (tpes, effs) = rules.map(visitCatchRule).unzip
-        c.unifyAllTypes(tpes, loc)
-        val ruleTpe = tpes.headOption.getOrElse(freshVar(Kind.Star, loc))
+        c.unifyAllTypes(tpes.toList, loc)
+        val ruleTpe = tpes.head
         c.unifyType(tpe, ruleTpe, loc)
         val resTpe = tpe
-        val resEff = Type.mkUnion(eff :: effs, loc)
+        val resEff = Type.mkUnion(eff :: effs.toList, loc)
         (resTpe, resEff)
 
       case KindedAst.Expr.Throw(exp, tvar, evar, loc) =>

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1878,6 +1878,17 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[ParseError.NeedAtleastOne](result)
   }
 
+  test("MissingCatchRules.02") {
+    // Multiple empty catch blocks must still be rejected (no empty rule list reaches later phases).
+    val input =
+      """
+        |def foo(): Bool =
+        |    try { true } catch {} catch {}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ParseError.NeedAtleastOne](result)
+  }
+
   test("MissingTypeParameter.Enum.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/EffectVerifier.scala
@@ -280,7 +280,7 @@ object EffectVerifier {
     case Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       visitExp(exp)
       rules.foreach { r => visitExp(r.exp) }
-      val expected = Type.mkUnion(exp.eff :: rules.map(_.exp.eff), loc)
+      val expected = Type.mkUnion(exp.eff :: rules.map(_.exp.eff).toList, loc)
       val actual = eff
       expectType(expected, actual, loc)
     case Expr.Throw(exp, _, eff, loc) =>


### PR DESCRIPTION
Closes #10363.

Follow-up to #10362, which found that `TryCatch` crashes for empty catch-rule lists.

This represents the catch rules of `TryCatch` as `Nel[CatchRule]` (a non-empty list) instead of `List[CatchRule]` across all compiler ASTs (`WeededAst` through `JvmAst`). A `try`-`catch` must always have at least one catch rule, so this makes the invariant unrepresentable-when-violated at the type level and prevents the empty-list crash.

### Notes

- The `List` → `Nel` conversion happens once, in `Weeder2.visitTryExpr`. It now uniformly rejects every empty case with `NeedAtleastOne`, including multiple empty catch blocks (`try e catch {} catch {}`) which previously slipped past the old `Nil | Nil :: Nil` guard and produced an empty list.
- `RunWith` is intentionally left on `List`, since an effect can have zero operations.
- Most phases traverse the rules via `map`/`foreach`/`foldLeft`/`unzip` and are unaffected (`Nel` is `Iterable`). A handful of sites that fed the rules into a `List`-only API (`unifyAllTypes`, `mkUnion`'s `::`, `ListOps.zip`, `visitExps`, `checkCatchRules`, and the `DocAst` debug printers) get a `.toList`.