### PR TITLE
fix: preserve channel put evaluation order in lowering (#10378)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -1175,12 +1175,25 @@ object Lowering {
     * Channel put expressions are rewritten as follows:
     * {{{ c <- 42 }}}
     * becomes a call to the standard library function:
-    * {{{ Concurrent/Channel.put(42, c) }}}
+    * {{{ let chan = c; let value = 42; Concurrent/Channel.put(value, chan) }}}
+    *
+    * Here `exp1` is the channel and `exp2` is the value (i.e. `exp1 <- exp2`). In source order
+    * the channel is evaluated before the value, but `Channel.put` takes the value before the
+    * channel. We let-bind both expressions in source order so that reordering them into the
+    * argument list does not change their evaluation order. See:
+    * https://github.com/flix/flix/issues/10378
     */
   private def mkPutChannel(exp1: MonoAst.Expr, exp2: MonoAst.Expr, eff: Type, loc: SourceLocation)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.Expr = {
+    val chanSym = mkLetSym("chan", loc)
+    val valueSym = mkLetSym("value", loc)
+    val chanVar = MonoAst.Expr.Var(chanSym, exp1.tpe, loc)
+    val valueVar = MonoAst.Expr.Var(valueSym, exp2.tpe, loc)
     val itpe = lowerType(Type.mkIoUncurriedArrow(List(exp2.tpe, exp1.tpe), Type.Unit, loc))
     val defnSym = lookup(Defs.ChannelPut, itpe)
-    MonoAst.Expr.ApplyDef(defnSym, List(exp2, exp1), itpe, Type.Unit, eff, loc)
+    val putExp = MonoAst.Expr.ApplyDef(defnSym, List(valueVar, chanVar), itpe, Type.Unit, eff, loc)
+    // The channel binding is the outermost let, so the channel is evaluated before the value.
+    val valueLet = MonoAst.Expr.Let(valueSym, exp2, putExp, Type.Unit, eff, Occur.Unknown, loc)
+    MonoAst.Expr.Let(chanSym, exp1, valueLet, Type.Unit, eff, Occur.Unknown, loc)
   }
 
   /**

--- a/main/test/flix/Test.Exp.Concurrency.Buffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Buffered.flix
@@ -254,4 +254,18 @@ mod Test.Exp.Concurrency.Buffered {
         assertEq(expected = 42, r)
     }
 
+    // A channel put `%%CHANNEL_PUT%%(channel, value)` must evaluate its channel
+    // expression before its value expression, matching left-to-right source order.
+    // See https://github.com/flix/flix/issues/10378.
+    @Test
+    def testBufferedChannelPutEvalOrder01(): Unit \ (Assert + Chan) = region rc {
+        let order = Ref.fresh(rc, "");
+        let (tx, _rx) = Channel.buffered(1);
+        %%CHANNEL_PUT%%(
+            { Ref.put(Ref.get(order) + "channel", order); tx },
+            { Ref.put(Ref.get(order) + "value", order); () }
+        );
+        assertEq(expected = "channelvalue", Ref.get(order))
+    }
+
 }


### PR DESCRIPTION
Fixes #10378.

## Problem

A channel put `ch <- v` should evaluate the channel before the value, matching Flix's left-to-right evaluation of source order. However, the standard library function takes its arguments in the opposite order — `Channel.put(value, channel)` — so the lowering reordered the two operands directly into the argument list:

```scala
MonoAst.Expr.ApplyDef(defnSym, List(exp2, exp1), ...) // put(value, channel)
```

Since function arguments are evaluated left-to-right, this evaluated the **value** (`exp2`) before the **channel** (`exp1`) — observably wrong whenever both operands have side effects.

## Fix

`mkPutChannel` now let-binds both operands in source order (channel first, then value) before the call, so reordering them into the argument list no longer changes evaluation order:

```
let chan = exp1;   // channel — evaluated first
let value = exp2;  // value   — evaluated second
Channel.put(value, chan)
```

The `Var` node types match their bound expressions (as required by `TypeVerifier`), and the existing effect is threaded through the `Let` nodes — safe and precise since it already unions both operands' effects.

Note: calling `Channel.send(m, sender)` was never affected, since its arguments are evaluated at the call site before reaching the intrinsic. The bug only manifested through the `%%CHANNEL_PUT%%` intrinsic with side-effecting operands, which is what the lowering generates.