### PR TITLE
fix: report undefined struct field without guessing the struct (#10151)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/StructFieldCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/StructFieldCompleter.scala
@@ -21,11 +21,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 object StructFieldCompleter {
   def getCompletions(e: ResolutionError.UndefinedStructField, root: TypedAst.Root): Iterable[Completion.StructFieldCompletion] = {
     val fields = root.structs.values.flatMap(struct => struct.fields.values)
-    val completions0 = fields.filter(_.sym.name.startsWith(e.field.name))
-    val completions = e.struct match {
-      case Some(sym) => completions0.filter(_.sym.structSym == sym)
-      case None => completions0
-    }
+    val completions = fields.filter(_.sym.name.startsWith(e.field.name))
     completions.map(field => Completion.StructFieldCompletion(field.sym.name, e.field.loc, field.tpe, Priority.Lowest(0)))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -1323,26 +1323,24 @@ object ResolutionError {
   /**
     * An error raised to indicate an undefined struct field in a struct get or struct put expression.
     *
-    * @param struct the optional symbol of the struct.
-    * @param field  the name of the missing field.
-    * @param loc    the location where the error occurred.
+    * The struct that the field is expected to belong to is intentionally not reported: a field access
+    * `e->f` is resolved by the field name alone, since the type of the receiver `e` is not yet known
+    * during resolution. Naming a struct here would therefore be a guess (see issue #10151).
+    *
+    * @param field the name of the missing field.
+    * @param loc   the location where the error occurred.
     */
-  case class UndefinedStructField(struct: Option[Symbol.StructSym], field: Name.Label, loc: SourceLocation) extends ResolutionError {
+  case class UndefinedStructField(field: Name.Label, loc: SourceLocation) extends ResolutionError {
     def code: ErrorCode = ErrorCode.E3574
 
-    def summary: String = s"Undefined struct field '$field'$structMessage"
+    def summary: String = s"Undefined struct field '$field'."
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Undefined struct field '${red(field.toString)}'$structMessage.
+      s""">> Undefined struct field '${red(field.toString)}'.
          |
          |${highlight(loc, "undefined field", fmt)}
          |""".stripMargin
-    }
-
-    private def structMessage: String = struct match {
-      case Some(sym) => s" on struct '$sym'."
-      case None => ""
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2306,15 +2306,9 @@ object Resolver {
     matches match {
       // Case 0: No matches. Error.
       case Nil =>
-        if (ns0.idents.nonEmpty) {
-          // The struct name is the same as the mod name
-          val struct_namespace = Name.NName(ns0.idents.init, ns0.loc)
-          val struct_name = ns0.idents.last
-          Result.Err(ResolutionError.UndefinedStructField(Some(Symbol.mkStructSym(struct_namespace, struct_name)), name, name.loc))
-        } else {
-          // If we are in the root namespace, we can't give figure out the struct name
-          Result.Err(ResolutionError.UndefinedStructField(None, name, name.loc))
-        }
+        // We cannot name the struct here: the field is resolved by name alone, since the type of the
+        // receiver is not yet known during resolution (see issue #10151).
+        Result.Err(ResolutionError.UndefinedStructField(name, name.loc))
       // Case 1: A match was found. Success. Note that multiple matches can be found, but they are prioritized by tryLookupName so this is fine.
       case field :: _ => Result.Ok(field)
     }


### PR DESCRIPTION
Fixes #10151.

## Problem

A struct field access `e->f` is resolved by the field name alone during resolution, because the type of the receiver `e` is not yet known at that phase. When no field matched, `Resolver.lookupStructField` fabricated a struct symbol from the *enclosing namespace* — assuming the struct name equals the last namespace segment ("the struct name is the same as the mod name").

That assumption is wrong whenever the access does not occur literally inside the struct's own namespace, so the message named the wrong struct. It also appended a `.` after a fragment that already ended in `.`, giving a double period:

```
>> Undefined struct field 'lock' on struct 'BPlusTree'..
```

even though the struct is `BPlusTree.Node`.

## Fix

The struct identity is genuinely unknown here, so stop guessing it:

- `Resolver.lookupStructField` raises `UndefinedStructField(name, loc)` directly in the not-found case.
- `UndefinedStructField` no longer carries an `Option[StructSym]`; the message is simply `Undefined struct field 'f'.` (double period gone).
- `StructFieldCompleter` no longer filters completions against the bogus struct symbol, so field-name completions are no longer incorrectly suppressed.

### Before / after

For a field access `leaf->missing` where `leaf: MyTree.Node`:

```diff
- >> Undefined struct field 'missing' on struct 'MyTree'..
+ >> Undefined struct field 'missing'.
```
