### PR TITLE
feat: add Formattable instance for Json

### DIFF
--- a/main/src/library/Util/Json.flix
+++ b/main/src/library/Util/Json.flix
@@ -41,6 +41,10 @@ pub mod Util.Json {
         pub def toString(j: Json): String = toCompactString(j)
     }
 
+    instance Formattable[Json] {
+        pub def format(j: Json): RichString = toRichString(2, j)
+    }
+
     ///
     /// The maximum nesting depth (number of enclosing arrays/objects) the parser
     /// accepts. Inputs nested deeper are rejected with `MaxDepthExceeded` rather


### PR DESCRIPTION
Adds a `Formattable[Json]` instance so JSON values can be formatted as a syntax-coloured `RichString`.

The instance delegates to the existing `Util.Json.toRichString` renderer (2-space indent), mirroring how `ToString[Json]` delegates to `toCompactString`. No new rendering logic is introduced.

```flix
instance Formattable[Json] {
    pub def format(j: Json): RichString = toRichString(2, j)
}
```

Closes #12056