### PR TITLE
fix: report a single clear error for arrow vs non-arrow type mismatch (#10175)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -225,7 +225,11 @@ object ConstraintSolver2 {
   private def simplify(constr: TypeConstraint, progress: Progress)(implicit scope: RegionScope, renv: RigidityEnv, eqenv: EqualityEnv, flix: Flix): List[TypeConstraint] = constr match {
     case TypeConstraint.Equality(tpe1, tpe2, prov) => (tpe1, tpe2) match {
       // (appU)
-      case (Type.Apply(t11, t12, _), Type.Apply(t21, t22, _)) if isSyntactic(tpe1.kind) && isSyntactic(tpe2.kind) =>
+      // We only decompose an application when the head type constructors can unify. Two types with
+      // distinct, known constructors (e.g. `Map[k, v]` against `a -> b`) can never be unified, and
+      // decomposing them structurally aligns unrelated components, producing a cascade of misleading
+      // positional errors. Leaving the constraint intact lets a single, clear error be reported.
+      case (Type.Apply(t11, t12, _), Type.Apply(t21, t22, _)) if isSyntactic(tpe1.kind) && isSyntactic(tpe2.kind) && constructorsMayUnify(tpe1, tpe2) =>
         progress.markProgress()
         simplify(TypeConstraint.Equality(t11, t21, prov), progress) ::: simplify(TypeConstraint.Equality(t12, t22, prov), progress)
 
@@ -683,6 +687,20 @@ object ConstraintSolver2 {
       val assoc = Type.AssocType(cst, tpe1, tpe2.kind, tpe1.loc)
       TypeConstraint.Equality(assoc, tpe2, Provenance.Match(tpe1, tpe2, loc))
   }
+
+  /**
+    * Returns `true` if the head type constructors of `tpe1` and `tpe2` may unify.
+    *
+    * Two types with distinct, known type constructors (e.g. `Map[k, v]` and `a -> b`) can never be
+    * unified, so decomposing such an application structurally only aligns unrelated components.
+    * Returns `true` if the constructors are equal, or if either head is a variable or otherwise
+    * unknown (e.g. an associated type), since those could still unify.
+    */
+  private def constructorsMayUnify(tpe1: Type, tpe2: Type): Boolean =
+    (tpe1.typeConstructor, tpe2.typeConstructor) match {
+      case (Some(tc1), Some(tc2)) => tc1 == tc2
+      case _ => true
+    }
 
   /**
     * Returns true if the kind should be unified syntactically.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -170,19 +170,27 @@ object ConstraintSolverInterface {
       List(mkErrorFromUnresolvedJvmMember(member, renv, subst, prov.loc))
 
     case TypeConstraint.Equality(tpe1, tpe2, Provenance.ExpectType(expected, actual, loc)) =>
+      val expectedTpe = subst(expected)
+      val actualTpe = subst(actual)
       (tpe1.kind, tpe2.kind) match {
         case (Kind.RecordRow, Kind.RecordRow) =>
           mkErrorsFromRecords(tpe1, tpe2, renv, loc)
         case (_, _) =>
-          List(TypeError.UnexpectedType(expected = subst(expected), inferred = subst(actual), renv, loc))
+          // A function type and a concrete non-function type can never be unified, regardless of effects.
+          mkArrowAndNonArrowError(expectedTpe, actualTpe, expectedTpe, actualTpe, renv, loc)
+            .getOrElse(List(TypeError.UnexpectedType(expected = expectedTpe, inferred = actualTpe, renv, loc)))
       }
 
     case TypeConstraint.Equality(tpe1, tpe2, Provenance.ExpectArgument(expected, actual, sym, num, loc)) =>
+      val expectedTpe = subst(expected)
+      val actualTpe = subst(actual)
       (tpe1.kind, tpe2.kind) match {
         case (Kind.RecordRow, Kind.RecordRow) =>
           mkErrorsFromRecords(tpe1, tpe2, renv, loc)
         case (_, _) =>
-          List(TypeError.UnexpectedArg(sym, num, expected = subst(expected), actual = subst(actual), renv, loc))
+          // A function type and a concrete non-function type can never be unified, regardless of effects.
+          mkArrowAndNonArrowError(expectedTpe, actualTpe, expectedTpe, actualTpe, renv, loc)
+            .getOrElse(List(TypeError.UnexpectedArg(sym, num, expected = expectedTpe, actual = actualTpe, renv, loc)))
       }
 
     case TypeConstraint.Equality(_, _, Provenance.NonUnitStatement(actual, loc)) =>
@@ -214,13 +222,8 @@ object ConstraintSolverInterface {
           }
 
         // A function type and a concrete non-function type can never be unified, regardless of effects.
-        case _ if isArrowType(baseTpe1) && isConcreteNonArrowType(baseTpe2) =>
-          List(TypeError.MismatchedArrowAndNonArrow(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc))
-
-        case _ if isArrowType(baseTpe2) && isConcreteNonArrowType(baseTpe1) =>
-          List(TypeError.MismatchedArrowAndNonArrow(baseTpe2, baseTpe1, fullTpe1, fullTpe2, renv, loc))
-
-        case _ => default
+        case _ =>
+          mkArrowAndNonArrowError(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc).getOrElse(default)
       }
 
     case TypeConstraint.Equality(tpe1, tpe2, prov) =>
@@ -279,6 +282,22 @@ object ConstraintSolverInterface {
       case _ =>
         TypeError.MismatchedTypes(baseType1, baseType2, fullType1, fullType2, renv, loc)
     }
+  }
+
+  /**
+    * Returns `Some` containing a [[TypeError.MismatchedArrowAndNonArrow]] error if exactly one of
+    * `baseType1` and `baseType2` is a function (arrow) type and the other is a concrete non-function
+    * type. Such types can never be unified, regardless of effects.
+    *
+    * Returns `None` otherwise (e.g. if either type is a variable, which could still unify with a function).
+    */
+  private def mkArrowAndNonArrowError(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix): Option[List[TypeError]] = {
+    if (isArrowType(baseType1) && isConcreteNonArrowType(baseType2))
+      Some(List(TypeError.MismatchedArrowAndNonArrow(baseType1, baseType2, fullType1, fullType2, renv, loc)))
+    else if (isArrowType(baseType2) && isConcreteNonArrowType(baseType1))
+      Some(List(TypeError.MismatchedArrowAndNonArrow(baseType2, baseType1, fullType1, fullType2, renv, loc)))
+    else
+      None
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -186,6 +186,24 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.MismatchedArrowAndNonArrow](result)
   }
 
+  test("MismatchedArrowAndNonArrow.03") {
+    // A function reference checked against a concrete non-function annotation (ExpectType).
+    val input = "def foo(): Int32 = x -> x"
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedArrowAndNonArrow](result)
+  }
+
+  test("MismatchedArrowAndNonArrow.04") {
+    // A function reference passed where a concrete non-function argument is expected (ExpectArgument).
+    val input =
+      """
+        |def f(x: Int32): Int32 = x
+        |def foo(): Int32 = f(y -> y)
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedArrowAndNonArrow](result)
+  }
+
   test("MismatchedTypes.06") {
     val input =
       """


### PR DESCRIPTION
Fixes #10175.

Referencing a nullary function without parentheses where a value is expected — e.g. `Map.empty` instead of `Map.empty()` in a `Map[String, Type]` position — produced a confusing cascade of three unrelated type errors. The constraint solver decomposed the application `Map[String, Type]` against `Unit -> Map[k, v]` structurally, aligning unrelated components and reporting a bogus `String -> Type`, an `expected Unit, got String`, and an `Int32` vs `Map[t0, t1]` mismatch — none of which named the real mistake.

## Fix

The `appU` rule in `ConstraintSolver2` now only decomposes an application when the head type constructors can unify. Two types with distinct, known constructors (e.g. `Map[k, v]` and `a -> b`) can never be unified, so the constraint is left intact and a single, clear error is reported with the correct, uncorrupted types.

The `ExpectType` and `ExpectArgument` error branches additionally emit the dedicated `MismatchedArrowAndNonArrow` error for arrow vs non-arrow clashes, sharing a helper with the existing `Match`-branch logic.

## Before

```
def f(): Map[String, Int32] = Map.empty
```

```
[E7796] expected 'Map[String, Int32]', found 'String -> Int32'
[E7685] 'Map.empty' expects its 1st argument to be of type 'Unit'
[E6794] Unable to unify the types: 'Int32' and 'Map[t0, t1]'
```

## After

```
[E6925] Unable to unify the function type 'Unit -> Map[t0, t1]' with the
        non-function type 'Map[String, Int32]'.
        Explanation: A function type can never be equal to a non-function type.
```