### PR TITLE
feat: disallow sealing top-level traits

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -198,6 +198,7 @@ object ErrorCode {
   case object E5952 extends ErrorCode
   case object E5963 extends ErrorCode
   case object E5975 extends ErrorCode
+  case object E5990 extends ErrorCode
   case object E6025 extends ErrorCode
   case object E6063 extends ErrorCode
   case object E6136 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
@@ -276,4 +276,34 @@ object NameError {
          |""".stripMargin
     }
   }
+
+  /**
+    * An error raised to indicate that a top-level trait is marked as sealed.
+    *
+    * A sealed trait may only be implemented within its declaring module. A top-level
+    * trait is declared in the root namespace, where any module is allowed to define
+    * instances, so sealing it has no effect.
+    *
+    * @param name the name of the sealed top-level trait.
+    * @param loc  the location of the trait declaration.
+    */
+  case class IllegalSealedTrait(name: String, loc: SourceLocation) extends NameError {
+    def code: ErrorCode = ErrorCode.E5990
+
+    def summary: String = s"A top-level trait cannot be sealed: '$name'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> A top-level trait cannot be sealed: '${red(name)}'.
+         |
+         |${highlight(loc, "sealed top-level trait", fmt)}
+         |
+         |${underline("Explanation:")} A sealed trait can only be implemented within its declaring
+         |module. A top-level trait is declared in the root namespace, where any module is
+         |allowed to define instances, so sealing it has no effect.
+         |
+         |Either remove the '${cyan("sealed")}' modifier or move the trait into a module.
+         |""".stripMargin
+    }
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -703,6 +703,10 @@ object Namer {
       val symNs = if (isCompanion) Name.NName(ns0.idents.init, ns0.loc) else ns0
       val sym = Symbol.mkTraitSym(symNs, ident)
       val mod = visitModifiers(mod0, ns0)
+      if (mod.isSealed && sym.namespace.isEmpty) {
+        // A top-level trait cannot be sealed: anyone may define an instance at the top level.
+        sctx.errors.add(NameError.IllegalSealedTrait(ident.name, ident.loc))
+      }
       val tparam = visitTypeParam(tparams0)
 
       val sts = superTraits.map(visitTraitConstraint)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -770,26 +770,4 @@ class TestNamer extends AnyFunSuite with TestUtils {
     val result = check(input, Options.TestWithLibNix)
     expectError[NameError.IllegalSealedTrait](result)
   }
-
-  test("IllegalSealedTrait.Nested.01") {
-    // A sealed trait nested in a module is allowed.
-    val input =
-      """
-        |mod N {
-        |    sealed trait C[a]
-        |}
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    rejectError[NameError.IllegalSealedTrait](result)
-  }
-
-  test("IllegalSealedTrait.Nested.02") {
-    // A non-sealed top-level trait is allowed.
-    val input =
-      """
-        |pub trait C[a]
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    rejectError[NameError.IllegalSealedTrait](result)
-  }
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -740,4 +740,56 @@ class TestNamer extends AnyFunSuite with TestUtils {
     expectError[NameError.DuplicateLowerName](result)
     rejectError[ResolutionError.UndefinedUse](result)
   }
+
+  test("IllegalSealedTrait.01") {
+    val input =
+      """
+        |sealed trait C[a]
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[NameError.IllegalSealedTrait](result)
+  }
+
+  test("IllegalSealedTrait.02") {
+    val input =
+      """
+        |pub sealed trait C[a]
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[NameError.IllegalSealedTrait](result)
+  }
+
+  test("IllegalSealedTrait.03") {
+    // A companion trait in the root namespace is also top-level.
+    val input =
+      """
+        |mod C {
+        |    sealed trait C[a]
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[NameError.IllegalSealedTrait](result)
+  }
+
+  test("IllegalSealedTrait.Nested.01") {
+    // A sealed trait nested in a module is allowed.
+    val input =
+      """
+        |mod N {
+        |    sealed trait C[a]
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    rejectError[NameError.IllegalSealedTrait](result)
+  }
+
+  test("IllegalSealedTrait.Nested.02") {
+    // A non-sealed top-level trait is allowed.
+    val input =
+      """
+        |pub trait C[a]
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    rejectError[NameError.IllegalSealedTrait](result)
+  }
 }


### PR DESCRIPTION
Closes #8254.

A `sealed` trait may only be implemented within its declaring module. A *top-level* trait is declared in the root namespace, where any module is allowed to define instances — so sealing it has no effect and is misleading.

This adds a new `NameError.IllegalSealedTrait` (`E5990`), raised in the Namer when a trait is `sealed` and its symbol namespace is empty:

```flix
sealed trait C[a]
```

```
-- Name Error [E5990] --------------------------------------------

>> A top-level trait cannot be sealed: 'C'.

1 | sealed trait C[a]
                 ^
                 sealed top-level trait

Explanation: A sealed trait can only be implemented within its declaring
module. A top-level trait is declared in the root namespace, where any module is
allowed to define instances, so sealing it has no effect.

Either remove the 'sealed' modifier or move the trait into a module.
```

The check uses the trait symbol's namespace, so it also covers a companion trait declared in the root (e.g. `mod C { sealed trait C[a] }`, whose canonical namespace is the root). Sealed traits nested inside a module, and non-sealed top-level traits, are unaffected.
