### PR TITLE
feat: add Java tests for varargs constructors/methods/staticmethods

### DIFF
--- a/main/test/flix/Test.Exp.Jvm.InvokeConstructor.VarArgs.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeConstructor.VarArgs.flix
@@ -1,0 +1,25 @@
+mod Test.Exp.Jvm.InvokeConstructor.VarArgs {
+
+    import java.lang.ProcessBuilder
+
+    use Assert.assertEq;
+
+    @Test
+    def testNewVarArgs01(): Unit \ Assert + IO =
+        // Individual varargs arguments
+        let pb = new ProcessBuilder("echo", "hello", "world");
+        assertEq(expected = "[echo, hello, world]", pb.command().toString())
+
+    @Test
+    def testNewVarArgs02(): Unit \ Assert + IO =
+        // Explicit varargs vector
+        let pb = new ProcessBuilder(Vector#{"echo", "hello"});
+        assertEq(expected = "[echo, hello]", pb.command().toString())
+
+    @Test
+    def testNewVarArgs03(): Unit \ Assert + IO =
+        // Varargs omitted entirely (auto empty array)
+        let pb = new ProcessBuilder();
+        assertEq(expected = "[]", pb.command().toString())
+
+}

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod.VarArgs.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod.VarArgs.flix
@@ -1,0 +1,25 @@
+mod Test.Exp.Jvm.InvokeMethod.VarArgs {
+
+    import java.lang.ProcessBuilder
+
+    use Assert.assertEq;
+
+    @Test
+    def testInvokeVarArgs01(): Unit \ Assert + IO =
+        // Individual varargs arguments
+        let pb = new ProcessBuilder("placeholder").command("a", "b", "c");
+        assertEq(expected = "[a, b, c]", pb.command().toString())
+
+    @Test
+    def testInvokeVarArgs02(): Unit \ Assert + IO =
+        // Explicit varargs vector
+        let pb = new ProcessBuilder("placeholder").command(Vector#{"x", "y"});
+        assertEq(expected = "[x, y]", pb.command().toString())
+
+    @Test
+    def testInvokeVarArgs03(): Unit \ Assert + IO =
+        // Explicit empty varargs vector
+        let pb = new ProcessBuilder("placeholder").command((Vector.empty(): Vector[String]));
+        assertEq(expected = "[]", pb.command().toString())
+
+}

--- a/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.VarArgs.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.VarArgs.flix
@@ -1,4 +1,4 @@
-mod Test.Exp.Jvm.InvokeMethod.VarArgs {
+mod Test.Exp.Jvm.InvokeStaticMethod.VarArgs {
 
     import java.nio.file.Path
 
@@ -21,5 +21,11 @@ mod Test.Exp.Jvm.InvokeMethod.VarArgs {
         // Varargs omitted entirely
         let p = Path.of("hello");
         assertEq(expected = "hello", p.getFileName().toString())
+
+    @Test
+    def testInvokeVarArgs04(): Unit \ Assert + IO =
+        // Explicit varargs vector
+        let p = Path.of("hello", Vector#{"foo", "bar.txt"});
+        assertEq(expected = "bar.txt", p.getFileName().toString())
 
 }


### PR DESCRIPTION
Adds running tests for calling Java varargs constructors, instance methods, and static methods from Flix, closing the remaining gaps in #9129.

All tests use `@Test` (they actually execute and assert on results, rather than only checking that the code compiles) and cover both forms — individual spread arguments and an explicit `Vector` — using only `java.lang.ProcessBuilder` and `java.nio.file.Path` from the standard library (no new Java helper classes).

## Changes

- **`Test.Exp.Jvm.InvokeConstructor.VarArgs.flix`** (new) — constructor varargs via `new ProcessBuilder(...)`: individual args, explicit `Vector`, and omitted (auto empty-array).
- **`Test.Exp.Jvm.InvokeMethod.VarArgs.flix`** (new) — instance-method varargs via `ProcessBuilder.command(...)`: individual args, explicit `Vector`, and explicit empty `Vector`. This category previously had no running coverage.
- **`Test.Exp.Jvm.InvokeStaticMethod.VarArgs.flix`** — fixed the module name to match the file name (it was `Test.Exp.Jvm.InvokeMethod.VarArgs`, which also collided with the new instance-method file) and added the missing explicit-`Vector` variant.

## Coverage

|                 | individual args | explicit `Vector` | omitted/empty |
|-----------------|:---------------:|:-----------------:|:-------------:|
| Constructor     | ✅              | ✅                | ✅            |
| Instance method | ✅              | ✅                | ✅            |
| Static method   | ✅              | ✅                | ✅            |

Closes #9129.
