### PR TITLE
refactor: use String.forAll for digit check in JsonPath.isArrayIndex

### DIFF
--- a/main/src/library/Util/Json/JsonPath.flix
+++ b/main/src/library/Util/Json/JsonPath.flix
@@ -186,7 +186,7 @@ pub mod Util.Json.JsonPath {
         if (String.isEmpty(s)) false
         else if (s == "0") true
         else if (String.charAt(0, s) == '0') false
-        else List.forAll(Char.isDigit, String.toList(s))
+        else String.forAll(Char.isDigit, s)
 
     ///
     /// Appends `k` to `sb`, escaped per RFC 6901: `~` becomes `~0`, `/` becomes


### PR DESCRIPTION
## Summary

In `Util.Json.JsonPath.isArrayIndex`, replace `List.forAll(Char.isDigit, String.toList(s))` with the equivalent `String.forAll(Char.isDigit, s)`.

`String.forAll` scans the string with `charAt` and short-circuits on the first non-digit, avoiding the eager intermediate `List[Char]` that `String.toList` allocated. Behavior is identical.
