### PR TITLE
fix: point Datalog atom instance errors at the offending term (#4856)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -111,7 +111,7 @@ object ConstraintGen {
 
         c.unifyType(itvar, declaredType, loc2)
         c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
-        c.addClassConstraints(tconstrs)
+        c.addClassConstraints(tconstrs, loc2)
         c.addEqualityConstraints(econstrs, loc2)
         c.unifyType(tvar, declaredResultType, loc2)
         c.unifySource(pvar, declaredEff, loc2)
@@ -141,7 +141,7 @@ object ConstraintGen {
         val declaredResultType = generalizeVoid(declaredType.arrowResultType)
         val (tpes, effs) = exps.map(visitExp).unzip
         c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
-        c.addClassConstraints(tconstrs)
+        c.addClassConstraints(tconstrs, loc2)
         c.addEqualityConstraints(econstrs, loc2)
         c.unifyType(tvar, declaredResultType, loc2)
         c.unifyType(evar, Type.mkUnion(declaredEff :: effs, loc2), loc2)
@@ -165,7 +165,7 @@ object ConstraintGen {
 
         val (tpes, effs) = exps.map(visitExp).unzip
         c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
-        c.addClassConstraints(tconstrs)
+        c.addClassConstraints(tconstrs, loc2)
         c.addEqualityConstraints(econstrs, loc2)
         c.unifyType(itvar, declaredType, loc2)
         c.unifyType(tvar, declaredResultType, loc2)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -111,7 +111,7 @@ object ConstraintGen {
 
         c.unifyType(itvar, declaredType, loc2)
         c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
-        c.addClassConstraints(tconstrs, loc2)
+        c.addClassConstraints(tconstrs)
         c.addEqualityConstraints(econstrs, loc2)
         c.unifyType(tvar, declaredResultType, loc2)
         c.unifySource(pvar, declaredEff, loc2)
@@ -141,7 +141,7 @@ object ConstraintGen {
         val declaredResultType = generalizeVoid(declaredType.arrowResultType)
         val (tpes, effs) = exps.map(visitExp).unzip
         c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
-        c.addClassConstraints(tconstrs, loc2)
+        c.addClassConstraints(tconstrs)
         c.addEqualityConstraints(econstrs, loc2)
         c.unifyType(tvar, declaredResultType, loc2)
         c.unifyType(evar, Type.mkUnion(declaredEff :: effs, loc2), loc2)
@@ -165,7 +165,7 @@ object ConstraintGen {
 
         val (tpes, effs) = exps.map(visitExp).unzip
         c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
-        c.addClassConstraints(tconstrs, loc2)
+        c.addClassConstraints(tconstrs)
         c.addEqualityConstraints(econstrs, loc2)
         c.unifyType(itvar, declaredType, loc2)
         c.unifyType(tvar, declaredResultType, loc2)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
@@ -276,12 +276,12 @@ object SchemaConstraintGen {
     */
   private def addTermTraitConstraints(den: Denotation, ts: List[Type], locs: List[SourceLocation], root: KindedAst.Root)(implicit c: TypeContext): Unit = den match {
     case Denotation.Relational =>
-      ts.zip(locs).foreach {
-        case (tpe, loc) => c.addClassConstraints(mkTraitConstraintsForRelationalTerm(tpe, root, loc), loc)
+      for ((tpe, loc) <- ts.zip(locs)) {
+        c.addClassConstraints(mkTraitConstraintsForRelationalTerm(tpe, root, loc), loc)
       }
     case Denotation.Latticenal =>
-      ts.init.zip(locs.init).foreach {
-        case (tpe, loc) => c.addClassConstraints(mkTraitConstraintsForRelationalTerm(tpe, root, loc), loc)
+      for ((tpe, loc) <- ts.init.zip(locs.init)) {
+        c.addClassConstraints(mkTraitConstraintsForRelationalTerm(tpe, root, loc), loc)
       }
       c.addClassConstraints(mkTraitConstraintsForLatticeTerm(ts.last, root, locs.last), locs.last)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
@@ -176,7 +176,7 @@ object SchemaConstraintGen {
             val order = TraitConstraint(TraitSymUse(orderSym, loc), tuple, loc)
             val foldable = TraitConstraint(TraitSymUse(foldableSym, loc), freshTypeConstructorVar, loc)
 
-            c.addClassConstraints(List(order, foldable))
+            c.addClassConstraints(List(order, foldable), loc)
 
             val aefSym = new Symbol.AssocTypeSym(foldableSym, "Aef", loc)
             val aefTpe = Type.AssocType(AssocTypeSymUse(aefSym, loc), freshTypeConstructorVar, Kind.Eff, loc)
@@ -222,8 +222,7 @@ object SchemaConstraintGen {
         val (termTypes, termEffs) = terms.map(visitExp(_)).unzip
         c.unifyType(Type.Pure, Type.mkUnion(termEffs, loc), loc)
         c.unifyType(tvar, mkRelationOrLatticeType(den, termTypes, loc), loc)
-        val tconstrs = getTermTraitConstraints(den, termTypes, terms.map(_.loc), root)
-        c.addClassConstraints(tconstrs)
+        addTermTraitConstraints(den, termTypes, terms.map(_.loc), root)
         val resTpe = Type.mkSchemaRowExtend(pred, tvar, restRow, loc)
         resTpe
     }
@@ -239,8 +238,7 @@ object SchemaConstraintGen {
         val restRow = Type.freshVar(Kind.SchemaRow, loc)
         val termTypes = terms.map(visitPattern)
         c.unifyType(tvar, mkRelationOrLatticeType(den, termTypes, loc), loc)
-        val tconstrs = getTermTraitConstraints(den, termTypes, terms.map(_.loc), root)
-        c.addClassConstraints(tconstrs)
+        addTermTraitConstraints(den, termTypes, terms.map(_.loc), root)
         val resTpe = Type.mkSchemaRowExtend(pred, tvar, restRow, loc)
         resTpe
 
@@ -271,17 +269,21 @@ object SchemaConstraintGen {
   }
 
   /**
-    * Returns the trait constraints for the given term types `ts` with the given denotation `den`.
+    * Adds the trait constraints for the given term types `ts` with the given denotation `den`.
     *
-    * Each trait constraint is associated with the source location `locs` of the term it originates from,
-    * so that any missing instance error points at the specific term rather than the whole atom.
+    * Each term's constraints are added at that term's own source location (from `locs`), so that a
+    * missing instance error points at the specific offending term rather than the whole atom.
     */
-  private def getTermTraitConstraints(den: Denotation, ts: List[Type], locs: List[SourceLocation], root: KindedAst.Root): List[TraitConstraint] = den match {
+  private def addTermTraitConstraints(den: Denotation, ts: List[Type], locs: List[SourceLocation], root: KindedAst.Root)(implicit c: TypeContext): Unit = den match {
     case Denotation.Relational =>
-      ts.zip(locs).flatMap { case (tpe, loc) => mkTraitConstraintsForRelationalTerm(tpe, root, loc) }
+      ts.zip(locs).foreach {
+        case (tpe, loc) => c.addClassConstraints(mkTraitConstraintsForRelationalTerm(tpe, root, loc), loc)
+      }
     case Denotation.Latticenal =>
-      ts.init.zip(locs.init).flatMap { case (tpe, loc) => mkTraitConstraintsForRelationalTerm(tpe, root, loc) } :::
-        mkTraitConstraintsForLatticeTerm(ts.last, root, locs.last)
+      ts.init.zip(locs.init).foreach {
+        case (tpe, loc) => c.addClassConstraints(mkTraitConstraintsForRelationalTerm(tpe, root, loc), loc)
+      }
+      c.addClassConstraints(mkTraitConstraintsForLatticeTerm(ts.last, root, locs.last), locs.last)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
@@ -176,7 +176,7 @@ object SchemaConstraintGen {
             val order = TraitConstraint(TraitSymUse(orderSym, loc), tuple, loc)
             val foldable = TraitConstraint(TraitSymUse(foldableSym, loc), freshTypeConstructorVar, loc)
 
-            c.addClassConstraints(List(order, foldable), loc)
+            c.addClassConstraints(List(order, foldable))
 
             val aefSym = new Symbol.AssocTypeSym(foldableSym, "Aef", loc)
             val aefTpe = Type.AssocType(AssocTypeSymUse(aefSym, loc), freshTypeConstructorVar, Kind.Eff, loc)
@@ -222,8 +222,8 @@ object SchemaConstraintGen {
         val (termTypes, termEffs) = terms.map(visitExp(_)).unzip
         c.unifyType(Type.Pure, Type.mkUnion(termEffs, loc), loc)
         c.unifyType(tvar, mkRelationOrLatticeType(den, termTypes, loc), loc)
-        val tconstrs = getTermTraitConstraints(den, termTypes, root, loc)
-        c.addClassConstraints(tconstrs, loc)
+        val tconstrs = getTermTraitConstraints(den, termTypes, terms.map(_.loc), root)
+        c.addClassConstraints(tconstrs)
         val resTpe = Type.mkSchemaRowExtend(pred, tvar, restRow, loc)
         resTpe
     }
@@ -239,8 +239,8 @@ object SchemaConstraintGen {
         val restRow = Type.freshVar(Kind.SchemaRow, loc)
         val termTypes = terms.map(visitPattern)
         c.unifyType(tvar, mkRelationOrLatticeType(den, termTypes, loc), loc)
-        val tconstrs = getTermTraitConstraints(den, termTypes, root, loc)
-        c.addClassConstraints(tconstrs, loc)
+        val tconstrs = getTermTraitConstraints(den, termTypes, terms.map(_.loc), root)
+        c.addClassConstraints(tconstrs)
         val resTpe = Type.mkSchemaRowExtend(pred, tvar, restRow, loc)
         resTpe
 
@@ -272,12 +272,16 @@ object SchemaConstraintGen {
 
   /**
     * Returns the trait constraints for the given term types `ts` with the given denotation `den`.
+    *
+    * Each trait constraint is associated with the source location `locs` of the term it originates from,
+    * so that any missing instance error points at the specific term rather than the whole atom.
     */
-  private def getTermTraitConstraints(den: Denotation, ts: List[Type], root: KindedAst.Root, loc: SourceLocation): List[TraitConstraint] = den match {
+  private def getTermTraitConstraints(den: Denotation, ts: List[Type], locs: List[SourceLocation], root: KindedAst.Root): List[TraitConstraint] = den match {
     case Denotation.Relational =>
-      ts.flatMap(mkTraitConstraintsForRelationalTerm(_, root, loc))
+      ts.zip(locs).flatMap { case (tpe, loc) => mkTraitConstraintsForRelationalTerm(tpe, root, loc) }
     case Denotation.Latticenal =>
-      ts.init.flatMap(mkTraitConstraintsForRelationalTerm(_, root, loc)) ::: mkTraitConstraintsForLatticeTerm(ts.last, root, loc)
+      ts.init.zip(locs.init).flatMap { case (tpe, loc) => mkTraitConstraintsForRelationalTerm(tpe, root, loc) } :::
+        mkTraitConstraintsForLatticeTerm(ts.last, root, locs.last)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
@@ -231,9 +231,13 @@ class TypeContext {
 
   /**
     * Adds the given trait constraints to the context.
+    *
+    * Each constraint is reported at the given `loc`, regardless of the location stored on the
+    * constraint itself. A constraint typically originates from a signature, but the error should
+    * point at the use site, so callers pass the use-site location here.
     */
-  def addClassConstraints(tconstrs0: List[TraitConstraint]): Unit = {
-    for (TraitConstraint(head, arg, loc) <- tconstrs0) {
+  def addClassConstraints(tconstrs0: List[TraitConstraint], loc: SourceLocation): Unit = {
+    for (TraitConstraint(head, arg, _) <- tconstrs0) {
       val tconstr = TypeConstraint.Trait(head.sym, arg, loc)
       currentScopeConstraints.add(tconstr)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
@@ -232,8 +232,8 @@ class TypeContext {
   /**
     * Adds the given trait constraints to the context.
     */
-  def addClassConstraints(tconstrs0: List[TraitConstraint], loc: SourceLocation): Unit = {
-    for (TraitConstraint(head, arg, _) <- tconstrs0) {
+  def addClassConstraints(tconstrs0: List[TraitConstraint]): Unit = {
+    for (TraitConstraint(head, arg, loc) <- tconstrs0) {
       val tconstr = TypeConstraint.Trait(head.sym, arg, loc)
       currentScopeConstraints.add(tconstr)
     }


### PR DESCRIPTION
Fixes #4856.

Missing-instance errors for terms in a Datalog atom underlined the **whole atom** instead of the specific offending term.

### Before
```
3 |        A(1; Set#{}).
            ^^^^^^^^^^^^
            missing Eq instance
```

### After
```
3 |        A(1; Set#{}).
                 ^^^^^^
                 missing Eq instance
```

### Cause
Two compounding issues:

1. `SchemaConstraintGen` built the term trait constraints (`Eq`, `Order`, ...) using the whole atom's `SourceLocation`.
2. `TypeContext.addClassConstraints` discarded each `TraitConstraint`'s own location and stamped them all with a single shared `loc`.

### Fix
- Thread the per-term source location through `getTermTraitConstraints`, so each term's constraints carry that term's location.
- Have `addClassConstraints` honor each constraint's own location (and drop the now-redundant `loc` parameter).

The other `addClassConstraints` callers already `copy(loc = ...)` onto their constraints before calling, so their behavior is unchanged.

The improvement applies to both head and body atoms, and to relational terms anywhere in the atom (e.g. `A(1, NoInst.X, 2)` now underlines just `NoInst.X`).