### PR TITLE
fix: make DelayList.tail return Option and add DelayList.init (#5178)

### DIFF
--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -201,17 +201,41 @@ pub mod DelayList {
     }
 
     ///
-    /// Returns `l` without the first element.
+    /// Returns `Some(xs)` where `xs` is `l` without the first element.
     ///
-    /// Does not force the tail of `l`.
+    /// Returns `None` if `l` is empty.
     ///
-    @Experimental @Lazy
-    pub def tail(l: DelayList[a]): DelayList[a] = match l {
-        case ENil         => ENil
-        case ECons(_, xs) => xs
-        case LCons(_, xs) => LList(xs)
-        case LList(xs)    => LList(lazy tail(force xs))
+    /// Forces `l` until the first element is found, but does not force the tail.
+    ///
+    @Experimental
+    pub def tail(l: DelayList[a]): Option[DelayList[a]] = match l {
+        case ENil         => None
+        case ECons(_, xs) => Some(xs)
+        case LCons(_, xs) => Some(LList(xs))
+        case LList(xs)    => tail(force xs)
     }
+
+    ///
+    /// Returns `Some(xs)` where `xs` is `l` without the last element.
+    ///
+    /// Returns `None` if `l` is empty.
+    ///
+    /// Forces the entire list `l`.
+    ///
+    @Experimental
+    pub def init(l: DelayList[a]): Option[DelayList[a]] =
+        def loop(prev, ll, acc) = match ll {
+            case ENil         => acc
+            case ECons(x, xs) => loop(x, xs, ECons(prev, acc))
+            case LCons(x, xs) => loop(x, force xs, ECons(prev, acc))
+            case LList(xs)    => loop(prev, force xs, acc)
+        };
+        match l {
+            case ENil         => None
+            case ECons(x, xs) => Some(reverse(loop(x, xs, ENil)))
+            case LCons(x, xs) => Some(reverse(loop(x, force xs, ENil)))
+            case LList(xs)    => init(force xs)
+        }
 
     ///
     /// Returns the number of elements in `l`.
@@ -1199,11 +1223,14 @@ pub mod DelayList {
     @Experimental @Lazy
     pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r =
         let cursor = Ref.fresh(rc, l);
-        let next = () -> match head(Ref.get(cursor)) {
-            case None => None
-            case Some(x) =>
-                Ref.put(tail(Ref.get(cursor)), cursor);
-                Some(x)
+        let next = () -> {
+            let ll = Ref.get(cursor);
+            match head(ll) {
+                case None => None
+                case Some(x) =>
+                    Ref.put(Option.getWithDefault(ENil, tail(ll)), cursor);
+                    Some(x)
+            }
         };
         Iterator.unfoldWithIter(rc, next)
 

--- a/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
@@ -226,51 +226,104 @@ mod TestDelayList {
 
     @Test
     def tail01(): Unit \ Assert =
-        assertEq(expected = ENil, DelayList.tail((ENil: DelayList[Unit])))
+        assertEq(expected = None, DelayList.tail((ENil: DelayList[Unit])))
 
     @Test
     def tail02(): Unit \ Assert =
-        assertEq(expected = ENil, DelayList.tail((LList(lazy ENil): DelayList[Unit])))
+        assertEq(expected = None, DelayList.tail((LList(lazy ENil): DelayList[Unit])))
 
     @Test
     def tail03(): Unit \ Assert =
-        assertEq(expected = ENil, DelayList.range(0, 1) |> DelayList.tail)
+        assertEq(expected = Some(ENil), DelayList.range(0, 1) |> DelayList.tail)
 
     @Test
     def tail04(): Unit \ Assert =
-    	assertEq(expected = ENil, LCons(1, lazy ENil) |> DelayList.tail)
+    	assertEq(expected = Some(ENil), LCons(1, lazy ENil) |> DelayList.tail)
 
     @Test
     def tail05(): Unit \ Assert =
-    	assertEq(expected = ENil, LList(lazy ECons(1, LList(lazy ENil))) |> DelayList.tail)
+    	assertEq(expected = Some(ENil), LList(lazy ECons(1, LList(lazy ENil))) |> DelayList.tail)
 
     @Test
     def tail06(): Unit \ Assert =
-    	assertEq(expected = ENil, ECons(1, LList(lazy ENil)) |> DelayList.tail)
+    	assertEq(expected = Some(ENil), ECons(1, LList(lazy ENil)) |> DelayList.tail)
 
     @Test
     def tail07(): Unit \ Assert =
-    	assertEq(expected = ENil, LCons(1, lazy LList(lazy ENil)) |> DelayList.tail)
+    	assertEq(expected = Some(ENil), LCons(1, lazy LList(lazy ENil)) |> DelayList.tail)
 
     @Test
     def tail08(): Unit \ Assert =
-    	assertEq(expected = DelayList.range(2, 4), LCons(1, lazy LCons(2, lazy LList(lazy LCons(3, lazy ENil)))) |> DelayList.tail)
+    	assertEq(expected = Some(DelayList.range(2, 4)), LCons(1, lazy LCons(2, lazy LList(lazy LCons(3, lazy ENil)))) |> DelayList.tail)
 
     @Test
     def tail09(): Unit \ Assert =
-    	assertEq(expected = DelayList.range(2, 4), LCons(1, lazy ECons(2, LCons(3, lazy LList(lazy ENil)))) |> DelayList.tail)
+    	assertEq(expected = Some(DelayList.range(2, 4)), LCons(1, lazy ECons(2, LCons(3, lazy LList(lazy ENil)))) |> DelayList.tail)
 
     @Test
     def tail10(): Unit \ Assert =
-    	assertEq(expected = DelayList.range(2, 4), LCons(1, lazy ECons(2, LList(lazy LCons(3, lazy LList(lazy ENil))))) |> DelayList.tail)
+    	assertEq(expected = Some(DelayList.range(2, 4)), LCons(1, lazy ECons(2, LList(lazy LCons(3, lazy LList(lazy ENil))))) |> DelayList.tail)
 
     @Test
     def tail11(): Unit \ Assert =
-    	assertEq(expected = DelayList.range(2, 4), LList(lazy LCons(1, lazy LList(lazy ECons(2, ECons(3, LList(lazy ENil)))))) |> DelayList.tail)
+    	assertEq(expected = Some(DelayList.range(2, 4)), LList(lazy LCons(1, lazy LList(lazy ECons(2, ECons(3, LList(lazy ENil)))))) |> DelayList.tail)
 
     @Test
     def tail12(): Unit \ Assert =
-    	assertEq(expected = DelayList.range(1, 1000), DelayList.range(0, 1000) |> DelayList.tail)
+    	assertEq(expected = Some(DelayList.range(1, 1000)), DelayList.range(0, 1000) |> DelayList.tail)
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // init                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def init01(): Unit \ Assert =
+        assertEq(expected = None, DelayList.init((ENil: DelayList[Unit])))
+
+    @Test
+    def init02(): Unit \ Assert =
+        assertEq(expected = None, DelayList.init((LList(lazy ENil): DelayList[Unit])))
+
+    @Test
+    def init03(): Unit \ Assert =
+        assertEq(expected = Some(ENil), DelayList.range(0, 1) |> DelayList.init)
+
+    @Test
+    def init04(): Unit \ Assert =
+    	assertEq(expected = Some(ENil), LCons(1, lazy ENil) |> DelayList.init)
+
+    @Test
+    def init05(): Unit \ Assert =
+    	assertEq(expected = Some(ENil), LList(lazy ECons(1, LList(lazy ENil))) |> DelayList.init)
+
+    @Test
+    def init06(): Unit \ Assert =
+    	assertEq(expected = Some(ENil), ECons(1, LList(lazy ENil)) |> DelayList.init)
+
+    @Test
+    def init07(): Unit \ Assert =
+    	assertEq(expected = Some(ENil), LCons(1, lazy LList(lazy ENil)) |> DelayList.init)
+
+    @Test
+    def init08(): Unit \ Assert =
+    	assertEq(expected = Some(DelayList.range(1, 3)), LCons(1, lazy LCons(2, lazy LList(lazy LCons(3, lazy ENil)))) |> DelayList.init)
+
+    @Test
+    def init09(): Unit \ Assert =
+    	assertEq(expected = Some(DelayList.range(1, 3)), LCons(1, lazy ECons(2, LCons(3, lazy LList(lazy ENil)))) |> DelayList.init)
+
+    @Test
+    def init10(): Unit \ Assert =
+    	assertEq(expected = Some(DelayList.range(1, 3)), LCons(1, lazy ECons(2, LList(lazy LCons(3, lazy LList(lazy ENil))))) |> DelayList.init)
+
+    @Test
+    def init11(): Unit \ Assert =
+    	assertEq(expected = Some(DelayList.range(1, 3)), LList(lazy LCons(1, lazy LList(lazy ECons(2, ECons(3, LList(lazy ENil)))))) |> DelayList.init)
+
+    @Test
+    def init12(): Unit \ Assert =
+    	assertEq(expected = Some(DelayList.range(0, 999)), DelayList.range(0, 1000) |> DelayList.init)
 
 
     /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Resolves #5178.

`DelayList`'s partial accessors `head` and `last` return `Option`, but `tail` returned a plain `DelayList` — an empty input and a singleton input both yielded an empty list, with no way to distinguish them.

## Changes
- **`tail` now returns `Option[DelayList[a]]`** — `None` for the empty list, `Some(xs)` otherwise. Consistent with `head`/`last` and the dual `List.init`. The `@Lazy` annotation is dropped because deciding `None` vs `Some` must force the leading `LList` thunks (the same forcing `head` already performs); the returned tail is still unforced.
- **Added `init`** — the symmetric drop-last accessor returning `Option[DelayList[a]]`, which `DelayList` previously lacked. Mirrors `List.init`.
- Updated the internal `iterator` caller (which consumed `tail`'s result) and the `tail` tests; added `init` tests.

Note: `DelayList` is `@Experimental`, so the `tail` signature change is an acceptable breaking change.