### PR TITLE
fix: widen source locations for map literals, record ops, and intrinsics

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SourceLocation.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SourceLocation.scala
@@ -70,6 +70,18 @@ case class SourceLocation(isReal: Boolean, source: Source, start: SourcePosition
   }
 
   /**
+    * Returns the smallest [[SourceLocation]] that contains both `this` and `that`.
+    *
+    * The result is real only if both `this` and `that` are real. Assumes both locations
+    * refer to the same source.
+    */
+  def spanWith(that: SourceLocation): SourceLocation = {
+    val start = SourcePosition.Order.min(this.start, that.start)
+    val end = SourcePosition.Order.max(this.end, that.end)
+    SourceLocation(this.isReal && that.isReal, this.source, start, end)
+  }
+
+  /**
     * Returns the one-indexed line where the entity ends.
     */
   def endLine: Int = end.lineOneIndexed

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -1322,7 +1322,7 @@ object Desugar {
       val unit = DesugaredAst.Expr.Cst(Constant.Unit, loc0)
       mkApplyFqn("Map.empty", List(unit), loc0)
     } else {
-      val es = exps0.map { case (k, v) => WeededAst.Expr.Tuple(List(k, v), k.loc) }
+      val es = exps0.map { case (k, v) => WeededAst.Expr.Tuple(List(k, v), k.loc.spanWith(v.loc)) }
       desugarCollectionLitToVec("Vector.toMap", es, loc0)
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -837,7 +837,7 @@ object Weeder2 {
         case TreeKind.Expr.FixpointQueryWithProvenance => visitFixpointQueryWithProvenanceExpr(tree)
         case TreeKind.Expr.ExtMatch => visitExtMatch(tree)
         case TreeKind.Expr.ExtTag => visitExtTag(tree)
-        case TreeKind.Expr.Intrinsic => visitIntrinsic(tree, None)
+        case TreeKind.Expr.Intrinsic => visitIntrinsic(tree, None, tree.loc)
         case TreeKind.ErrorTree(err) => Expr.Error(err)
         case k =>
           throw InternalCompilerException(s"Expected expression, got '$k'.", tree.loc)
@@ -1012,7 +1012,7 @@ object Weeder2 {
       val exprTree = pick(TreeKind.Expr.Expr, tree)
       val args = pickArguments(tree, synctx = SyntacticContext.Expr.OtherExpr)
       tryPick(TreeKind.Expr.Intrinsic, exprTree) match {
-        case Some(intrinsic) => visitIntrinsic(intrinsic, Some(args))
+        case Some(intrinsic) => visitIntrinsic(intrinsic, Some(args), tree.loc)
         case None => Expr.Apply(visitExpr(exprTree), args, tree.loc)
       }
     }
@@ -1652,22 +1652,25 @@ object Weeder2 {
         val error = NeedAtleastOne(NamedTokenSet.FromKinds(Set(TokenKind.Plus, TokenKind.Minus, TokenKind.NameLowercase)), SyntacticContext.Expr.OtherExpr, hint = Some("Record operations must contain at least one operation"), tree.loc)
         sctx.errors.add(error)
       }
-      ops.foldRight(pickExpr(tree))((op, acc) =>
+      ops.foldRight(pickExpr(tree))((op, acc) => {
+        // The base record `acc` appears to the right of `op` (e.g. `{ op | acc }`), so the location
+        // of each constructed node must span both the operation and the accumulated base record.
+        val loc = op.loc.spanWith(acc.loc)
         op.kind match {
           case TreeKind.Expr.RecordOpExtend =>
             val id = pickNameIdent(op)
-            Expr.RecordExtend(Name.mkLabel(id), pickExpr(op), acc, op.loc)
+            Expr.RecordExtend(Name.mkLabel(id), pickExpr(op), acc, loc)
           case TreeKind.Expr.RecordOpRestrict =>
             val id = pickNameIdent(op)
-            Expr.RecordRestrict(Name.mkLabel(id), acc, op.loc)
+            Expr.RecordRestrict(Name.mkLabel(id), acc, loc)
           case TreeKind.Expr.RecordOpUpdate =>
             val id = pickNameIdent(op)
             // An update is a restrict followed by an extension
-            val restricted = Expr.RecordRestrict(Name.mkLabel(id), acc, op.loc)
-            Expr.RecordExtend(Name.mkLabel(id), pickExpr(op), restricted, op.loc)
+            val restricted = Expr.RecordRestrict(Name.mkLabel(id), acc, loc)
+            Expr.RecordExtend(Name.mkLabel(id), pickExpr(op), restricted, loc)
           case k => throw InternalCompilerException(s"'$k' is not a record operation", op.loc)
         }
-      )
+      })
     }
 
     private def visitLiteralArrayExpr(tree: Tree)(implicit sctx: SharedContext): Expr = {
@@ -2120,10 +2123,9 @@ object Weeder2 {
       *   - `args = Some(Nil)` is an applied intrinsic with zero arguments (e.g. `%%EXAMPLE%%()`)
       *   - `args = Some(Cons(.., ..))` is an applied intrinsic with some arguments (e.g. `%%VECTOR_LENGTH%%(v)`)
       */
-    private def visitIntrinsic(tree: Tree, args: Option[List[Expr]])(implicit sctx: SharedContext): Expr = {
+    private def visitIntrinsic(tree: Tree, args: Option[List[Expr]], loc: SourceLocation)(implicit sctx: SharedContext): Expr = {
       expect(tree, TreeKind.Expr.Intrinsic)
       val intrinsic = text(tree).head.stripPrefix("%%").stripSuffix("%%")
-      val loc = tree.loc
       val res = (intrinsic, args) match {
         case ("ARRAY_LENGTH", Some(e1 :: Nil)) => Expr.ArrayLength(e1, loc)
         case ("ARRAY_LOAD", Some(e1 :: e2 :: Nil)) => Expr.ArrayLoad(e1, e2, loc)


### PR DESCRIPTION
## Summary

Several AST nodes were assigned source locations narrower than the syntax they represent. This adds a small helper and corrects three cases.

- **`SourceLocation.spanWith`** — new method returning the smallest `SourceLocation` containing two locations (real only if both inputs are real; assumes the same source).
- **Map literals** (`Desugar.scala`) — each desugared `(k, v)` tuple now spans from the key through the value, instead of being collapsed onto the key's location.
- **Record operations** (`Weeder2.scala`) — `RecordExtend`/`RecordRestrict`/`RecordUpdate` nodes now span the operation through the accumulated base record (which appears to the right, e.g. `{ op | acc }`), rather than just the operation.
- **Intrinsics** (`Weeder2.scala`) — `visitIntrinsic` now takes the enclosing call tree's location, so an applied intrinsic like `%%VECTOR_LENGTH%%(v)` is located at the whole call rather than just the intrinsic token.