### PR TITLE
fix: give arrow types a real source location (#12271)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3037,7 +3037,7 @@ object Weeder2 {
             // ARROW FUNCTIONS
             case "->" =>
               val eff = tryPickEffect(tree)
-              val l = tree.loc.asSynthetic
+              val synthLoc = tree.loc.asSynthetic
               val (lastParam, initParams) = t1 match {
                 // Normally singleton tuples `((a, b))` are treated as `(a, b)`. That's fine unless we are doing an arrow type!
                 // In this case we need t1 "unflattened" so we redo the visit.
@@ -3047,8 +3047,18 @@ object Weeder2 {
                   (params.last, params.init)
                 case t => (t, List.empty)
               }
-              val base = Type.Arrow(List(lastParam), eff, t2, l)
-              initParams.foldRight(base)((acc, tpe) => Type.Arrow(List(acc), None, tpe, l))
+              // The outermost arrow corresponds to the actual source location of the whole
+              // arrow type. The inner arrows produced by currying a tuple parameter list are
+              // synthetic since they do not appear directly in the source. The innermost arrow
+              // carries the effect.
+              initParams match {
+                case Nil =>
+                  Type.Arrow(List(lastParam), eff, t2, tree.loc)
+                case head :: tail =>
+                  val base = Type.Arrow(List(lastParam), eff, t2, synthLoc)
+                  val inner = tail.foldRight(base: Type)((param, acc) => Type.Arrow(List(param), None, acc, synthLoc))
+                  Type.Arrow(List(head), None, inner, tree.loc)
+              }
             // REGULAR TYPE OPERATORS
             case "+" => Type.Union(t1, t2, tree.loc)
             case "-" => Type.Difference(t1, t2, tree.loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3037,28 +3037,15 @@ object Weeder2 {
             // ARROW FUNCTIONS
             case "->" =>
               val eff = tryPickEffect(tree)
-              val synthLoc = tree.loc.asSynthetic
-              val (lastParam, initParams) = t1 match {
+              val params = t1 match {
                 // Normally singleton tuples `((a, b))` are treated as `(a, b)`. That's fine unless we are doing an arrow type!
                 // In this case we need t1 "unflattened" so we redo the visit.
                 case Type.Tuple(_, _) =>
                   val t1Tree = pick(TreeKind.Type.Tuple, pick(TreeKind.Type.Type, tree))
-                  val params = pickAll(TreeKind.Type.Type, t1Tree).map(visitType)
-                  (params.last, params.init)
-                case t => (t, List.empty)
+                  pickAll(TreeKind.Type.Type, t1Tree).map(visitType)
+                case t => List(t)
               }
-              // The outermost arrow corresponds to the actual source location of the whole
-              // arrow type. The inner arrows produced by currying a tuple parameter list are
-              // synthetic since they do not appear directly in the source. The innermost arrow
-              // carries the effect.
-              initParams match {
-                case Nil =>
-                  Type.Arrow(List(lastParam), eff, t2, tree.loc)
-                case head :: tail =>
-                  val base = Type.Arrow(List(lastParam), eff, t2, synthLoc)
-                  val inner = tail.foldRight(base: Type)((param, acc) => Type.Arrow(List(param), None, acc, synthLoc))
-                  Type.Arrow(List(head), None, inner, tree.loc)
-              }
+              mkCurriedArrow(params, eff, t2, tree.loc)
             // REGULAR TYPE OPERATORS
             case "+" => Type.Union(t1, t2, tree.loc)
             case "-" => Type.Difference(t1, t2, tree.loc)
@@ -3080,6 +3067,30 @@ object Weeder2 {
           }
 
         case operands => throw InternalCompilerException(s"Type.Binary tree with ${operands.length} operands: $operands", tree.loc)
+      }
+    }
+
+    /**
+      * Returns the curried arrow type formed from the parameter types `params`, effect `eff`, and result
+      * type `tresult`.
+      *
+      * A multi-parameter arrow `(a, b) -> c` is curried into nested single-parameter arrows `a -> (b -> c)`.
+      * The outermost arrow is given the real location `loc` since it corresponds to the source arrow type,
+      * whereas the inner arrows introduced by currying are synthetic since they do not appear directly in the
+      * source. The innermost arrow carries the effect `eff`.
+      */
+    private def mkCurriedArrow(params: List[Type], eff: Option[Type], tresult: Type, loc: SourceLocation): Type = {
+      val synthLoc = loc.asSynthetic
+      params match {
+        case Nil =>
+          // A parameterless arrow cannot be written in source.
+          tresult
+        case onlyParam :: Nil =>
+          Type.Arrow(List(onlyParam), eff, tresult, loc)
+        case firstParam :: restParams =>
+          val innermost = Type.Arrow(List(restParams.last), eff, tresult, synthLoc)
+          val inner = restParams.init.foldRight(innermost: Type)((param, acc) => Type.Arrow(List(param), None, acc, synthLoc))
+          Type.Arrow(List(firstParam), None, inner, loc)
       }
     }
 


### PR DESCRIPTION
Fixes #12271.

The arrow-type weeder in `Weeder2` marked **every** arrow it constructed as synthetic (`tree.loc.asSynthetic`). As a result, even a function type written directly in source — e.g. `Int32 -> Int32` — carried a synthetic location.

This matters because several LSP providers gate on `loc.isReal`:

- `SemanticTokensProvider.visitType` returns early for synthetic types, so the component types inside a function annotation were not highlighted.
- `GotoProvider`, `HighlightProvider`, `RenameProvider`, and `FindReferencesProvider` require `tpe.loc.isReal` to treat a type node as a valid target.

So go-to-definition, highlight, rename, and semantic highlighting silently skipped function type annotations.

### Fix

The outermost arrow corresponds to the actual source span and is now given the real `tree.loc`. Only the inner arrows produced by currying a tuple parameter list — e.g. the `b -> c` in `(a, b) -> c` desugaring to `a -> (b -> c)` — remain synthetic, since they do not appear contiguously in the source. The innermost arrow still carries the effect, as before.