### PR TITLE
refactor: remove laws from the language

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -206,7 +206,7 @@ object Visitor {
   }
 
   private def visitTrait(t: Trait)(implicit a: Acceptor, c: Consumer): Unit = {
-    val Trait(_, ann, _, _, tparam, superTraits, assocs, sigs, laws, loc) = t
+    val Trait(_, ann, _, _, tparam, superTraits, assocs, sigs, loc) = t
     if (!a.accept(loc)) {
       return
     }
@@ -218,7 +218,6 @@ object Visitor {
     superTraits.foreach(visitTraitConstraint)
     assocs.foreach(visitAssocTypeSig)
     sigs.foreach(visitSig)
-    laws.foreach(visitDef)
   }
 
   private def visitAssocTypeSig(assoc: AssocTypeSig)(implicit a: Acceptor, c: Consumer): Unit = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -128,7 +128,7 @@ object FindReferencesProvider {
   }
 
   private def isReal(x: AnyRef): Boolean = x match {
-    case TypedAst.Trait(_, _, _, _, _, _, _, _, _, loc) => loc.isReal
+    case TypedAst.Trait(_, _, _, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Instance(_, _, _, _, _, _, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Sig(_, _, _, loc) => loc.isReal
     case TypedAst.Def(_, _, _, loc) => loc.isReal
@@ -220,7 +220,7 @@ object FindReferencesProvider {
     case TypedAst.StructField(sym, _, _) => Some(getStructFieldSymOccurs(sym))
     case SymUse.StructFieldSymUse(sym, _) => Some(getStructFieldSymOccurs(sym))
     // Traits
-    case TypedAst.Trait(_, _, _, sym, _, _, _, _, _, _) => Some(getTraitSymOccurs(sym))
+    case TypedAst.Trait(_, _, _, sym, _, _, _, _, _) => Some(getTraitSymOccurs(sym))
     case SymUse.TraitSymUse(sym, _) => Some(getTraitSymOccurs(sym))
     // Type Alias
     case TypedAst.TypeAlias(_, _, _, sym, _, _, _) => Some(getTypeAliasSymOccurs(sym))

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -129,7 +129,7 @@ object GotoProvider {
   }
 
   private def isReal(x: AnyRef): Boolean = x match {
-    case TypedAst.Trait(_, _, _, _, _, _, _, _, _, loc) => loc.isReal
+    case TypedAst.Trait(_, _, _, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Instance(_, _, _, _, _, _, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Sig(_, _, _, loc) => loc.isReal
     case TypedAst.Def(_, _, _, loc) => loc.isReal

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
@@ -167,7 +167,7 @@ object HighlightProvider {
   }
 
   private def isReal(x: AnyRef): Boolean = x match {
-    case TypedAst.Trait(_, _, _, _, _, _, _, _, _, loc) => loc.isReal
+    case TypedAst.Trait(_, _, _, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Instance(_, _, _, _, _, _, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Sig(_, _, _, loc) => loc.isReal
     case TypedAst.Def(_, _, _, loc) => loc.isReal
@@ -243,7 +243,7 @@ object HighlightProvider {
   }
 
   private def ifTraitThenInSym(uri: String, pos: Position)(x: AnyRef): Boolean = x match {
-    case TypedAst.Trait(_, _, _, sym, _, _, _, _, _, _) if !Visitor.inside(uri, pos)(sym.loc) => false
+    case TypedAst.Trait(_, _, _, sym, _, _, _, _, _) if !Visitor.inside(uri, pos)(sym.loc) => false
     case _ => true
   }
 
@@ -293,7 +293,7 @@ object HighlightProvider {
       case TypedAst.StructField(sym, _, _) => Some(getStructFieldSymOccurs(sym))
       case SymUse.StructFieldSymUse(sym, _) => Some(getStructFieldSymOccurs(sym))
       // Traits
-      case TypedAst.Trait(_, _, _, sym, _, _, _, _, _, _) => Some(getTraitSymOccurs(sym))
+      case TypedAst.Trait(_, _, _, sym, _, _, _, _, _) => Some(getTraitSymOccurs(sym))
       case SymUse.TraitSymUse(sym, _) => Some(getTraitSymOccurs(sym))
       // Type Aliases
       case TypedAst.TypeAlias(_, _, _, sym, _, _, _) => Some(getTypeAliasSymOccurs(sym))

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
@@ -116,7 +116,7 @@ object RenameProvider {
   }
 
   private def isReal(x: AnyRef): Boolean = x match {
-    case TypedAst.Trait(_, _, _, _, _, _, _, _, _, loc) => loc.isReal
+    case TypedAst.Trait(_, _, _, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Instance(_, _, _, _, _, _, _, _, _, _, _, loc) => loc.isReal
     case TypedAst.Sig(_, _, _, loc) => loc.isReal
     case TypedAst.Def(_, _, _, loc) => loc.isReal

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -156,7 +156,7 @@ object SemanticTokensProvider {
     * Returns all semantic tokens in the given trait `traitDecl`.
     */
   private def visitTrait(traitDecl: TypedAst.Trait): Iterator[SemanticToken] = traitDecl match {
-    case TypedAst.Trait(_, ann, _, sym, tparam, superTraits, assocs, signatures, laws, _) =>
+    case TypedAst.Trait(_, ann, _, sym, tparam, superTraits, assocs, signatures, _) =>
       val t = SemanticToken(SemanticTokenType.Interface, Nil, sym.loc)
       IteratorOps.all(
         visitAnnotations(ann),
@@ -165,7 +165,6 @@ object SemanticTokensProvider {
         assocs.flatMap(visitAssocTypeSig),
         visitTypeParam(tparam),
         signatures.flatMap(visitSig),
-        laws.flatMap(visitDef),
       )
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
@@ -56,7 +56,7 @@ object SymbolProvider {
     * Returns an Interface SymbolInformation from a Trait node.
     */
   private def mkTraitWorkSpaceSymbol(t: TypedAst.Trait) = t match {
-    case TypedAst.Trait(_, _, _, sym, _, _, _, _, _, _) => WorkspaceSymbol(
+    case TypedAst.Trait(_, _, _, sym, _, _, _, _, _) => WorkspaceSymbol(
       sym.name, SymbolKind.Interface, Nil, None, Location(sym.loc.source.name, Range.from(sym.loc)),
     )
   }
@@ -66,7 +66,7 @@ object SymbolProvider {
     * It navigates the AST and adds Sig and TypeParam of t and as children DocumentSymbols.
     */
   private def mkTraitDocumentSymbol(t: TypedAst.Trait): DocumentSymbol = t match {
-    case TypedAst.Trait(doc, _, _, sym, tparam, _, _, signatures, _, _) => DocumentSymbol( // TODO ASSOC-TYPES visit assocs
+    case TypedAst.Trait(doc, _, _, sym, tparam, _, _, signatures, _) => DocumentSymbol( // TODO ASSOC-TYPES visit assocs
       sym.name,
       Some(doc.text),
       SymbolKind.Interface,

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
@@ -53,7 +53,7 @@ object ModuleCompleter {
     val thisName = module.toString
     val isResolved = scope.m.values.exists(_.exists {
       case Resolution.Declaration(Mod(_, _, _, thatName, _, _, _, _)) => thatName.toString == thisName
-      case Resolution.Declaration(Trait(_, _, _, thatName, _, _, _, _, _, _)) => thatName.toString == thisName
+      case Resolution.Declaration(Trait(_, _, _, thatName, _, _, _, _, _)) => thatName.toString == thisName
       case Resolution.Declaration(Enum(_, _, _, thatName, _, _, _, _)) => thatName.toString == thisName
       case Resolution.Declaration(Struct(_, _, _, thatName, _, _, _)) => thatName.toString == thisName
       case Resolution.Declaration(Effect(_, _, _, thatName, _, _, _)) => thatName.toString == thisName

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
@@ -67,7 +67,7 @@ object SignatureCompleter {
     */
   private def partiallyQualifiedCompletions(qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope, ectx: ExprContext)(implicit root: TypedAst.Root): Iterable[Completion] = {
     val fullyQualifiedNamespaceHead = scp.resolve(qn.namespace.idents.head.name) match {
-      case Some(Resolution.Declaration(Trait(_, _, _, name, _, _, _, _, _, _))) => name.toString
+      case Some(Resolution.Declaration(Trait(_, _, _, name, _, _, _, _, _))) => name.toString
       case Some(Resolution.Declaration(Mod(_, _, _, name, _, _, _, _))) => name.toString
       case _ => return Nil
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TraitCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TraitCompleter.scala
@@ -75,7 +75,7 @@ object TraitCompleter {
   private def inScope(struct: TypedAst.Trait, scope: LocalScope): Boolean = {
     val thisName = struct.sym.toString
     val isResolved = scope.m.values.exists(_.exists {
-      case Resolution.Declaration(Trait(_, _, _, thatName, _, _, _, _, _, _)) => thisName == thatName.toString
+      case Resolution.Declaration(Trait(_, _, _, thatName, _, _, _, _, _)) => thisName == thatName.toString
       case _ => false
     })
     val isRoot = struct.sym.namespace.isEmpty

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -34,15 +34,13 @@ object DesugaredAst {
 
     case class Mod(doc: Doc, ann: Annotations, mod: Modifiers, qname: Name.QName, usesAndImports: List[UseOrImport], decls: List[Declaration], loc: SourceLocation) extends Declaration
 
-    case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[Declaration.AssocTypeSig], sigs: List[Declaration.Sig], laws: List[Declaration.Def], loc: SourceLocation) extends Declaration
+    case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[Declaration.AssocTypeSig], sigs: List[Declaration.Sig], loc: SourceLocation) extends Declaration
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: Name.QName, tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], loc: SourceLocation) extends Declaration
 
     case class Sig(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Option[Expr], tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], loc: SourceLocation)
 
     case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
-
-    case class Law(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Type, tconstrs: List[TraitConstraint], loc: SourceLocation) extends Declaration
 
     case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], derives: Derivations, cases: List[Case], loc: SourceLocation) extends Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -44,7 +44,7 @@ object KindedAst {
 
   case class Mod(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.ModuleSym, loc: SourceLocation)
 
-  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: Map[Symbol.SigSym, Sig], laws: List[Def], loc: SourceLocation)
+  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: Map[Symbol.SigSym, Sig], loc: SourceLocation)
 
   case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, symUse: TraitSymUse, tparams: List[TypeParam], tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -41,7 +41,7 @@ object NamedAst {
 
     case class Mod(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.ModuleSym, nameLoc: SourceLocation, usesAndImports: List[UseOrImport], decls: List[Declaration], loc: SourceLocation) extends Declaration
 
-    case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[Declaration.AssocTypeSig], sigs: List[Declaration.Sig], laws: List[Declaration.Def], loc: SourceLocation) extends Declaration
+    case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[Declaration.AssocTypeSig], sigs: List[Declaration.Sig], loc: SourceLocation) extends Declaration
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: Name.QName, tparams: List[TypeParam], tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], ns: List[String], loc: SourceLocation) extends Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -43,7 +43,6 @@ object ResolvedAst {
                   availableClasses: AvailableClasses,
                   tokens: Map[Source, Array[Token]])
 
-  // TODO use Law for laws
   case class CompilationUnit(usesAndImports: List[UseOrImport], decls: List[Declaration], loc: SourceLocation)
 
   sealed trait Declaration
@@ -51,7 +50,7 @@ object ResolvedAst {
   object Declaration {
     case class Mod(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.ModuleSym, usesAndImports: List[UseOrImport], decls: List[Declaration], loc: SourceLocation) extends Declaration
 
-    case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[Declaration.AssocTypeSig], sigs: Map[Symbol.SigSym, Declaration.Sig], laws: List[Declaration.Def], loc: SourceLocation) extends Declaration
+    case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[Declaration.AssocTypeSig], sigs: Map[Symbol.SigSym, Declaration.Sig], loc: SourceLocation) extends Declaration
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, symUse: TraitSymUse, tparams: List[TypeParam], tpe: UnkindedType, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], ns: Name.NName, loc: SourceLocation) extends Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -153,8 +153,6 @@ object SyntaxTree {
 
       case object Instance extends Decl
 
-      case object Law extends Decl
-
       case object Module extends Decl
 
       case object Op extends Decl

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -101,8 +101,6 @@ sealed trait TokenKind {
       case TokenKind.KeywordInstance => "'instance'"
       case TokenKind.KeywordInstanceOf => "'instanceof'"
       case TokenKind.KeywordInto => "'into'"
-      case TokenKind.KeywordLaw => "'law'"
-      case TokenKind.KeywordLawful => "'lawful'"
       case TokenKind.KeywordLazy => "'lazy'"
       case TokenKind.KeywordLet => "'let'"
       case TokenKind.KeywordMatch => "'match'"
@@ -237,8 +235,6 @@ sealed trait TokenKind {
     case TokenKind.KeywordInstance => true
     case TokenKind.KeywordInstanceOf => true
     case TokenKind.KeywordInto => true
-    case TokenKind.KeywordLaw => true
-    case TokenKind.KeywordLawful => true
     case TokenKind.KeywordLazy => true
     case TokenKind.KeywordLet => true
     case TokenKind.KeywordMatch => true
@@ -290,7 +286,6 @@ sealed trait TokenKind {
 
   /** Returns `true` if this token is a modifier (e.g. `pub`). */
   def isModifier: Boolean = this match {
-    case TokenKind.KeywordLawful => true
     case TokenKind.KeywordMut => true
     case TokenKind.KeywordOverride => true
     case TokenKind.KeywordPub => true
@@ -350,7 +345,6 @@ sealed trait TokenKind {
   /** Returns `true` if this token can validly appear after [[TokenKind.CommentDoc]]. */
   def isDocumentable: Boolean = this match {
     case TokenKind.KeywordCase => true
-    case TokenKind.KeywordLaw => true
     case _ if this.isFirstInDecl => true
     case _ => false
   }
@@ -391,7 +385,6 @@ sealed trait TokenKind {
     case TokenKind.Annotation => true
     case TokenKind.CommentDoc => true
     case TokenKind.KeywordDef => true
-    case TokenKind.KeywordLaw => true
     case TokenKind.KeywordType => true
     case _ if this.isModifier => true
     case _ => false
@@ -844,10 +837,6 @@ object TokenKind {
   case object KeywordInstanceOf extends TokenKind
 
   case object KeywordInto extends TokenKind
-
-  case object KeywordLaw extends TokenKind
-
-  case object KeywordLawful extends TokenKind
 
   case object KeywordLazy extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -57,7 +57,7 @@ object TypedAst {
 
   case class Mod(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.ModuleSym, children: List[Symbol], loc: SourceLocation) extends Decl
 
-  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation) extends Decl
+  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], loc: SourceLocation) extends Decl
 
   case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tparams: List[TypeParam], tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation) extends Sourceable with Decl {
     override def src: Source = loc.source

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -36,7 +36,7 @@ object WeededAst {
 
     case class Mod(doc: Doc, ann: Annotations, mod: Modifiers, qname: Name.QName, usesAndImports: List[UseOrImport], decls: List[Declaration], loc: SourceLocation) extends Declaration
 
-    case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[Declaration.AssocTypeSig], sigs: List[Declaration.Sig], laws: List[Declaration.Def], loc: SourceLocation) extends Declaration
+    case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[Declaration.AssocTypeSig], sigs: List[Declaration.Sig], loc: SourceLocation) extends Declaration
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, clazz: Name.QName, tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], redefs: List[Declaration.Redef], loc: SourceLocation) extends Declaration
 
@@ -45,8 +45,6 @@ object WeededAst {
     case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
 
     case class Redef(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
-
-    case class Law(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Type, tconstrs: List[TraitConstraint], loc: SourceLocation) extends Declaration
 
     case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], derives: Derivations, cases: List[Case], loc: SourceLocation) extends Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/Modifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/Modifier.scala
@@ -23,14 +23,8 @@ sealed trait Modifier
 object Modifier {
 
   /**
-    * The lawful modifier.
-    */
-  case object Lawful extends Modifier
-
-  /**
     * The mutable modifier.
     */
-
   case object Mutable extends Modifier
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/Modifiers.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/Modifiers.scala
@@ -36,11 +36,6 @@ case class Modifiers(mod: List[Modifier]) {
   def asPublic: Modifiers = if (isPublic) this else Modifiers(Modifier.Public :: mod)
 
   /**
-    * Returns `true` if these modifiers contain the lawful modifier.
-    */
-  def isLawful: Boolean = mod contains Modifier.Lawful
-
-  /**
     * Returns `true` if these modifiers contain the mutable modifier.
     */
   def isMutable: Boolean = mod contains Modifier.Mutable

--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -120,7 +120,6 @@ object ErrorCode {
   case object E3190 extends ErrorCode
   case object E3236 extends ErrorCode
   case object E3249 extends ErrorCode
-  case object E3281 extends ErrorCode
   case object E3347 extends ErrorCode
   case object E3352 extends ErrorCode
   case object E3394 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -416,29 +416,6 @@ object InstanceError {
   }
 
   /**
-    * Error indicating an unlawful signature in a lawful trait.
-    *
-    * @param sym the symbol of the unlawful signature.
-    * @param loc the location where the error occurred.
-    */
-  case class UnlawfulSignature(sym: Symbol.SigSym, loc: SourceLocation) extends InstanceError {
-    def code: ErrorCode = ErrorCode.E3281
-
-    def summary: String = s"Unlawful signature '${sym.name}' in lawful trait '${sym.trt.name}'."
-
-    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
-      import fmt.*
-      s""">> Unlawful signature '${red(sym.name)}' in lawful trait '${magenta(sym.trt.name)}'.
-         |
-         |${highlight(loc, "signature not covered by any law", fmt)}
-         |
-         |${underline("Explanation:")} Each signature in a lawful trait must appear in at least one law.
-         |Add a law that uses '${sym.name}' or remove the 'lawful' modifier from the trait.
-         |""".stripMargin
-    }
-  }
-
-  /**
     * Error indicating an unmarked redefinition (def used instead of redef).
     *
     * @param sym the def that should use redef.

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -100,7 +100,6 @@ object Dependencies {
     trt.superTraits.foreach(visitTraitConstraint)
     trt.assocs.foreach(visitAssocTypeSig)
     trt.sigs.foreach(visitSig)
-    trt.laws.foreach(visitDef)
     trt
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -71,7 +71,6 @@ object Desugar {
     case d: WeededAst.Declaration.Instance => visitInstance(d)
     case d: WeededAst.Declaration.Def => visitDef(d)
     case d: WeededAst.Declaration.Redef => visitRedef(d)
-    case d: WeededAst.Declaration.Law => visitLaw(d)
     case d: WeededAst.Declaration.Enum => visitEnum(d)
     case d: WeededAst.Declaration.RestrictableEnum => visitRestrictableEnum(d)
     case d: WeededAst.Declaration.Struct => visitStruct(d)
@@ -83,13 +82,12 @@ object Desugar {
     * Desugars the given [[WeededAst.Declaration.Trait]] `trait0`.
     */
   private def visitTrait(trait0: WeededAst.Declaration.Trait)(implicit flix: Flix): DesugaredAst.Declaration.Trait = trait0 match {
-    case WeededAst.Declaration.Trait(doc, ann, mod, ident, tparam0, superTraits0, assocs0, sigs0, laws0, loc) =>
+    case WeededAst.Declaration.Trait(doc, ann, mod, ident, tparam0, superTraits0, assocs0, sigs0, loc) =>
       val tparam = visitTypeParam(tparam0)
       val superTraits = superTraits0.map(visitTraitConstraint)
       val assocs = assocs0.map(visitAssocTypeSig)
       val sigs = sigs0.map(visitSig)
-      val laws = laws0.map(visitDef)
-      DesugaredAst.Declaration.Trait(doc, ann, mod, ident, tparam, superTraits, assocs, sigs, laws, loc)
+      DesugaredAst.Declaration.Trait(doc, ann, mod, ident, tparam, superTraits, assocs, sigs, loc)
   }
 
   /**
@@ -136,20 +134,6 @@ object Desugar {
       val tconstrs = tconstrs0.map(visitTraitConstraint)
       val econstrs = econstrs0.map(visitEqualityConstraint)
       DesugaredAst.Declaration.Def(doc, ann, mod, ident, tparams, fparams, exp, tpe, eff, tconstrs, econstrs, loc)
-  }
-
-  /**
-    * Desugars the given [[WeededAst.Declaration.Law]] `law0`.
-    */
-  private def visitLaw(law0: WeededAst.Declaration.Law)(implicit flix: Flix): DesugaredAst.Declaration.Law = law0 match {
-    case WeededAst.Declaration.Law(doc, ann, mod, ident, tparams0, fparams0, exp0, tpe0, eff0, tconstrs0, loc) =>
-      val tparams = tparams0.map(visitTypeParam)
-      val fparams = visitFormalParams(fparams0)
-      val exp = visitExp(exp0)
-      val tpe = visitType(tpe0)
-      val eff = visitType(eff0)
-      val tconstrs = tconstrs0.map(visitTraitConstraint)
-      DesugaredAst.Declaration.Law(doc, ann, mod, ident, tparams, fparams, exp, tpe, eff, tconstrs, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -381,7 +381,7 @@ object HtmlDocumentor {
     * i.e. this should be called before `pairModules`.
     */
   private def filterTrait(trt: Trait): Trait = trt match {
-    case Trait(TypedAst.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, _, laws, loc), signatures, defs, instances, parent, _) =>
+    case Trait(TypedAst.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, _, loc), signatures, defs, instances, parent, _) =>
       Trait(
         TypedAst.Trait(
           doc,
@@ -392,7 +392,6 @@ object HtmlDocumentor {
           superTraits,
           assocs,
           Nil,
-          laws.filter(l => l.spec.mod.isPublic),
           loc
         ),
         signatures.filter(s => s.spec.mod.isPublic),

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -17,7 +17,6 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.shared.SymUse.TraitSymUse
 import ca.uwaterloo.flix.language.ast.shared.{EqualityConstraint, Instance, RegionScope, TraitConstraint}
 import ca.uwaterloo.flix.language.ast.{ChangeSet, RigidityEnv, Scheme, Symbol, Type, TypeConstructor, TypedAst}
@@ -56,35 +55,8 @@ object Instances {
     implicit val sctx: SharedContext = SharedContext.mk()
     flix.phaseNew("Instances") {
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList2(_)(checkInstancesOfTrait(_, root)))
-      val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
-      (root.copy(instances = instances, traits = traits), sctx.errors.asScala.toList)
+      (root.copy(instances = instances), sctx.errors.asScala.toList)
     }
-  }
-
-
-  /**
-    * Checks that all signatures in `trait0` are used in laws if `trait0` is marked `lawful`.
-    */
-  private def checkLawApplication(trait0: TypedAst.Trait)(implicit sctx: SharedContext): Unit = trait0 match {
-    // Case 1: lawful trait
-    case TypedAst.Trait(_, _, mod, _, _, _, _, sigs, laws, _) if mod.isLawful =>
-      val usedSigs = laws.foldLeft(Set.empty[Symbol.SigSym]) {
-        case (acc, TypedAst.Def(_, _, exp, _)) => acc ++ TypedAstOps.sigSymsOf(exp)
-      }
-      val unusedSigs = sigs.map(_.sym).toSet -- usedSigs
-      unusedSigs.toList.foreach {
-        sig => sctx.errors.add(InstanceError.UnlawfulSignature(sig, sig.loc))
-      }
-    // Case 2: non-lawful trait
-    case _ => ()
-  }
-
-  /**
-    * Performs validations on a single trait.
-    */
-  private def visitTrait(trait0: TypedAst.Trait)(implicit sctx: SharedContext): TypedAst.Trait = {
-    checkLawApplication(trait0)
-    trait0
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -227,7 +227,7 @@ object Kinder {
     * Performs kinding on the given trait.
     */
   private def visitTrait(trt: ResolvedAst.Declaration.Trait, root: ResolvedAst.Root)(implicit renv: RootEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): KindedAst.Trait = trt match {
-    case ResolvedAst.Declaration.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, sigs0, laws0, loc) =>
+    case ResolvedAst.Declaration.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, sigs0, loc) =>
       val kenv = getKindEnvFromTypeParam(tparam0)
       val tparam = visitTypeParam(tparam0, kenv)
       val superTraits = superTraits0.map(visitTraitConstraint(_, kenv, root))
@@ -237,8 +237,7 @@ object Kinder {
           val sig = visitSig(sig0, tparam, kenv, root)
           sigSym -> sig
       }
-      val laws = laws0.map(visitDef(_, kenv, root)) // TODO ASSOC-TYPES need to include super traits?
-      KindedAst.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, laws, loc)
+      KindedAst.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, loc)
   }
 
   /**
@@ -314,7 +313,7 @@ object Kinder {
   private def visitDef(def0: ResolvedAst.Declaration.Def, kenv0: KindEnv, root: ResolvedAst.Root)(implicit renv: RootEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): KindedAst.Def = def0 match {
     case ResolvedAst.Declaration.Def(sym, spec0, exp0, loc) =>
       // For a top-level def the spec and its kind environment were already computed
-      // in `visitDefSpecs`, so we reuse them. Instance defs and laws are not in
+      // in `visitDefSpecs`, so we reuse them. Instance defs are not in
       // `defSpecs`, so we compute them here under the given `kenv0`.
       val (spec, kenv) = renv.defSpecs.getOrElse(sym, {
         val kenv = getKindEnvFromSpec(spec0, kenv0, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -86,8 +86,6 @@ object Lexer {
       ("instance", TokenKind.KeywordInstance),
       ("instanceof", TokenKind.KeywordInstanceOf),
       ("into", TokenKind.KeywordInto),
-      ("law", TokenKind.KeywordLaw),
-      ("lawful", TokenKind.KeywordLawful),
       ("lazy", TokenKind.KeywordLazy),
       ("let", TokenKind.KeywordLet),
       ("match", TokenKind.KeywordMatch),

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -194,7 +194,6 @@ object Namer {
     case decl: DesugaredAst.Declaration.RestrictableEnum => visitRestrictableEnum(decl, ns0)
     case decl: DesugaredAst.Declaration.TypeAlias => visitTypeAlias(decl, ns0)
     case decl: DesugaredAst.Declaration.Effect => visitEffect(decl, ns0)
-    case decl: DesugaredAst.Declaration.Law => throw InternalCompilerException("unexpected law", decl.loc)
   }
 
   /**
@@ -258,7 +257,7 @@ object Namer {
       val table3 = addUsesToTable(table2, sym.ns, usesAndImports)
       liftCompanion(table3, sym, decls)
 
-    case NamedAst.Declaration.Trait(_, _, _, sym, _, _, assocs, sigs, _, _) =>
+    case NamedAst.Declaration.Trait(_, _, _, sym, _, _, assocs, sigs, _) =>
       val table1 = tryAddToTable(table0, sym.namespace, sym.name, decl)
       val assocsAndSigs = assocs ++ sigs
       assocsAndSigs.foldLeft(table1)(tableDecl)
@@ -694,7 +693,7 @@ object Namer {
     * Performs naming on the given trait `trt`.
     */
   private def visitTrait(trt: DesugaredAst.Declaration.Trait, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): NamedAst.Declaration.Trait = trt match {
-    case DesugaredAst.Declaration.Trait(doc, ann, mod0, ident, tparams0, superTraits, assocs, signatures, laws, loc) =>
+    case DesugaredAst.Declaration.Trait(doc, ann, mod0, ident, tparams0, superTraits, assocs, signatures, loc) =>
       if (isReservedName(ident.name)) {
         sctx.errors.add(NameError.IllegalReservedName(ident))
       }
@@ -708,9 +707,8 @@ object Namer {
       val sts = superTraits.map(visitTraitConstraint)
       val ascs = assocs.map(visitAssocTypeSig(_, sym)) // TODO switch param order to match visitSig
       val sigs = signatures.map(visitSig(_, ns0, sym))
-      val ls = laws.map(visitDef(_, ns0, DefKind.Member))
 
-      NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, sts, ascs, sigs, ls, loc)
+      NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, sts, ascs, sigs, loc)
   }
 
   /**
@@ -1746,7 +1744,7 @@ object Namer {
     * Gets the location of the symbol of the declaration.
     */
   private def getSymLocation(f: NamedAst.Declaration): SourceLocation = f match {
-    case NamedAst.Declaration.Trait(_, _, _, sym, _, _, _, _, _, _) => sym.loc
+    case NamedAst.Declaration.Trait(_, _, _, sym, _, _, _, _, _) => sym.loc
     case NamedAst.Declaration.Sig(sym, _, _, _) => sym.loc
     case NamedAst.Declaration.Def(sym, _, _, _) => sym.loc
     case NamedAst.Declaration.Enum(_, _, _, sym, _, _, _, _) => sym.loc

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1020,7 +1020,6 @@ object Parser2 {
           modifiers()
           nth(0) match {
             case TokenKind.CurlyR => continue = false
-            case TokenKind.KeywordLaw => lawDecl(openBefore(docMark))
             case TokenKind.KeywordDef => signatureDecl(openBefore(docMark))
             case TokenKind.KeywordType => associatedTypeSigDecl(openBefore(docMark))
             case at =>
@@ -1030,7 +1029,7 @@ object Parser2 {
               while (!nth(0).isFirstInTraitDecl && !eat(TokenKind.CurlyR) && !eof()) {
                 advance()
               }
-              val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordType, TokenKind.KeywordDef, TokenKind.KeywordLaw)), actual = Some(at), sctx, loc = loc)
+              val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordType, TokenKind.KeywordDef)), actual = Some(at), sctx, loc = loc)
               closeWithError(errMark, error, Some(at))
           }
         }
@@ -1143,29 +1142,6 @@ object Parser2 {
 
       val treeKind = if (declKind == TokenKind.KeywordRedef) TreeKind.Decl.Redef else TreeKind.Decl.Def
       close(mark, treeKind)
-    }
-
-    private def lawDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
-      implicit val sctx: SyntacticContext = SyntacticContext.Decl.Module
-      assert(at(TokenKind.KeywordLaw))
-      expect(TokenKind.KeywordLaw)
-      nameUnqualified(NAME_FUNCTION)
-      expect(TokenKind.Colon)
-      expect(TokenKind.KeywordForall)
-      if (at(TokenKind.BracketL)) {
-        Type.parameters()
-      }
-      if (at(TokenKind.ParenL)) {
-        parameters()
-      }
-      if (at(TokenKind.KeywordWith)) {
-        Type.constraints()
-      }
-      if (at(TokenKind.KeywordWhere)) {
-        equalityConstraints()
-      }
-      Expr.expression()
-      close(mark, TreeKind.Decl.Law)
     }
 
     private def enumerationDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -56,7 +56,6 @@ object PredDeps {
   }
 
   private def visitTrait(trt: Trait)(implicit sctx: SharedContext): Trait = {
-    trt.laws.foreach(visitDef)
     trt.sigs.foreach(visitSig)
     trt
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -350,7 +350,7 @@ object Resolver {
             case decls => ResolvedAst.Declaration.Mod(doc, ann, mod, sym, usesAndImports, decls, loc)
           }
       }
-    case trt@NamedAst.Declaration.Trait(_, _, _, _, _, _, _, _, _, _) =>
+    case trt@NamedAst.Declaration.Trait(_, _, _, _, _, _, _, _, _) =>
       resolveTrait(trt, scp0, ns0)
     case inst@NamedAst.Declaration.Instance(_, _, _, _, _, _, _, _, _, _, _, _) =>
       resolveInstance(inst, scp0, ns0)
@@ -414,19 +414,17 @@ object Resolver {
     * Resolves all the traits in the given root.
     */
   private def resolveTrait(c0: NamedAst.Declaration.Trait, scp0: LocalScope, ns0: Name.NName)(implicit taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): Validation[ResolvedAst.Declaration.Trait, ResolutionError] = c0 match {
-    case NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, signatures, laws0, loc) =>
+    case NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, signatures, loc) =>
       val tparam = resolveTypeParam(tparam0, scp0, ns0, root)
       val scp = scp0 ++ mkTypeParamScp(List(tparam))
       // ignore the parameter of the super traits; we don't use it
       val superTraitsVal = traverse(superTraits0)(tconstr => resolveSuperTrait(tconstr, scp, taenv, ns0, root))
-      val tconstr = ResolvedAst.TraitConstraint(TraitSymUse(sym, sym.loc), UnkindedType.Var(tparam.sym, tparam.sym.loc), sym.loc)
       val assocs = assocs0.map(resolveAssocTypeSig(_, scp, taenv, ns0, root))
       val sigsList = signatures.map(resolveSig(_, sym, tparam.sym, scp)(ns0, taenv, sctx, root, flix))
-      val laws = laws0.map(resolveDef(_, Some(tconstr), scp)(ns0, taenv, sctx, root, flix))
       mapN(superTraitsVal) {
         case superTraits =>
           val sigs = sigsList.map(sig => (sig.sym, sig)).toMap
-          ResolvedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, laws, loc)
+          ResolvedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, loc)
       }
   }
 
@@ -2898,7 +2896,7 @@ object Resolver {
       // Then see if there's a module with this name declared in our namespace
       root.symbols.getOrElse(ns0, Map.empty).getOrElse(name, Nil).collectFirst {
         case Declaration.Mod(_, _, _, sym, _, _, _, _) => sym.ns
-        case Declaration.Trait(_, _, _, sym, _, _, _, _, _, _) => sym.namespace :+ sym.name
+        case Declaration.Trait(_, _, _, sym, _, _, _, _, _) => sym.namespace :+ sym.name
         case Declaration.Enum(_, _, _, sym, _, _, _, _) => sym.namespace :+ sym.name
         case Declaration.Struct(_, _, _, sym, _, _, _) => sym.namespace :+ sym.name
         case Declaration.RestrictableEnum(_, _, _, sym, _, _, _, _, _) => sym.namespace :+ sym.name
@@ -2908,7 +2906,7 @@ object Resolver {
       // Then see if there's a module with this name declared in the root namespace
       root.symbols.getOrElse(Name.RootNS, Map.empty).getOrElse(name, Nil).collectFirst {
         case Declaration.Mod(_, _, _, sym, _, _, _, _) => sym.ns
-        case Declaration.Trait(_, _, _, sym, _, _, _, _, _, _) => sym.namespace :+ sym.name
+        case Declaration.Trait(_, _, _, sym, _, _, _, _, _) => sym.namespace :+ sym.name
         case Declaration.Enum(_, _, _, sym, _, _, _, _) => sym.namespace :+ sym.name
         case Declaration.Struct(_, _, _, sym, _, _, _) => sym.namespace :+ sym.name
         case Declaration.RestrictableEnum(_, _, _, sym, _, _, _, _, _) => sym.namespace :+ sym.name
@@ -3283,7 +3281,7 @@ object Resolver {
     */
   private def getSym(symbol: NamedAst.Declaration): Symbol = symbol match {
     case NamedAst.Declaration.Mod(_, _, _, sym, _, _, _, _) => sym
-    case NamedAst.Declaration.Trait(_, _, _, sym, _, _, _, _, _, _) => sym
+    case NamedAst.Declaration.Trait(_, _, _, sym, _, _, _, _, _) => sym
     case NamedAst.Declaration.Sig(sym, _, _, _) => sym
     case NamedAst.Declaration.Def(sym, _, _, _) => sym
     case NamedAst.Declaration.Enum(_, _, _, sym, _, _, _, _) => sym

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -68,9 +68,8 @@ object Stratifier {
     * Performs Stratification of the given trait `t0`.
     */
   private def visitTrait(t0: TypedAst.Trait)(implicit g: LabelledPrecedenceGraph, sctx: SharedContext, root: Root, flix: Flix): TypedAst.Trait = {
-    val nl = t0.laws.map(visitDef)
     val ns = t0.sigs.map(visitSig)
-    t0.copy(laws = nl, sigs = ns)
+    t0.copy(sigs = ns)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -233,7 +233,7 @@ object Typer {
     * Reassembles a single trait.
     */
   private def visitTrait(trt: KindedAst.Trait, root: KindedAst.Root, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit sctx: SharedContext, flix: Flix): TypedAst.Trait = trt match {
-    case KindedAst.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, sigs0, laws0, loc) =>
+    case KindedAst.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, sigs0, loc) =>
       val tparam = visitTypeParam(tparam0)
       val renv = RigidityEnv.empty.markRigid(tparam0.sym)
       val superTraits = superTraits0 // no subst to be done
@@ -244,8 +244,7 @@ object Typer {
       }
       val tconstr = TraitConstraint(TraitSymUse(sym, sym.loc), Type.Var(tparam.sym, tparam.loc), sym.loc)
       val sigs = sigs0.values.map(visitSig(_, renv, List(tconstr), root, traitEnv, eqEnv)).toList
-      val laws = laws0.map(visitDef(_, List(tconstr), Nil, renv, root, traitEnv, eqEnv, open = false))
-      TypedAst.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, laws, loc)
+      TypedAst.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -256,7 +256,7 @@ object Weeder2 {
       expect(tree, TreeKind.Decl.Trait)
       val doc = pickDocumentation(tree)
       val ann = pickAnnotations(tree)
-      val mod = pickModifiers(tree, allowed = Set(TokenKind.KeywordLawful, TokenKind.KeywordPub, TokenKind.KeywordSealed))
+      val mod = pickModifiers(tree, allowed = Set(TokenKind.KeywordPub, TokenKind.KeywordSealed))
       val ident = pickNameIdent(tree)
       val tparamsList = pick(TreeKind.TypeParameterList, tree)
       if (pickAll(TreeKind.Parameter, tparamsList).length != 1) {
@@ -267,9 +267,7 @@ object Weeder2 {
       val assocs = pickAll(TreeKind.Decl.AssociatedTypeSig, tree).map(visitAssociatedTypeSigDecl(_, tparam))
       val sigs = pickAll(TreeKind.Decl.Signature, tree)
       val sigs0 = sigs.map(visitSignatureDecl)
-      val laws = pickAll(TreeKind.Decl.Law, tree)
-      val laws0 = laws.map(visitLawDecl)
-      Declaration.Trait(doc, ann, mod, ident, tparam, tconstr, assocs, sigs0, laws0, tree.loc)
+      Declaration.Trait(doc, ann, mod, ident, tparam, tconstr, assocs, sigs0, tree.loc)
     }
 
     private def visitInstanceDecl(tree: Tree)(implicit sctx: SharedContext, flix: Flix): Declaration.Instance = {
@@ -336,22 +334,6 @@ object Weeder2 {
       val tconstrs = Types.pickConstraints(tree)
       val constrs = pickEqualityConstraints(tree)
       Declaration.Redef(doc, ann, mod, ident, tparams, fparams, exp, ttype, eff, tconstrs, constrs, tree.loc)
-    }
-
-    private def visitLawDecl(tree: Tree)(implicit sctx: SharedContext): Declaration.Def = {
-      val doc = pickDocumentation(tree)
-      val ann = pickAnnotations(tree)
-      val mod = pickModifiers(tree, allowed = Set.empty)
-      val ident = pickNameIdent(tree)
-      val tparams = Types.pickKindedParameters(tree)
-      val fparams = pickFormalParameters(tree)
-      val expr = Exprs.pickExpr(tree)
-      val tpe = WeededAst.Type.Ambiguous(Name.mkQName("Bool"), ident.loc)
-      val eff = None
-      val tconstrs = Types.pickConstraints(tree)
-      val econstrs = pickEqualityConstraints(tree)
-      // TODO: There is a `Declaration.Law` but old Weeder produces a Def
-      Declaration.Def(doc, ann, mod, ident, tparams, fparams, expr, tpe, eff, tconstrs, econstrs, tree.loc)
     }
 
     private def visitEnumDecl(tree: Tree)(implicit sctx: SharedContext): Declaration.Enum = {
@@ -656,7 +638,6 @@ object Weeder2 {
 
     private val ALL_MODIFIERS: Set[TokenKind] = Set(
       TokenKind.KeywordSealed,
-      TokenKind.KeywordLawful,
       TokenKind.KeywordPub,
       TokenKind.KeywordOverride,
       TokenKind.KeywordMut)
@@ -693,7 +674,6 @@ object Weeder2 {
       }
       token.kind match {
         case TokenKind.KeywordSealed => Modifier.Sealed
-        case TokenKind.KeywordLawful => Modifier.Lawful
         case TokenKind.KeywordPub => Modifier.Public
         case TokenKind.KeywordMut => Modifier.Mutable
         case TokenKind.KeywordOverride => Modifier.Override

--- a/main/src/library/Applicative.flix
+++ b/main/src/library/Applicative.flix
@@ -36,7 +36,7 @@ pub mod Applicative {
     ///     `ap(f: m[a -> b \ e], x: m[a]): m[b] \ ef = map2(identity, f, x)`
     ///     `map2(f: a -> b -> c \ e, x: m[a], y: m[b]): m[c] \ ef = ap(Functor.map(f, x), y)`
     ///
-    pub lawful trait Applicative[m: Type -> Type] with Functor[m] {
+    pub trait Applicative[m: Type -> Type] with Functor[m] {
         ///
         /// Puts `x` into a default context.
         ///
@@ -74,54 +74,6 @@ pub mod Applicative {
         /// (which is `Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)`).
         ///
         pub def map5(f: t1 -> t2 -> t3 -> t4 -> t5 -> r \ ef, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]): m[r] \ ef = Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
-
-        ///
-        /// Applying the identity function wrapped into an applicative preserves every applicative value.
-        ///
-        law identity: forall (x: m[a]) with Eq[m[a]] Applicative.ap(Applicative.point(identity), x) == x
-
-        ///
-        /// Applicatively composing two functions and then applicatively applying the resulting function is the same
-        /// as applicatively applying the functions one by one.
-        ///
-        law composition: forall (f: m[b -> c], g: m[a -> b], v: m[a]) with Eq[m[c]] Applicative.ap(Applicative.ap(Applicative.ap(Applicative.point((f, g) -> g >> f), f), g), v) == Applicative.ap(f, Applicative.ap(g, v))
-
-        ///
-        /// `point` is a homomorphism from normal to applicative values regarding application (normal vs. applicative).
-        ///
-        // TODO error in type checker does not allow to compile this, see #2099
-        // law homomorphism: forall(f: a -> b, x: a) with Eq[m[b]] Applicative.ap(Applicative.point(f), Applicative.point(x)) == Applicative.point(f(x))
-
-        ///
-        /// Directly applicatively applying a function `f` to an argument `x` put into a default context is the same as putting the function that takes a function and applies it to `x` into a default context and applicatively applying it to `f`.
-        ///
-        law interchange: forall (f: m[a -> b], x: a) with Eq[m[b]] Applicative.ap(f, Applicative.point(x)) == Applicative.ap(Applicative.point(f -> f(x)), f)
-
-        ///
-        /// `map2` is equivalent to its default implementation.
-        ///
-        law map2Correspondence: forall (f: t1 -> t2 -> r, x1: m[t1], x2: m[t2]) with Eq[m[r]] Applicative.map2(f, x1, x2) == Applicative.ap(Functor.map(f, x1), x2)
-
-        ///
-        /// `map3` is equivalent to its default implementation.
-        ///
-        law map3Correspondence: forall (f: t1 -> t2 -> t3 -> r, x1: m[t1], x2: m[t2], x3: m[t3]) with Eq[m[r]] Applicative.map3(f, x1, x2, x3) == Applicative.ap(Applicative.map2(f, x1, x2), x3)
-
-        ///
-        /// `map4` is equivalent to its default implementation.
-        ///
-        law map4Correspondence: forall (f: t1 -> t2 -> t3 -> t4 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]) with Eq[m[r]] Applicative.map4(f, x1, x2, x3, x4) == Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)
-
-        ///
-        /// `map5` is equivalent to its default implementation.
-        ///
-        law map5Correspondence: forall (f: t1 -> t2 -> t3 -> t4 -> t5 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]) with Eq[m[r]] Applicative.map5(f, x1, x2, x3, x4, x5) == Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
-
-        ///
-        /// Mapping a function over an applicative (with `Functor.map`) is the same as putting the function
-        /// into a default context and applying it to the applicative.
-        ///
-        law mapCorrespondence: forall (f: a -> b, x: m[a]) with Eq[m[b]] Functor.map(f, x) == Applicative.ap(Applicative.point(f), x)
     }
 
     ///

--- a/main/src/library/CommutativeGroup.flix
+++ b/main/src/library/CommutativeGroup.flix
@@ -22,7 +22,7 @@ pub mod CommutativeGroup {
     ///
     /// The default instances for number define the additive inverse in the real numbers.
     ///
-    pub lawful trait CommutativeGroup[a] with Group[a], CommutativeMonoid[a] {}
+    pub trait CommutativeGroup[a] with Group[a], CommutativeMonoid[a] {}
 
     instance CommutativeGroup[Unit]
 

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -19,7 +19,7 @@ pub mod CommutativeMonoid {
     ///
     /// A trait for types that form a commutative monoid.
     ///
-    pub lawful trait CommutativeMonoid[a] with Monoid[a] {
+    pub trait CommutativeMonoid[a] with Monoid[a] {
 
         ///
         /// Returns a neutral element.
@@ -31,15 +31,6 @@ pub mod CommutativeMonoid {
         ///
         pub def combine(x: a, y: a): a =
             Monoid.combine(x, y)
-
-        law leftIdentity: forall (x: a) with Eq[a] CommutativeMonoid.combine(CommutativeMonoid.empty(), x) == x
-
-        law rightIdentity: forall (x: a) with Eq[a] CommutativeMonoid.combine(x, CommutativeMonoid.empty()) == x
-
-        law associative: forall (x: a, y: a, z: a) with Eq[a] CommutativeMonoid.combine(CommutativeMonoid.combine(x, y), z) == CommutativeMonoid.combine(x, CommutativeMonoid.combine(y, z))
-
-        law commutative: forall (x: a, y: a) with Eq[a] CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
-
     }
 
     instance CommutativeMonoid[Unit]

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -24,17 +24,12 @@ pub mod CommutativeSemiGroup {
     ///
     /// A trait for types that form a commutative semigroup.
     ///
-    pub lawful trait CommutativeSemiGroup[a] with SemiGroup[a] {
+    pub trait CommutativeSemiGroup[a] with SemiGroup[a] {
 
         ///
         /// An associative & commutative binary operation on `a`.
         ///
         pub def combine(x: a, y: a): a = SemiGroup.combine(x, y)
-
-        law associative: forall (x: a, y: a, z: a) with Eq[a] CommutativeSemiGroup.combine(CommutativeSemiGroup.combine(x, y), z) == CommutativeSemiGroup.combine(x, CommutativeSemiGroup.combine(y, z))
-
-        law commutative: forall (x: a, y: a) with Eq[a] CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
-
     }
 
     instance CommutativeSemiGroup[Unit]

--- a/main/src/library/Eq.flix
+++ b/main/src/library/Eq.flix
@@ -16,12 +16,10 @@
 
 pub mod Eq {
 
-    use Bool.{==>, <==>}
-
     ///
     /// A trait for equality and inequality.
     ///
-    pub lawful trait Eq[a] {
+    pub trait Eq[a] {
 
         ///
         /// Returns `true` if and only if `x` is equal to `y`.
@@ -32,26 +30,6 @@ pub mod Eq {
         /// Returns `true` if and only if `x` is not equal to `y`.
         ///
         pub def neq(x: a, y: a): Bool = not Eq.eq(x, y)
-
-        ///
-        /// Reflexivity: An element `x` is equal to itself.
-        ///
-        law reflexivity: forall (x: a) x == x
-
-        ///
-        /// Symmetry: If `x` is equal to `y` then `y` must also be equal to `x`.
-        ///
-        law symmetry: forall (x: a, y: a) (x == y) ==> (y == x)
-
-        ///
-        /// Transitivity: If `x` is equal to `y` and `y` is equal to `z` then `x` must be equal to `z`.
-        ///
-        law transitivity: forall (x: a, y: a, z: a) ((x == y) and (y == z)) ==> (x == z)
-
-        ///
-        /// x != y is logically equivalent to not (x == y).
-        ///
-        law inverseNeq: forall (x: a, y: a) (x != y) <==> (not (x == y))
     }
 
     instance Eq[Unit] {

--- a/main/src/library/Functor.flix
+++ b/main/src/library/Functor.flix
@@ -19,22 +19,11 @@ pub mod Functor {
     ///
     /// A trait for types that can be mapped over.
     ///
-    pub lawful trait Functor[m: Type -> Type] {
+    pub trait Functor[m: Type -> Type] {
         ///
         /// Applies the function `f` to `x` preserving its structure.
         ///
         pub def map(f: a -> b \ ef, x: m[a]): m[b] \ ef
-
-        ///
-        /// Mapping the identity function over a functor preserves the functor.
-        ///
-        law identity: forall (x: m[a]) with Eq[m[a]] Functor.map(identity, x) == x
-
-        ///
-        /// Composing two functions and mapping the resulting function over a functor is the same as
-        /// mapping the functions one after the other over the functor.
-        ///
-        law composition: forall (f: b -> c, g: a -> b, v: m[a]) with Eq[m[c]] Functor.map(g >> f, v) == Functor.map(f, Functor.map(g, v))
     }
 
     ///

--- a/main/src/library/Group.flix
+++ b/main/src/library/Group.flix
@@ -47,25 +47,6 @@ pub mod Group {
         ///
         pub def remove(x: a, y: a): a =
             Group.combine(x, Group.inverse(y))
-
-        ///
-        /// Combining the inverse of `x` with `x` yields the neutral element in the group.
-        ///
-        /// The operation is commutative i.e. if `y` is the inverse of `x` and `e` is the
-        /// identity (neutral element) then
-        /// `combine(x, y) == combine(y, x) == e`
-        ///
-        law leftInvertible: forall (x: a) with Eq[a] Group.combine(Group.inverse(x), x) == Group.empty()
-
-        ///
-        /// Combining the inverse of `x` with `x` yields the neutral element in the group.
-        ///
-        /// The operation is commutative i.e. if `y` is the inverse of `x` and `e` is the
-        /// identity (neutral element) then
-        /// `combine(x, y) == combine(y, x) == e`
-        ///
-        law rightInvertible: forall (x: a) with Eq[a] Group.combine(x, Group.inverse(x)) == Group.empty()
-
     }
 
     instance Group[Unit] {

--- a/main/src/library/Hash.flix
+++ b/main/src/library/Hash.flix
@@ -16,8 +16,6 @@
 
 pub mod Hash {
 
-    use Bool.{==>}
-
     import java.lang.Byte
     import java.lang.Character
     import java.lang.Double
@@ -29,16 +27,11 @@ pub mod Hash {
     ///
     /// A trait for types that can be hashed.
     ///
-    pub lawful trait Hash[a] {
+    pub trait Hash[a] {
         ///
         /// Returns a hash value for the given x.
         ///
         pub def hash(x: a): Int32
-
-        ///
-        /// Hash values are consistent with equality: equal values have equal hashes.
-        ///
-        law consistency: forall (x: a, y: a) with Eq[a] (x == y) ==> (Hash.hash(x) == Hash.hash(y))
     }
 
     instance Hash[Unit] {

--- a/main/src/library/JoinLattice.flix
+++ b/main/src/library/JoinLattice.flix
@@ -17,32 +17,15 @@
 
 pub mod JoinLattice {
 
-    use Bool.{==>}
-
     ///
     /// A trait for join semi lattices.
     ///
-    pub lawful trait JoinLattice[a] with PartialOrder[a] {
+    pub trait JoinLattice[a] with PartialOrder[a] {
 
         ///
         /// Returns the least upper bound of `x` and `y`.
         ///
         pub def leastUpperBound(x: a, y: a): a
-
-        ///
-        /// The law asserts that the least upper bound operator returns
-        /// an element that is greater than or equal to each of its arguments.
-        ///
-        law leastUpperBound1: forall (x: a, y: a) PartialOrder.lessEqual(x, JoinLattice.leastUpperBound(x, y))
-            and PartialOrder.lessEqual(y, JoinLattice.leastUpperBound(x, y))
-
-        ///
-        /// The law asserts that the least upper bound operator returns
-        /// the smallest element that is larger than its two arguments.
-        ///
-        law leastUpperBound2: forall (x: a, y: a, z: a) (PartialOrder.lessEqual(x, z) and PartialOrder.lessEqual(y, z))
-            ==> PartialOrder.lessEqual(JoinLattice.leastUpperBound(x, y), z)
-
     }
 
     instance JoinLattice[Int8] {

--- a/main/src/library/MeetLattice.flix
+++ b/main/src/library/MeetLattice.flix
@@ -16,34 +16,17 @@
 
 pub mod MeetLattice {
 
-    use Bool.{==>}
-
     ///
     /// A trait for meet semi lattices.
     /// A Meet Lattice is pair of functions (⊑, ⊓) where ⊑ is a partial order and ⊓ satisfy two properties:
     /// lower-bound and greatest-lower-bound.
     ///
-    pub lawful trait MeetLattice[a] with PartialOrder[a] {
+    pub trait MeetLattice[a] with PartialOrder[a] {
 
         ///
         /// Returns the greatest lower bound of `x` and `y`.
         ///
         pub def greatestLowerBound(x: a, y: a): a
-
-        ///
-        /// The lower bound law asserts that the greatest lower bound operator returns an element that
-        /// is less than or equal to each of its arguments.
-        ///
-        law greatestLowerBound1: forall (x: a, y: a) PartialOrder.lessEqual(MeetLattice.greatestLowerBound(x, y), x)
-            and PartialOrder.lessEqual(MeetLattice.greatestLowerBound(x, y), y)
-
-        ///
-        /// The greatest lower bound law asserts that the greatest lower bound operator returns the
-        /// largest element that is smaller than its two arguments.
-        ///
-        law greatestLowerBound2: forall (x: a, y: a, z: a) (PartialOrder.lessEqual(z, x) and PartialOrder.lessEqual(z, y))
-            ==> PartialOrder.lessEqual(z, MeetLattice.greatestLowerBound(x, y))
-
     }
 
     instance MeetLattice[Int8] {

--- a/main/src/library/Monad.flix
+++ b/main/src/library/Monad.flix
@@ -22,35 +22,12 @@ pub mod Monad {
     /// supports extraction of monadic values, or, viewed differently, allows to combine (flatten) nested
     /// monadic values (`flapMap` can be understood as a `Functor.map` followed by a `flatten`).
     ///
-    pub lawful trait Monad[m: Type -> Type] with Applicative[m] {
+    pub trait Monad[m: Type -> Type] with Applicative[m] {
 
         ///
         /// Apply function `f` to the monadic value `x`, resulting in a combined monadic value.
         ///
         pub def flatMap(f: a -> m[b] \ ef, x: m[a]): m[b] \ ef
-
-        ///
-        /// Applying `flatMap` to the `point` function is the identity function.
-        ///
-        law leftIdentity: forall (f: a -> m[b], x: m[a]) with Eq[m[a]] Monad.flatMap(Applicative.point, x) == x
-
-        ///
-        /// Applying `flatMap` to a function and to a non-monadic argument after applying `point` to it is the same
-        /// as applying the function directly to that argument.
-        ///
-        law rightIdentity: forall (f: a -> m[b], x: a) with Eq[m[b]] Monad.flatMap(f, Applicative.point(x)) == f(x)
-
-        ///
-        /// Subsequent `flatMap` calls (nested in the monadic argument) can be moved to the outside by
-        /// providing a lambda as first argument which then calls `flatMap`.
-        ///
-        law associativity: forall (x: m[a], f: a -> m[b], g: b -> m[c]) with Eq[m[c]] Monad.flatMap(g, Monad.flatMap(f, x)) == Monad.flatMap(y -> Monad.flatMap(g, f(y)), x)
-
-        ///
-        /// Applicatively applying a monadic function to a monadic argument is the same as using `flatMap`
-        /// to extract function and argument, applying them normally and then applying `point` to the result.
-        ///
-        law apCorrespondence: forall (f: m[a -> b], x: m[a]) with Eq[m[b]] Applicative.ap(f, x) == Monad.flatMap(g -> Monad.flatMap(y -> Applicative.point(g(y)), x), f)
     }
 
     ///

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -20,7 +20,7 @@ pub mod Monoid {
     /// A trait for Monoids, objects that support an associative binary
     /// operation `combine` and neutral element `empty`.
     ///
-    pub lawful trait Monoid[a] with SemiGroup[a] {
+    pub trait Monoid[a] with SemiGroup[a] {
         ///
         /// Returns a neutral element.
         ///
@@ -31,13 +31,6 @@ pub mod Monoid {
         ///
         pub def combine(x: a, y: a): a =
             SemiGroup.combine(x, y)
-
-        law leftIdentity: forall (x: a) with Eq[a] Monoid.combine(Monoid.empty(), x) == x
-
-        law rightIdentity: forall (x: a) with Eq[a] Monoid.combine(x, Monoid.empty()) == x
-
-        law associative: forall (x: a, y: a, z: a) with Eq[a] Monoid.combine(Monoid.combine(x, y), z) == Monoid.combine(x, Monoid.combine(y, z))
-
     }
 
     instance Monoid[Unit] {

--- a/main/src/library/Order.flix
+++ b/main/src/library/Order.flix
@@ -16,12 +16,10 @@
 
 pub mod Order {
 
-    use Bool.{==>, <==>}
-
     ///
     /// A trait for types with a total order.
     ///
-    pub lawful trait Order[a] with Eq[a] {
+    pub trait Order[a] with Eq[a] {
 
         ///
         /// Returns `Comparison.LessThan` if `x` < `y`, `Equal` if `x` == `y` or `Comparison.GreaterThan` `if `x` > `y`.
@@ -77,57 +75,6 @@ pub mod Order {
             case Comparison.LessThan => y
             case _                   => x
         }
-
-        ///
-        /// Reflexivity: An element `x` is lower or equal to itself.
-        ///
-        law reflexivity: forall (x: a) x <= x
-
-        ///
-        /// Antisymmetry: If `x` is lower or equal to `y` and `y` is lower or equal to `x` then `x` must be equal to `y`.
-        ///
-        law symmetry: forall (x: a, y: a) ((x <= y) and (y <= x)) ==> (x == y)
-
-        ///
-        /// Transitivity: If `x` is lower or equal to `y` and `y` is lower equal to `z` then `x` must be lower or equal to `z`.
-        ///
-        law transitivity: forall (x: a, y: a, z: a) ((x <= y) and (y <= z)) ==> (x <= z)
-
-        ///
-        /// Totality: For each two elements `x` and `y` either `x` is lower or equal to `y` or the other way round.
-        ///
-        law totality: forall (x: a, y: a) ((x <= y) or (y <= x))
-
-        ///
-        /// Definition of the minimum function.
-        ///
-        law min: forall (x: a, y: a) ((x <= y) ==> (Order.min(x, y) == x)) and ((y <= x) ==> (Order.min(x, y) == y))
-
-        ///
-        /// Definition of the maximum function.
-        ///
-        law max: forall (x: a, y: a) ((y <= x) ==> (Order.max(x, y) == x)) and ((x <= y) ==> (Order.max(x, y) == y))
-
-        ///
-        /// x < y is logically equivalent to not (y <= x).
-        /// This law defines the associated strict total order "<" associated with "<=".
-        ///
-        law strictTotalOrder: forall (x: a, y: a) (x < y) <==> (not (y <= x))
-
-        ///
-        /// This law defines ">" based on "<".
-        ///
-        law inverseOrder1: forall (x: a, y: a) (x > y) <==> (y < x)
-
-        ///
-        /// This law defines ">=" based on "<=".
-        ///
-        law inverseOrder2: forall (x: a, y: a) (x >= y) <==> (y <= x)
-
-        ///
-        /// Definition of `compare` based on the defined total order.
-        ///
-        law compare: forall (x: a, y: a) ((x < y) ==> (Order.compare(x, y) == Comparison.LessThan)) and ((x == y) ==> (Order.compare(x, y) == Comparison.EqualTo)) and ((x > y) ==> (Order.compare(x, y) == Comparison.GreaterThan))
     }
 
     ///

--- a/main/src/library/PartialOrder.flix
+++ b/main/src/library/PartialOrder.flix
@@ -16,28 +16,16 @@
 
 pub mod PartialOrder {
 
-    use Bool.{==>}
-
     ///
     /// A Partial Order is a function ⊑ which satisfies three properties: reflexivity, anti-symmetry, and transitivity.
     ///
-    pub lawful trait PartialOrder[a] {
+    pub trait PartialOrder[a] {
 
         ///
         /// Returns `true` if `x` is smaller or equal to `y`.
         ///
         pub def lessEqual(x: a, y: a): Bool
         // TODO This should not return a Boolean, but instead perform a three-way comparison.
-
-        ///
-        /// Reflexivity: An element `x` is lower or equal to itself.
-        ///
-        law reflexivity: forall (x: a) PartialOrder.lessEqual(x, x)
-
-        ///
-        /// Transitivity: If `x` is lower or equal to `y` and `y` is lower equal to `z` then `x` must be lower or equal to `z`.
-        ///
-        law transitivity: forall (x: a, y: a, z: a) (PartialOrder.lessEqual(x, y) and PartialOrder.lessEqual(y, z)) ==> PartialOrder.lessEqual(x, z)
     }
 
     instance PartialOrder[Int8] {

--- a/main/src/library/SemiGroup.flix
+++ b/main/src/library/SemiGroup.flix
@@ -38,9 +38,6 @@ pub mod SemiGroup {
                 x
             else
                 SemiGroup.combine(x, SemiGroup.combineN(x, n - 1))
-
-        law associative: forall (x: a, y: a, z: a) with Eq[a] SemiGroup.combine(SemiGroup.combine(x, y), z) == SemiGroup.combine(x, SemiGroup.combine(y, z))
-
     }
 
     instance SemiGroup[Unit] {

--- a/main/src/library/Traversable.flix
+++ b/main/src/library/Traversable.flix
@@ -33,20 +33,6 @@ pub mod Traversable {
         ///
         pub def sequence(t: t[m[a]]): m[t[a]] \ Foldable.Aef[t] with Applicative[m] =
             Traversable.traverse(identity, t)
-
-        ///
-        /// Traversing with the identity function wrapped into an applicative preserves the container `t`
-        /// where accessing elements within `t` is pure.
-        ///
-        law identity: forall (t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {} Traversable.traverse(f, t) == Applicative.point(t)
-
-        ///
-        /// sequence identity.
-        ///
-        law identity: forall (t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {} Traversable.sequence(Functor.map(f, t)) == Applicative.point(t)
-
-        // Missing laws: naturality and composition.
-
     }
 
     ///

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -643,36 +643,6 @@ class TestInstances extends AnyFunSuite with TestUtils {
     expectError[InstanceError.MissingSuperTraitInstance](result)
   }
 
-  test("Test.UnlawfulSignature.01") {
-    val input =
-      """
-        |lawful trait C[a] {
-        |    pub def f(): a
-        |}
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[InstanceError.UnlawfulSignature](result)
-  }
-
-  test("Test.UnlawfulSignature.02") {
-    val input =
-      """
-        |instance C[Int32] {
-        |    pub def f(x: Int32): Bool = true
-        |    pub def g(x: Int32): Bool = true
-        |}
-        |
-        |lawful trait C[a] {
-        |  pub def f(x: a): Bool
-        |  pub def g(x: a): Bool
-        |
-        |  law l: forall (x: a) C.f(x)
-        |}
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[InstanceError.UnlawfulSignature](result)
-  }
-
   test("Test.MultipleErrors.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -1188,17 +1188,6 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  test("KindError.UnexpectedKind.Trait.Law.01") {
-    val input =
-      """
-        |trait C[a: Type -> Type] {
-        |  law l: forall (x: a) ???
-        |}
-        |""".stripMargin
-    val result = check(input, DefaultOptions)
-    expectError[KindError.UnexpectedKind](result)
-  }
-
   test("KindError.UnexpectedKind.Trait.Sig.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParserRecovery.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParserRecovery.scala
@@ -103,19 +103,6 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
-  test("IllegalDefName.05") {
-    val input =
-      """
-        |trait B[a] {
-        |    law A:forall() false
-        |}
-        |def main(): Unit = ()
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibMin)
-    expectError[ParseError](result)
-    expectMain(result)
-  }
-
   test("IllegalDefName.06") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -865,18 +865,6 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
-  test("Test.UnexpectedArgument.04") {
-    val input =
-      """
-        |trait A[a] {
-        |    pub def f(x: Bool, y: a): Bool
-        |    law l: forall (x: Int32, y: Bool) A.f(x, y)
-        |}
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibMin)
-    expectError[TypeError](result)
-  }
-
   test("Test.UnexpectedArgument.05") {
     // Regression test.
     // See https://github.com/flix/flix/issues/3634

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -797,7 +797,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("IllegalModifier.01") {
     val input =
       """
-        |lawful enum A
+        |sealed enum A
         |
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)

--- a/main/test/flix/Test.Dec.Trait.flix
+++ b/main/test/flix/Test.Dec.Trait.flix
@@ -118,11 +118,8 @@ mod Test.Dec.Trait {
     }
 
     mod Test11 {
-        lawful trait C[a] {
+        trait C[a] {
             pub def f(x: a, y: a): Bool
-
-            // TODO handle mods better
-            law reflexivity: forall (x: a, y: a) Test.Dec.Trait.Test11.C.f(x, y) == Test.Dec.Trait.Test11.C.f(y, x)
         }
 
         instance C[Int32] {
@@ -134,11 +131,7 @@ mod Test.Dec.Trait {
         trait C[a] {
             pub def f(): a
 
-            law l: forall (_x: a) true
-
             pub def g(): a
-
-            law m: forall[a: Type](_x: a) true
         }
     }
 
@@ -192,9 +185,7 @@ mod Test.Dec.Trait {
             pub def f(x: a, y: a): Bool
         }
 
-        trait C[a] {
-            law l: forall (x: a, y: a) with D[a] Test.Dec.Trait.Test16.D.f(x, y)
-        }
+        trait C[a]
     }
 
     mod Test17 {
@@ -202,9 +193,7 @@ mod Test.Dec.Trait {
             pub def f(x: a): Bool
         }
 
-        trait E[a: Type -> Type] {
-            law l: forall (x: a[b]) with D[a[b]] Test.Dec.Trait.Test17.D.f(x)
-        }
+        trait E[a: Type -> Type]
     }
 
 }

--- a/main/test/flix/Test.Kind.Trait.flix
+++ b/main/test/flix/Test.Kind.Trait.flix
@@ -50,36 +50,6 @@ mod Test.Kind.Trait {
                 }
             }
         }
-
-        mod Law {
-            mod FormalParams {
-                trait CStar1[a] {
-                    law star: forall(x: a) ???
-                }
-            }
-
-            mod TypeConstraint {
-                trait CStar[a: Type]
-
-                trait CStar1[a] {
-                    law star: forall(x: a) with CStar[a] ???
-                }
-            }
-
-            mod Enum {
-                pub enum EStar[_a: Type]
-
-                trait CStar1[a] {
-                    law star: forall(x: EStar[a]) ???
-                }
-            }
-
-            mod Exp {
-                trait CStar1[a] {
-                    law star: forall(x: a) { discard (???: a); ??? }
-                }
-            }
-        }
     }
 
     mod Explicit {
@@ -147,55 +117,6 @@ mod Test.Kind.Trait {
             mod Exp {
                 trait CStar1[a: Type] {
                     pub def star(x: a): Int32 = let _: a = ???; ???
-                }
-            }
-        }
-
-        mod Law {
-            mod FormalParams {
-                trait CStar1[a: Type] {
-                    law star: forall(x: a) ???
-                }
-
-                trait CStarToStar1[a: Type -> Type] {
-                    law starToStar: forall(x: a[Int32]) ???
-                }
-            }
-
-            mod TypeConstraint {
-                trait CStar[a: Type]
-                trait CStarToStar[a: Type -> Type]
-                trait CBoolToStar[a: Eff -> Type]
-
-                trait CStar1[a: Type] {
-                    law star: forall(x: a) with CStar[a] ???
-                }
-
-                trait CStarToStar1[a: Type -> Type] {
-                    law starToStar: forall(x: a[Int32]) with CStarToStar[a] ???
-                }
-
-                trait CBoolToStar1[a: Eff -> Type] {
-                    law boolToStar: forall(x: a[{}]) with CBoolToStar[a] ???
-                }
-            }
-
-            mod Enum {
-                pub enum EStar[_a: Type]
-                pub enum EStarToStar[_a: Type -> Type]
-
-                trait CStar1[a: Type] {
-                    law star: forall(x: EStar[a]) ???
-                }
-
-                trait CStarToStar1[a: Type -> Type] {
-                    law starToStar: forall(x: EStarToStar[a]) ???
-                }
-            }
-
-            mod Exp {
-                trait CStar1[a: Type] {
-                    law star: forall(x: a) { discard (???: a); ??? }
                 }
             }
         }


### PR DESCRIPTION
Removes the `law` keyword and the `lawful` trait modifier from the language, along with all associated compiler infrastructure.

## Compiler
- Remove `law`/`lawful` keywords from the lexer, `TokenKind`, and `TreeKind.Decl.Law`.
- Remove the parser's `lawDecl` and the weeder's `visitLawDecl` / `lawful` modifier handling.
- Remove the `laws` field on `Trait` and the dead `Declaration.Law` nodes across all ASTs (Weeded → Typed), plus `Modifier.Lawful` / `isLawful`.
- Drop the `laws` threading in the Desugar, Namer, Resolver, Kinder, Typer, Stratifier, Dependencies, and PredDeps phases.
- Remove the lawful-trait validation in `Instances` (`checkLawApplication`), the `InstanceError.UnlawfulSignature` error, and its `ErrorCode.E3281`.
- Update the affected LSP providers (Visitor, SemanticTokens, Find References, Goto, Highlight, Rename, Symbol, and the Module/Signature/Trait completers) and the `HtmlDocumentor`.

## Standard library
- Remove all 49 law declarations from the traits and drop `lawful` from the 13 lawful traits.
- Clean up the now-unused `use Bool.{==>, <==>}` imports.

## Tests
- Remove the law declarations from `Test.Dec.Trait.flix` and `Test.Kind.Trait.flix`.
- Remove the obsolete law-specific cases (`UnlawfulSignature`, `Trait.Law` kinding, law parser-recovery, law typing) and retarget the `lawful enum` weeder test to `sealed enum`.

Closes #8351 — the `// TODO: There is a Declaration.Law but old Weeder produces a Def` comment it tracked is removed entirely, since laws no longer exist.