### PR TITLE
refactor: drop iterator region from the effect parameter (#10077)

### DIFF
--- a/examples/unsorted/restrictable-variants/sequences.flix
+++ b/examples/unsorted/restrictable-variants/sequences.flix
@@ -815,7 +815,7 @@ mod Seq {
     ///
     /// Returns an iterator over `l`.
     ///
-    pub def iterator(rc: Region[r], xs: Seq[s][a]): Iterator[a, r, r] \ r =
+    pub def iterator(rc: Region[r], xs: Seq[s][a]): Iterator[a, {}, r] \ r =
         let ls = Ref.fresh(rc, open_variant_as Seq xs);
         let next = () -> {
             choose (Ref.get(ls)) {
@@ -824,7 +824,7 @@ mod Seq {
                 case Seq.Cons(x, rs) => Ref.put(rs, ls); Some(x)
             }
         };
-        Iterator.unfoldWithIter(rc, next)
+        Iterator.unfoldWithIter(rc, next) |> Iterator.absorbRegion
 
     ///
     /// Returns the association list `l` as a `DelayMap`.
@@ -879,7 +879,7 @@ instance Foldable[Seq.Seq[s]] {
 
 instance Iterable[Seq.Seq[s][a]] {
     type Elm = a
-    pub def iterator(rc: Region[r], l: Seq.Seq[s][a]): Iterator[a, r, r] \ r = Seq.iterator(rc, l)
+    pub def iterator(rc: Region[r], l: Seq.Seq[s][a]): Iterator[a, {}, r] \ r = Seq.iterator(rc, l)
 }
 
 instance ForEach[Seq.Seq[s][a]] {

--- a/main/src/library/Adaptor.flix
+++ b/main/src/library/Adaptor.flix
@@ -72,7 +72,7 @@ pub mod Adaptor {
     ///
     /// Returns a Flix Iterator of the elements in the given Java List.
     ///
-    pub def fromListToIterator(rc: Region[r], l: JList[a]): Iterator[a, r, r] \ r =
+    pub def fromListToIterator(rc: Region[r], l: JList[a]): Iterator[a, {}, r] \ r =
         def iterator(x) = unsafe IO as r { x.iterator() };
         iterator(l) |> fromIterator(rc, (Proxy.Proxy: Proxy[a]))
 
@@ -89,7 +89,7 @@ pub mod Adaptor {
     ///
     /// Returns a Flix Iterator of the elements in the given Java Set.
     ///
-    pub def fromSetToIterator(rc: Region[r], s: JSet[a]): Iterator[a, r, r] \ r =
+    pub def fromSetToIterator(rc: Region[r], s: JSet[a]): Iterator[a, {}, r] \ r =
         def iterator(x) = unsafe IO as r { x.iterator() };
         iterator(s) |> fromIterator(rc, (Proxy.Proxy: Proxy[a]))
 
@@ -109,7 +109,7 @@ pub mod Adaptor {
     ///
     /// Returns a Flix Iterator of the key-value pairs in the given Java Map.
     ///
-    pub def fromMapToIterator(rc: Region[r], m: JMap[k, v]): Iterator[(k, v), r, r] \ r =
+    pub def fromMapToIterator(rc: Region[r], m: JMap[k, v]): Iterator[(k, v), {}, r] \ r =
         def entrySet(x) = unsafe IO as r { x.entrySet() };
         def iterator(x) = unsafe IO as r { x.iterator() };
         def hasNext(x) = unsafe IO as r { x.hasNext() };
@@ -124,12 +124,12 @@ pub mod Adaptor {
             }
             case false => None
         };
-        Iterator.unfoldWithIter(rc, getNext)
+        Iterator.unfoldWithIter(rc, getNext) |> Iterator.absorbRegion
 
     ///
     /// Returns a fresh Flix `Iterator` from the Java iterator `iter`.
     ///
-    pub def fromIterator(rc: Region[r], _: Proxy[a], iter: JIterator[a]): Iterator[a, r, r] =
+    pub def fromIterator(rc: Region[r], _: Proxy[a], iter: JIterator[a]): Iterator[a, {}, r] =
         def hasNext(x) = unsafe IO as r { x.hasNext() };
         def next(x) = unsafe IO as r { x.next() };
         let step = () -> {
@@ -139,12 +139,12 @@ pub mod Adaptor {
             }
         };
         let iterF = () -> (step());
-        Iterator.unfoldWithIter(rc, iterF)
+        Iterator.unfoldWithIter(rc, iterF) |> Iterator.absorbRegion
 
     ///
     /// Returns a Flix Iterator of the elements in the given Java Stream.
     ///
-    pub def fromStreamToIterator(rc: Region[r], strm: Stream[a]): Iterator[a, r, r] \ r =
+    pub def fromStreamToIterator(rc: Region[r], strm: Stream[a]): Iterator[a, {}, r] \ r =
         let baseStream: BaseStream[a, Stream[a]] = checked_cast(strm);
         let iter = unsafe IO as r { baseStream.iterator() };
         Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a]), iter)
@@ -152,7 +152,7 @@ pub mod Adaptor {
     ///
     /// Returns a Flix Iterator of the elements in the given Java Collection.
     ///
-    pub def fromCollectionToIterator(rc: Region[r], col: Collection[a]): Iterator[a, r, r] \ r =
+    pub def fromCollectionToIterator(rc: Region[r], col: Collection[a]): Iterator[a, {}, r] \ r =
         let iter = unsafe IO as r { col.iterator() };
         Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a]), iter)
 

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -47,7 +47,7 @@ instance Iterable[Array[a, r]] {
     type Elm = a
     type Aef = r
 
-    pub def iterator(rc: Region[r1], a: Array[a, r]): Iterator[a, r + r1, r1] \ (r + r1) =
+    pub def iterator(rc: Region[r1], a: Array[a, r]): Iterator[a, r, r1] \ (r + r1) =
         checked_ecast(Array.iterator(rc, a))
 }
 
@@ -1367,7 +1367,7 @@ pub mod Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], a: Array[a, r2]): Iterator[a, r1 + r2, r1] \ r1 =
+    pub def iterator(rc: Region[r1], a: Array[a, r2]): Iterator[a, r2, r1] \ r1 =
         Iterator.range(rc, 0, length(a)) |> Iterator.map(i -> Array.get(i, a))
 
     ///

--- a/main/src/library/BPlusTree.flix
+++ b/main/src/library/BPlusTree.flix
@@ -277,7 +277,7 @@ pub mod BPlusTree {
     ///
     /// Not thread-safe: The iterator reads from the live leaf chain of `t`.
     ///
-    pub def iteratorWithKeys(rc1: Region[r1], t: BPlusTree[k, v, r2]): Iterator[k, r1 + r2, r1] \ r1 + r2 =
+    pub def iteratorWithKeys(rc1: Region[r1], t: BPlusTree[k, v, r2]): Iterator[k, r2, r1] \ r1 + r2 =
         Iterator.map(match (k, _) -> k, iterator(rc1, t))
 
     ///
@@ -285,7 +285,7 @@ pub mod BPlusTree {
     ///
     /// Not thread-safe: The iterator reads from the live leaf chain of `t`.
     ///
-    pub def iteratorValues(rc1: Region[r1], t: BPlusTree[k, v, r2]): Iterator[v, r1 + r2, r1] \ r1 + r2 =
+    pub def iteratorValues(rc1: Region[r1], t: BPlusTree[k, v, r2]): Iterator[v, r2, r1] \ r1 + r2 =
         Iterator.map(match (_, v) -> v, iterator(rc1, t))
 
     ///
@@ -293,7 +293,7 @@ pub mod BPlusTree {
     ///
     /// Not thread-safe: The iterator reads from the live leaf chain of `t`.
     ///
-    pub def iterator(rc1: Region[r1], t: BPlusTree[k, v, r]): Iterator[(k, v), r + r1, r1] \ r + r1 = {
+    pub def iterator(rc1: Region[r1], t: BPlusTree[k, v, r]): Iterator[(k, v), r, r1] \ r + r1 = {
         let nodeRef = Ref.fresh(rc1, Node.leftMostLeafUnconditional(t->root));
         let indexRef = Ref.fresh(rc1, 0);
         def next() = {
@@ -312,7 +312,7 @@ pub mod BPlusTree {
                     }
                 }
         };
-        Iterator.unfoldWithIter(rc1, next)
+        Iterator.unfoldWithIter(rc1, next) |> Iterator.absorbRegion
     }
 
     ///

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -126,7 +126,7 @@ pub mod Chain {
 
     instance Iterable[Chain[a]] {
         type Elm = a
-        pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r = Chain.iterator(rc, c)
+        pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, {}, r] \ r = Chain.iterator(rc, c)
     }
 
     instance ForEach[Chain[a]] {
@@ -823,7 +823,7 @@ pub mod Chain {
     ///
     /// Returns an iterator over `c`.
     ///
-    pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r =
+    pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, {}, r] \ r =
         let cursor = Ref.fresh(rc, viewLeft(c));
         let next = () -> match (Ref.get(cursor)) {
             case ViewLeft.NoneLeft => None
@@ -831,7 +831,7 @@ pub mod Chain {
                 Ref.put(viewLeft(xs), cursor);
                 Some(x)
         };
-        Iterator.unfoldWithIter(rc, next)
+        Iterator.unfoldWithIter(rc, next) |> Iterator.absorbRegion
 
     ///
     /// Returns the chain `c` as a Nel.

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -126,7 +126,7 @@ pub mod DelayList {
 
     instance Iterable[DelayList[a]] {
         type Elm = a
-        pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r = DelayList.iterator(rc, l)
+        pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, {}, r] \ r = DelayList.iterator(rc, l)
     }
 
     instance ForEach[DelayList[a]] {
@@ -1221,7 +1221,7 @@ pub mod DelayList {
     /// Does not force any elements of the list.
     ///
     @Experimental @Lazy
-    pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r =
+    pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, {}, r] \ r =
         let cursor = Ref.fresh(rc, l);
         let next = () -> {
             let ll = Ref.get(cursor);
@@ -1232,7 +1232,7 @@ pub mod DelayList {
                     Some(x)
             }
         };
-        Iterator.unfoldWithIter(rc, next)
+        Iterator.unfoldWithIter(rc, next) |> Iterator.absorbRegion
 
     ///
     /// Returns `l` as a `List`.

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -59,7 +59,7 @@ pub mod DelayMap {
 
     instance Iterable[DelayMap[k, v]] {
         type Elm = (k, v)
-        pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[(k, v), r, r] \ r =
+        pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[(k, v), {}, r] \ r =
             DelayMap.iterator(rc, m)
     }
 
@@ -765,7 +765,7 @@ pub mod DelayMap {
     /// Returns an iterator over all key-value pairs in `m`.
     ///
     @Experimental
-    pub def iterator(rc: Region[r], m: DelayMap[a, b]): Iterator[(a, b), r, r] \ r =
+    pub def iterator(rc: Region[r], m: DelayMap[a, b]): Iterator[(a, b), {}, r] \ r =
         let DMap(t) = m;
         RedBlackTree.iterator(rc, t) |> Iterator.map(match (k, v) -> (k, force v))
 

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -36,7 +36,7 @@ pub mod Iterable {
         ///
         /// Returns an iterator over `t`.
         ///
-        pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], r + aef, r] \ (r + aef) where Iterable.Aef[t] ~ aef
+        pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], aef, r] \ (r + aef) where Iterable.Aef[t] ~ aef
 
     }
 

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -55,13 +55,24 @@ pub mod Iterator {
         Iterator(rc, iterF)
 
     ///
+    /// Re-wraps `iter` so that its own region does not appear in its effect set.
+    ///
+    /// An iterator's stepper always runs in its region `rc`, so a region effect on the
+    /// iterator's own region is not observable to consumers. This removes that region
+    /// from the visible effect `ef`, leaving only the genuinely foreign effects.
+    ///
+    pub def absorbRegion(iter: Iterator[a, { ef, r }, r]): Iterator[a, ef, r] =
+        let Iterator(rc, g) = iter;
+        Iterator(rc, g)
+
+    ///
     /// Build an iterator by applying `f` to the seed value `st`.
     ///
     /// `f` should return `Some(a, st1)` to signal a new element `a` and a new seed value `st1`.
     ///
     /// `f` should return `None` to signal the end of the iterator.
     ///
-    pub def unfold(rc: Region[r], f: s -> Option[(a, s)] \ ef, st: s): Iterator[a, ef + r, r] \ r =
+    pub def unfold(rc: Region[r], f: s -> Option[(a, s)] \ ef, st: s): Iterator[a, ef, r] \ r =
         let state = Ref.fresh(rc, st);
         let f1 = () -> match f(Ref.get(state)) {
             case None           => Done
@@ -77,7 +88,7 @@ pub mod Iterator {
     ///
     /// `f` should return `None` to signal the end of the iterator.
     ///
-    pub def iterate(rc: Region[r], f: a -> Option[a] \ ef, x: a): Iterator[a, ef + r, r] \ r =
+    pub def iterate(rc: Region[r], f: a -> Option[a] \ ef, x: a): Iterator[a, ef, r] \ r =
         let state = Ref.fresh(rc, x);
         let f1 = () -> match f(Ref.get(state)) {
             case None     => Done
@@ -89,14 +100,14 @@ pub mod Iterator {
     ///
     /// Returns an empty iterator.
     ///
-    pub def empty(rc: Region[r]): Iterator[a, r, r] =
+    pub def empty(rc: Region[r]): Iterator[a, {}, r] =
         let f = _ -> checked_ecast(Done);
         Iterator(rc, f)
 
     ///
     /// Returns an iterator containing only a single element, `x`.
     ///
-    pub def singleton(rc: Region[r], x: a): Iterator[a, r, r] \ r =
+    pub def singleton(rc: Region[r], x: a): Iterator[a, {}, r] \ r =
         repeat(rc, 1, x)
 
     ///
@@ -118,7 +129,7 @@ pub mod Iterator {
     ///
     /// Returns an empty iterator if `b >= e`.
     ///
-    pub def range(rc: Region[r], b: Int32, e: Int32): Iterator[Int32, r, r] \ r =
+    pub def range(rc: Region[r], b: Int32, e: Int32): Iterator[Int32, {}, r] \ r =
         let pos = Ref.fresh(rc, b);
         if (e <= b)
             empty(rc)
@@ -135,7 +146,7 @@ pub mod Iterator {
     ///
     /// Returns an empty iterator if `n < 0`.
     ///
-    pub def repeat(rc: Region[r], n: Int32, x: a): Iterator[a, r, r] \ r =
+    pub def repeat(rc: Region[r], n: Int32, x: a): Iterator[a, {}, r] \ r =
         let ix = Ref.fresh(rc, n);
         let iterF = () -> {
             let i = Ref.get(ix);
@@ -409,10 +420,10 @@ pub mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def zipWithIndex(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef + r, r] \ r =
+    pub def zipWithIndex(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef, r] \ r =
         let Iterator(rc, _) = iter;
         let ix = Ref.fresh(rc, 0);
-        map(x -> { let i = Ref.get(ix); Ref.put(i + 1, ix); (i, x) }, iter)
+        absorbRegion(map(x -> { let i = Ref.get(ix); Ref.put(i + 1, ix); (i, x) }, iter))
 
     ///
     /// Applies `f` to a start value `s` and all elements in `iter` going from left to right.
@@ -488,7 +499,7 @@ pub mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def drop(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef + r, r] \ r =
+    pub def drop(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef, r] \ r =
         let Iterator(rc, iterF) = iter;
         let ix = Ref.fresh(rc, n);
         def loop() = {
@@ -513,7 +524,7 @@ pub mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def take(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef + r, r] \ r =
+    pub def take(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef, r] \ r =
         let Iterator(rc, iterF) = iter;
         let ix = Ref.fresh(rc, n);
         def loop() = {
@@ -554,7 +565,7 @@ pub mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def dropWhile(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, r + ef1 + ef2, r] \ r =
+    pub def dropWhile(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, ef1 + ef2, r] \ r =
         let Iterator(rc, iterF) = iter;
         let start = Ref.fresh(rc, true);
         def loop() = match iterF() {
@@ -577,7 +588,7 @@ pub mod Iterator {
     ///
     /// Currently `f` has to generate an iterator with region `r`.
     ///
-    pub def flatMap(f: a -> Iterator[b, ef2, r] \ ef3, ma: Iterator[a, ef1, r]): Iterator[b, r + ef1 + ef2 + ef3, r] \ r =
+    pub def flatMap(f: a -> Iterator[b, ef2, r] \ ef3, ma: Iterator[a, ef1, r]): Iterator[b, ef1 + ef2 + ef3, r] \ r =
         let Iterator(rc, iterF) = ma;
         let innerIter = Ref.fresh(rc, polymorphicEmpty(rc));
         let inside = Ref.fresh(rc, false);
@@ -625,7 +636,7 @@ pub mod Iterator {
     ///
     /// Does *not* consume any elements from the iterator.
     ///
-    pub def intersperse(sep: a, iter: Iterator[a, ef, r]): Iterator[a, ef + r, r] \ r =
+    pub def intersperse(sep: a, iter: Iterator[a, ef, r]): Iterator[a, ef, r] \ r =
         let Iterator(rc, _) = iter;
         let start = Ref.fresh(rc, true);
         let step = x ->
@@ -635,7 +646,7 @@ pub mod Iterator {
             } else {
                 cons(sep, singleton(rc, x))
             };
-        flatMap(step, iter)
+        absorbRegion(flatMap(step, iter))
 
     ///
     /// Returns the concatenation of the elements in `iter` with the elements of `sep` inserted between every two adjacent elements.
@@ -646,7 +657,7 @@ pub mod Iterator {
     ///
     /// The original iterators `sep` and `iter` should not be reused.
     ///
-    pub def intercalate(sep: t[a], iter: Iterator[Iterator[a, ef, r], ef, r]): Iterator[a, ef + r, r] \ (r + Foldable.Aef[t]) with Foldable[t] =
+    pub def intercalate(sep: t[a], iter: Iterator[Iterator[a, ef, r], ef, r]): Iterator[a, ef, r] \ (r + Foldable.Aef[t]) with Foldable[t] =
         let Iterator(rc, _) = iter;
         let start = Ref.fresh(rc, true);
         let sepL = Foldable.toList(sep);
@@ -658,13 +669,10 @@ pub mod Iterator {
                 append(ofList(rc, sepL), innerIter)
             }
         };
-        flatMap(step, iter)
+        absorbRegion(flatMap(step, iter))
 
     ///
     /// Helper for `intercalate`.
-    ///
-    /// Note - this is not the "best" return type. Ideally it should be `Iterator[a, r, r]` but
-    /// then `intercalate` fails.
     ///
     def ofList(rc: Region[r], xs: List[a]): Iterator[a, {}, r] \ r =
         let ls = Ref.fresh(rc, xs);
@@ -752,7 +760,7 @@ pub mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def flatten(iter: Iterator[Iterator[a, ef1, r], ef2, r]): Iterator[a, r + ef1 + ef2, r] \ r =
+    pub def flatten(iter: Iterator[Iterator[a, ef1, r], ef2, r]): Iterator[a, ef1 + ef2, r] \ r =
         flatMap(identity, iter)
 
 }

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -139,7 +139,7 @@ pub mod List {
 
     instance Iterable[List[a]] {
         type Elm = a
-        pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ r = List.iterator(rc, l)
+        pub def iterator(rc: Region[r], l: List[a]): Iterator[a, {}, r] \ r = List.iterator(rc, l)
     }
 
     instance ForEach[List[a]] {
@@ -1550,7 +1550,7 @@ pub mod List {
     ///
     /// Returns an iterator over `l`.
     ///
-    pub def iterator(rc: Region[r], xs: List[a]): Iterator[a, r, r] \ r =
+    pub def iterator(rc: Region[r], xs: List[a]): Iterator[a, {}, r] \ r =
         let ls = Ref.fresh(rc, xs);
         let next = () -> {
             match (Ref.get(ls)) {
@@ -1558,7 +1558,7 @@ pub mod List {
                 case x :: rs => Ref.put(rs, ls); Some(x)
             }
         };
-        Iterator.unfoldWithIter(rc, next)
+        Iterator.unfoldWithIter(rc, next) |> Iterator.absorbRegion
 
     ///
     /// Helper function for `sequence` and `traverse`.

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -123,7 +123,7 @@ pub mod Map {
 
     instance Iterable[Map[k, v]] {
         type Elm = (k, v)
-        pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[(k, v), r, r] \ r = Map.iterator(rc, m)
+        pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[(k, v), {}, r] \ r = Map.iterator(rc, m)
     }
 
     instance ForEach[Map[k, v]] {
@@ -879,20 +879,20 @@ pub mod Map {
     ///
     /// Returns an iterator over all key-value pairs in `m`.
     ///
-    pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[(k, v), r, r] \ r =
+    pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[(k, v), {}, r] \ r =
         let Map(t) = m;
         RedBlackTree.iterator(rc, t)
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
-    pub def iteratorKeys(rc: Region[r], m: Map[k, v]): Iterator[k, r, r] \ r =
+    pub def iteratorKeys(rc: Region[r], m: Map[k, v]): Iterator[k, {}, r] \ r =
         iterator(rc, m) |> Iterator.map(fst)
 
     ///
     /// Returns an iterator over values in `m`.
     ///
-    pub def iteratorValues(rc: Region[r], m: Map[k, v]): Iterator[v, r, r] \ r =
+    pub def iteratorValues(rc: Region[r], m: Map[k, v]): Iterator[v, {}, r] \ r =
         iterator(rc, m) |> Iterator.map(snd)
 
     ///

--- a/main/src/library/MultiMap.flix
+++ b/main/src/library/MultiMap.flix
@@ -523,7 +523,7 @@ pub mod MultiMap {
     ///
     /// Returns an iterator over all key-value pairs in `m` i.e. `k => Set#{v_1, ..., v_n}`.
     ///
-    pub def iterator(rc: Region[r], m: MultiMap[k, v]): Iterator[(k, Set[v]), r, r] \ r =
+    pub def iterator(rc: Region[r], m: MultiMap[k, v]): Iterator[(k, Set[v]), {}, r] \ r =
         let MultiMap(m1) = m;
         Map.iterator(rc, m1)
 

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -39,7 +39,7 @@ pub mod MutDeque {
     instance Iterable[MutDeque[a, r]] {
         type Elm = a
         type Aef = r
-        pub def iterator(rc: Region[r1], md: MutDeque[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutDeque.iterator(rc, md)
+        pub def iterator(rc: Region[r1], md: MutDeque[a, r]): Iterator[a, r, r1] \ (r + r1) = MutDeque.iterator(rc, md)
     }
 
     instance ForEach[MutDeque[a, r]] {
@@ -411,7 +411,7 @@ pub mod MutDeque {
     ///
     /// Modifying `d` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], d: MutDeque[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], d: MutDeque[a, r2]): Iterator[a, r2, r1] \ { r1, r2 } =
         let i = Ref.fresh(rc, d->front);
         let next = () -> {
             if (Ref.get(i) < d->back) {
@@ -422,7 +422,7 @@ pub mod MutDeque {
                 None
             }
         };
-        Iterator.unfoldWithIter(rc, next)
+        Iterator.unfoldWithIter(rc, next) |> Iterator.absorbRegion
 
     ///
     /// Apply the effectful function `f` to all the elements in the MutDeque `d`.

--- a/main/src/library/MutHashMap.flix
+++ b/main/src/library/MutHashMap.flix
@@ -33,7 +33,7 @@ pub mod MutHashMap {
     instance Iterable[MutHashMap[k, v, r]] {
         type Elm = (k, v)
         type Aef = r
-        pub def iterator(rc: Region[r1], m: MutHashMap[k, v, r]): Iterator[(k, v), r + r1, r1] \ (r + r1) =
+        pub def iterator(rc: Region[r1], m: MutHashMap[k, v, r]): Iterator[(k, v), r, r1] \ (r + r1) =
             MutHashMap.iterator(rc, m)
     }
 
@@ -570,7 +570,7 @@ pub mod MutHashMap {
     ///
     /// Returns an iterator over key-value pairs in `m` in insertion order.
     ///
-    pub def iterator(rc: Region[r2], m: MutHashMap[k, v, r]): Iterator[(k, v), r2 + r, r2] \ { r, r2 } =
+    pub def iterator(rc: Region[r2], m: MutHashMap[k, v, r]): Iterator[(k, v), r, r2] \ { r, r2 } =
         let curr = Ref.fresh(rc, m->head);
         def next() = match Ref.get(curr) {
             case None => None
@@ -578,18 +578,18 @@ pub mod MutHashMap {
                 Ref.put(Node.getOrderNext(entry), curr);
                 Some((Node.getKey(entry), Node.getValue(entry)))
         };
-        Iterator.unfoldWithIter(rc, next)
+        Iterator.unfoldWithIter(rc, next) |> Iterator.absorbRegion
 
     ///
     /// Returns an iterator over keys in `m` in insertion order.
     ///
-    pub def iteratorKeys(rc: Region[r2], m: MutHashMap[k, v, r]): Iterator[k, r2 + r, r2] \ { r, r2 } =
+    pub def iteratorKeys(rc: Region[r2], m: MutHashMap[k, v, r]): Iterator[k, r, r2] \ { r, r2 } =
         iterator(rc, m) |> Iterator.map(fst)
 
     ///
     /// Returns an iterator over values in `m` in insertion order.
     ///
-    pub def iteratorValues(rc: Region[r2], m: MutHashMap[k, v, r]): Iterator[v, r2 + r, r2] \ { r, r2 } =
+    pub def iteratorValues(rc: Region[r2], m: MutHashMap[k, v, r]): Iterator[v, r, r2] \ { r, r2 } =
         iterator(rc, m) |> Iterator.map(snd)
 
     ///

--- a/main/src/library/MutHashSet.flix
+++ b/main/src/library/MutHashSet.flix
@@ -33,7 +33,7 @@ pub mod MutHashSet {
     instance Iterable[MutHashSet[a, r]] {
         type Elm = a
         type Aef = r
-        pub def iterator(rc: Region[r1], s: MutHashSet[a, r]): Iterator[a, r + r1, r1] \ (r + r1) =
+        pub def iterator(rc: Region[r1], s: MutHashSet[a, r]): Iterator[a, r, r1] \ (r + r1) =
             MutHashSet.iterator(rc, s)
     }
 
@@ -92,7 +92,7 @@ pub mod MutHashSet {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(rc: Region[r1], s: MutHashSet[t, r]): Iterator[t, r + r1, r1] \ { r, r1 } =
+    pub def iterator(rc: Region[r1], s: MutHashSet[t, r]): Iterator[t, r, r1] \ { r, r1 } =
         MutHashMap.iteratorKeys(rc, s->inner)
 
     ///

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -33,7 +33,7 @@ pub mod MutList {
     instance Iterable[MutList[a, r]] {
         type Elm = a
         type Aef = r
-        pub def iterator(rc: Region[r1], l: MutList[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutList.iterator(rc, l)
+        pub def iterator(rc: Region[r1], l: MutList[a, r]): Iterator[a, r, r1] \ (r + r1) = MutList.iterator(rc, l)
     }
 
     instance ForEach[MutList[a, r]] {
@@ -806,7 +806,7 @@ pub mod MutList {
     ///
     /// Modifying `l` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], l: MutList[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], l: MutList[a, r2]): Iterator[a, r2, r1] \ { r1, r2 } =
         let ix = Ref.fresh(rc, 0);
         let len = length(l);
         let next = () -> {
@@ -819,7 +819,7 @@ pub mod MutList {
                 None
             }
         };
-        Iterator.unfoldWithIter(rc, next)
+        Iterator.unfoldWithIter(rc, next) |> Iterator.absorbRegion
 
     ///
     /// Applies `f` to all the elements in `v`.

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -46,7 +46,7 @@ pub mod MutMap {
     instance Iterable[MutMap[k, v, r]] {
         type Elm = (k, v)
         type Aef = r
-        pub def iterator(rc: Region[r1], m: MutMap[k, v, r]): Iterator[(k, v), r + r1, r1] \ (r + r1) =
+        pub def iterator(rc: Region[r1], m: MutMap[k, v, r]): Iterator[(k, v), r, r1] \ (r + r1) =
             MutMap.iterator(rc, m)
     }
 
@@ -542,19 +542,19 @@ pub mod MutMap {
     ///
     /// Returns an iterator over all key-value pairs in `m`.
     ///
-    pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r2, r1] \ { r1, r2 } =
         Map.iterator(rc, m->inner) |> Iterator.map(x -> checked_ecast(x))
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
-    pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 + r2, r1] \ { r1, r2 } =
+    pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r2, r1] \ { r1, r2 } =
         Map.iteratorKeys(rc, m->inner) |> Iterator.map(x -> checked_ecast(x))
 
     ///
     /// Returns an iterator over values in `m`.
     ///
-    pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 + r2, r1] \ { r1, r2 } =
+    pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r2, r1] \ { r1, r2 } =
         Map.iteratorValues(rc, m->inner) |> Iterator.map(x -> checked_ecast(x))
 
     ///

--- a/main/src/library/MutPriorityQueue.flix
+++ b/main/src/library/MutPriorityQueue.flix
@@ -34,7 +34,7 @@ pub mod MutPriorityQueue {
     instance Iterable[MutPriorityQueue[a, r]] {
         type Elm = a
         type Aef = r
-        pub def iterator(rc: Region[r1], q: MutPriorityQueue[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutPriorityQueue.iterator(rc, q)
+        pub def iterator(rc: Region[r1], q: MutPriorityQueue[a, r]): Iterator[a, r, r1] \ (r + r1) = MutPriorityQueue.iterator(rc, q)
     }
 
     instance ForEach[MutPriorityQueue[a, r]] {
@@ -155,7 +155,7 @@ pub mod MutPriorityQueue {
     ///
     /// Modifying `mq` during iteration is undefined and not recommended.
     ///
-    pub def iterator(rc: Region[r1], mq: MutPriorityQueue[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], mq: MutPriorityQueue[a, r2]): Iterator[a, r2, r1] \ { r1, r2 } =
         let it1 = Iterator.range(rc, 0, mq->size);
         Iterator.map(x -> Array.get(x, mq->values), it1)
 

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -27,7 +27,7 @@ pub mod MutSet {
     instance Iterable[MutSet[a, r]] {
         type Elm = a
         type Aef = r
-        pub def iterator(rc: Region[r1], s: MutSet[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutSet.iterator(rc, s)
+        pub def iterator(rc: Region[r1], s: MutSet[a, r]): Iterator[a, r, r1] \ (r + r1) = MutSet.iterator(rc, s)
     }
 
     instance ForEach[MutSet[a, r]] {
@@ -302,7 +302,7 @@ pub mod MutSet {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r2, r1] \ { r1, r2 } =
         Set.iterator(rc, s->inner) |> Iterator.map(x -> checked_ecast(x))
 
     ///

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -147,7 +147,7 @@ pub mod Nec {
 
     instance Iterable[Nec[a]] {
         type Elm = a
-        pub def iterator(rc: Region[r], l: Nec[a]): Iterator[a, r, r] \ r = Nec.iterator(rc, l)
+        pub def iterator(rc: Region[r], l: Nec[a]): Iterator[a, {}, r] \ r = Nec.iterator(rc, l)
     }
 
     instance ForEach[Nec[a]] {
@@ -813,13 +813,13 @@ pub mod Nec {
     ///
     /// Returns an iterator over `c`.
     ///
-    pub def iterator(rc: Region[r], c: Nec[a]): Iterator[a, r, r] \ r =
+    pub def iterator(rc: Region[r], c: Nec[a]): Iterator[a, {}, r] \ r =
         iteratorHelper(rc, Some(viewLeft(c)))
 
     ///
     /// Returns an iterator over `l`.
     ///
-    def iteratorHelper(rc: Region[r], vl: Option[ViewLeft[a]]): Iterator[a, r, r] \ r =
+    def iteratorHelper(rc: Region[r], vl: Option[ViewLeft[a]]): Iterator[a, {}, r] \ r =
         let cursor = Ref.fresh(rc, vl);
         let next = () -> match (Ref.get(cursor)) {
             case None => None
@@ -830,7 +830,7 @@ pub mod Nec {
                 Ref.put(Some(viewLeft(xs)), cursor);
                 Some(x)
         };
-        Iterator.unfoldWithIter(rc, next)
+        Iterator.unfoldWithIter(rc, next) |> Iterator.absorbRegion
 
     ///
     /// Helper for the `sort` functions.

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -127,7 +127,7 @@ pub mod Nel {
 
     instance Iterable[Nel[a]] {
         type Elm = a
-        pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ r = Nel.iterator(rc, l)
+        pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, {}, r] \ r = Nel.iterator(rc, l)
     }
 
     instance ForEach[Nel[a]] {
@@ -649,7 +649,7 @@ pub mod Nel {
     ///
     /// Returns an iterator over `l`.
     ///
-    pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ r =
+    pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, {}, r] \ r =
         let Nel(x, xs) = l;
         List.iterator(rc, x :: xs)
 

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -155,7 +155,7 @@ pub mod Option {
 
     instance Iterable[Option[a]] {
         type Elm = a
-        pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ r = Option.iterator(rc, o)
+        pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, {}, r] \ r = Option.iterator(rc, o)
     }
 
     instance ForEach[Option[a]] {
@@ -601,7 +601,7 @@ pub mod Option {
     ///
     /// Returns an iterator over `o` with 1 element or an empty iterator if `o` is `None`.
     ///
-    pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ r = match o {
+    pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, {}, r] \ r = match o {
         case None    => Iterator.empty(rc)
         case Some(x) => Iterator.singleton(rc, x)
     }

--- a/main/src/library/Range.flix
+++ b/main/src/library/Range.flix
@@ -30,7 +30,7 @@ pub mod Range {
 
     instance Iterable[Range[t]] with Discrete[t] {
         type Elm = t
-        pub def iterator(rc: Region[r], rng: Range[t]): Iterator[t, r, r] \ r = Range.iterator(rc, rng)
+        pub def iterator(rc: Region[r], rng: Range[t]): Iterator[t, {}, r] \ r = Range.iterator(rc, rng)
     }
 
     ///
@@ -77,7 +77,7 @@ pub mod Range {
     ///
     /// Returns an iterator over the elements of `r`.
     ///
-    pub def iterator(rc: Region[r], rng: Range[t]): Iterator[t, r, r] \ r with Discrete[t] =
+    pub def iterator(rc: Region[r], rng: Range[t]): Iterator[t, {}, r] \ r with Discrete[t] =
         let Range(b, e) = rng;
         Iterator.unfold(rc, i -> if (i < e) Some((i, Discrete.succ(i))) else None, b)
 

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -90,7 +90,7 @@ pub mod RedBlackTree {
 
     instance Iterable[RedBlackTree[k, v]] {
         type Elm = (k, v)
-        pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), r, r] \ r =
+        pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), {}, r] \ r =
             RedBlackTree.iterator(rc, t)
     }
 
@@ -1061,7 +1061,7 @@ pub mod RedBlackTree {
     ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), r, r] \ r =
+    pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), {}, r] \ r =
         let stack1 = leftmost(t, Nil);
         let state = Ref.fresh(rc, stack1);
         let next = () -> match Ref.get(state) {
@@ -1070,7 +1070,7 @@ pub mod RedBlackTree {
                 Ref.put(leftmost(rtree, es), state);
                 Some((k, v))
         };
-        Iterator.unfoldWithIter(rc, next)
+        Iterator.unfoldWithIter(rc, next) |> Iterator.absorbRegion
 
     ///
     /// This represents pending items `(key, value, right-tree)` encountered while finding the

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -430,7 +430,7 @@ pub mod Result {
     ///
     /// Returns an iterator over `r` with 1 element or an empty iterator if `r` is `Err`.
     ///
-    pub def iterator(rc: Region[r], r: Result[e, t]): Iterator[t, r, r] \ r = match r {
+    pub def iterator(rc: Region[r], r: Result[e, t]): Iterator[t, {}, r] \ r = match r {
         case Err(_) => Iterator.empty(rc)
         case Ok(x)  => Iterator.singleton(rc, x)
     }

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -105,7 +105,7 @@ pub mod Set {
 
     instance Iterable[Set[a]] {
         type Elm = a
-        pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ r = Set.iterator(rc, s)
+        pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, {}, r] \ r = Set.iterator(rc, s)
     }
 
     instance ForEach[Set[a]] {
@@ -571,7 +571,7 @@ pub mod Set {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ r =
+    pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, {}, r] \ r =
         let Set(t) = s;
         RedBlackTree.iterator(rc, t) |> Iterator.map(fst)
 

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -1422,7 +1422,7 @@ pub mod String {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(rc: Region[r], s: String): Iterator[Char, r, r] \ r =
+    pub def iterator(rc: Region[r], s: String): Iterator[Char, {}, r] \ r =
         Iterator.range(rc, 0, length(s)) |> Iterator.map(i -> charAt(i, s))
 
 }

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -114,7 +114,7 @@ pub mod StringBuilder {
     ///
     /// Returns an iterator over `sb`.
     ///
-    pub def iterator(rc: Region[r1], sb: StringBuilder[r2]): Iterator[Char, r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], sb: StringBuilder[r2]): Iterator[Char, r2, r1] \ { r1, r2 } =
         let StringBuilder(msb) = sb;
         Iterator.range(rc, 0, length(sb)) |> Iterator.map(i -> unsafe IO as r2 { msb.charAt(i) })
 

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -124,7 +124,7 @@ instance Collectable[Vector[a]] {
 
 instance Iterable[Vector[a]] {
     type Elm = a
-    pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ r = Vector.iterator(rc, v)
+    pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, {}, r] \ r = Vector.iterator(rc, v)
 }
 
 instance ForEach[Vector[a]] {
@@ -1442,7 +1442,7 @@ pub mod Vector {
     ///
     /// Returns an iterator over `v`
     ///
-    pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ r =
+    pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, {}, r] \ r =
         Iterator.range(rc, 0, length(v)) |> Iterator.map(i -> get(i, v))
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestChain.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChain.flix
@@ -9,7 +9,7 @@ mod TestChain {
 
     @Test
     def collect01(): Unit \ Assert = region rc {
-        assertEq(expected = Chain.empty(), Collectable.collect((Iterator.empty(rc): Iterator[Int32, rc, rc])))
+        assertEq(expected = Chain.empty(), Collectable.collect((Iterator.empty(rc): Iterator[Int32, {}, rc])))
     }
 
     @Test

--- a/main/test/ca/uwaterloo/flix/library/TestCollectable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestCollectable.flix
@@ -8,7 +8,7 @@ mod TestCollectable {
 
     @Test
     def collectChain01(): Unit \ Assert = region rc {
-        let iter: Iterator[Int32, rc, rc] = Iterator.empty(rc);
+        let iter: Iterator[Int32, {}, rc] = Iterator.empty(rc);
         assertEq(expected = Chain.empty(), (Collectable.collect(iter) : Chain[Int32]))
     }
 
@@ -36,7 +36,7 @@ mod TestCollectable {
 
     @Test
     def collectList01(): Unit \ Assert = region rc {
-        let iter: Iterator[Int32, rc, rc] = Iterator.empty(rc);
+        let iter: Iterator[Int32, {}, rc] = Iterator.empty(rc);
         assertEq(expected = Nil, (Collectable.collect(iter) : List[Int32]))
     }
 
@@ -64,7 +64,7 @@ mod TestCollectable {
 
     @Test
     def collectSet01(): Unit \ Assert = region rc {
-        let iter: Iterator[Int32, rc, rc] = Iterator.empty(rc);
+        let iter: Iterator[Int32, {}, rc] = Iterator.empty(rc);
         assertEq(expected = Set.empty(), (Collectable.collect(iter) : Set[Int32]))
     }
 
@@ -92,7 +92,7 @@ mod TestCollectable {
 
     @Test
     def collectVector01(): Unit \ Assert = region rc {
-        let iter: Iterator[Int32, rc, rc] = Iterator.empty(rc);
+        let iter: Iterator[Int32, {}, rc] = Iterator.empty(rc);
         assertEq(expected = Vector#{}, (Collectable.collect(iter) : Vector[Int32]))
     }
 

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -754,7 +754,7 @@ mod TestIterator {
 
     @Test
     def zipWithIndex01(): Unit \ Assert = region rc {
-        assertEq(expected = Nil, Iterator.zipWithIndex((Iterator.empty(rc): Iterator[Int32, rc, rc])) |> Iterator.toList)
+        assertEq(expected = Nil, Iterator.zipWithIndex((Iterator.empty(rc): Iterator[Int32, {}, rc])) |> Iterator.toList)
     }
 
     @Test

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -10,7 +10,7 @@ mod TestList {
     /////////////////////////////////////////////////////////////////////////////
     @Test
     def collect01(): Unit \ Assert = region rc {
-        assertEq(expected = Nil, Collectable.collect((Iterator.empty(rc): Iterator[Int32, rc, rc])))
+        assertEq(expected = Nil, Collectable.collect((Iterator.empty(rc): Iterator[Int32, {}, rc])))
     }
 
     @Test

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -10,7 +10,7 @@ mod TestSet {
 
     @Test
     def collect01(): Unit \ Assert = region rc {
-        assertEq(expected = Set.empty(), Collectable.collect((Iterator.empty(rc): Iterator[Int32, rc, rc])))
+        assertEq(expected = Set.empty(), Collectable.collect((Iterator.empty(rc): Iterator[Int32, {}, rc])))
     }
 
     @Test

--- a/main/test/flix/Test.Dec.AssocEff.flix
+++ b/main/test/flix/Test.Dec.AssocEff.flix
@@ -57,13 +57,13 @@ mod Test.Dec.AssocEff {
     trait Iterable[t: Type] {
         type Elm: Type
         type Aef: Eff
-        pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], r + Iterable.Aef[t], r] \ r + Iterable.Aef[t]
+        pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], Iterable.Aef[t], r] \ r + Iterable.Aef[t]
     }
 
     instance Iterable[List[a]] {
         type Elm = a
         type Aef = {}
-        pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ r = {
+        pub def iterator(rc: Region[r], l: List[a]): Iterator[a, {}, r] \ r = {
             List.iterator(rc, l)
         }
     }
@@ -71,7 +71,7 @@ mod Test.Dec.AssocEff {
     instance Iterable[MutList[a, r1]] {
         type Elm = a
         type Aef = r1
-        pub def iterator(rc: Region[r], l: MutList[a, r1]): Iterator[a, r + r1, r] \ r + r1 = {
+        pub def iterator(rc: Region[r], l: MutList[a, r1]): Iterator[a, r1, r] \ r + r1 = {
             MutList.iterator(rc, l)
         }
     }
@@ -79,7 +79,7 @@ mod Test.Dec.AssocEff {
     instance Iterable[Map[k, v]] {
         type Elm = (k, v)
         type Aef = {}
-        pub def iterator(rc: Region[r], l: Map[k, v]): Iterator[(k, v), r, r] \ r = {
+        pub def iterator(rc: Region[r], l: Map[k, v]): Iterator[(k, v), {}, r] \ r = {
             Map.iterator(rc, l)
         }
     }
@@ -87,7 +87,7 @@ mod Test.Dec.AssocEff {
     instance Iterable[MutMap[k, v, r1]] {
         type Elm = (k, v)
         type Aef = r1
-        pub def iterator(rc: Region[r], l: MutMap[k, v, r1]): Iterator[(k, v), r + r1, r] \ r + r1 = {
+        pub def iterator(rc: Region[r], l: MutMap[k, v, r1]): Iterator[(k, v), r1, r] \ r + r1 = {
             MutMap.iterator(rc, l)
         }
     }
@@ -108,13 +108,13 @@ mod Test.Dec.AssocEff {
     trait DeepIterable[a] {
         type Elm
         type Aef: Eff
-        pub def iterator(rc: Region[r], x: a): Iterator[DeepIterable.Elm[a], r + DeepIterable.Aef[a], r] \ r + DeepIterable.Aef[a]
+        pub def iterator(rc: Region[r], x: a): Iterator[DeepIterable.Elm[a], DeepIterable.Aef[a], r] \ r + DeepIterable.Aef[a]
     }
 
     instance DeepIterable[Int32] {
         type Elm = Int32
         type Aef = {}
-        pub def iterator(rc: Region[r], x: Int32): Iterator[Int32, r, r] \ r = Iterator.singleton(rc, x)
+        pub def iterator(rc: Region[r], x: Int32): Iterator[Int32, {}, r] \ r = Iterator.singleton(rc, x)
     }
 
     enum LoudInt32(Int32) with Eq
@@ -122,7 +122,7 @@ mod Test.Dec.AssocEff {
     instance DeepIterable[LoudInt32] {
         type Elm = Int32
         type Aef = Console
-        pub def iterator(rc: Region[r], x: LoudInt32): Iterator[Int32, r + Console, r] \ r + Console = {
+        pub def iterator(rc: Region[r], x: LoudInt32): Iterator[Int32, Console, r] \ r + Console = {
             let LoudInt32.LoudInt32(i) = x;
             Console.println("${i}!");
             Iterator.singleton(rc, i) |> Iterator.map(y -> {Console.println("${y}!"); y})
@@ -132,10 +132,10 @@ mod Test.Dec.AssocEff {
     instance DeepIterable[List[a]] with DeepIterable[a] {
         type Elm = DeepIterable.Elm[a]
         type Aef = DeepIterable.Aef[a]
-        pub def iterator(rc: Region[r], x: List[a]): Iterator[DeepIterable.Elm[a], r + DeepIterable.Aef[a], r] \ r + DeepIterable.Aef[a] = {
+        pub def iterator(rc: Region[r], x: List[a]): Iterator[DeepIterable.Elm[a], DeepIterable.Aef[a], r] \ r + DeepIterable.Aef[a] = {
             // this is needed because the nested Aef isn't actually executed when we flatMap
             let _ = (checked_ecast(123): _ \ DeepIterable.Aef[a]);
-            List.iterator(rc, x) |> Iterator.flatMap(DeepIterable.iterator(rc))
+            List.iterator(rc, x) |> Iterator.flatMap(DeepIterable.iterator(rc)) |> Iterator.absorbRegion
 
         }
     }

--- a/main/test/flix/Test.Dec.AssocType.flix
+++ b/main/test/flix/Test.Dec.AssocType.flix
@@ -41,21 +41,21 @@ mod Test.Dec.AssocType {
         type Eff[a]: Eff
         type Elem[a]: Type
 
-        pub def iterator(rc: Region[r], x: a): Iterator[Iterable2.Elem[a], Iterable2.Eff[a] + r, r] \ Iterable2.Eff[a] + r
+        pub def iterator(rc: Region[r], x: a): Iterator[Iterable2.Elem[a], Iterable2.Eff[a], r] \ Iterable2.Eff[a] + r
     }
 
     instance Iterable2[String] {
         type Eff[String] = {}
         type Elem[String] = Char
 
-        pub def iterator(rc: Region[r], x: String): Iterator[Char, r, r] \ r = String.iterator(rc, x)
+        pub def iterator(rc: Region[r], x: String): Iterator[Char, {}, r] \ r = String.iterator(rc, x)
     }
 
     instance Iterable2[MutList[a, r]] {
         type Eff[MutList[a, r]] = r
         type Elem[MutList[a, r]] = a
 
-        pub def iterator(rc: Region[r2], x: MutList[a, r]): Iterator[a, r + r2, r2] \ r + r2 = MutList.iterator(rc, x)
+        pub def iterator(rc: Region[r2], x: MutList[a, r]): Iterator[a, r, r2] \ r + r2 = MutList.iterator(rc, x)
     }
 
     trait C[a] {


### PR DESCRIPTION
Closes #10077.

## Background

An iterator's stepper always runs in its region `rc` (`Iterator[a, ef, r]` is `Region[r]` paired with `Unit -> Step[a] \ { r, ef }`), so a region effect on the iterator's **own** region is not observable to consumers. Yet every iterator producer baked that region into the `ef` type parameter — `Iterator[Elm, r + aef, r]` instead of `Iterator[Elm, aef, r]`. This was redundant and unnecessarily strict, and the library was already internally inconsistent about it (`Iterator.ofList` was forced into the clean `Iterator[a, {}, r]` form, with a comment noting the `r + aef` form broke `intercalate`).

## Change

Adopt the convention that **`ef` excludes the iterator's own region** (the region still lives in the third type parameter and structurally in the stepper).

- Swept every iterator producer — `Iterator` constructors/combinators, and the `iterator`/`iteratorKeys`/`iteratorValues` methods on `List`, `Map`, `Set`, `Vector`, `Chain`, `RedBlackTree`, `BPlusTree`, `MultiMap`, the `Mut*` collections, `Adaptor`, etc. — plus the `Iterable` trait, to drop the own region from the `ef` slot.
- Added `Iterator.absorbRegion`, which re-wraps an iterator so its own region no longer appears in `ef` (the raw constructor unifies `ef` flexibly, collapsing the region to `{}`). It is used by the leaf builders that go through `unfoldWithIter`, and by `zipWithIndex`/`intersperse`/`intercalate`, which pass a region-effecting function to `map`/`flatMap`.
- `unfoldWithIter`/`unfoldWithOk` keep their general contract (the result `ef` is the stepper's effect), and the obsolete `ofList` comment is removed.

No change to the `Iterator` enum was needed — it was already shaped for this convention. Runtime behaviour is unchanged.

### Example

```flix
// before
pub def iterator(rc: Region[r], xs: List[a]): Iterator[a, r, r] \ r
// after
pub def iterator(rc: Region[r], xs: List[a]): Iterator[a, {}, r] \ r
```