### PR TITLE
feat: support jump to definition for type aliases

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
@@ -92,6 +92,18 @@ object LocationLink {
   }
 
   /**
+    * Returns a location link to the given type alias symbol `sym`.
+    */
+  def fromTypeAliasSym(sym: Symbol.TypeAliasSym, loc: SourceLocation)(implicit root: Root): LocationLink = {
+    val aliasDecl = root.typeAliases(sym)
+    val originSelectionRange = Range.from(loc)
+    val targetUri = sym.loc.source.name
+    val targetRange = Range.from(aliasDecl.loc)
+    val targetSelectionRange = Range.from(sym.loc)
+    LocationLink(originSelectionRange, targetUri, targetRange, targetSelectionRange)
+  }
+
+  /**
     * Returns a location link to the given symbol `sym`.
     */
   def fromCaseSym(sym: Symbol.CaseSym, loc: SourceLocation)(implicit root: Root): LocationLink = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -121,6 +121,8 @@ object GotoProvider {
     // Traits
     case SymUse.TraitSymUse(sym, loc) => Some(LocationLink.fromTraitSym(sym, loc))
     case SymUse.SigSymUse(sym, loc) => Some(LocationLink.fromSigSym(sym, loc))
+    // Type Aliases
+    case Type.Alias(symUse, _, _, _) => Some(LocationLink.fromTypeAliasSym(symUse.sym, symUse.loc))
     // Type Vars
     case Type.Var(sym, loc) => Some(LocationLink.fromTypeVarSym(sym, loc))
     // Vars


### PR DESCRIPTION
Closes #10988.

Go-to-Definition in the LSP now resolves a type alias use to its declaration.

Type alias uses are preserved in the typed AST as `Type.Alias` and are already pushed onto the cursor-resolution stack by the `Visitor`, but `GotoProvider` had no case for them (so it returned `None`). This adds the missing case and a `LocationLink.fromTypeAliasSym` helper, bringing goto to parity with find-references and highlight, which already handle type aliases.

### Changes
- `GotoProvider`: match `Type.Alias`, using the `TypeAliasSymUse` location (the alias name) as the origin span.
- `LocationLink.fromTypeAliasSym`: link a type alias use to its declaration (full declaration as `targetRange`, alias name as `targetSelectionRange`), mirroring `fromEnumSym`/`fromStructSym`.

Works for type aliases appearing in return types, parameter types, parameterized uses, nested inside another type alias, and enum case types.