### PR TITLE
fix: crash on handler for duplicate effect (#12003)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3636,6 +3636,23 @@ object Resolver {
         Some(ResolvedAst.Declaration.Enum(doc1, ann1, mod1, sym, combinedTparams, combinedDerivations, combinedCases, loc1))
     }
 
+    /**
+      * Optionally merges `eff1` and `eff2`. If `eff2` is [[None]] `eff1` is returned. If `eff2`
+      * is [[Some]] it indicates that it is a duplicate, and we merge the 2 effects.
+      *
+      * This is done to ensure that all operations of the effect are included.
+      * This is assumed to be the case by later phases which can cause crashes.
+      *
+      * No guarantees about whether operations from `eff1` or `eff2` are kept.
+      */
+    private def resilientMergeEffects(eff1: ResolvedAst.Declaration.Effect, eff2: Option[ResolvedAst.Declaration.Effect]): Option[ResolvedAst.Declaration.Effect] = (eff1, eff2) match {
+      case (_, None) => Some(eff1)
+      case (ResolvedAst.Declaration.Effect(doc1, ann1, mod1, sym, tparams1, ops1, loc1), Some(ResolvedAst.Declaration.Effect(_, _, _, _, tparams2, ops2, _))) =>
+        val combinedTparams = (tparams1 ++ tparams2).distinctBy(_.name.name)
+        val combinedOps = (ops1 ++ ops2).distinctBy(_.sym)
+        Some(ResolvedAst.Declaration.Effect(doc1, ann1, mod1, sym, combinedTparams, combinedOps, loc1))
+    }
+
     private def ++(that: SymbolTable): SymbolTable = {
       SymbolTable(
         modules = this.modules ++ that.modules,
@@ -3648,7 +3665,9 @@ object Resolver {
         structs = this.structs ++ that.structs,
         structFields = this.structFields ++ that.structFields,
         restrictableEnums = this.restrictableEnums ++ that.restrictableEnums,
-        effects = this.effects ++ that.effects,
+        effects = that.effects.foldLeft(this.effects) {
+          case (acc, (newSym, eff0)) => acc.updatedWith(newSym)(resilientMergeEffects(eff0, _))
+        },
         typeAliases = this.typeAliases ++ that.typeAliases
       )
     }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.language.errors.{ResolutionError, TypeError}
+import ca.uwaterloo.flix.language.errors.{NameError, ResolutionError, TypeError}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -1826,6 +1826,74 @@ class TestResolver extends AnyFunSuite with TestUtils {
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
     expectError[ResolutionError.OverAppliedOp](result)
+  }
+
+  test("DuplicateUpperName.Eff.Handler.01") {
+    // Regression test for https://github.com/flix/flix/issues/12003.
+    // A duplicate effect must not crash a later phase, even when a handler refers to
+    // an operation of the duplicated effect. Here the empty (operation-less) duplicate
+    // is declared last, so without merging it would shadow the operation.
+    val input =
+      """
+        |eff E {
+        |    def op(): Unit
+        |}
+        |
+        |eff E
+        |
+        |def foo(): Unit = {
+        |    run checked_ecast(()) with handler E {
+        |        def op(cont) = ()
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  test("DuplicateUpperName.Eff.Handler.02") {
+    // Regression test for https://github.com/flix/flix/issues/12003.
+    // As DuplicateUpperName.Eff.Handler.01, but with the empty duplicate declared first.
+    val input =
+      """
+        |eff E
+        |
+        |eff E {
+        |    def op(): Unit
+        |}
+        |
+        |def foo(): Unit = {
+        |    run checked_ecast(()) with handler E {
+        |        def op(cont) = ()
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  test("DuplicateUpperName.Eff.Handler.03") {
+    // Regression test for https://github.com/flix/flix/issues/12003.
+    // Both duplicate effects declare operations; a handler refers to an operation from
+    // the declaration that would otherwise be shadowed.
+    val input =
+      """
+        |eff E {
+        |    def op1(): Unit
+        |}
+        |
+        |eff E {
+        |    def op2(): Unit
+        |}
+        |
+        |def foo(): Unit = {
+        |    run checked_ecast(()) with handler E {
+        |        def op1(cont) = ()
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
   }
 
   test("Test.UnderAppliedOp.Handler.01") {


### PR DESCRIPTION
Fixes #12003.

## Problem

Declaring an effect whose name collides with an existing effect — e.g. the standard library's operation-less `eff Debug` — and then writing a handler for it crashed the compiler:

```
java.util.NoSuchElementException: key not found: Debug.break
  at ca.uwaterloo.flix.language.phase.typer.ConstraintGen$.visitHandlerRule(ConstraintGen.scala:1300)
```

The duplicate is correctly reported as `E5407 Duplicate definition`, but resilient compilation continues into the typer, which then crashes.

## Cause

The resolver assembles `root.effects` by folding per-compilation-unit symbol tables with `this.effects ++ that.effects`, where a duplicate `EffSym` lets one effect declaration overwrite the other. The surviving effect can be missing operations that a handler still references (e.g. the stdlib's empty `Debug` shadowing the user's `Debug.break`), leaving a dangling `OpSym` that `visitHandlerRule` fails to look up.

Enums already guard against the analogous duplicate-definition crash via `resilientMergeEnums` (#12068); effects had no such merge.

## Fix

Add `resilientMergeEffects`, mirroring `resilientMergeEnums`: when two effect declarations share an `EffSym`, merge their type parameters and operations instead of overwriting. For non-duplicate effects the behavior is unchanged (`resilientMergeEffects(eff, None) == Some(eff)`). The duplicate is still reported as an error, but the compiler no longer crashes.
