### PR TITLE
fix: preserve spawn evaluation order (#10707)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -158,7 +158,16 @@ object Simplifier {
           val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("_spawn", BoundBy.FormalParam, loc), SimpleType.Unit, loc)
           val lambdaExp = SimplifiedAst.Expr.Lambda(List(fp), e1, lambdaTyp, loc)
           val t = visitType(tpe)
-          SimplifiedAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(lambdaExp, e2), t, Purity.Impure, loc)
+          // Here `e1` is the spawned expression and `e2` is the region (i.e. `spawn e1 @ e2`).
+          // In source order the closure for `e1` is created before the region is evaluated, but
+          // codegen pushes the region (the receiver of `Region.spawn`) before the closure (its
+          // argument). We let-bind the closure so that it is created first; the region stays the
+          // second argument so codegen can still recognize the `Static` region.
+          // See: https://github.com/flix/flix/issues/10707
+          val closureSym = Symbol.freshVarSym("spawnClosure" + Flix.Delimiter, BoundBy.Let, loc)
+          val closureVar = SimplifiedAst.Expr.Var(closureSym, lambdaTyp, loc)
+          val spawnExp = SimplifiedAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(closureVar, e2), t, Purity.Impure, loc)
+          SimplifiedAst.Expr.Let(closureSym, lambdaExp, spawnExp, t, Purity.Impure, loc)
 
         case AtomicOp.Lazy =>
           // Wrap the expression in a closure: () -> tpe \ Pure

--- a/main/test/flix/Test.Exp.Concurrency.Spawn.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Spawn.flix
@@ -3,6 +3,7 @@ mod Test.Exp.Concurrency.Spawn {
     import java.lang.NullPointerException
     import java.lang.{Thread => JThread}
 
+    use Assert.assertEq
     use Assert.assertTrue
 
     @Test
@@ -58,6 +59,21 @@ mod Test.Exp.Concurrency.Spawn {
 
     @Test
     def testSpawn18(): Unit = region rc { spawn spawn spawn 123 @ rc @ rc @ rc }
+
+    // A spawn `spawn exp @ region` must evaluate its region expression at the spawn site,
+    // and the spawned thread must run. The closure for `exp` is created before the region is
+    // evaluated, matching left-to-right source order, even though codegen pushes the region
+    // (the receiver of `Region.spawn`) before the closure (its argument).
+    // See https://github.com/flix/flix/issues/10707.
+    @Test
+    def testSpawnRegionEvalOrder01(): Unit \ (Assert + Chan + NonDet) = region rc {
+        let regionEvaluated = Ref.fresh(rc, false);
+        let (tx, rx) = Channel.buffered(1);
+        spawn { Channel.send(42, tx) } @ { Ref.put(true, regionEvaluated); rc };
+        let received = Channel.recv(rx);
+        assertEq(expected = 42, received);
+        assertEq(expected = true, Ref.get(regionEvaluated))
+    }
 
     @Test
     def testExceptionsInChildThread01(): Unit \ (Assert + IO) =


### PR DESCRIPTION
Fixes #10707.

`spawn e1 @ e2` evaluated the region `e2` before the spawned expression `e1`, flipping left-to-right source order (`spawn e1 @ Static` was unaffected).

## Cause

`Region.spawn` is a JVM *instance* method, so codegen must push the region (the receiver) before the closure (its argument). This reorders the two operands relative to source order — the same class of bug as the recent channel-send fix (#10378).

## Fix

In the simplifier, where the spawned expression is wrapped into a closure, let-bind that closure so it is created before the region is evaluated:

```
let spawnClosure = <closure for e1>;  // created first (source order)
spawn(spawnClosure, e2)               // region evaluated in codegen, closure is now a pure var load
```

Only the closure is let-bound; the region stays the second argument so codegen can still recognize the `Static` region and start a thread directly (this also covers the internal `spawn … @ Static` emitted for channel sends).