### PR TITLE
ci: add ababup1192/flix_game_engine to community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -66,6 +66,7 @@ jobs:
           - "rywiese/scope-graphs"
           - "stephentetley/flix-htmldoc"
           - "stephentetley/flix-pretty"
+          - "ababup1192/flix_game_engine"
     runs-on: ubuntu-latest
     steps:
       - name: Install JDK

--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -58,6 +58,7 @@ jobs:
           - "JonathanStarup/Flix-ANSI-Terminal"
           - "JonathanStarup/ListSet"
           - "JonathanStarup/talpin1992-in-flix"
+          - "ababup1192/flix_game_engine"
           - "magnus-madsen/bibblitz"
           - "jaschdoc/flix-test-pkg-trust-transitive-plain"
           - "jaschdoc/flix-test-pkg-trust-transitive-java"
@@ -66,7 +67,6 @@ jobs:
           - "rywiese/scope-graphs"
           - "stephentetley/flix-htmldoc"
           - "stephentetley/flix-pretty"
-          - "ababup1192/flix_game_engine"
     runs-on: ubuntu-latest
     steps:
       - name: Install JDK

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -100,3 +100,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Andreas Gotthelf Kühlwein Pedersen](https://github.com/ACoolWine)
 - [Fridolin Karger](https://github.com/LordBurtz)
 - [Vipul Bhardwaj](https://github.com/vipulbhj)
+- [Mirai Tomiyama](https://github.com/ababup1192)


### PR DESCRIPTION
Adds [flix_game_engine](https://github.com/ababup1192/flix_game_engine), a 2D game engine written in Flix (a 5-package monorepo), to the community build. The repo root has a `flix.toml` and a `src/` symlink tree so a plain `flix build` type-checks the whole engine — no `github:` deps, only LWJGL Maven artifacts. Builds cleanly on 0.75.1.

https://github.com/flix/flix/issues/12885#issuecomment-4825200905