### PR TITLE
feat: allow Boolean/effect side conditions in where clauses

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/effectlock/Util.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/Util.scala
@@ -52,7 +52,7 @@ object Util {
 
     val base = visit(sc0.base)
     val tconstrs = sc0.tconstrs.map(tc => tc.copy(arg = visit(tc.arg)))
-    val econstrs = sc0.econstrs.map(ec => ec.copy(tpe1 = visit(ec.tpe1), tpe2 = visit(ec.tpe2)))
+    val econstrs = sc0.econstrs.map(ec => ec.withTypes(visit(ec.tpe1), visit(ec.tpe2)))
     val qs = sc0.quantifiers.map {
       q =>
         seen.get(q.kind) match {

--- a/main/src/ca/uwaterloo/flix/api/effectlock/serialization/Deserialize.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/serialization/Deserialize.scala
@@ -215,8 +215,10 @@ object Deserialize {
   }
 
   private def deserializeEqualityConstraint(econstr0: EqConstr): EqualityConstraint = econstr0 match {
-    case EqConstr(sym, tpe1, tpe2) =>
-      EqualityConstraint(deserializeAssocTypeSymUse(sym), deserializeType(tpe1), deserializeType(tpe2), SourceLocation.Unknown)
+    case EqConstr(Some(sym), tpe1, tpe2) =>
+      EqualityConstraint.AssocEq(deserializeAssocTypeSymUse(sym), deserializeType(tpe1), deserializeType(tpe2), SourceLocation.Unknown)
+    case EqConstr(None, tpe1, tpe2) =>
+      EqualityConstraint.BoolEq(deserializeType(tpe1), deserializeType(tpe2), SourceLocation.Unknown)
   }
 
   private def deserializeTraitConstraint(tconstr0: TraitConstr): TraitConstraint = tconstr0 match {

--- a/main/src/ca/uwaterloo/flix/api/effectlock/serialization/Serialize.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/serialization/Serialize.scala
@@ -199,8 +199,11 @@ object Serialize {
     TraitConstr(serializeTraitSym(tconstr0.symUse.sym), serializeType(tconstr0.arg))
   }
 
-  private def serializeEqualityConstraint(econstr0: EqualityConstraint): EqConstr = {
-    EqConstr(serializeAssocTypeSym(econstr0.symUse.sym), serializeType(econstr0.tpe1), serializeType(econstr0.tpe2))
+  private def serializeEqualityConstraint(econstr0: EqualityConstraint): EqConstr = econstr0 match {
+    case EqualityConstraint.AssocEq(symUse, tpe1, tpe2, _) =>
+      EqConstr(Some(serializeAssocTypeSym(symUse.sym)), serializeType(tpe1), serializeType(tpe2))
+    case EqualityConstraint.BoolEq(tpe1, tpe2, _) =>
+      EqConstr(None, serializeType(tpe1), serializeType(tpe2))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/api/effectlock/serialization/package.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/serialization/package.scala
@@ -224,7 +224,9 @@ package object serialization {
 
   case class TraitConstr(sym: TraitSym, tpe: SType)
 
-  case class EqConstr(sym: AssocTypeSym, tpe1: SType, tpe2: SType)
+  // `sym` is `Some` for an associated-type equality (`sym[tpe1] ~ tpe2`) and `None` for a
+  // Boolean/effect equality (`tpe1 ~ tpe2`).
+  case class EqConstr(sym: Option[AssocTypeSym], tpe1: SType, tpe2: SType)
 
   /** Implicitly defines type hints for json4s for each of the serializable constructors. */
   implicit val formats: org.json4s.Formats = org.json4s.native.Serialization.formats(

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -174,7 +174,7 @@ object FindReferencesProvider {
     case SymUse.StructFieldSymUse(_, loc) => loc.isReal
     case SymUse.TraitSymUse(_, loc) => loc.isReal
 
-    case EqualityConstraint(_, _, _, loc) => loc.isReal
+    case ec: EqualityConstraint => ec.loc.isReal
     case TraitConstraint(_, _, loc) => loc.isReal
 
     case tpe: Type => tpe.loc.isReal

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -179,7 +179,7 @@ object GotoProvider {
 
     case TraitConstraint(_, _, loc) => loc.isReal
 
-    case EqualityConstraint(_, _, _, loc) => loc.isReal
+    case ec: EqualityConstraint => ec.loc.isReal
 
     case _: Symbol => true
     case tpe: Type => tpe.loc.isReal

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
@@ -164,7 +164,7 @@ object RenameProvider {
 
     case TraitConstraint(_, _, loc) => loc.isReal
 
-    case EqualityConstraint(_, _, _, loc) => loc.isReal
+    case ec: EqualityConstraint => ec.loc.isReal
 
     case _: Symbol => true
     case tpe: Type => tpe.loc.isReal

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -421,7 +421,7 @@ object DesugaredAst {
 
   case class TraitConstraint(trt: Name.QName, tpe: Type, loc: SourceLocation)
 
-  case class EqualityConstraint(qname: Name.QName, tpe1: Type, tpe2: Type, loc: SourceLocation)
+  case class EqualityConstraint(qname: Option[Name.QName], tpe1: Type, tpe2: Type, loc: SourceLocation)
 
   case class Constraint(head: Predicate.Head, body: List[Predicate.Body], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -458,7 +458,7 @@ object NamedAst {
 
   case class TraitConstraint(trt: Name.QName, tpe: Type, loc: SourceLocation)
 
-  case class EqualityConstraint(qname: Name.QName, tpe1: Type, tpe2: Type, loc: SourceLocation)
+  case class EqualityConstraint(qname: Option[Name.QName], tpe1: Type, tpe2: Type, loc: SourceLocation)
 
   case class ParYieldFragment(pat: Pattern, exp: Expr, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -107,8 +107,10 @@ object Scheme {
     }
 
     val newEconstrs = sc.econstrs.map {
-      case EqualityConstraint(symUse, tpe1, tpe2, _) =>
-        EqualityConstraint(symUse, visitType(tpe1), visitType(tpe2), loc)
+      case EqualityConstraint.AssocEq(symUse, tpe1, tpe2, _) =>
+        EqualityConstraint.AssocEq(symUse, visitType(tpe1), visitType(tpe2), loc)
+      case EqualityConstraint.BoolEq(tpe1, tpe2, _) =>
+        EqualityConstraint.BoolEq(visitType(tpe1), visitType(tpe2), loc)
     }
 
     (newTconstrs, newEconstrs, newBase, substMap)
@@ -154,16 +156,22 @@ object Scheme {
     val subst0 = Substitution(substMap)
     val eenv0 = ConstraintSolverInterface.expandEqualityEnv(globalEqEnv0, localEconstrs.map(subst0.apply))
 
-    // Resolve what we can from the new econstrs
-    val tconstrs2_0 = econstrs2_0.map { case EqualityConstraint(symUse, t1, t2, loc) => TypeConstraint.Equality(Type.AssocType(symUse, t1, t2.kind, loc), t2, Provenance.Match(t1, t2, loc)) }
+    // Split the new econstrs into associated-type equalities and Boolean/effect equalities.
+    val (assocEc2, boolEc2) = econstrs2_0.partitionMap {
+      case a: EqualityConstraint.AssocEq => Left(a)
+      case b: EqualityConstraint.BoolEq => Right(b)
+    }
+
+    // Resolve what we can from the new associated-type econstrs
+    val tconstrs2_0 = assocEc2.map { case EqualityConstraint.AssocEq(symUse, t1, t2, loc) => TypeConstraint.Equality(Type.AssocType(symUse, t1, t2.kind, loc), t2, Provenance.Match(t1, t2, loc)) }
     val (econstrs2_1, subst) = ConstraintSolver2.solveAllTypes(tconstrs2_0)(scope, RigidityEnv.empty, eenv0, flix)
 
     // Anything we didn't solve must be a standard equality constraint
-    // Apply the substitution to the new scheme 2
+    // Apply the substitution to the new scheme 2. Boolean/effect equalities are carried through unchanged.
     val econstrs2 = econstrs2_1.map {
-      case TypeConstraint.Equality(Type.AssocType(symUse, t1, _, _), t2, prov) => EqualityConstraint(symUse, subst(t1), subst(t2), prov.loc)
+      case TypeConstraint.Equality(Type.AssocType(symUse, t1, _, _), t2, prov) => EqualityConstraint.AssocEq(symUse, subst(t1), subst(t2), prov.loc)
       case _ => throw InternalCompilerException("unexpected constraint", SourceLocation.Unknown)
-    }
+    } ++ boolEc2.map(subst.apply)
     val tpe2 = subst(tpe2_0)
     val cconstrs2 = cconstrs2_0.map {
       case TraitConstraint(head, arg, loc) =>
@@ -186,9 +194,16 @@ object Scheme {
     // Check that the constraints from sc1 hold
     // And that the bases unify
     val cconstrs = sc1.tconstrs.map { case TraitConstraint(head, arg, loc) => TypeConstraint.Trait(head.sym, arg, loc) }
-    val econstrs = sc1.econstrs.map { case EqualityConstraint(symUse, t1, t2, loc) => TypeConstraint.Equality(Type.AssocType(symUse, t1, t2.kind, loc), t2, Provenance.Match(t1, t2, loc)) }
+    val econstrs = sc1.econstrs.map {
+      case EqualityConstraint.AssocEq(symUse, t1, t2, loc) => TypeConstraint.Equality(Type.AssocType(symUse, t1, t2.kind, loc), t2, Provenance.Match(t1, t2, loc))
+      case EqualityConstraint.BoolEq(t1, t2, loc) => TypeConstraint.Equality(t1, t2, Provenance.Match(t1, t2, loc))
+    }
     val baseConstr = TypeConstraint.Equality(sc1.base, tpe2, Provenance.Match(sc1.base, tpe2, SourceLocation.Unknown))
-    ConstraintSolver2.solveAll(baseConstr :: cconstrs ::: econstrs, SubstitutionTree.shallow(subst))(scope, renv, cenv, eenv, flix) match {
+
+    // Discharge sc2's Boolean/effect equalities by assumption (see ConstraintSolverInterface.mkAssumptionSubst).
+    val assumeSubst = ConstraintSolverInterface.mkAssumptionSubst(econstrs2, scope).getOrElse(Substitution.empty)
+    val goals = (baseConstr :: cconstrs ::: econstrs).map(SubstitutionTree.shallow(assumeSubst).apply)
+    ConstraintSolver2.solveAll(goals, SubstitutionTree.shallow(subst))(scope, renv, cenv, eenv, flix) match {
       // We succeed only if there are no leftover constraints
       case (Nil, _) => true
       case (_ :: _, _) => false

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -446,7 +446,7 @@ object WeededAst {
 
   case class TraitConstraint(trt: Name.QName, tpe: Type, loc: SourceLocation)
 
-  case class EqualityConstraint(qname: Name.QName, tpe1: Type, tpe2: Type, loc: SourceLocation)
+  case class EqualityConstraint(qname: Option[Name.QName], tpe1: Type, tpe2: Type, loc: SourceLocation)
 
   case class Constraint(head: Predicate.Head, body: List[Predicate.Body], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/EqualityConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/EqualityConstraint.scala
@@ -19,6 +19,49 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Type}
 
 /**
-  * Represents that `cst[tpe1]` and `tpe2` are equivalent types.
+  * Represents an equality constraint appearing in a `where` clause.
+  *
+  * There are two forms:
+  *   - [[EqualityConstraint.AssocEq]] asserts that an associated type `cst[tpe1]` equals `tpe2`.
+  *   - [[EqualityConstraint.BoolEq]] asserts that two Boolean/effect formulas `tpe1` and `tpe2` are equal.
   */
-case class EqualityConstraint(symUse: AssocTypeSymUse, tpe1: Type, tpe2: Type, loc: SourceLocation)
+sealed trait EqualityConstraint {
+  def tpe1: Type
+
+  def tpe2: Type
+
+  def loc: SourceLocation
+
+  /**
+    * Returns this constraint with its source location replaced by `newLoc`.
+    */
+  def withLoc(newLoc: SourceLocation): EqualityConstraint = this match {
+    case c: EqualityConstraint.AssocEq => c.copy(loc = newLoc)
+    case c: EqualityConstraint.BoolEq => c.copy(loc = newLoc)
+  }
+
+  /**
+    * Returns this constraint with its two types replaced by `newTpe1` and `newTpe2`.
+    */
+  def withTypes(newTpe1: Type, newTpe2: Type): EqualityConstraint = this match {
+    case c: EqualityConstraint.AssocEq => c.copy(tpe1 = newTpe1, tpe2 = newTpe2)
+    case c: EqualityConstraint.BoolEq => c.copy(tpe1 = newTpe1, tpe2 = newTpe2)
+  }
+}
+
+object EqualityConstraint {
+
+  /**
+    * Represents that `symUse[tpe1]` and `tpe2` are equivalent types.
+    */
+  case class AssocEq(symUse: AssocTypeSymUse, tpe1: Type, tpe2: Type, loc: SourceLocation) extends EqualityConstraint
+
+  /**
+    * Represents that the Boolean/effect formulas `tpe1` and `tpe2` are equivalent.
+    *
+    * Both `tpe1` and `tpe2` have kind [[ca.uwaterloo.flix.language.ast.Kind.Bool]] or both have
+    * kind [[ca.uwaterloo.flix.language.ast.Kind.Eff]].
+    */
+  case class BoolEq(tpe1: Type, tpe2: Type, loc: SourceLocation) extends EqualityConstraint
+
+}

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatEqualityConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatEqualityConstraint.scala
@@ -31,10 +31,14 @@ object FormatEqualityConstraint {
     * Formats the given `econstr` as `Assoc[Arg] ~ Type`.
     */
   def formatEqualityConstraintWithOptions(tconstr: EqualityConstraint, fmt: FormatOptions): String = tconstr match {
-    case EqualityConstraint(symUse, tpe1, tpe2, _) =>
+    case EqualityConstraint.AssocEq(symUse, tpe1, tpe2, _) =>
       val assocString = symUse.sym.name
       val tpe1String = FormatType.formatTypeWithOptions(tpe1, fmt)
       val tpe2String = FormatType.formatTypeWithOptions(tpe2, fmt)
       s"$assocString[$tpe1String] ~ $tpe2String"
+    case EqualityConstraint.BoolEq(tpe1, tpe2, _) =>
+      val tpe1String = FormatType.formatTypeWithOptions(tpe1, fmt)
+      val tpe2String = FormatType.formatTypeWithOptions(tpe2, fmt)
+      s"$tpe1String ~ $tpe2String"
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.shared.SymUse.TraitSymUse
 import ca.uwaterloo.flix.language.ast.shared.{EqualityConstraint, Instance, RegionScope, TraitConstraint}
-import ca.uwaterloo.flix.language.ast.{ChangeSet, RigidityEnv, Scheme, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{ChangeSet, Kind, RigidityEnv, Scheme, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugTypedAst
 import ca.uwaterloo.flix.language.errors.InstanceError
 import ca.uwaterloo.flix.language.errors.InstanceError.MissingEqualityConstraint
@@ -44,7 +44,9 @@ object Instances {
     */
   private def toShared(ec: TypedAst.EqualityConstraint): Option[EqualityConstraint] = ec match {
     case TypedAst.EqualityConstraint(Type.AssocType(cst, arg, _, _), tpe2, loc) =>
-      Some(EqualityConstraint(cst, arg, tpe2, loc))
+      Some(EqualityConstraint.AssocEq(cst, arg, tpe2, loc))
+    case TypedAst.EqualityConstraint(tpe1, tpe2, loc) if tpe1.kind == Kind.Bool || tpe1.kind == Kind.Eff =>
+      Some(EqualityConstraint.BoolEq(tpe1, tpe2, loc))
     case TypedAst.EqualityConstraint(_, _, _) =>
       None
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -251,10 +251,7 @@ object Kinder {
       val tparams = tparams0.map(visitTypeParam(_, kenv))
       val t = visitType(tpe0, kind, kenv, root)
       val tconstrs = tconstrs0.map(visitTraitConstraint(_, kenv, root))
-      val econstrs = econstrs0.collect {
-        case ResolvedAst.EqualityConstraint(UnkindedType.AssocType(symUse, arg, _), tpe2, loc) =>
-          visitEqualityConstraint(symUse, arg, tpe2, loc, kenv, root)
-      }
+      val econstrs = econstrs0.flatMap(visitAnyEqualityConstraint(_, kenv, root))
       val assocs = assocs0.map(visitAssocTypeDef(_, kind, kenv, root))
       val defs = defs0.map(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn, kenv, root)))
       KindedAst.Instance(doc, ann, mod, symUse, tparams, t, tconstrs, econstrs, assocs, defs, ns, loc)
@@ -370,10 +367,7 @@ object Kinder {
           )
       }
       val tconstrs = tconstrs0.map(visitTraitConstraint(_, kenv, root))
-      val econstrs = econstrs0.collect {
-        case ResolvedAst.EqualityConstraint(UnkindedType.AssocType(symUse, arg, _), tpe2, loc) =>
-          visitEqualityConstraint(symUse, arg, tpe2, loc, kenv, root)
-      }
+      val econstrs = econstrs0.flatMap(visitAnyEqualityConstraint(_, kenv, root))
       val allQuantifiers = quantifiers ::: tparams.map(_.sym)
       val base = Type.mkUncurriedArrowWithEffect(fparams.map(_.tpe), eff.getOrElse(Type.Pure), tpe, tpe.loc)
       val sc = Scheme(allQuantifiers, tconstrs, econstrs, base)
@@ -1387,10 +1381,64 @@ object Kinder {
     *
     * The caller is responsible for filtering out ill-shaped constraints before invoking this helper.
     */
+  /**
+    * Performs kinding on the given equality constraint, dispatching on its form.
+    *
+    * Returns `None` for an ill-shaped associated-type constraint whose head failed to resolve (the
+    * error has already been reported); otherwise returns the kinded constraint.
+    */
+  private def visitAnyEqualityConstraint(econstr: ResolvedAst.EqualityConstraint, kenv: KindEnv, root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): Option[EqualityConstraint] = econstr match {
+    case ResolvedAst.EqualityConstraint(UnkindedType.AssocType(symUse, arg, _), tpe2, loc) =>
+      Some(visitEqualityConstraint(symUse, arg, tpe2, loc, kenv, root))
+    case ResolvedAst.EqualityConstraint(UnkindedType.Error(_), _, _) =>
+      // The associated-type head failed to resolve; the error was already reported.
+      None
+    case ResolvedAst.EqualityConstraint(tpe1, tpe2, loc) =>
+      Some(visitBoolEqualityConstraint(tpe1, tpe2, loc, kenv, root))
+  }
+
   private def visitEqualityConstraint(symUse: AssocTypeSymUse, arg: UnkindedType, tpe2: UnkindedType, loc: SourceLocation, kenv: KindEnv, root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): EqualityConstraint = {
     val t1 = visitType(arg, Kind.Wild, kenv, root)
     val t2 = visitType(tpe2, Kind.Wild, kenv, root)
-    EqualityConstraint(symUse, t1, t2, loc)
+    EqualityConstraint.AssocEq(symUse, t1, t2, loc)
+  }
+
+  /**
+    * Performs kinding on the given Boolean/effect equality side condition `tpe1 ~ tpe2`.
+    *
+    * Both sides must have kind [[Kind.Bool]] or both must have kind [[Kind.Eff]]; otherwise a
+    * kind error is reported.
+    */
+  private def visitBoolEqualityConstraint(tpe1: UnkindedType, tpe2: UnkindedType, loc: SourceLocation, kenv: KindEnv, root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): EqualityConstraint = {
+    // Prefer a Boolean/effect kind determined by either side so bare variables link to the right kind.
+    val expected = boolEffHint(tpe1).orElse(boolEffHint(tpe2)).getOrElse(Kind.Wild)
+    val t1 = visitType(tpe1, expected, kenv, root)
+    val t2 = visitType(tpe2, expected, kenv, root)
+    (t1.kind, t2.kind) match {
+      case (Kind.Bool, Kind.Bool) => ()
+      case (Kind.Eff, Kind.Eff) => ()
+      case (k1, k2) if k1 == k2 =>
+        // Same kind, but not a Boolean/effect kind: a side condition must range over Bool or Eff.
+        sctx.errors.add(KindError.MismatchedKinds(Kind.Bool, k1, loc))
+      case (k1, k2) =>
+        sctx.errors.add(KindError.MismatchedKinds(k1, k2, loc))
+    }
+    EqualityConstraint.BoolEq(t1, t2, loc)
+  }
+
+  /**
+    * Returns [[Kind.Bool]] or [[Kind.Eff]] if the head constructor of `tpe` determines it, else `None`.
+    */
+  private def boolEffHint(tpe: UnkindedType): Option[Kind] = tpe match {
+    case UnkindedType.Apply(t1, _, _) => boolEffHint(t1)
+    case UnkindedType.Effect(_, _) => Some(Kind.Eff)
+    case UnkindedType.Cst(tc, _) => tc match {
+      case TypeConstructor.True | TypeConstructor.False | TypeConstructor.And | TypeConstructor.Or | TypeConstructor.Not => Some(Kind.Bool)
+      case TypeConstructor.Pure | TypeConstructor.Univ | TypeConstructor.Union | TypeConstructor.Intersection | TypeConstructor.Complement => Some(Kind.Eff)
+      case TypeConstructor.Effect(_, _) => Some(Kind.Eff)
+      case _ => None
+    }
+    case _ => None
   }
 
   /**
@@ -1520,8 +1568,10 @@ object Kinder {
           val kenv2 = inferType(tpe2, kind2, kenv, root)
           kenv1 ++ kenv2
         case _ =>
-          // Ill-shaped or error constraint; still infer kinds from the parts we can resolve.
-          inferType(tpe2, Kind.Wild, kenv, root)
+          // A Boolean/effect side condition (or an error constraint): infer kinds from both sides,
+          // using a Boolean/effect hint from either side so bare variables link to the right kind.
+          val hint = boolEffHint(tpe1).orElse(boolEffHint(tpe2)).getOrElse(Kind.Wild)
+          inferType(tpe1, hint, kenv, root) ++ inferType(tpe2, hint, kenv, root)
       }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1737,8 +1737,11 @@ object Namer {
     val effTvars = eff.toList.flatMap(freeTypeVars)
 
     val econstrTvars = econstrs.flatMap {
-      // We only infer vars from the right-hand-side of the constraint.
-      case DesugaredAst.EqualityConstraint(_, _, tpe2, _) => freeTypeVars(tpe2)
+      // For an associated-type constraint we only infer vars from the right-hand side (the left-hand
+      // side variables are bound by the associated type's argument, which appears elsewhere).
+      case DesugaredAst.EqualityConstraint(Some(_), _, tpe2, _) => freeTypeVars(tpe2)
+      // For a Boolean/effect side condition both sides are real formulas, so infer from both.
+      case DesugaredAst.EqualityConstraint(None, tpe1, tpe2, _) => freeTypeVars(tpe1) ::: freeTypeVars(tpe2)
     }
 
     (fparamTvars ::: tpeTvars ::: effTvars ::: econstrTvars).distinct.map {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2077,7 +2077,7 @@ object Resolver {
     * Performs name resolution on the given equality constraint `econstr0`.
     */
   private def resolveEqualityConstraint(tconstr0: NamedAst.EqualityConstraint, scp0: LocalScope, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit sctx: SharedContext, flix: Flix): ResolvedAst.EqualityConstraint = tconstr0 match {
-    case NamedAst.EqualityConstraint(qname, tpe1, tpe2, loc) =>
+    case NamedAst.EqualityConstraint(Some(qname), tpe1, tpe2, loc) =>
       val t1 = resolveType(tpe1, None, Wildness.ForbidWild, scp0, taenv, ns0, root)(RegionScope.Top, sctx, flix)
       val t2 = resolveType(tpe2, None, Wildness.ForbidWild, scp0, taenv, ns0, root)(RegionScope.Top, sctx, flix)
 
@@ -2090,6 +2090,13 @@ object Resolver {
           sctx.errors.add(error)
           ResolvedAst.EqualityConstraint(UnkindedType.Error(qname.loc), t2, loc)
       }
+
+    case NamedAst.EqualityConstraint(None, tpe1, tpe2, loc) =>
+      // A Boolean/effect side condition: both sides are resolved as ordinary types (the left-hand
+      // side is not an associated type). The kinds are checked in the Kinder.
+      val t1 = resolveType(tpe1, None, Wildness.ForbidWild, scp0, taenv, ns0, root)(RegionScope.Top, sctx, flix)
+      val t2 = resolveType(tpe2, None, Wildness.ForbidWild, scp0, taenv, ns0, root)(RegionScope.Top, sctx, flix)
+      ResolvedAst.EqualityConstraint(t1, t2, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.Type.instantiateJavaTypeWithObjectArgs
 import ca.uwaterloo.flix.language.ast.TypedAst.ApplyPosition
-import ca.uwaterloo.flix.language.ast.shared.{CheckedCastType, Constant, Decreasing}
+import ca.uwaterloo.flix.language.ast.shared.{CheckedCastType, Constant, Decreasing, EqualityConstraint}
 import ca.uwaterloo.flix.language.errors.TypeError
 import ca.uwaterloo.flix.language.phase.typer.SubstitutionTree
 import ca.uwaterloo.flix.util.InternalCompilerException
@@ -57,7 +57,10 @@ object TypeReconstruction {
       val fparams = fparams0.map(visitFormalParam(_, SubstitutionTree.empty))
       val eff1 = eff.getOrElse(Type.Pure)
       // We do not perform substitution on any of the types because they should all be rigid.
-      val typedEconstrs = econstrs.map(ec => TypedAst.EqualityConstraint(Type.AssocType(ec.symUse, ec.tpe1, ec.tpe2.kind, ec.loc), ec.tpe2, ec.loc))
+      val typedEconstrs = econstrs.map {
+        case EqualityConstraint.AssocEq(symUse, tpe1, tpe2, loc) => TypedAst.EqualityConstraint(Type.AssocType(symUse, tpe1, tpe2.kind, loc), tpe2, loc)
+        case EqualityConstraint.BoolEq(tpe1, tpe2, loc) => TypedAst.EqualityConstraint(tpe1, tpe2, loc)
+      }
       TypedAst.Spec(doc, ann, mod, tparams, fparams, sc, tpe, eff1, tconstrs, typedEconstrs)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -317,7 +317,10 @@ object Typer {
             visitDef(defn, tconstrs, econstrs, renv, root, traitEnv, eqEnv, open)
           }
       }
-      val typedEconstrs = econstrs.map(ec => TypedAst.EqualityConstraint(Type.AssocType(ec.symUse, ec.tpe1, ec.tpe2.kind, ec.loc), ec.tpe2, ec.loc))
+      val typedEconstrs = econstrs.map {
+        case EqualityConstraint.AssocEq(symUse, tpe1, tpe2, ecLoc) => TypedAst.EqualityConstraint(Type.AssocType(symUse, tpe1, tpe2.kind, ecLoc), tpe2, ecLoc)
+        case EqualityConstraint.BoolEq(tpe1, tpe2, ecLoc) => TypedAst.EqualityConstraint(tpe1, tpe2, ecLoc)
+      }
       TypedAst.Instance(doc, ann, mod, symUse, tparams, tpe, tconstrs, typedEconstrs, assocs, defs, ns, loc)
   }
 
@@ -478,9 +481,11 @@ object Typer {
     * Returns a list containing both types in the constraint.
     */
   private def getTypes(econstr: EqualityConstraint): List[Type] = econstr match {
-    case EqualityConstraint(cst, tpe1, tpe2, _) =>
+    case EqualityConstraint.AssocEq(cst, tpe1, tpe2, _) =>
       // Kind is irrelevant for our purposes
       List(Type.AssocType(cst, tpe1, Kind.Wild, tpe1.loc), tpe2) // TODO ASSOC-TYPES better location for left
+    case EqualityConstraint.BoolEq(tpe1, tpe2, _) =>
+      List(tpe1, tpe2)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -646,7 +646,13 @@ object Weeder2 {
     private def visitEqualityConstraint(tree: Tree)(implicit sctx: SharedContext): Option[EqualityConstraint] = {
       pickAll(TreeKind.Type.Type, tree).map(Types.visitType) match {
         case Type.Apply(Type.Ambiguous(qname, _), t1, _) :: t2 :: Nil =>
-          Some(EqualityConstraint(qname, t1, t2, tree.loc))
+          // An associated-type equality constraint: `Trait.Assoc[arg] ~ Type`.
+          Some(EqualityConstraint(Some(qname), t1, t2, tree.loc))
+
+        case t1 :: t2 :: Nil =>
+          // A general (Boolean/effect) equality side condition: `formula ~ formula`.
+          // The kinds are checked later, in the Kinder.
+          Some(EqualityConstraint(None, t1, t2, tree.loc))
 
         case _ =>
           val error = IllegalEqualityConstraint(tree.loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -99,7 +99,7 @@ object ConstraintGen {
         val subst = Substitution(tparams.zip(targs).toMap)
 
         val tconstrs = defn.spec.tconstrs.map(subst.apply).map(_.copy(loc = loc2))
-        val econstrs = defn.spec.econstrs.map(subst.apply).map(_.copy(loc = loc2))
+        val econstrs = defn.spec.econstrs.map(subst.apply).map(_.withLoc(loc2))
 
         // If no effect specified, we assume the function is pure
         val declaredEff = subst(defn.spec.eff.getOrElse(Type.Pure))
@@ -135,7 +135,7 @@ object ConstraintGen {
         val op = lookupOp(sym, loc1)
         val (tconstrs0, econstrs0, declaredType, _) = Scheme.instantiate(op.spec.sc, loc1.asSynthetic)
         val tconstrs = tconstrs0.map(_.copy(loc = loc2))
-        val econstrs = econstrs0.map(_.copy(loc = loc2))
+        val econstrs = econstrs0.map(_.withLoc(loc2))
         val declaredEff = declaredType.arrowEffectType
         val declaredArgumentTypes = declaredType.arrowArgTypes
         val declaredResultType = generalizeVoid(declaredType.arrowResultType)
@@ -156,7 +156,7 @@ object ConstraintGen {
         val mapping = (trt.tparam.sym -> targ) :: sig.spec.tparams.map(_.sym).zip(targs)
         val subst = Substitution(mapping.toMap)
         val tconstrs = sig.spec.tconstrs.map(subst.apply).map(_.copy(loc = loc2))
-        val econstrs = sig.spec.econstrs.map(subst.apply).map(_.copy(loc = loc2))
+        val econstrs = sig.spec.econstrs.map(subst.apply).map(_.withLoc(loc2))
 
         val declaredEff = subst(sig.spec.eff.getOrElse(Type.Pure))
         val declaredResultType = subst(sig.spec.tpe)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -683,9 +683,11 @@ object ConstraintSolver2 {
     * Replaces the location with the given location.
     */
   private def equalityConstraintToTypeConstraint(constr: EqualityConstraint, loc: SourceLocation): TypeConstraint = constr match {
-    case EqualityConstraint(cst, tpe1, tpe2, _) =>
+    case EqualityConstraint.AssocEq(cst, tpe1, tpe2, _) =>
       val assoc = Type.AssocType(cst, tpe1, tpe2.kind, tpe1.loc)
       TypeConstraint.Equality(assoc, tpe2, Provenance.Match(tpe1, tpe2, loc))
+    case EqualityConstraint.BoolEq(tpe1, tpe2, _) =>
+      TypeConstraint.Equality(tpe1, tpe2, Provenance.Match(tpe1, tpe2, loc))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -23,9 +23,9 @@ import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.SourcePosition.moveRight
 import ca.uwaterloo.flix.language.errors.TypeError
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint.Provenance
-import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, Substitution, TraitEnv}
+import ca.uwaterloo.flix.language.phase.unification.{BoolUnification, EffUnification3, EqualityEnv, Substitution, TraitEnv}
 import ca.uwaterloo.flix.language.phase.util.PredefinedTraits
-import ca.uwaterloo.flix.util.Build
+import ca.uwaterloo.flix.util.{Build, Result}
 
 import scala.annotation.tailrec
 
@@ -65,7 +65,9 @@ object ConstraintSolverInterface {
       }
 
       // Wildcard tparams are not counted in the tparams, so we need to traverse the types to get them.
-      val allTparams = tpe.typeVars ++ eff.getOrElse(Type.Pure).typeVars ++ fparams.flatMap(_.tpe.typeVars) ++ econstrs.flatMap(_.tpe2.typeVars)
+      // Both sides of an equality constraint contribute: for a Bool/effect side condition, the LHS is a
+      // real formula whose variables must be rigid while checking the body.
+      val allTparams = tpe.typeVars ++ eff.getOrElse(Type.Pure).typeVars ++ fparams.flatMap(_.tpe.typeVars) ++ econstrs.flatMap(ec => ec.tpe1.typeVars ++ ec.tpe2.typeVars)
 
       // The rigidity environment is made up of:
       // 1. rigid variables from the context (e.g. from instance type parameters)
@@ -97,7 +99,19 @@ object ConstraintSolverInterface {
 
       // Apply the initial substitution to all the constraints
       val initialTree = SubstitutionTree.shallow(initialSubst)
-      val constrs = constrs0.map(initialTree.apply)
+
+      // Discharge Boolean/effect `where` equalities by assumption: compute a reproductive unifier of
+      // the assumed equations and apply it to the body's constraints before solving. It is applied
+      // only to the goals, never folded into `initialTree` or the returned substitution, so the type
+      // parameters remain intact in the reconstructed body.
+      val assumeTree = mkAssumptionSubst(econstrs ++ econstrs0, RegionScope.Top) match {
+        case Some(s) => SubstitutionTree.shallow(s)
+        case None =>
+          // The `where` clause is unsatisfiable (e.g. `where true ~ false`). We do not apply any
+          // assumption; the equality remains as an ordinary goal and produces the type error.
+          SubstitutionTree.empty
+      }
+      val constrs = constrs0.map(initialTree.apply).map(assumeTree.apply)
 
       ///////////////////////////////////////////////////////////////////
       //             This is where the stuff happens!                  //
@@ -121,7 +135,7 @@ object ConstraintSolverInterface {
               val declaredEffWithDebug = Type.mkUnion(eff.getOrElse(Type.Pure), Type.Debug, loc)
               val declaredEffConstrWithDebug = TypeConstraint.Equality(declaredEffWithDebug, infEff, Provenance.ExpectEffect(expected = declaredEffWithDebug, actual = infEff, loc))
               val constrs0 = declaredTpeConstr :: declaredEffConstrWithDebug :: infConstrs
-              val constrsWithDebug = constrs0.map(initialTree.apply)
+              val constrsWithDebug = constrs0.map(initialTree.apply).map(assumeTree.apply)
               val (leftovers2, subst2) = ConstraintSolver2.solveAll(constrsWithDebug, initialTree)(RegionScope.Top, renv, tenv, eenv, flix)
 
               leftovers2 match {
@@ -463,10 +477,59 @@ object ConstraintSolverInterface {
     *   Elm[b] ~ String
     * }}}
     */
+  /**
+    * Computes a substitution that discharges the Boolean/effect equality constraints in `econstrs`
+    * by treating them as assumptions.
+    *
+    * For a `where` clause containing Boolean/effect equalities `b1 ~ b2`, we compute a reproductive
+    * most-general unifier of those equations with all their type variables flexible. Because Boolean
+    * and effect unification are unitary, the ground instances of the returned substitution coincide
+    * exactly with the assignments satisfying the equations. Applying it to the body's constraints
+    * before solving (with the type parameters rigid again) therefore checks the body only for the
+    * type-parameter assignments permitted by the `where` clause.
+    *
+    * The returned substitution is used only to transform the constraint goals; it must NOT be folded
+    * into the substitution returned by the solver, since the type parameters must remain in the
+    * reconstructed body.
+    *
+    * Returns `None` if any equation is unsatisfiable (e.g. `where true ~ false`).
+    */
+  def mkAssumptionSubst(econstrs: List[EqualityConstraint], scope: RegionScope)(implicit flix: Flix): Option[Substitution] = {
+    val boolEqs = econstrs.collect { case EqualityConstraint.BoolEq(tpe1, tpe2, loc) => (tpe1, tpe2, loc) }
+    if (boolEqs.isEmpty) {
+      return Some(Substitution.empty)
+    }
+
+    // All variables in the assumed equations are treated as flexible when computing the unifier.
+    val renv = RigidityEnv.empty
+
+    // Discharge the Boolean-kinded equations via Boolean unification.
+    val boolSubstOpt = boolEqs.filter { case (tpe1, _, _) => tpe1.kind == Kind.Bool }.foldLeft(Option(Substitution.empty)) {
+      case (Some(acc), (tpe1, tpe2, _)) => BoolUnification.unify(acc(tpe1), acc(tpe2), renv).map(s => s @@ acc)
+      case (None, _) => None
+    }
+
+    // Discharge the effect-kinded equations via effect unification.
+    val effEqs = boolEqs.collect { case (tpe1, tpe2, loc) if tpe1.kind == Kind.Eff => TypeConstraint.Equality(tpe1, tpe2, Provenance.Match(tpe1, tpe2, loc)) }
+    val effSubstOpt = EffUnification3.unifyAll(effEqs, scope, renv) match {
+      case Result.Ok(s) => Some(s)
+      case Result.Err(_) => None
+    }
+
+    for {
+      bs <- boolSubstOpt
+      es <- effSubstOpt
+    } yield es @@ bs
+  }
+
   def expandEqualityEnv(eqEnv: EqualityEnv, econstrs: List[EqualityConstraint]): EqualityEnv = {
     econstrs.foldLeft(eqEnv) {
-      case (acc, EqualityConstraint(AssocTypeSymUse(sym, _), tpe1, tpe2, _)) =>
+      case (acc, EqualityConstraint.AssocEq(AssocTypeSymUse(sym, _), tpe1, tpe2, _)) =>
         acc.addAssocTypeDef(sym, tpe1, tpe2)
+      // Boolean/effect equalities are not associated-type rewrites; they are discharged via the
+      // assumption substitution (see mkAssumptionSubst), so they do not enter the equality env.
+      case (acc, _: EqualityConstraint.BoolEq) =>
+        acc
     }
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
@@ -247,11 +247,14 @@ class TypeContext {
     * Adds the given equality constraints to the context.
     */
   def addEqualityConstraints(econstrs0: List[EqualityConstraint], loc: SourceLocation): Unit = {
-    for (EqualityConstraint(symUse, tpe1, tpe2, _) <- econstrs0) {
-      val t1 = Type.AssocType(symUse, tpe1, tpe2.kind, loc)
-      val t2 = tpe2
-      val prov = Provenance.Match(t1, t2, loc)
-      val tconstr = TypeConstraint.Equality(t1, t2, prov)
+    for (econstr <- econstrs0) {
+      val tconstr = econstr match {
+        case EqualityConstraint.AssocEq(symUse, tpe1, tpe2, _) =>
+          val t1 = Type.AssocType(symUse, tpe1, tpe2.kind, loc)
+          TypeConstraint.Equality(t1, tpe2, Provenance.Match(t1, tpe2, loc))
+        case EqualityConstraint.BoolEq(tpe1, tpe2, _) =>
+          TypeConstraint.Equality(tpe1, tpe2, Provenance.Match(tpe1, tpe2, loc))
+      }
       currentScopeConstraints.add(tconstr)
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EqualityEnvironment.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EqualityEnvironment.scala
@@ -33,9 +33,11 @@ object EqualityEnvironment {
     */
   def entail(econstrs0: List[EqualityConstraint], econstr0: EqualityConstraint, traitEnv: TraitEnv, eqEnv: EqualityEnv)(implicit scope: RegionScope, flix: Flix): Result[Unit, List[TypeConstraint]] = {
     val econstr = econstr0 match {
-      case EqualityConstraint(symUse, tpe1, tpe2, loc) =>
+      case EqualityConstraint.AssocEq(symUse, tpe1, tpe2, loc) =>
         val assoc = Type.AssocType(symUse, tpe1, tpe2.kind, loc)
         TypeConstraint.Equality(assoc, tpe2, Provenance.Match(assoc, tpe2, loc))
+      case EqualityConstraint.BoolEq(tpe1, tpe2, loc) =>
+        TypeConstraint.Equality(tpe1, tpe2, Provenance.Match(tpe1, tpe2, loc))
     }
 
     val eenv = ConstraintSolverInterface.expandEqualityEnv(eqEnv, econstrs0)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
@@ -133,7 +133,8 @@ case class Substitution(m: Map[Symbol.KindedTypeVarSym, Type]) {
     * Applies `this` substitution to the given equality constraint.
     */
   def apply(ec: EqualityConstraint): EqualityConstraint = if (isEmpty) ec else ec match {
-    case EqualityConstraint(cst, t1, t2, loc) => EqualityConstraint(cst, apply(t1), apply(t2), loc)
+    case EqualityConstraint.AssocEq(cst, t1, t2, loc) => EqualityConstraint.AssocEq(cst, apply(t1), apply(t2), loc)
+    case EqualityConstraint.BoolEq(t1, t2, loc) => EqualityConstraint.BoolEq(apply(t1), apply(t2), loc)
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -1719,4 +1719,35 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
+  test("KindError.BoolEqualityConstraint.01") {
+    // A Boolean/effect side condition requires both sides to have kind Bool or Eff;
+    // here the right-hand side has kind Type.
+    val input =
+      """
+        |def f(g: a -> b \ ef, x: a): b \ ef where ef ~ Int32 = g(x)
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[KindError](result)
+  }
+
+  test("KindError.BoolEqualityConstraint.02") {
+    // Both sides have kind Type, which is neither Bool nor Eff.
+    val input =
+      """
+        |def f(): String where Int32 ~ Int32 = ???
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[KindError](result)
+  }
+
+  test("KindError.BoolEqualityConstraint.03") {
+    // Both sides have kind Type (distinct constructors).
+    val input =
+      """
+        |def f(): String where Int32 ~ Int64 = ???
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[KindError](result)
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -2964,4 +2964,42 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.MismatchedTypes](result)
   }
 
+  test("BoolEqualityConstraint.Demand.Bool.01") {
+    // The caller violates the side condition `b ~ true` by instantiating `b` to `false`.
+    val input =
+      """
+        |enum B[_: Bool] { case B }
+        |def mkFalse(): B[false] = B.B
+        |def useAsTrue(x: B[b]): Bool where b ~ true = isTrue(x)
+        |def isTrue(_: B[true]): Bool = true
+        |def test(): Bool = useAsTrue(mkFalse())
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError](result)
+  }
+
+  test("BoolEqualityConstraint.Demand.Eff.01") {
+    // The caller violates the side condition `ef ~ {}` by passing an impure function.
+    val input =
+      """
+        |eff Print { def print(): Unit }
+        |def onlyPure(f: a -> b \ ef, x: a): b \ ef where ef ~ {} = f(x)
+        |def test(): Int32 \ Print = onlyPure(x -> { Print.print(); x }, 42)
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError](result)
+  }
+
+  test("BoolEqualityConstraint.Assume.Required.01") {
+    // Without the `where b ~ true` assumption, the body does not typecheck.
+    val input =
+      """
+        |enum B[_: Bool] { case B }
+        |def isTrue(_: B[true]): Bool = true
+        |def useAsTrue(x: B[b]): Bool = isTrue(x)
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError](result)
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -350,32 +350,9 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[ParseError.NeedAtleastOne](result)
   }
 
-  test("IllegalEqualityConstraint.01") {
-    val input =
-      """
-        |def f(): String where Int32 ~ Int32 = ???
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEqualityConstraint](result)
-  }
-
-  test("IllegalEqualityConstraint.02") {
-    val input =
-      """
-        |def f(): String where Int32 ~ Elem[a] = ???
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEqualityConstraint](result)
-  }
-
-  test("IllegalEqualityConstraint.03") {
-    val input =
-      """
-        |def f(): String where Int32 ~ Int64 = ???
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEqualityConstraint](result)
-  }
+  // Note: a `where` fragment whose left-hand side is not an associated type is no longer a weeder
+  // error; it is treated as a Boolean/effect side condition and its kinds are checked in the Kinder
+  // (see TestKinder "KindError.BoolEqualityConstraint.*").
 
   test("IllegalEscapeSequence.Char.01") {
     val input =

--- a/main/test/flix/Test.Dec.BoolEqualityConstraint.flix
+++ b/main/test/flix/Test.Dec.BoolEqualityConstraint.flix
@@ -1,0 +1,60 @@
+mod Test.Dec.BoolEqualityConstraint {
+
+    use Assert.assertTrue
+
+    ///
+    /// A phantom type indexed by a type-level Boolean (kind `Bool`).
+    ///
+    enum B[_: Bool] {
+        case B
+    }
+
+    def mkTrue(): B[true] = B.B
+
+    def mkFalse(): B[false] = B.B
+
+    def isTrue(_: B[true]): Bool = true
+
+    ///
+    /// Assume side (Bool): under the assumption `b ~ true`, a value of type `B[b]` may be used
+    /// where a `B[true]` is expected.
+    ///
+    def useAsTrue(x: B[b]): Bool where b ~ true = isTrue(x)
+
+    ///
+    /// Assume side (Bool), conjunctive: `a and b ~ true` forces both `a` and `b` to be `true`.
+    ///
+    def bothTrue(x: B[a], y: B[b]): Bool where a and b ~ true = isTrue(x) and isTrue(y)
+
+    ///
+    /// Assume side (Bool), negation: under `a ~ not b`, a `B[a]` is a `B[not b]`.
+    ///
+    def asNotB(x: B[a], _y: B[b]): B[not b] where a ~ not b = x
+
+    ///
+    /// Assume side (Eff): the body `f(x)` has effect `ef`, but the declared effect is `ef2`.
+    /// The `where ef ~ ef2` lets the body typecheck under the assumption that they are equal.
+    ///
+    def applyAssume(f: a -> b \ ef, x: a): b \ ef2 where ef ~ ef2 = f(x)
+
+    ///
+    /// Demand side (Eff): the caller must satisfy `ef ~ {}`, i.e. the passed function must be pure.
+    ///
+    def onlyPure(f: a -> b \ ef, x: a): b \ ef where ef ~ {} = f(x)
+
+    @Test
+    def testBoolAssume01(): Unit \ Assert = assertTrue(useAsTrue(mkTrue()))
+
+    @Test
+    def testBoolConjunction01(): Unit \ Assert = assertTrue(bothTrue(mkTrue(), mkTrue()))
+
+    @Test
+    def testBoolNegation01(): Unit \ Assert = assertTrue(isTrue(asNotB(mkTrue(), mkFalse())))
+
+    @Test
+    def testEffAssume01(): Unit \ Assert = assertTrue(applyAssume(x -> x, true))
+
+    @Test
+    def testEffDemandPure01(): Unit \ Assert = assertTrue(onlyPure(x -> x, true))
+
+}


### PR DESCRIPTION
Below generated by Claude

Closes #1230.

The `where` clause currently only accepts associated-type equality constraints of the form `Trait.Assoc[var] ~ Type`; anything else is rejected by the Weeder. This extends it to also accept **Boolean/effect equality side conditions** `b1 ~ b2`, where both sides have kind `Bool` or both have kind `Eff`. Both forms may be mixed freely in the same comma-separated clause.

```flix
def useAsTrue(x: B[b]): Bool where b ~ true = isTrue(x)
def bothTrue(x: B[a], y: B[b]): Bool where a and b ~ true = isTrue(x) and isTrue(y)
def applyAssume(f: a -> b \ ef, x: a): b \ ef2 where ef ~ ef2 = f(x)
def onlyPure(f: a -> b \ ef, x: a): b \ ef where ef ~ {} = f(x)
```

Issue #1230 was written against a nullable-record feature that no longer exists, but the underlying request — attaching a side condition to a signature — still applies to the type-level Booleans we do have.

## Semantics

A side condition is both **assumed** when checking the annotated body and **demanded** of callers, exactly parallel to the existing associated-type equality constraints.

- **Demand** is nearly free: a `BoolEq` emits a direct `TypeConstraint.Equality`, which `booleanUnification` and `blockEffectUnification` already solve.
- **Assume** is the interesting part. There is no assumption store for Bool/Eff — the `EqualityEnv` is an associated-type rewrite map only. Instead we compute a *reproductive* most-general unifier of the assumed equations with their variables flexible, and apply it to the body's constraints before solving, with the type parameters rigid again. Because Boolean and effect unification are unitary, the instances of that substitution coincide with the equation's solution set, so this checks the body exactly for the assignments the `where` clause permits. This needs no changes to `SveAlgorithm`, `EffUnification3`, or `SetUnification`.

  The assumption substitution is applied only to the goals and is never folded into the substitution returned by the solver, so the type parameters remain intact in the reconstructed body.

## Representation

`shared.EqualityConstraint` becomes a sealed trait with `AssocEq` and `BoolEq`. This keeps `Scheme`'s arity and all the existing `econstrs` list-threading unchanged, and localises the branching to the few places that must distinguish the two forms. In the Weeded/Desugared/Named ASTs the associated-type head becomes `Option[Name.QName]`; the Resolved AST already distinguished the forms structurally.

The parser needed no change — `equalityConstraints()` already parses arbitrary `Type ~ Type`.

## Notes for reviewers

- A `where` fragment whose left-hand side is not an associated type is no longer a weeder error, so the three `IllegalEqualityConstraint` tests that covered that restriction are replaced by equivalent `KindError` tests. `IllegalEqualityConstraint` is retained for the malformed-arity case.
- An unsatisfiable side condition on a never-called definition (e.g. `where true ~ false`) is not reported at the definition itself; the demand side makes such a definition uncallable. Adding a dedicated error would be a reasonable follow-up.
- The effect assume path relies on `EffUnification3.unifyAll` returning an exact unifier for these equations. There is no slack in a `where` clause so Phase 0/1 should solve them exactly, but this is the part I'd most like a second opinion on.