### PR TITLE
feat: constraint based monomorphization pipeline signatures

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Constraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Constraint.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Simon Lykke Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.monomorph2
+
+import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type}
+
+/**
+  * A monomorphization variable (def/enum/sig/struct/restrictable-enum) whose concrete
+  * type-argument tuple the solver determines, then substitutes back wherever `MonoArg.Param`
+  * references it.
+  */
+sealed trait MonoVar
+
+object MonoVar {
+  case class Def(sym: Symbol.DefnSym) extends MonoVar
+
+  case class Enum(sym: Symbol.EnumSym) extends MonoVar
+
+  case class Sig(sym: Symbol.SigSym) extends MonoVar
+
+  case class RestrictableEnum(sym: Symbol.RestrictableEnumSym) extends MonoVar
+
+  case class Struct(sym: Symbol.StructSym) extends MonoVar
+}
+
+/** A type argument that flows into a `MonoVar`. */
+sealed trait MonoArg
+
+object MonoArg {
+  /**
+    * The i'th type parameter slot belonging to a specific MonoVar.
+    */
+  case class Param(v: MonoVar, index: Int) extends MonoArg
+
+  /**
+    * A type the solver does not decompose further. Usually ground, but can also be a type
+    * variable the solver deliberately does not track (e.g. a local region var).
+    */
+  case class Const(tpe: Type) extends MonoArg
+
+  /**
+    * A type constructor applied to symbolic mono-arguments.
+    * `tycon` is itself a MonoArg so higher-kinded type params can appear as the head.
+    */
+  case class App(tycon: MonoArg, args: List[MonoArg]) extends MonoArg
+
+  /**
+    * An associated type applied to a symbolic mono-argument, e.g. `Collection.Elm[a]` becomes
+    * `Assoc(Elm, Param(v, i))`.
+    * `kind` and `loc` are stored so the solver can reconstruct `Type.AssocType` for reduction.
+    */
+  case class Assoc(sym: Symbol.AssocTypeSym, arg: MonoArg, kind: Kind, loc: SourceLocation) extends MonoArg
+
+  /** Returns every `(MonoVar, index)` pair referenced by a `Param` inside `arg`, however deeply wrapped. */
+  def collectParams(arg: MonoArg): List[(MonoVar, Int)] = arg match {
+    case MonoArg.Const(_)          => Nil
+    case MonoArg.Param(v, i)       => List((v, i))
+    case MonoArg.App(tycon, args)  => collectParams(tycon) ++ args.flatMap(collectParams)
+    case MonoArg.Assoc(_, a, _, _) => collectParams(a)
+  }
+}
+
+/**
+  * A component-wise flow constraint.
+  * Read as: "The type-argument tuple `args` flows into the parameter slots of `dst`."
+  */
+case class Flow(args: List[MonoArg], dst: MonoVar)
+
+/**
+  * The result of constraint solving: for each polymorphic def/enum/struct/restrictable-enum
+  * symbol, the set of concrete type-argument tuples it must be specialized at. A restrictable
+  * enum's tuple always starts with its case-set index (`Kind.CaseSet`).
+  */
+case class Solution(
+  defs: Map[Symbol.DefnSym, Set[List[Type]]],
+  enums: Map[Symbol.EnumSym, Set[List[Type]]],
+  structs: Map[Symbol.StructSym, Set[List[Type]]],
+  restrictableEnums: Map[Symbol.RestrictableEnumSym, Set[List[Type]]]
+)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Constraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Constraint.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase.monomorph2
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type}
 
 /**
-  * A monomorphization variable (def/enum/sig/struct/restrictable-enum) whose concrete
+  * A monomorphization target-variable (def/enum/sig/struct/restrictable-enum) whose concrete
   * type-argument tuple the solver determines, then substitutes back wherever `MonoArg.Param`
   * references it.
   */

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintCollection.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintCollection.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 
 /**
   * Constraint generation for constraint-based monomorphization: emits `Flow` constraints
-  * describing how concrete types propagate through the program, for `ConstraintSolver` to solve.
+  * describing how concrete types propagate through the program, for [[ConstraintSolver]] to solve.
   */
 object ConstraintCollection {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintCollection.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintCollection.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Simon Lykke Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.monomorph2
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.TypedAst
+
+/**
+  * Constraint generation for constraint-based monomorphization: emits `Flow` constraints
+  * describing how concrete types propagate through the program, for `ConstraintSolver` to solve.
+  */
+object ConstraintCollection {
+
+  /** Generates specialization constraints for every top-level declaration in `root`. */
+  def generate(root: TypedAst.Root)(implicit flix: Flix): Set[Flow] = ???
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintMonomorphization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintMonomorphization.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Simon Lykke Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.monomorph2
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.{MonoAst, TypedAst}
+
+/**
+  * Entry point for constraint-based monomorphization, following the approach of "The Simple
+  * Essence of Monomorphization" by Matthew Lutze, Philipp Schuster, and Jonathan Immanuel
+  * Brachthäuser.
+  *
+  * At a high level, this pipeline works as follows:
+  *
+  *   - 1. [[ConstraintCollection]] generates flow constraints describing how concrete types and
+  *     type shapes propagate into the type-parameter slots of every polymorphic def, enum,
+  *     struct, and restrictable enum.
+  *   - 2. [[NonMonomorphizableCheck]] rejects programs with no finite solution (e.g. polymorphic
+  *     recursion) before solving, so the next step cannot loop forever.
+  *   - 3. [[ConstraintSolver]] solves the flow constraints to a fixpoint, producing the set of
+  *     concrete type-argument tuples each polymorphic symbol must be specialized at.
+  *   - 4. [[SolutionSpecialization]] specializes (and lowers) every def/enum/struct/
+  *     restrictable-enum accordingly.
+  *
+  * Caution: step 4's lowering can synthesize references to specific stdlib defs/enums that step 1
+  * would not otherwise have any reason to see. Any such construct needs its own constraints
+  * generated in step 1, or it won't be in the solution by the time step 4 needs to specialize it.
+  */
+object ConstraintMonomorphization {
+
+  /** Performs constraint-based monomorphization of the given AST `root`. */
+  def run(root: TypedAst.Root)(implicit flix: Flix): MonoAst.Root = {
+    val constraints = ConstraintCollection.generate(root)
+    NonMonomorphizableCheck.checkMonomorphizable(constraints)
+    val solution = ConstraintSolver.solve(constraints, root)
+    SolutionSpecialization.run(root, solution)
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintMonomorphization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintMonomorphization.scala
@@ -27,8 +27,8 @@ import ca.uwaterloo.flix.language.ast.{MonoAst, TypedAst}
   * At a high level, this pipeline works as follows:
   *
   *   - 1. [[ConstraintCollection]] generates flow constraints describing how concrete types and
-  *     type shapes propagate into the type-parameter slots of every polymorphic def, enum,
-  *     struct, and restrictable enum.
+  *     type shapes propagate into the type-parameter slots of every polymorphic def/enum/struct/
+  *     restrictable-enum.
   *   - 2. [[NonMonomorphizableCheck]] rejects programs with no finite solution (e.g. polymorphic
   *     recursion) before solving, so the next step cannot loop forever.
   *   - 3. [[ConstraintSolver]] solves the flow constraints to a fixpoint, producing the set of

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Simon Lykke Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.monomorph2
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.TypedAst
+
+/**
+  * Solves the flow constraints produced by [[ConstraintCollection]] to a fixpoint: starting from
+  * the ground (all-constant) flows, each newly solved tuple is substituted into the flows that
+  * depend on it until no new tuples appear. Sig destinations are additionally dispatched to their
+  * implementing (or default) def. The result is, per polymorphic symbol, exactly the ground
+  * type-argument tuples that actually arise.
+  */
+object ConstraintSolver {
+
+  /**
+    * Solves `flows` to a fixpoint and returns the set of required specializations.
+    *
+    * Callers must run [[NonMonomorphizableCheck.checkMonomorphizable]] first; without it, a
+    * non-monomorphizable flow set makes the fixpoint loop grow without bound.
+    */
+  def solve(flows: Set[Flow], root: TypedAst.Root)(implicit flix: Flix): Solution = ???
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
@@ -18,34 +18,27 @@ package ca.uwaterloo.flix.language.phase.monomorph2
 
 import ca.uwaterloo.flix.language.ast.SourceLocation
 
+// TODO Make it a proper compiler error-message
 /**
   * Thrown when the flow set contains a growing cycle (see [[NonMonomorphizableCheck]]).
-  *
-  * Deliberately not an [[ca.uwaterloo.flix.util.InternalCompilerException]]: it indicates a
-  * property of the user's program, not a compiler bug. Routing it through the ordinary
-  * `CompilationMessage` pipeline is a known follow-up.
   */
 case class NonMonomorphizableProgramException(message: String, loc: SourceLocation) extends RuntimeException(s"$message ($loc)")
 
 /**
-  * Rejects non-monomorphizable programs — flow sets with no finite solution — before
-  * [[ConstraintSolver.solve]]'s fixpoint loop would grow without bound and exhaust the heap.
+  * Rejects non-monomorphizable programs (flow sets with no finite solution) before
+  * [[ConstraintSolver.solve]]'s fixpoint loop, which would otherwise grow without bound.
   *
   * Following "The Simple Essence of Monomorphization" (§3.3.2), the flow set is reinterpreted as
   * a graph over `(MonoVar, tuple-position)` vertices, and we look for a "growing cycle": a reachable
   * cycle with at least one edge that wraps the flowing type in an additional type constructor
   * (`a` flowing into `List[a]`). Such a cycle arises from polymorphic recursion
-  * (`def f(x: a): List[a] = ...f(lst)...`) or a non-regular recursive enum/struct
+  * (e.g. `def f(x: a): List[a] = f(x::Nil)`) or a non-regular recursive enum/struct
   * (`enum T[a] { case Base(a); case Recurse(T[Poly[a]]) }`). A cycle of only direct-copy edges is
-  * ordinary, convergent self-recursion and is fine. (The paper's third case — escaping
-  * existentials — cannot arise: Flix has no existential types.)
+  * ordinary, convergent self-recursion and is fine.
   *
-  * Every `MonoVar` kind participates, including `RestrictableEnum` (which the `Solution` never
-  * reports): the solver propagates flows uniformly regardless of destination kind, so a growing
-  * cycle through any kind still diverges. The check over-approximates in one known way: a
-  * non-regular enum whose growing case is declared but never constructed is still rejected once
-  * any other case of it is constructed, even though demand-driven specialization would not need
-  * the growing case.
+  * The check over-approximates in one known way: a non-regular enum whose growing case is declared
+  * but never constructed is still rejected once any other case of it is constructed, even though
+  * demand-driven specialization would not need the growing case.
   */
 object NonMonomorphizableCheck {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
@@ -16,14 +16,6 @@
 
 package ca.uwaterloo.flix.language.phase.monomorph2
 
-import ca.uwaterloo.flix.language.ast.SourceLocation
-
-// TODO Make it a proper compiler error-message
-/**
-  * Thrown when the flow set contains a growing cycle (see [[NonMonomorphizableCheck]]).
-  */
-case class NonMonomorphizableProgramException(message: String, loc: SourceLocation) extends RuntimeException(s"$message ($loc)")
-
 /**
   * Rejects non-monomorphizable programs (flow sets with no finite solution) before
   * [[ConstraintSolver.solve]]'s fixpoint loop, which would otherwise grow without bound.
@@ -42,9 +34,10 @@ case class NonMonomorphizableProgramException(message: String, loc: SourceLocati
   */
 object NonMonomorphizableCheck {
 
+  // TODO Make it a proper compiler error-message
   /**
     * Checks whether `flows` contains a reachable growing cycle and throws
-    * [[NonMonomorphizableProgramException]] if so.
+    * [[InternalCompilerException]] if so.
     */
   def checkMonomorphizable(flows: Set[Flow]): Unit = ???
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Simon Lykke Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.monomorph2
+
+import ca.uwaterloo.flix.language.ast.SourceLocation
+
+/**
+  * Thrown when the flow set contains a growing cycle (see [[NonMonomorphizableCheck]]).
+  *
+  * Deliberately not an [[ca.uwaterloo.flix.util.InternalCompilerException]]: it indicates a
+  * property of the user's program, not a compiler bug. Routing it through the ordinary
+  * `CompilationMessage` pipeline is a known follow-up.
+  */
+case class NonMonomorphizableProgramException(message: String, loc: SourceLocation) extends RuntimeException(s"$message ($loc)")
+
+/**
+  * Rejects non-monomorphizable programs — flow sets with no finite solution — before
+  * [[ConstraintSolver.solve]]'s fixpoint loop would grow without bound and exhaust the heap.
+  *
+  * Following "The Simple Essence of Monomorphization" (§3.3.2), the flow set is reinterpreted as
+  * a graph over `(MonoVar, tuple-position)` vertices, and we look for a "growing cycle": a reachable
+  * cycle with at least one edge that wraps the flowing type in an additional type constructor
+  * (`a` flowing into `List[a]`). Such a cycle arises from polymorphic recursion
+  * (`def f(x: a): List[a] = ...f(lst)...`) or a non-regular recursive enum/struct
+  * (`enum T[a] { case Base(a); case Recurse(T[Poly[a]]) }`). A cycle of only direct-copy edges is
+  * ordinary, convergent self-recursion and is fine. (The paper's third case — escaping
+  * existentials — cannot arise: Flix has no existential types.)
+  *
+  * Every `MonoVar` kind participates, including `RestrictableEnum` (which the `Solution` never
+  * reports): the solver propagates flows uniformly regardless of destination kind, so a growing
+  * cycle through any kind still diverges. The check over-approximates in one known way: a
+  * non-regular enum whose growing case is declared but never constructed is still rejected once
+  * any other case of it is constructed, even though demand-driven specialization would not need
+  * the growing case.
+  */
+object NonMonomorphizableCheck {
+
+  /**
+    * Checks whether `flows` contains a reachable growing cycle and throws
+    * [[NonMonomorphizableProgramException]] if so.
+    */
+  def checkMonomorphizable(flows: Set[Flow]): Unit = ???
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SolutionSpecialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SolutionSpecialization.scala
@@ -20,8 +20,8 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{MonoAst, TypedAst}
 
 /**
-  * Solution-driven specialization: uses the solver's solution to specialize all defs, enums, and
-  * structs in a single parallel pass.
+  * Solution-driven specialization: uses the solver's solution to specialize all def/enum/struct/
+  * restrictable-enum in a single parallel pass.
   *
   * `run` and [[SolutionLowering]] have different responsibilities: `run` builds the tables mapping
   * each original polymorphic symbol/instantiation to its fresh specialized symbol, and

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SolutionSpecialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SolutionSpecialization.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Simon Lykke Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.monomorph2
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.{MonoAst, TypedAst}
+
+/**
+  * Solution-driven specialization: uses the solver's solution to specialize all defs, enums, and
+  * structs in a single parallel pass.
+  *
+  * `run` and [[SolutionLowering]] have different responsibilities: `run` builds the tables mapping
+  * each original polymorphic symbol/instantiation to its fresh specialized symbol, and
+  * [[SolutionLowering]] does the actual `TypedAst`-to-`MonoAst` transformation, using those tables
+  * to resolve which fresh symbol each call/tag/struct-access site should point to.
+  */
+object SolutionSpecialization {
+
+  /** Specializes `root` per `solution`, the constraint solver's output. */
+  def run(root: TypedAst.Root, solution: Solution)(implicit flix: Flix): MonoAst.Root = ???
+}


### PR DESCRIPTION
Depends on https://github.com/flix/flix/pull/12945

The entrypoint for the new constraint based monomorphization pipeline is `ConstraintMonomorphization.scala`.