### PR TITLE
refactor: use a shared mutable Context in ConstraintCollection instead of threading a List[Flow] accumulator

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintCollection.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintCollection.scala
@@ -89,28 +89,31 @@ object ConstraintCollection {
   /**
     * Emits flow constraints for enum type applications occurring in `tpe`.
     */
-  private def visitType(tpe0: Type, acc: List[Flow])(implicit ctx: Context): List[Flow] = Type.eraseAliases(tpe0) match {
-    case at @ Type.AssocType(_, arg, _, _) =>
-      if (at.typeVars.isEmpty)
-        visitType(MonomorphCanon.reduceAssocType(at)(ctx.root, ctx.flix), acc)
-      else
-        visitType(arg, acc)
-    case _: Type.BaseType
-         | Type.Var(_, _)
-         | Type.Cst(_, _) => acc
-    case app @ Type.Apply(_, _, _) =>
-      val args = app.typeArguments
-      val acc1 = args.foldLeft(acc)((a, t) => visitType(t, a))
-      val mvarOpt = app.baseType match {
-        case Type.Cst(TypeConstructor.Enum(sym, _), _)             => Some(MonoVar.Enum(sym))
-        case Type.Cst(TypeConstructor.RestrictableEnum(sym, _), _) => Some(MonoVar.RestrictableEnum(sym))
-        case Type.Cst(TypeConstructor.Struct(sym, _), _)           => Some(MonoVar.Struct(sym))
-        case _                                                     => None
-      }
-      mvarOpt match {
-        case Some(mvar) => Flow(args.map(t => typeToMonoArg(t)), mvar) :: acc1
-        case None       => acc1
-      }
+  private def visitType(tpe0: Type, acc: List[Flow])(implicit ctx: Context): List[Flow] = {
+    def dealiasedVisitType(tpe: Type, acc: List[Flow]): List[Flow] = tpe match {
+      case at @ Type.AssocType(_, arg, _, _) =>
+        if (at.typeVars.isEmpty)
+          visitType(MonomorphCanon.reduceAssocType(at)(ctx.root, ctx.flix), acc)
+        else
+          dealiasedVisitType(arg, acc)
+      case _: Type.BaseType
+           | Type.Var(_, _)
+           | Type.Cst(_, _) => acc
+      case app @ Type.Apply(_, _, _) =>
+        val args = app.typeArguments
+        val acc1 = args.foldLeft(acc)((a, t) => dealiasedVisitType(t, a))
+        val mvarOpt = app.baseType match {
+          case Type.Cst(TypeConstructor.Enum(sym, _), _)             => Some(MonoVar.Enum(sym))
+          case Type.Cst(TypeConstructor.RestrictableEnum(sym, _), _) => Some(MonoVar.RestrictableEnum(sym))
+          case Type.Cst(TypeConstructor.Struct(sym, _), _)           => Some(MonoVar.Struct(sym))
+          case _                                                     => None
+        }
+        mvarOpt match {
+          case Some(mvar) => Flow(args.map(t => dealiasedTypeToMonoArg(t)), mvar) :: acc1
+          case None       => acc1
+        }
+    }
+    dealiasedVisitType(Type.eraseAliases(tpe0), acc)
   }
 
   /**
@@ -132,8 +135,11 @@ object ConstraintCollection {
     structDecl.fields.values.foldLeft(acc) { (a, field) => visitType(field.tpe, a) }
 
   /** Converts `tpe0` to a `MonoArg` relative to the current declaration context. */
-  private def typeToMonoArg(tpe0: Type)(implicit ctx: Context): MonoArg = {
-    val tpe = Type.eraseAliases(tpe0)
+  private def typeToMonoArg(tpe0: Type)(implicit ctx: Context): MonoArg =
+    dealiasedTypeToMonoArg(Type.eraseAliases(tpe0))
+
+  /** Like [[typeToMonoArg]], but `tpe` must already have its aliases erased (deeply). */
+  private def dealiasedTypeToMonoArg(tpe: Type)(implicit ctx: Context): MonoArg =
     tpe match {
       case Type.Var(sym, _) =>
         // A type variable that is not a tparam of the current decl (absent from tparamEnv) — e.g.
@@ -144,18 +150,17 @@ object ConstraintCollection {
         if (tpe.typeVars.isEmpty)
           MonoArg.Const(MonomorphCanon.reduceAssocType(at)(ctx.root, ctx.flix))
         else
-          MonoArg.Assoc(symUse.sym, typeToMonoArg(arg), kind, assocLoc)
+          MonoArg.Assoc(symUse.sym, dealiasedTypeToMonoArg(arg), kind, assocLoc)
       case Type.Cst(_, _) | _: Type.BaseType =>
         MonoArg.Const(tpe)
       case Type.Apply(_, _, _) =>
         if (tpe.kind == Kind.Eff && tpe.typeVars.isEmpty)
           MonoArg.Const(MonomorphCanon.simplify(tpe, isGround = true)(ctx.root, ctx.flix))
         else {
-          MonoArg.App(typeToMonoArg(tpe.baseType), tpe.typeArguments.map(arg => typeToMonoArg(arg)))
+          MonoArg.App(dealiasedTypeToMonoArg(tpe.baseType), tpe.typeArguments.map(arg => dealiasedTypeToMonoArg(arg)))
         }
       case other =>
         MonoArg.Const(other)
     }
-  }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintCollection.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintCollection.scala
@@ -21,6 +21,8 @@ import ca.uwaterloo.flix.language.ast.{Kind, Symbol, Type, TypeConstructor, Type
 import ca.uwaterloo.flix.language.ast.TypedAst.FormalParam
 import ca.uwaterloo.flix.util.ParOps
 
+import scala.collection.mutable
+
 /**
   * Constraint generation for constraint-based monomorphization: emits `Flow` constraints
   * describing how concrete types propagate through the program, for [[ConstraintSolver]] to solve.
@@ -28,134 +30,130 @@ import ca.uwaterloo.flix.util.ParOps
 object ConstraintCollection {
 
   /**
-    * Generation context.
+    * The mutable data used throughout constraint generation.
     *
-    * @param tparamEnv maps the current declaration's type parameters to `MonoArg.Param` — always
-    *                  `Param`, not statically enforced, so a future scope could use more than one
-    *                  `MonoVar`.
-    * @param root the typed AST root (needed to resolve ground associated types)
-    * @param flix the Flix context (needed by TypeReduction2)
+    * This class is thread-safe.
     */
-  case class Context(
-    tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg],
-    root: TypedAst.Root,
-    flix: Flix
-  )
+  private class Context {
+    private val flows: mutable.ArrayBuffer[Flow] = mutable.ArrayBuffer.empty
+
+    /** Emits `flow` as one of the generated constraints. */
+    def addFlow(flow: Flow): Unit = synchronized { flows.addOne(flow) }
+
+    /** Returns every flow emitted so far. */
+    def result: Set[Flow] = synchronized { flows.toSet }
+  }
 
   /**
     * Generates specialization constraints for every top-level declaration in `root`.
     */
-  def generate(root: TypedAst.Root)(implicit flix: Flix): Set[Flow] = {
+  def generate(root0: TypedAst.Root)(implicit flix: Flix): Set[Flow] = {
+    implicit val ctx: Context = new Context()
+    implicit val root: TypedAst.Root = root0
+
     val fromDefs: Set[Flow] = ???
 
-    val fromEnums = ParOps.parMap(root.enums.values) { enm =>
+    ParOps.parMap(root.enums.values) { enm =>
       val mvar = MonoVar.Enum(enm.sym)
-      val tparamEnv = enm.tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap
-      implicit val ctx: Context = Context(tparamEnv, root, flix)
-      visitEnum(enm, Nil)
-    }.flatten.toSet
+      implicit val tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg] = enm.tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap
+      visitEnum(enm)
+    }
 
     val fromInstances: Set[Flow] = ???
 
-    val fromRestrictableEnums = ParOps.parMap(root.restrictableEnums.values) { enm =>
+    ParOps.parMap(root.restrictableEnums.values) { enm =>
       val mvar = MonoVar.RestrictableEnum(enm.sym)
-      val tparamEnv = (enm.index :: enm.tparams).zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap
-      implicit val ctx: Context = Context(tparamEnv, root, flix)
-      visitRestrictableEnum(enm, Nil)
-    }.flatten.toSet
+      implicit val tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg] = (enm.index :: enm.tparams).zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap
+      visitRestrictableEnum(enm)
+    }
 
-    val fromStructs = ParOps.parMap(root.structs.values) { struct =>
+    ParOps.parMap(root.structs.values) { struct =>
       val mvar = MonoVar.Struct(struct.sym)
-      val tparamEnv = struct.tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap
-      implicit val ctx: Context = Context(tparamEnv, root, flix)
-      visitStruct(struct, Nil)
-    }.flatten.toSet
+      implicit val tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg] = struct.tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap
+      visitStruct(struct)
+    }
 
     val fromSigs: Set[Flow] = ???
 
-    val fromEffects = ParOps.parMap(root.effects.values.flatMap(_.ops)) { op =>
+    ParOps.parMap(root.effects.values.flatMap(_.ops)) { op =>
       // We need a Synthetic DefnSym to tie the tparams to
       val defnSym = new Symbol.DefnSym(None, op.sym.namespace, op.sym.name, op.sym.loc)
       val mvar = MonoVar.Def(defnSym)
-      val tparamEnv = op.spec.tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap
-      implicit val ctx: Context = Context(tparamEnv, root, flix)
-      val acc1 = op.spec.fparams.foldLeft(List.empty[Flow]) { case (a, FormalParam(_, tpe, _, _, _)) => visitType(tpe, a) }
-      visitType(op.spec.retTpe, acc1)
-    }.flatten.toSet
+      implicit val tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg] = op.spec.tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap
+      op.spec.fparams.foreach { case FormalParam(_, tpe, _, _, _) => visitType(tpe) }
+      visitType(op.spec.retTpe)
+    }
 
-    fromDefs ++ fromEnums ++ fromInstances ++ fromRestrictableEnums ++ fromStructs ++ fromSigs ++ fromEffects
+    ctx.result ++ fromDefs ++ fromInstances ++ fromSigs
   }
 
   /**
     * Emits flow constraints for enum type applications occurring in `tpe`.
     */
-  private def visitType(tpe0: Type, acc: List[Flow])(implicit ctx: Context): List[Flow] = {
-    def dealiasedVisitType(tpe: Type, acc: List[Flow]): List[Flow] = tpe match {
+  private def visitType(tpe0: Type)(implicit ctx: Context, tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg], root: TypedAst.Root, flix: Flix): Unit = {
+    def dealiasedVisitType(tpe: Type): Unit = tpe match {
       case at @ Type.AssocType(_, arg, _, _) =>
         if (at.typeVars.isEmpty)
-          visitType(MonomorphCanon.reduceAssocType(at)(ctx.root, ctx.flix), acc)
+          visitType(MonomorphCanon.reduceAssocType(at)(root, flix))
         else
-          dealiasedVisitType(arg, acc)
+          dealiasedVisitType(arg)
       case _: Type.BaseType
            | Type.Var(_, _)
-           | Type.Cst(_, _) => acc
+           | Type.Cst(_, _) => ()
       case app @ Type.Apply(_, _, _) =>
         val args = app.typeArguments
-        val acc1 = args.foldLeft(acc)((a, t) => dealiasedVisitType(t, a))
+        args.foreach(dealiasedVisitType)
         val mvarOpt = app.baseType match {
           case Type.Cst(TypeConstructor.Enum(sym, _), _)             => Some(MonoVar.Enum(sym))
           case Type.Cst(TypeConstructor.RestrictableEnum(sym, _), _) => Some(MonoVar.RestrictableEnum(sym))
           case Type.Cst(TypeConstructor.Struct(sym, _), _)           => Some(MonoVar.Struct(sym))
           case _                                                     => None
         }
-        mvarOpt match {
-          case Some(mvar) => Flow(args.map(t => dealiasedTypeToMonoArg(t)), mvar) :: acc1
-          case None       => acc1
-        }
+        mvarOpt.foreach(mvar => ctx.addFlow(Flow(args.map(t => dealiasedTypeToMonoArg(t)), mvar)))
     }
-    dealiasedVisitType(Type.eraseAliases(tpe0), acc)
+    dealiasedVisitType(Type.eraseAliases(tpe0))
   }
 
   /**
     * Emits flow constraints for all case field types in `enumDecl`.
     */
-  private def visitEnum(enumDecl: TypedAst.Enum, acc: List[Flow])(implicit ctx: Context): List[Flow] =
-    enumDecl.cases.values.foldLeft(acc) { (a, cas) => cas.tpes.foldLeft(a)((a2, t) => visitType(t, a2)) }
+  private def visitEnum(enumDecl: TypedAst.Enum)(implicit ctx: Context, tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg], root: TypedAst.Root, flix: Flix): Unit =
+    enumDecl.cases.values.foreach(cas => cas.tpes.foreach(visitType(_)))
 
   /**
     * Emits flow constraints for all case field types in `restrictableEnumDecl`.
     */
-  private def visitRestrictableEnum(restrictableEnumDecl: TypedAst.RestrictableEnum, acc: List[Flow])(implicit ctx: Context): List[Flow] =
-    restrictableEnumDecl.cases.values.foldLeft(acc) { (a, cas) => cas.tpes.foldLeft(a)((a2, t) => visitType(t, a2)) }
+  private def visitRestrictableEnum(restrictableEnumDecl: TypedAst.RestrictableEnum)(implicit ctx: Context, tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg], root: TypedAst.Root, flix: Flix): Unit =
+    restrictableEnumDecl.cases.values.foreach(cas => cas.tpes.foreach(visitType(_)))
 
   /**
     * Emits flow constraints for all field types in `structDecl`.
     */
-  private def visitStruct(structDecl: TypedAst.Struct, acc: List[Flow])(implicit ctx: Context): List[Flow] =
-    structDecl.fields.values.foldLeft(acc) { (a, field) => visitType(field.tpe, a) }
+  private def visitStruct(structDecl: TypedAst.Struct)(implicit ctx: Context, tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg], root: TypedAst.Root, flix: Flix): Unit =
+    structDecl.fields.values.foreach(field => visitType(field.tpe))
 
   /** Converts `tpe0` to a `MonoArg` relative to the current declaration context. */
-  private def typeToMonoArg(tpe0: Type)(implicit ctx: Context): MonoArg =
+  private def typeToMonoArg(tpe0: Type)(implicit tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg], root: TypedAst.Root, flix: Flix): MonoArg =
     dealiasedTypeToMonoArg(Type.eraseAliases(tpe0))
 
   /** Like [[typeToMonoArg]], but `tpe` must already have its aliases erased (deeply). */
-  private def dealiasedTypeToMonoArg(tpe: Type)(implicit ctx: Context): MonoArg =
+  private def dealiasedTypeToMonoArg(tpe: Type)(implicit tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg], root: TypedAst.Root, flix: Flix): MonoArg =
     tpe match {
       case Type.Var(sym, _) =>
         // A type variable that is not a tparam of the current decl (absent from tparamEnv) — e.g.
         // a region var introduced by `region r { ... }`. We record it as an opaque constant so the
         // flow is still emitted but the solver does not propagate it.
-        ctx.tparamEnv.getOrElse(sym, MonoArg.Const(tpe))
+        tparamEnv.getOrElse(sym, MonoArg.Const(tpe))
       case at @ Type.AssocType(symUse, arg, kind, assocLoc) =>
         if (tpe.typeVars.isEmpty)
-          MonoArg.Const(MonomorphCanon.reduceAssocType(at)(ctx.root, ctx.flix))
+          MonoArg.Const(MonomorphCanon.reduceAssocType(at)(root, flix))
         else
           MonoArg.Assoc(symUse.sym, dealiasedTypeToMonoArg(arg), kind, assocLoc)
       case Type.Cst(_, _) | _: Type.BaseType =>
         MonoArg.Const(tpe)
       case Type.Apply(_, _, _) =>
         if (tpe.kind == Kind.Eff && tpe.typeVars.isEmpty)
-          MonoArg.Const(MonomorphCanon.simplify(tpe, isGround = true)(ctx.root, ctx.flix))
+          MonoArg.Const(MonomorphCanon.simplify(tpe, isGround = true)(root, flix))
         else {
           MonoArg.App(dealiasedTypeToMonoArg(tpe.baseType), tpe.typeArguments.map(arg => dealiasedTypeToMonoArg(arg)))
         }


### PR DESCRIPTION
Depends on:
- https://github.com/flix/flix/pull/12955.

Addresses the comment about accumulating flows in a mutable collection from https://github.com/flix/flix/pull/12949.