### PR TITLE
fix: include arrow effects when computing type alias dependencies

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -260,7 +260,7 @@ object Resolver {
     case _: UnkindedType.UnappliedNative => Nil
     case _: UnkindedType.Cst => Nil
     case UnkindedType.Apply(tpe1, tpe2, _) => getAliasUses(tpe1) ::: getAliasUses(tpe2)
-    case _: UnkindedType.Arrow => Nil
+    case UnkindedType.Arrow(eff, _, _) => eff.toList.flatMap(getAliasUses)
     case _: UnkindedType.CaseSet => Nil
     case UnkindedType.CaseComplement(tpe, _) => getAliasUses(tpe)
     case UnkindedType.CaseUnion(tpe1, tpe2, _) => getAliasUses(tpe1) ::: getAliasUses(tpe2)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -480,6 +480,31 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.CyclicTypeAliases](result)
   }
 
+  test("CyclicTypeAliases.07") {
+    val input =
+      s"""
+         |type alias Foo = Int32 -> Int32 \\ Foo
+         |
+         |def f(): Foo = x -> x
+         |
+       """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.CyclicTypeAliases](result)
+  }
+
+  test("CyclicTypeAliases.08") {
+    val input =
+      s"""
+         |type alias Foo = Int32 -> Int32 \\ Bar
+         |type alias Bar = Int32 -> Int32 \\ Foo
+         |
+         |def f(): Foo = x -> x
+         |
+       """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.CyclicTypeAliases](result)
+  }
+
   test("UndefinedName.01") {
     val input = "def f(): Int32 = x"
     val result = check(input, Options.TestWithLibNix)

--- a/main/test/flix/Test.Dec.TypeAlias.flix
+++ b/main/test/flix/Test.Dec.TypeAlias.flix
@@ -229,9 +229,13 @@ mod Test.Dec.TypeAlias {
     type alias AssertEff = Assert
     type alias AssertFun = Int32 -> Int32 \ AssertEff
 
+    def testTypeAlias34Fn(x: Int32): Int32 \ Assert =
+        assertEq(expected = 21, x);
+        x * 2
+
     def testTypeAlias34Helper(f: AssertFun): Int32 \ Assert = f(21)
 
     @Test
     def testTypeAlias34(): Unit \ Assert =
-        assertEq(expected = 42, testTypeAlias34Helper(x -> x * 2))
+        assertEq(expected = 42, testTypeAlias34Helper(testTypeAlias34Fn))
 }

--- a/main/test/flix/Test.Dec.TypeAlias.flix
+++ b/main/test/flix/Test.Dec.TypeAlias.flix
@@ -222,4 +222,16 @@ mod Test.Dec.TypeAlias {
     @Test
     def testTypeAlias33(): Unit \ Assert =
         assertEq(expected = true, testTypeAlias33Helper({x = 10, y = true, z = "Hello World"}))
+
+    ///
+    /// An effect alias used in the effect position of a function type alias.
+    ///
+    type alias AssertEff = Assert
+    type alias AssertFun = Int32 -> Int32 \ AssertEff
+
+    def testTypeAlias34Helper(f: AssertFun): Int32 \ Assert = f(21)
+
+    @Test
+    def testTypeAlias34(): Unit \ Assert =
+        assertEq(expected = 42, testTypeAlias34Helper(x -> x * 2))
 }


### PR DESCRIPTION
_Below written by Claude_

`Resolver.getAliasUses` returned `Nil` for `UnkindedType.Arrow`, but `Arrow(eff: Option[UnkindedType], arity, loc)` carries its effect in `eff`. A type alias referenced *only* in an arrow's effect position therefore contributed no edge to the type alias dependency graph:

```flix
type alias BotEffects = {Math.Random, Logger, BotState}
type alias Bot = (Pitch, Player) -> Direction \ BotEffects   // the edge Bot -> BotEffects was lost
```

`findResolutionOrder` then sorted the two aliases as unrelated, and `finishResolveTypeAliases` builds `taenv` incrementally in that order. Whenever `Bot` happened to land first, `finishResolveType` recursed into the arrow's effect, found `UnappliedAlias(BotEffects)`, and hit the unguarded `taenv(sym)` lookup:

```
java.util.NoSuchElementException: key not found: BotEffects
    at ca.uwaterloo.flix.language.phase.Resolver$.finishResolveType(Resolver.scala:2565)
    at ca.uwaterloo.flix.language.phase.Resolver$.finishResolveTypeAliases(Resolver.scala:311)
```

Because the ordering comes from iterating a `Map`, this was latent and would surface or vanish on unrelated edits — the report that turned it up was triggered by moving an unrelated type alias into its own file.

The same gap also meant a cycle running through an arrow effect was never detected: `type alias Foo = Int32 -> Int32 \ Foo` crashed instead of reporting `CyclicTypeAliases`.

`UnkindedType.map` already substitutes into `Arrow.eff` correctly, so `getAliasUses` was the only place that dropped it.

The two new `CyclicTypeAliases` cases are the regression guard — they are independent of map ordering and crash under the old behaviour.

Note: `taenv(sym)` in `finishResolveType` remains an unguarded lookup. A missing key there is a real invariant violation, so turning it into an `InternalCompilerException` would be a reasonable separate cleanup.