### PR TITLE
ci: add Flixball 2 to community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -63,6 +63,7 @@ jobs:
           - "jaschdoc/flix-test-pkg-trust-transitive-java"
           - "mlutze/flix-json"
           - "mlutze/flixball"
+          - "mlutze/flixball-2"
           - "rywiese/scope-graphs"
           - "stephentetley/flix-htmldoc"
           - "stephentetley/flix-pretty"


### PR DESCRIPTION
Flixball 2 makes extensive use of Java interop, which no other community build does at the moment.