### PR TITLE
feat: introduce type variables from instance equality constraint RHS

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/shared/AssocTypeDef.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/AssocTypeDef.scala
@@ -21,5 +21,10 @@ import ca.uwaterloo.flix.language.ast.{Type, Symbol}
   * Represents the definition of an associated type.
   * If this associated type is named `Assoc`, then
   * Assoc[arg] = ret.
+  *
+  * `econstrs` are the equality constraints of the instance this definition comes from. They are
+  * carried here so that reduction can determine any type variables that `ret` shares with them but
+  * that do not appear in `arg` (i.e. variables introduced solely on the right-hand side of an
+  * instance equality constraint). They reference the same variables as `tparams`, `arg`, and `ret`.
   */
-case class AssocTypeDef(tparams: List[Symbol.KindedTypeVarSym], arg: Type, ret: Type)
+case class AssocTypeDef(tparams: List[Symbol.KindedTypeVarSym], arg: Type, ret: Type, econstrs: List[EqualityConstraint])

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -247,7 +247,12 @@ object Kinder {
   private def visitInstance(inst: ResolvedAst.Declaration.Instance, root: ResolvedAst.Root)(implicit renv: RootEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): KindedAst.Instance = inst match {
     case ResolvedAst.Declaration.Instance(doc, ann, mod, symUse, tparams0, tpe0, tconstrs0, econstrs0, assocs0, defs0, ns, loc) =>
       val kind = declKinds.traitKinds(symUse.sym)
-      val kenv = inferType(tpe0, kind, KindEnv.empty, root)
+      // The kind environment is inferred from the head type together with the equality constraints,
+      // so that type variables introduced on the right-hand side of an equality constraint (which
+      // do not appear in the head) are assigned the kind of the associated type's result.
+      val headKenv = inferType(tpe0, kind, KindEnv.empty, root)
+      val econstrsKenv = KindEnv.merge(econstrs0.map(inferEqualityConstraint(_, headKenv, root)))
+      val kenv = KindEnv.merge(headKenv, econstrsKenv)
       val tparams = tparams0.map(visitTypeParam(_, kenv))
       val t = visitType(tpe0, kind, kenv, root)
       val tconstrs = tconstrs0.map(visitTraitConstraint(_, kenv, root))

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -722,7 +722,7 @@ object Namer {
     */
   private def visitInstance(instance: DesugaredAst.Declaration.Instance, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): NamedAst.Declaration.Instance = instance match {
     case DesugaredAst.Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, econstrs, assocs, defs, loc) =>
-      val tparams = getImplicitTypeParamsFromTypes(List(tpe))
+      val tparams = getImplicitTypeParamsFromInstance(tpe, econstrs)
       val t = visitType(tpe)
       val tcsts = tconstrs.map(visitTraitConstraint)
       val ecsts = econstrs.map(visitEqualityConstraint)
@@ -1711,11 +1711,24 @@ object Namer {
   }
 
   /**
-    * Returns the implicit type parameters constructed from the given types.
+    * Returns the implicit type parameters of an instance, constructed from its head type `tpe`
+    * and its equality constraints `econstrs`.
+    *
+    * In addition to the free variables of the head type, we introduce a type variable for every
+    * free variable on the right-hand side of an equality constraint. This mirrors how defs treat
+    * their equality constraints (see [[visitImplicitTypeParamsFromFormalParams]]) and lets an
+    * instance name the result of an associated type, e.g.
+    * `instance Foo[Map[k, v]] where Bar.Baz[k] ~ a` introduces `a`.
     */
-  private def getImplicitTypeParamsFromTypes(types: List[DesugaredAst.Type])(implicit flix: Flix): List[NamedAst.TypeParam] = {
-    val tvars = types.flatMap(freeTypeVars).distinct
-    tvars.map {
+  private def getImplicitTypeParamsFromInstance(tpe: DesugaredAst.Type, econstrs: List[DesugaredAst.EqualityConstraint])(implicit flix: Flix): List[NamedAst.TypeParam] = {
+    val tpeTvars = freeTypeVars(tpe)
+
+    val econstrTvars = econstrs.flatMap {
+      // We only introduce vars from the right-hand-side of the constraint.
+      case DesugaredAst.EqualityConstraint(_, _, tpe2, _) => freeTypeVars(tpe2)
+    }
+
+    (tpeTvars ::: econstrTvars).distinct.map {
       ident => NamedAst.TypeParam.Implicit(ident, mkTypeVarSym(ident), ident.loc)
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -170,9 +170,9 @@ object Typer {
         case None =>
           val subst = Substitution.singleton(trt.tparam.sym, inst.tpe)
           val tpe = subst(assocSig.tpe.get)
-          AssocTypeDef(tparams, inst.tpe, tpe)
+          AssocTypeDef(tparams, inst.tpe, tpe, inst.econstrs)
         case Some(KindedAst.AssocTypeDef(_, _, _, arg, tpe, _)) =>
-          AssocTypeDef(tparams, arg, tpe)
+          AssocTypeDef(tparams, arg, tpe, inst.econstrs)
       }
     } yield {
       ((assocSig.sym, head), assocDef)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -170,15 +170,31 @@ object Typer {
         case None =>
           val subst = Substitution.singleton(trt.tparam.sym, inst.tpe)
           val tpe = subst(assocSig.tpe.get)
-          AssocTypeDef(tparams, inst.tpe, tpe, inst.econstrs)
+          AssocTypeDef(tparams, inst.tpe, tpe, relevantEconstrs(inst.tpe, tpe, inst.econstrs))
         case Some(KindedAst.AssocTypeDef(_, _, _, arg, tpe, _)) =>
-          AssocTypeDef(tparams, arg, tpe, inst.econstrs)
+          AssocTypeDef(tparams, arg, tpe, relevantEconstrs(arg, tpe, inst.econstrs))
       }
     } yield {
       ((assocSig.sym, head), assocDef)
     }
 
     EqualityEnv(assocs.toMap)
+  }
+
+  /**
+    * Returns the equality constraints of `econstrs` that are needed to reduce an associated type
+    * definition with argument `arg` and result `ret`.
+    *
+    * A constraint is relevant only if its right-hand side mentions a variable that occurs in `ret`
+    * but is not bound by `arg` — i.e. a variable introduced solely on the right-hand side of the
+    * constraint. All other constraints play no role in reducing the associated type, so they are
+    * dropped; this keeps reduction of pre-existing instances (whose result is fully determined by
+    * the head) free of spurious obligations.
+    */
+  private def relevantEconstrs(arg: Type, ret: Type, econstrs: List[EqualityConstraint]): List[EqualityConstraint] = {
+    val argVars = arg.typeVars.map(_.sym)
+    val needed = ret.typeVars.map(_.sym).diff(argVars)
+    econstrs.filter(_.tpe2.typeVars.map(_.sym).exists(needed.contains))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.{CaseSymUse, DefSymUse, Loca
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
 import ca.uwaterloo.flix.language.ast.{Kind, MonoAst, Name, RigidityEnv, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
-import ca.uwaterloo.flix.language.phase.typer.{ConstraintSolver2, Progress, TypeReduction2}
+import ca.uwaterloo.flix.language.phase.typer.{ConstraintSolver2, Progress, TypeConstraint, TypeReduction2}
 import ca.uwaterloo.flix.language.phase.unification.Substitution
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListMap, ListOps, MapOps, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
@@ -1330,10 +1330,24 @@ object Specialization {
     val progress = Progress()
 
     val (res, cs) = TypeReduction2.reduce(assoc)(scope, renv, progress, root.eqEnv, flix)
-    if (cs.nonEmpty) throw InternalCompilerException(s"unexpected constraints: $cs", assoc.loc)
 
-    if (progress.query()) res
-    else throw InternalCompilerException(s"Could not reduce associated type $assoc", assoc.loc)
+    if (!progress.query())
+      throw InternalCompilerException(s"Could not reduce associated type $assoc", assoc.loc)
+
+    // Reduction may emit equality obligations when the matched instance introduces a variable on the
+    // right-hand side of an equality constraint (e.g. `type Elm = a` with `Elm[c] ~ a`). Since
+    // `assoc` is ground, each obligation is between ground types and fully determines the variables
+    // in `res`; solve them and apply the solution. Any associated types remaining in the result are
+    // reduced by the caller (`simplify`), matching the behavior when there are no obligations.
+    val subst = cs.foldLeft(Substitution.empty) {
+      case (acc, TypeConstraint.Equality(t1, t2, _)) =>
+        ConstraintSolver2.fullyUnify(acc(t1), acc(t2), scope, renv)(root.eqEnv, flix) match {
+          case Some(s) => s @@ acc
+          case None => throw InternalCompilerException(s"Could not solve constraint '$t1 ~ $t2' while reducing $assoc", assoc.loc)
+        }
+      case (_, c) => throw InternalCompilerException(s"unexpected constraint: $c", assoc.loc)
+    }
+    subst(res)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonomorphCanon.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonomorphCanon.scala
@@ -19,7 +19,8 @@ package ca.uwaterloo.flix.language.phase.monomorph2
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{Kind, Name, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
-import ca.uwaterloo.flix.language.phase.typer.{Progress, TypeReduction2}
+import ca.uwaterloo.flix.language.phase.typer.{ConstraintSolver2, Progress, TypeConstraint, TypeReduction2}
+import ca.uwaterloo.flix.language.phase.unification.Substitution
 import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.CofiniteSet
 
@@ -66,11 +67,26 @@ private[monomorph2] object MonomorphCanon {
   // Copied from monomorph.Specialization.reduceAssocType
   /** Reduces the given associated into its definition, will crash if not able to. */
   def reduceAssocType(assoc: Type.AssocType)(implicit root: TypedAst.Root, flix: Flix): Type = {
+    val scope = RegionScope.Top
+    val renv = RigidityEnv.empty
     val progress = Progress()
-    val (res, cs) = TypeReduction2.reduce(assoc)(RegionScope.Top, RigidityEnv.empty, progress, root.eqEnv, flix)
-    if (cs.nonEmpty) throw InternalCompilerException(s"unexpected constraints: $cs", assoc.loc)
-    if (progress.query()) res
-    else throw InternalCompilerException(s"Could not reduce associated type $assoc", assoc.loc)
+    val (res, cs) = TypeReduction2.reduce(assoc)(scope, renv, progress, root.eqEnv, flix)
+
+    if (!progress.query())
+      throw InternalCompilerException(s"Could not reduce associated type $assoc", assoc.loc)
+
+    // Reduction may emit equality obligations when the matched instance introduces a variable on the
+    // right-hand side of an equality constraint. Since `assoc` is ground, each obligation is between
+    // ground types and fully determines the variables in `res`; solve them and apply the solution.
+    val subst = cs.foldLeft(Substitution.empty) {
+      case (acc, TypeConstraint.Equality(t1, t2, _)) =>
+        ConstraintSolver2.fullyUnify(acc(t1), acc(t2), scope, renv)(root.eqEnv, flix) match {
+          case Some(s) => s @@ acc
+          case None => throw InternalCompilerException(s"Could not solve constraint '$t1 ~ $t2' while reducing $assoc", assoc.loc)
+        }
+      case (_, c) => throw InternalCompilerException(s"unexpected constraint: $c", assoc.loc)
+    }
+    subst(res)
   }
 
   // Ported from monomorph.Specialization.normalizeApply, with a small difference

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -19,7 +19,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.Type.JvmMember
 import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
-import ca.uwaterloo.flix.language.ast.shared.{AssocTypeDef, RegionScope}
+import ca.uwaterloo.flix.language.ast.shared.{AssocTypeDef, EqualityConstraint, RegionScope}
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, Substitution}
 import ca.uwaterloo.flix.util.JvmUtils
 import org.apache.commons.lang3.reflect.{ConstructorUtils, MethodUtils}
@@ -57,7 +57,7 @@ object TypeReduction2 {
 
       // Find the instance that matches
       val matches = assocOpt.flatMap {
-        case AssocTypeDef(tparams, assocTpe0, ret0) =>
+        case AssocTypeDef(tparams, assocTpe0, ret0, econstrs0) =>
 
 
           // We fully rigidify `tpe`, because we need the substitution to go from instance type to constraint type.
@@ -74,10 +74,16 @@ object TypeReduction2 {
           val assocSubst = Substitution(assocVarMap)
           val assocTpe = assocSubst(assocTpe0)
           val ret = assocSubst(ret0)
+          // The instance's equality constraints are refreshed with the same substitution as `ret`,
+          // so any variable `ret` shares with them (e.g. one introduced solely on the right-hand
+          // side of an equality constraint) is the same fresh variable in both. Emitting them as
+          // obligations lets the solver determine that variable, e.g. `Elm[Wrapper[c]] = a` together
+          // with `Elm[c] ~ a` reduces `Elm[Wrapper[List[Int32]]]` to `Int32` rather than a loose var.
+          val econstrs = econstrs0.map(assocSubst.apply)
 
           // Instantiate all the instance constraints according to the substitution.
           ConstraintSolver2.fullyUnify(t, assocTpe, scope, assocRenv).map {
-            case subst => subst(ret)
+            case subst => (subst(ret), econstrs.map(subst.apply).map(equalityConstraintToTypeConstraint(_, loc)))
           }
       }
 
@@ -94,10 +100,11 @@ object TypeReduction2 {
           else
             (Type.AssocType(symUse, t, kind, loc), cs)
 
-        // Case 2: One match. Use it.
-        case Some(newTpe) =>
+        // Case 2: One match. Use it, together with any obligations from the instance's
+        // equality constraints.
+        case Some((newTpe, newCs)) =>
           progress.markProgress()
-          (newTpe, cs)
+          (newTpe, cs ::: newCs)
       }
 
     case Type.JvmToType(tpe, loc) =>
@@ -181,6 +188,13 @@ object TypeReduction2 {
             case _ => (unresolved, cs)
           }
       }
+  }
+
+  /** Converts an equality constraint `cst[tpe1] ~ tpe2` into the corresponding [[TypeConstraint]]. */
+  private def equalityConstraintToTypeConstraint(constr: EqualityConstraint, loc: SourceLocation): TypeConstraint = constr match {
+    case EqualityConstraint(cst, tpe1, tpe2, _) =>
+      val assoc = Type.AssocType(cst, tpe1, tpe2.kind, tpe1.loc)
+      TypeConstraint.Equality(assoc, tpe2, TypeConstraint.Provenance.Match(tpe1, tpe2, loc))
   }
 
   /** Tries to find a constructor of `clazz` that takes arguments of type `ts`. */

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EqualityEnv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EqualityEnv.scala
@@ -46,9 +46,11 @@ case class EqualityEnv(private val m: Map[(Symbol.AssocTypeSym, TypeHead), Assoc
       case None => this
 
       case Some(head) =>
-        // tparams are Nil because we are adding instances directly, but not schemas of instances
+        // tparams are Nil because we are adding instances directly, but not schemas of instances.
+        // econstrs are Nil because this is a leaf assumption (e.g. a where-clause equality), not an
+        // instance definition that could introduce right-hand-side variables.
         val tparams = Nil
-        val defn = AssocTypeDef(tparams, arg, ret)
+        val defn = AssocTypeDef(tparams, arg, ret, Nil)
 
         EqualityEnv(m + ((sym, head) -> defn))
     }

--- a/main/test/flix/Test.Instance.Eq.Constraint.FreshVar.flix
+++ b/main/test/flix/Test.Instance.Eq.Constraint.FreshVar.flix
@@ -17,26 +17,58 @@ mod Test.Instance.Eq.Constraint.FreshVar {
 
     // `Wrapper[c]` has no `a` in its head; the type variable `a` is introduced
     // solely by the right-hand side of the equality constraint
-    // `Container.Elm[c] ~ a`. It names the element type of `c` and is used as an
-    // abbreviation in the method signature below.
+    // `Container.Elm[c] ~ a`, where it names the element type of `c`.
+    //
+    // The associated type is defined directly as `a`. Reducing
+    // `Container.Elm[Wrapper[List[Int32]]]` must therefore consult the equality
+    // constraint and yield `Int32`, rather than a loose type variable.
     enum Wrapper[c](c)
 
     instance Container[Wrapper[c]] with Container[c] where Container.Elm[c] ~ a {
-        type Elm = Container.Elm[c]
+        type Elm = a
         pub def first(w: Wrapper[c]): a =
             let Wrapper.Wrapper(inner) = w;
             Container.first(inner)
     }
 
-    // A second wrapper, showing the fresh variable is genuinely determined by
-    // the element type of the wrapped value and not fixed to any single type.
+    // The introduced variable may appear inside a compound associated type.
     enum Twice[c](c, c)
 
     instance Container[Twice[c]] with Container[c] where Container.Elm[c] ~ a {
-        type Elm = (Container.Elm[c], Container.Elm[c])
+        type Elm = (a, a)
         pub def first(t: Twice[c]): (a, a) =
             let Twice.Twice(x, y) = t;
             (Container.first(x), Container.first(y))
+    }
+
+    // -----------------------------------------------------------------
+    // A compound right-hand side introduces several variables at once and
+    // effectively destructures the associated type of the wrapped value.
+
+    trait Producer[p] {
+        type Elm: Type
+        pub def produce(p: p): Producer.Elm[p]
+    }
+
+    enum Pair[a, b](a, b)
+
+    instance Producer[Pair[a, b]] {
+        type Elm = (a, b)
+        pub def produce(p: Pair[a, b]): (a, b) =
+            let Pair.Pair(x, y) = p;
+            (x, y)
+    }
+
+    enum FirstOf[p](p)
+
+    // `Producer.Elm[p] ~ (a, b)` introduces both `a` and `b`; the element type
+    // of `FirstOf[p]` is the first component, `a`.
+    instance Producer[FirstOf[p]] with Producer[p] where Producer.Elm[p] ~ (a, b) {
+        type Elm = a
+        pub def produce(f: FirstOf[p]): a =
+            let FirstOf.FirstOf(inner) = f;
+            let (x, _) = Producer.produce(inner);
+            x
     }
 
     @Test
@@ -54,5 +86,9 @@ mod Test.Instance.Eq.Constraint.FreshVar {
     @Test
     def testFirstTwice(): Unit \ Assert =
         assertEq(expected = (1, 4), Container.first(Twice.Twice(1 :: 2 :: Nil, 4 :: 5 :: Nil)))
+
+    @Test
+    def testProduceFirstOf(): Unit \ Assert =
+        assertEq(expected = 1, Producer.produce(FirstOf.FirstOf(Pair.Pair(1, true))))
 
 }

--- a/main/test/flix/Test.Instance.Eq.Constraint.FreshVar.flix
+++ b/main/test/flix/Test.Instance.Eq.Constraint.FreshVar.flix
@@ -1,0 +1,58 @@
+mod Test.Instance.Eq.Constraint.FreshVar {
+
+    use Assert.assertEq
+
+    trait Container[c] {
+        type Elm: Type
+        pub def first(c: c): Container.Elm[c]
+    }
+
+    instance Container[List[a]] {
+        type Elm = a
+        pub def first(c: List[a]): a = match c {
+            case hd :: _ => hd
+            case Nil     => unreachable!()
+        }
+    }
+
+    // `Wrapper[c]` has no `a` in its head; the type variable `a` is introduced
+    // solely by the right-hand side of the equality constraint
+    // `Container.Elm[c] ~ a`. It names the element type of `c` and is used as an
+    // abbreviation in the method signature below.
+    enum Wrapper[c](c)
+
+    instance Container[Wrapper[c]] with Container[c] where Container.Elm[c] ~ a {
+        type Elm = Container.Elm[c]
+        pub def first(w: Wrapper[c]): a =
+            let Wrapper.Wrapper(inner) = w;
+            Container.first(inner)
+    }
+
+    // A second wrapper, showing the fresh variable is genuinely determined by
+    // the element type of the wrapped value and not fixed to any single type.
+    enum Twice[c](c, c)
+
+    instance Container[Twice[c]] with Container[c] where Container.Elm[c] ~ a {
+        type Elm = (Container.Elm[c], Container.Elm[c])
+        pub def first(t: Twice[c]): (a, a) =
+            let Twice.Twice(x, y) = t;
+            (Container.first(x), Container.first(y))
+    }
+
+    @Test
+    def testFirstList(): Unit \ Assert =
+        assertEq(expected = 1, Container.first(1 :: 2 :: 3 :: Nil))
+
+    @Test
+    def testFirstWrapperInt(): Unit \ Assert =
+        assertEq(expected = 1, Container.first(Wrapper.Wrapper(1 :: 2 :: 3 :: Nil)))
+
+    @Test
+    def testFirstWrapperString(): Unit \ Assert =
+        assertEq(expected = "a", Container.first(Wrapper.Wrapper("a" :: "b" :: Nil)))
+
+    @Test
+    def testFirstTwice(): Unit \ Assert =
+        assertEq(expected = (1, 4), Container.first(Twice.Twice(1 :: 2 :: Nil, 4 :: 5 :: Nil)))
+
+}


### PR DESCRIPTION
_Below generated by Claude_

## Summary

This PR lets an instance introduce and *use* a type variable that is bound by the right-hand side of an equality constraint, rather than requiring every type variable to appear in the instance head. It comes in two parts.

### 1. Introduce type variables from an equality-constraint RHS

Previously an instance could only mention type variables appearing in its head type; a variable used solely on the RHS of a `where ... ~ ...` constraint failed with `UndefinedTypeVar`. Now such a variable is introduced automatically, mirroring how definitions already treat their equality constraints (`visitImplicitTypeParamsFromFormalParams`).

- **Namer** (`getImplicitTypeParamsFromInstance`): collects the free variables of the head type together with the free variables on the RHS of each equality constraint. Only the RHS is used — the associated-type application on the LHS never introduces variables. Existing instances are unaffected: a concrete RHS contributes nothing, and a RHS variable already bound by the head is deduplicated.
- **Kinder** (`visitInstance`): the kind environment is now inferred from the head type *and* the equality constraints, so a RHS variable is assigned the kind of the associated type's result rather than being left unconstrained.

### 2. Reduce associated types defined by such a variable

With part 1 alone, an associated type defined directly as the introduced variable reduced to a *loose* type variable at external use sites, because associated-type reduction unified only the instance head and never consulted the instance's equality constraints:

```flix
instance Container[Wrapper[c]] with Container[c] where Container.Elm[c] ~ a {
    type Elm = a                 // Container.Elm[Wrapper[List[Int32]]] used to reduce to a loose var
    pub def first(w: Wrapper[c]): a = ...
}
```

The equality constraints of the instance are now carried on `AssocTypeDef`. During reduction they are instantiated with the **same** substitution as the definition's result type and emitted as equality obligations. Because the result type and the constraints share the freshened variables, solving the obligations determines the result — `Container.Elm[Wrapper[List[Int32]]]` now reduces to `Int32`. This also handles compound right-hand sides such as `Producer.Elm[p] ~ (a, b)`, which destructure the associated type of the wrapped value.

- `shared/AssocTypeDef`: new `econstrs` field.
- `Typer.mkEqualityEnv`: populates it from the instance's equality constraints.
- `EqualityEnv.addAssocTypeDef`: passes `Nil` for leaf where-clause assumptions.
- `TypeReduction2`: instantiates the carried constraints alongside the result type and emits them into the constraint set that `reduce` already threads out.

## Soundness

There is no soundness issue. At instance selection the RHS variable is refreshed to a fresh flexible variable, left unbound by head unification, and then determined by the equality constraint. Associated-type reduction is functional — the equality environment is keyed by `(assoc sym, TypeHead)` with a single definition per head, and overlapping instances are forbidden — so the variable is uniquely determined. No coverage/ambiguity check requires an instance's type parameters to appear in its head. When the argument is abstract the associated type simply stays irreducible and the obligation is deferred, exactly as before.
