### PR TITLE
fix: use declared arity when lowering inject into

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -1613,22 +1613,12 @@ object Lowering {
 
   private def lowerInjectInto(exps: List[TypedAst.Expr], predsAndArities: List[PredicateAndArity], loc: SourceLocation)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.Expr = {
     val loweredExps = exps.zip(predsAndArities).map {
-      case (exp, PredicateAndArity(pred, _)) =>
-        // Compute the types arguments of the functor F[(a, b, c)] or F[a].
-        val (_, targsLength) = exp.tpe match {
-          case Type.Apply(tycon, innerType, _) => innerType.typeConstructor match {
-            case Some(TypeConstructor.Tuple(_)) => (tycon, innerType.typeArguments.length)
-            case Some(TypeConstructor.Unit) => (tycon, 0)
-            case _ => (tycon, 1)
-          }
-          case _ => throw InternalCompilerException(s"Unexpected non-foldable type: '${exp.tpe}'.", loc)
-        }
-
+      case (exp, PredicateAndArity(pred, arity)) =>
         // The type of the function.
         val defTpe = Type.mkPureUncurriedArrow(List(Types.PredSym, lowerType(exp.tpe)), Types.Datalog, loc)
 
         // Compute the symbol of the function.
-        val sym = lookup(Defs.ProjectInto(targsLength), defTpe)
+        val sym = lookup(Defs.ProjectInto(arity), defTpe)
 
         // Put everything together.
         val argExps = mkPredSym(pred) :: lowerExp(exp) :: Nil

--- a/main/test/flix/Test.Exp.Fixpoint.Inject.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.Inject.flix
@@ -207,4 +207,47 @@ mod Test.Exp.Fixpoint.Inject {
         assertEq(expected = l3, r3)
     }
 
+    @Test
+    def inject23(): Unit \ Assert = {
+        let l = Vector#{(1, 2, 3), (4, 5, 6)};
+        let pr = inject l into A/1;
+        let r = query pr select x from A(x);
+        assertEq(expected = l, r)
+    }
+
+    @Test
+    def inject24(): Unit \ Assert = {
+        let l = Vector#{(1, 2), (2, 3), (3, 4)};
+        let pr = inject l into A/1;
+        let r = query pr select x from A(x);
+        assertEq(expected = l, r)
+    }
+
+    @Test
+    def inject25(): Unit \ Assert = {
+        let l = Vector#{()};
+        let pr = inject l into A/1;
+        let r = query pr select x from A(x);
+        assertEq(expected = l, r)
+    }
+
+    @Test
+    def inject26(): Unit \ Assert = {
+        let l = Vector#{((1, 2), 3), ((4, 5), 6)};
+        let pr = inject l into A/1;
+        let r = query pr select x from A(x);
+        assertEq(expected = l, r)
+    }
+
+    @Test
+    def inject27(): Unit \ Assert = {
+        let l1 = Vector#{(1, 2), (2, 3)};
+        let l2 = Vector#{(1, 2), (2, 3)};
+        let pr = inject l1, l2 into A/1, B/2;
+        let r1 = query pr select x from A(x);
+        let r2 = query pr select (x, y) from B(x, y);
+        assertEq(expected = l1, r1);
+        assertEq(expected = l2, r2)
+    }
+
 }


### PR DESCRIPTION
Resolves #12966

`inject l into A/1` with `l: Vector[(Int32, Int32, Int32)]` type-checked but crashed at runtime with `HoleError` ("BUG: Reached unreachable expression").

The typer accepts the program as an arity-1 relation whose single term is the whole tuple: for `A/n` it builds `mkTuplish` of `n` fresh element variables, so for `n = 1` the element type is a single variable that happily unifies with a tuple (or Unit). The query side type-checks consistently against that schema.

However, `lowerInjectInto` ignored the declared arity and re-derived it from the shape of the element type (tuple → tuple width, Unit → 0, otherwise → 1). It therefore emitted `injectInto3`, producing arity-3 facts `A(1, 2, 3)` that clash with the arity-1 schema the rest of the program was compiled against, crashing the fixpoint solver. The Unit case was also broken: `inject Vector#{()} into A/1` crashed the compiler itself looking up the nonexistent `injectInto0`.

This PR changes `lowerInjectInto` to use the declared arity directly and deletes the shape analysis. This is safe because the typer already forces the element type to be an n-tuple for declared arity n >= 2 (and Unit for n = 0), so the declared and shape-derived arities only diverged in the broken cases.

The program from the issue now prints `Vector#{(1, 2, 3), (4, 5, 6)}`, i.e. each vector element becomes the single argument of the predicate, matching what the type system already promised.

Adds regression tests `inject23`-`inject27`: 3-tuples into `A/1` (the issue scenario), pairs into `A/1`, Unit into `A/1`, nested tuples into `A/1`, and a multi-inject where the same pair vector goes whole into `A/1` and split into `B/2`.