### PR TITLE
fix: cast erased return value of generic Java calls

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -905,6 +905,8 @@ object GenExpression {
         // If the method is void, put a unit on top of the stack
         if (asm.Type.getType(method.getReturnType) == asm.Type.VOID_TYPE) {
           mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
+        } else {
+          castFromJavaType(method.getReturnType, tpe)
         }
 
       case AtomicOp.InvokeSuperMethod(sym, method) =>
@@ -933,6 +935,8 @@ object GenExpression {
         // If the method is void, put a unit on top of the stack
         if (asm.Type.getType(method.getReturnType) == asm.Type.VOID_TYPE) {
           mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
+        } else {
+          castFromJavaType(method.getReturnType, tpe)
         }
 
       case AtomicOp.InvokeStaticMethod(method) =>
@@ -953,6 +957,8 @@ object GenExpression {
         }
         if (asm.Type.getType(method.getReturnType) == asm.Type.VOID_TYPE) {
           mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
+        } else {
+          castFromJavaType(method.getReturnType, tpe)
         }
 
       case AtomicOp.GetField(field) =>
@@ -1633,6 +1639,24 @@ object GenExpression {
         mv.visitFieldInsn(PUTFIELD, className, s"clo$i", JvmOps.getErasedClosureAbstractClassType(e.tpe).toDescriptor)
       }
 
+  }
+
+  /**
+    * Casts the value on top of the stack from the Java type `javaTpe` to the Flix type `tpe`,
+    * if the two do not already agree.
+    *
+    * Java generics are erased, so the declared type of a Java method may be less precise than
+    * the type Flix has inferred for the call. For example, `JComboBox[(String, String)].getItemAt`
+    * is declared to return `Object`, but Flix knows that the result is a tuple. Without the cast,
+    * the JVM verifier rejects any subsequent use of the value at its Flix type.
+    */
+  private def castFromJavaType(javaTpe: Class[?], tpe: SimpleType)(implicit mv: MethodVisitor, root: Root): Unit = {
+    if (!javaTpe.isPrimitive) {
+      val expectedTpe = BackendType.toBackendType(tpe)
+      if (expectedTpe.toDescriptor != asm.Type.getDescriptor(javaTpe)) {
+        BytecodeInstructions.castIfNotPrim(expectedTpe)
+      }
+    }
   }
 
   private def getStructType(struct: Struct)(implicit root: Root): BackendObjType.Struct = {

--- a/main/test/flix/Test.Exp.Jvm.Generic.Poly.flix
+++ b/main/test/flix/Test.Exp.Jvm.Generic.Poly.flix
@@ -187,4 +187,35 @@ mod Test.Exp.Jvm.Generic.Poly {
         polyPut(m, "x", 1);
         assertEq(expected = 1, polyGet2(m, "x"))
 
+    @Test
+    def testArrayListOfTuples28(): Unit \ {Assert, IO} =
+        let l: ArrayList[(String, String)] = new ArrayList();
+        discard l.add(("Red", "#FF0000"));
+        let (name, hex) = l.get(0);
+        assertEq(expected = "Red/#FF0000", "${name}/${hex}")
+
+    @Test
+    def testArrayListOfLists29(): Unit \ {Assert, IO} =
+        let l: ArrayList[List[Int32]] = new ArrayList();
+        discard l.add(1 :: 2 :: 3 :: Nil);
+        assertEq(expected = 6, List.sum(l.get(0)))
+
+    @Test
+    def testHashMapOfTuples30(): Unit \ {Assert, IO} =
+        let m: HashMap[String, (Int32, Int32)] = new HashMap();
+        discard m.put("k", (1, 2));
+        let (a, b) = m.get("k");
+        assertEq(expected = 3, a + b)
+
+    @Test
+    def testOptionalOfTuple31(): Unit \ {Assert, IO} =
+        let opt: Optional[(String, Int32)] = Optional.of(("x", 42));
+        let (s, i) = opt.get();
+        assertEq(expected = "x42", "${s}${i}")
+
+    @Test
+    def testStaticMethodReturnsTuple32(): Unit \ {Assert, IO} =
+        let (a, b) = Objects.requireNonNull(("a", "b"));
+        assertEq(expected = "ab", "${a}${b}")
+
 }


### PR DESCRIPTION
_PR by Claude_

Fixes #12970.

Java generics are erased, so `JComboBox[(String, String)].getItemAt` is declared to return `Object`, while Flix knows the result is a tuple. The backend emitted no cast after the invocation, so the JVM verifier rejected any subsequent use of the value at its Flix type:

```
Type 'java/lang/Object' (current frame, stack[0]) is not assignable to 'Tuple$Obj$Obj'
```

`GenExpression` now inserts a `CHECKCAST` to the Flix type after `InvokeMethod`, `InvokeSuperMethod`, and `InvokeStaticMethod` whenever the declared Java return type is less precise than the type Flix inferred. This complements the boxing and unboxing of primitives that `Lowering` already performs for generic Java calls.

The cast is skipped when the declared Java return type already matches the Flix type (the common, non-generic case) and when the Flix type is primitive (handled by auto-unboxing).