### PR TITLE
chore: run community builds with an 8MB stack

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -87,4 +87,6 @@ jobs:
         timeout-minutes: 10
         run: |
           # Build the project.
-          java -jar out.jar build --github-token ${{ secrets.GITHUB_TOKEN }}
+          # Note: -Xss8m because type inference recurses once per AST node along a
+          # function's spine, so large functions exhaust the default 1MB stack.
+          java -Xss8m -jar out.jar build --github-token ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Community Build has been failing on `ababup1192/flix_game_engine` since #12937 added it to the matrix — it has never passed. Both runs on master since then (`ae5b1c4`, `db88240`) are red with a `StackOverflowError`.

### Cause

`ConstraintGen.visitExp` recurses once per AST node along the *spine* of a function body, so the stack required grows with a function's **length**, not its nesting depth. Two things make that expensive:

- `visitExp` is a single 1095-line method compiling to ~30KB of bytecode, so all match arms share one large stack frame.
- The affected project has functions of 295–2945 lines.

Measured at `-Xss1m`, the compiler handles only ~36–67 sequential bindings in one function before overflowing. The workflow runs `java -jar out.jar build` with no `-Xss`, so it gets the JVM default 1MB main-thread stack.

### Fix

Pass `-Xss8m` to the community build. Verified locally: `flix_game_engine` needs ≥2MB and builds cleanly at 8MB (exit 0), so this leaves 4× headroom.

This is a stopgap that unblocks CI. The underlying recursion is worth addressing separately — splitting `visitExp` into per-case methods would shrink the frame, and making the spine traversal iterative would bound depth by nesting rather than length. A large-stack thread in `Main` would also fix this for all users rather than just CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
