### PR TITLE
fix: don't unify JVM implementations with JVM signatures

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -564,27 +564,27 @@ object Safety {
         // Allow all null casts.
         case (Type.Null, _) => ()
 
-          // Allow casts where one side is a type variable.
+        // Allow casts where one side is a type variable.
         case (Type.Var(_, _), _) => ()
         case (_, Some(Type.Var(_, _))) => ()
 
-          // Allow casts between Java types.
+        // Allow casts between Java types.
         case (Type.Cst(TypeConstructor.Native(_), _), _) => ()
         case (_, Some(Type.Cst(TypeConstructor.Native(_), _))) => ()
 
-          // Disallow casting a Boolean to another primitive type.
+        // Disallow casting a Boolean to another primitive type.
         case (Type.Bool, Some(t2)) if primitives.filter(_ != Type.Bool).contains(t2) =>
           sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
-          // Disallow casting a Boolean to another primitive type (symmetric case).
+        // Disallow casting a Boolean to another primitive type (symmetric case).
         case (t1, Some(Type.Bool)) if primitives.filter(_ != Type.Bool).contains(t1) =>
           sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
-          // Disallowing casting a non-primitive type to a primitive type.
+        // Disallowing casting a non-primitive type to a primitive type.
         case (t1, Some(t2)) if primitives.contains(t1) && !primitives.contains(t2) =>
           sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
-          // Disallowing casting a non-primitive type to a primitive type (symmetric case).
+        // Disallowing casting a non-primitive type to a primitive type (symmetric case).
         case (t1, Some(t2)) if primitives.contains(t2) && !primitives.contains(t1) =>
           sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
@@ -840,6 +840,7 @@ object Safety {
           }
       }
 
+      // `methods` must cover all the class's abstract methods and must not include any extra methods
       val targs = tpe.typeArguments
       val getTargOpt = targs.lift // returns the targ at the given index, or None
       val javaMethods = JvmUtils.getOverridableInstanceMethods(clazz)
@@ -850,22 +851,24 @@ object Safety {
 
           val name = method.getName
           val types = method.getGenericParameterTypes.map(resolveJavaType(_, substMap, loc))
-          (method, name, types)
-      }.sortBy { case (_, name, types) => (name, types.length) }
+          val retTpe = resolveJavaType(method.getGenericReturnType, substMap, loc)
+          (method, name, types, retTpe)
+      }.sortBy { case (_, name, types, _) => (name, types.length) }
 
       val actualMethods = methods.map {
-        case JvmMethod(_, ident, fparams, _, _, _, _) =>
+        case JvmMethod(_, ident, fparams, _, retTpe, _, _) =>
           val name = ident.name
           val types = fparams.map(_.tpe).tail // drop the `this` parameter
-          (ident, name, types)
-      }.sortBy { case (_, name, types) => (name, types.length) }
+          (ident, name, types, retTpe)
+      }.sortBy { case (_, name, types, _) => (name, types.length) }
 
-      val (_, unimplemented, extra) = ListOps.unorderedCorresponds(expectedMethods, actualMethods) {
-        case ((_, expectedName, expectedTypes), (_, actualName, actualTypes)) =>
+      // matching methods are the ones whose names match and whose formal parameter types are equivalent
+      val (_, unimplemented, extra) = ListOps.fullOuterJoin(expectedMethods, actualMethods) {
+        case ((_, expectedName, expectedTypes, expectedRetType), (_, actualName, actualTypes, actualRetType)) =>
           if (expectedName != actualName) {
             false
           } else {
-            expectedTypes.corresponds(actualTypes) {
+            (expectedRetType :: expectedTypes.toList).corresponds(actualRetType :: actualTypes) {
               // TODO support equality env here
               case (expectedType, actualType) => ConstraintSolver2.isEquivalent(expectedType, actualType)(EqualityEnv.empty, flix)
             }
@@ -873,9 +876,9 @@ object Safety {
       }
 
       // an unimplemented method is only a problem if it's abstract and isn't auto-implemented by Object
-      val missing = unimplemented.filter { case (method, _, _) => isAbstractMethod(method) && !isObjectMethod(method) }
-      missing.foreach { case (method, _, _) => sctx.errors.add(NewObjectMissingMethod(clazz, method, loc)) }
-      extra.foreach { case (ident, name, _) => sctx.errors.add(NewObjectUndefinedMethod(clazz, name, ident.loc)) }
+      val missing = unimplemented.filter { case (method, _, _, _) => isAbstractMethod(method) && !isObjectMethod(method) }
+      missing.foreach { case (method, _, _, _) => sctx.errors.add(NewObjectMissingMethod(clazz, method, loc)) }
+      extra.foreach { case (ident, name, _, _) => sctx.errors.add(NewObjectUndefinedMethod(clazz, name, ident.loc)) }
 
       // `methods` must not let control effects escape.
       val controlEffecting = methods.filter(m => hasControlEffects(m.eff))

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -9,8 +9,12 @@ import ca.uwaterloo.flix.language.ast.{ChangeSet, RigidityEnv, SourceLocation, S
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
+import ca.uwaterloo.flix.language.phase.typer.{ConstraintGen, ConstraintSolver2}
+import ca.uwaterloo.flix.language.phase.unification.EqualityEnv
+import ca.uwaterloo.flix.util.collection.ListOps
 import ca.uwaterloo.flix.util.{JvmUtils, ParOps}
 
+import java.lang.reflect.{ParameterizedType, TypeVariable}
 import java.math.BigInteger
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.tailrec
@@ -842,24 +846,39 @@ object Safety {
         case JvmMethod(_, ident, fparams, _, _, _, _) => (ident.name, fparams.tail.length)
       }.toSet
 
+      val objTparams = clazz.getTypeParameters.toList.map(_.getName)
+      val objTargs = tpe.typeArguments
+      val substMap = objTparams.zip(objTargs).toMap
+
       val javaMethods = JvmUtils.getOverridableInstanceMethods(clazz)
-      val objectMethodNameAndArity = JvmUtils.getInstanceMethods(classOf[Object])
-        .map(m => (m.getName, m.getParameterCount)).toSet
+      val expectedMethods = javaMethods.map {
+        case method =>
+          val name = method.getName
+          val types = method.getGenericParameterTypes.map(resolveJavaType(_, substMap, loc))
+          (method, name, types)
+      }.sortBy { case (_method, name, types) => (name, types.length) }
 
-      val unimplementedMethods = javaMethods.filter { m =>
-        isAbstractMethod(m) &&
-        !objectMethodNameAndArity.contains((m.getName, m.getParameterCount)) &&
-        !flixMethodNameAndArity.contains((m.getName, m.getParameterCount))
-      }
-      unimplementedMethods.foreach(m => sctx.errors.add(NewObjectMissingMethod(clazz, m, loc)))
-
-      // Check for undefined methods (Flix methods not matching any Java method).
-      val javaMethodNameAndArity = javaMethods.map(m => (m.getName, m.getParameterCount)).toSet
-      val undefinedMethods = methods.filter {
+      val actualMethods = methods.map {
         case JvmMethod(_, ident, fparams, _, _, _, _) =>
-          !javaMethodNameAndArity.contains((ident.name, fparams.tail.length))
+          val name = ident.name
+          val types = fparams.map(_.tpe)
+          (ident, name, types)
+      }.sortBy { case (_ident, name, types) => (name, types.length) }
+
+      val (_pairs, missing, extra) = ListOps.unorderedCorresponds(expectedMethods, actualMethods) {
+        case ((_method, expectedName, expectedTypes), (_ident, actualName, actualTypes)) =>
+          if (expectedName != actualName) {
+            false
+          } else {
+            expectedTypes.corresponds(actualTypes) {
+              // TODO support equality env here
+              case (expectedType, actualType) => ConstraintSolver2.isEquivalent(expectedType, actualType)(EqualityEnv.empty, flix)
+            }
+          }
       }
-      undefinedMethods.foreach(m => sctx.errors.add(NewObjectUndefinedMethod(clazz, m.ident.name, m.loc)))
+
+      missing.foreach { case (method, _, _) => sctx.errors.add(NewObjectMissingMethod(clazz, method, loc)) }
+      extra.foreach { case (ident, name, _) => sctx.errors.add(NewObjectUndefinedMethod(clazz, name, ident.loc)) }
 
       // `methods` must not let control effects escape.
       val controlEffecting = methods.filter(m => hasControlEffects(m.eff))
@@ -875,6 +894,29 @@ object Safety {
       case _: NoSuchMethodException => false
     }
   }
+
+  /**
+    * Resolves a `java.lang.reflect.Type` to a Flix [[Type]] using the given
+    * substitution map. Falls back to the erased (Object-filled) type.
+    */
+  private def resolveJavaType(javaType: java.lang.reflect.Type, substMap: Map[String, Type], loc: SourceLocation): Type = javaType match {
+    case tv: TypeVariable[_] =>
+      substMap.getOrElse(tv.getName, Type.instantiateJavaTypeWithObjectArgs(classOf[Object], loc))
+    case pt: ParameterizedType =>
+      pt.getRawType match {
+        case rawClazz: Class[_] =>
+          val base = Type.getFlixType(rawClazz)
+          val resolvedArgs = pt.getActualTypeArguments.toList.map(resolveJavaType(_, substMap, loc))
+          Type.mkApply(base, resolvedArgs, loc)
+        case _ =>
+          Type.instantiateJavaTypeWithObjectArgs(classOf[Object], loc)
+      }
+    case clazz: Class[_] =>
+      Type.instantiateJavaTypeWithObjectArgs(clazz, loc)
+    case _ =>
+      Type.instantiateJavaTypeWithObjectArgs(classOf[Object], loc)
+  }
+
 
   /** Returns `true` if `c` is public. */
   private def isPublicClass(c: Class[?]): Boolean =

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -11,7 +11,7 @@ import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
 import ca.uwaterloo.flix.language.phase.typer.{ConstraintGen, ConstraintSolver2}
 import ca.uwaterloo.flix.language.phase.unification.EqualityEnv
-import ca.uwaterloo.flix.util.collection.ListOps
+import ca.uwaterloo.flix.util.collection.{ListOps, MapOps}
 import ca.uwaterloo.flix.util.{JvmUtils, ParOps}
 
 import java.lang.reflect.{ParameterizedType, TypeVariable}
@@ -68,7 +68,6 @@ object Safety {
     checkSpecPermissions(sig.spec)
     sig.exp.foreach(visitExp(_))
   }
-
 
 
   /**
@@ -449,47 +448,47 @@ object Safety {
         case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Regex, _)) => ()
         case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Array, _)) => ()
 
-        // Allow casting one Java type to another if there is a subtype relationship.
+          // Allow casting one Java type to another if there is a subtype relationship.
         case (Type.Cst(TypeConstructor.Native(left), _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(left)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-        // Similar, but for String.
+          // Similar, but for String.
         case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[String])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-        // Similar, but for Regex.
+          // Similar, but for Regex.
         case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[java.util.regex.Pattern])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-        // Similar, but for BigInt.
+          // Similar, but for BigInt.
         case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[BigInteger])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-        // Similar, but for BigDecimal.
+          // Similar, but for BigDecimal.
         case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[java.math.BigDecimal])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-        // Similar, but for Arrays.
+          // Similar, but for Arrays.
         case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[Array[Object]])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-        // Disallow casting a type variable.
+          // Disallow casting a type variable.
         case (src@Type.Var(_, _), _) =>
           sctx.errors.add(IllegalCheckedCastFromVar(src, to, loc))
 
-        // Disallow casting a type variable (symmetric case)
+          // Disallow casting a type variable (symmetric case)
         case (_, dst@Type.Var(_, _)) =>
           sctx.errors.add(IllegalCheckedCastToVar(from, dst, loc))
 
-        // Disallow casting a Java type to any other type.
+          // Disallow casting a Java type to any other type.
         case (Type.Cst(TypeConstructor.Native(clazz), _), _) =>
           sctx.errors.add(IllegalCheckedCastToNonJava(clazz, to, loc))
 
-        // Disallow casting a Java type to any other type (symmetric case).
+          // Disallow casting a Java type to any other type (symmetric case).
         case (_, Type.Cst(TypeConstructor.Native(clazz), _)) =>
           sctx.errors.add(IllegalCheckedCastFromNonJava(from, clazz, loc))
 
-        // Disallow all other casts.
+          // Disallow all other casts.
         case _ => sctx.errors.add(IllegalCheckedCast(from, to, loc))
       }
   }
@@ -565,27 +564,27 @@ object Safety {
         // Allow all null casts.
         case (Type.Null, _) => ()
 
-        // Allow casts where one side is a type variable.
+          // Allow casts where one side is a type variable.
         case (Type.Var(_, _), _) => ()
         case (_, Some(Type.Var(_, _))) => ()
 
-        // Allow casts between Java types.
+          // Allow casts between Java types.
         case (Type.Cst(TypeConstructor.Native(_), _), _) => ()
         case (_, Some(Type.Cst(TypeConstructor.Native(_), _))) => ()
 
-        // Disallow casting a Boolean to another primitive type.
+          // Disallow casting a Boolean to another primitive type.
         case (Type.Bool, Some(t2)) if primitives.filter(_ != Type.Bool).contains(t2) =>
           sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
-        // Disallow casting a Boolean to another primitive type (symmetric case).
+          // Disallow casting a Boolean to another primitive type (symmetric case).
         case (t1, Some(Type.Bool)) if primitives.filter(_ != Type.Bool).contains(t1) =>
           sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
-        // Disallowing casting a non-primitive type to a primitive type.
+          // Disallowing casting a non-primitive type to a primitive type.
         case (t1, Some(t2)) if primitives.contains(t1) && !primitives.contains(t2) =>
           sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
-        // Disallowing casting a non-primitive type to a primitive type (symmetric case).
+          // Disallowing casting a non-primitive type to a primitive type (symmetric case).
         case (t1, Some(t2)) if primitives.contains(t2) && !primitives.contains(t1) =>
           sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
@@ -841,13 +840,14 @@ object Safety {
           }
       }
 
-      val objTparams = clazz.getTypeParameters.toList.map(_.getName)
-      val objTargs = tpe.typeArguments
-      val substMap = objTparams.zip(objTargs).toMap
-
+      val targs = tpe.typeArguments
+      val getTargOpt = targs.lift // returns the targ at the given index, or None
       val javaMethods = JvmUtils.getOverridableInstanceMethods(clazz)
       val expectedMethods = javaMethods.map {
         case method =>
+          val tparamNameToIndex = JvmUtils.resolveTypeParamMapping(method, clazz)
+          val substMap = MapOps.filterMapValues(tparamNameToIndex)(getTargOpt)
+
           val name = method.getName
           val types = method.getGenericParameterTypes.map(resolveJavaType(_, substMap, loc))
           (method, name, types)
@@ -874,10 +874,6 @@ object Safety {
 
       // an unimplemented method is only a problem if it's abstract and isn't auto-implemented by Object
       val missing = unimplemented.filter { case (method, _, _) => isAbstractMethod(method) && !isObjectMethod(method) }
-      if (missing.nonEmpty && extra.nonEmpty) { // TODO debugging
-        println(unimplemented)
-        println(extra)
-      }
       missing.foreach { case (method, _, _) => sctx.errors.add(NewObjectMissingMethod(clazz, method, loc)) }
       extra.foreach { case (ident, name, _) => sctx.errors.add(NewObjectUndefinedMethod(clazz, name, ident.loc)) }
 
@@ -930,7 +926,7 @@ object Safety {
   /** Returns `true` if `m` is or overrides a method found on the Object class. */
   private def isObjectMethod(method: java.lang.reflect.Method): Boolean = {
     try {
-      classOf[Object].getDeclaredMethod(method.getName, method.getParameterTypes*)
+      classOf[Object].getDeclaredMethod(method.getName, method.getParameterTypes *)
       true
     } catch {
       case _: NoSuchMethodException => false

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -856,7 +856,7 @@ object Safety {
       val actualMethods = methods.map {
         case JvmMethod(_, ident, fparams, _, _, _, _) =>
           val name = ident.name
-          val types = fparams.map(_.tpe)
+          val types = fparams.map(_.tpe).tail // drop the `this` parameter
           (ident, name, types)
       }.sortBy { case (_, name, types) => (name, types.length) }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -448,47 +448,47 @@ object Safety {
         case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Regex, _)) => ()
         case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Array, _)) => ()
 
-          // Allow casting one Java type to another if there is a subtype relationship.
+        // Allow casting one Java type to another if there is a subtype relationship.
         case (Type.Cst(TypeConstructor.Native(left), _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(left)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-          // Similar, but for String.
+        // Similar, but for String.
         case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[String])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-          // Similar, but for Regex.
+        // Similar, but for Regex.
         case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[java.util.regex.Pattern])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-          // Similar, but for BigInt.
+        // Similar, but for BigInt.
         case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[BigInteger])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-          // Similar, but for BigDecimal.
+        // Similar, but for BigDecimal.
         case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[java.math.BigDecimal])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-          // Similar, but for Arrays.
+        // Similar, but for Arrays.
         case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right), _)) =>
           if (right.isAssignableFrom(classOf[Array[Object]])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
-          // Disallow casting a type variable.
+        // Disallow casting a type variable.
         case (src@Type.Var(_, _), _) =>
           sctx.errors.add(IllegalCheckedCastFromVar(src, to, loc))
 
-          // Disallow casting a type variable (symmetric case)
+        // Disallow casting a type variable (symmetric case)
         case (_, dst@Type.Var(_, _)) =>
           sctx.errors.add(IllegalCheckedCastToVar(from, dst, loc))
 
-          // Disallow casting a Java type to any other type.
+        // Disallow casting a Java type to any other type.
         case (Type.Cst(TypeConstructor.Native(clazz), _), _) =>
           sctx.errors.add(IllegalCheckedCastToNonJava(clazz, to, loc))
 
-          // Disallow casting a Java type to any other type (symmetric case).
+        // Disallow casting a Java type to any other type (symmetric case).
         case (_, Type.Cst(TypeConstructor.Native(clazz), _)) =>
           sctx.errors.add(IllegalCheckedCastFromNonJava(from, clazz, loc))
 
-          // Disallow all other casts.
+        // Disallow all other casts.
         case _ => sctx.errors.add(IllegalCheckedCast(from, to, loc))
       }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -860,7 +860,7 @@ object Safety {
           (ident, name, types)
       }.sortBy { case (_, name, types) => (name, types.length) }
 
-      val (_, missing, extra) = ListOps.unorderedCorresponds(expectedMethods, actualMethods) {
+      val (_, unimplemented, extra) = ListOps.unorderedCorresponds(expectedMethods, actualMethods) {
         case ((_, expectedName, expectedTypes), (_, actualName, actualTypes)) =>
           if (expectedName != actualName) {
             false
@@ -872,7 +872,13 @@ object Safety {
           }
       }
 
-      missing.foreach { case (method, _, _) => sctx.errors.add(NewObjectMissingMethod(clazz, method, loc)) }
+      unimplemented.foreach {
+        case (method, _, _) =>
+          // an unimplemented method is only a problem if it's abstract
+          if (isAbstractMethod(method)) {
+            sctx.errors.add(NewObjectMissingMethod(clazz, method, loc))
+          }
+      }
       extra.foreach { case (ident, name, _) => sctx.errors.add(NewObjectUndefinedMethod(clazz, name, ident.loc)) }
 
       // `methods` must not let control effects escape.

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -873,7 +873,7 @@ object Safety {
       }
 
       // an unimplemented method is only a problem if it's abstract and isn't auto-implemented by Object
-      val missing = unimplemented.filter { method => isAbstractMethod(method) && !isObjectMethod(method) }
+      val missing = unimplemented.filter { case (method, _, _) => isAbstractMethod(method) && !isObjectMethod(method) }
       if (missing.nonEmpty && extra.nonEmpty) { // TODO debugging
         println(unimplemented)
         println(extra)

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -841,11 +841,6 @@ object Safety {
           }
       }
 
-      // Check for missing abstract method implementations (by name + arity).
-      val flixMethodNameAndArity = methods.map {
-        case JvmMethod(_, ident, fparams, _, _, _, _) => (ident.name, fparams.tail.length)
-      }.toSet
-
       val objTparams = clazz.getTypeParameters.toList.map(_.getName)
       val objTargs = tpe.typeArguments
       val substMap = objTparams.zip(objTargs).toMap
@@ -856,17 +851,17 @@ object Safety {
           val name = method.getName
           val types = method.getGenericParameterTypes.map(resolveJavaType(_, substMap, loc))
           (method, name, types)
-      }.sortBy { case (_method, name, types) => (name, types.length) }
+      }.sortBy { case (_, name, types) => (name, types.length) }
 
       val actualMethods = methods.map {
         case JvmMethod(_, ident, fparams, _, _, _, _) =>
           val name = ident.name
           val types = fparams.map(_.tpe)
           (ident, name, types)
-      }.sortBy { case (_ident, name, types) => (name, types.length) }
+      }.sortBy { case (_, name, types) => (name, types.length) }
 
-      val (_pairs, missing, extra) = ListOps.unorderedCorresponds(expectedMethods, actualMethods) {
-        case ((_method, expectedName, expectedTypes), (_ident, actualName, actualTypes)) =>
+      val (_, missing, extra) = ListOps.unorderedCorresponds(expectedMethods, actualMethods) {
+        case ((_, expectedName, expectedTypes), (_, actualName, actualTypes)) =>
           if (expectedName != actualName) {
             false
           } else {

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -872,6 +872,10 @@ object Safety {
           }
       }
 
+      if (unimplemented.nonEmpty && extra.nonEmpty) { // TODO debugging
+        println(unimplemented)
+        println(extra)
+      }
       unimplemented.foreach {
         case (method, _, _) =>
           // an unimplemented method is only a problem if it's abstract and isn't auto-implemented by Object

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -874,8 +874,8 @@ object Safety {
 
       unimplemented.foreach {
         case (method, _, _) =>
-          // an unimplemented method is only a problem if it's abstract
-          if (isAbstractMethod(method)) {
+          // an unimplemented method is only a problem if it's abstract and isn't auto-implemented by Object
+          if (isAbstractMethod(method) && !isObjectMethod(method)) {
             sctx.errors.add(NewObjectMissingMethod(clazz, method, loc))
           }
       }
@@ -926,6 +926,16 @@ object Safety {
   /** Return `true` if `m` is abstract. */
   private def isAbstractMethod(m: java.lang.reflect.Method): Boolean =
     java.lang.reflect.Modifier.isAbstract(m.getModifiers)
+
+  /** Returns `true` if `m` is or overrides a method found on the Object class. */
+  private def isObjectMethod(method: java.lang.reflect.Method): Boolean = {
+    try {
+      classOf[Object].getDeclaredMethod(method.getName, method.getParameterTypes*)
+      true
+    } catch {
+      case _: NoSuchMethodException => false
+    }
+  }
 
   /** Returns `true` if `eff` includes control effects (e.g. Console). */
   private def hasControlEffects(eff: Type): Boolean = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -872,17 +872,13 @@ object Safety {
           }
       }
 
-      if (unimplemented.nonEmpty && extra.nonEmpty) { // TODO debugging
+      // an unimplemented method is only a problem if it's abstract and isn't auto-implemented by Object
+      val missing = unimplemented.filter { method => isAbstractMethod(method) && !isObjectMethod(method) }
+      if (missing.nonEmpty && extra.nonEmpty) { // TODO debugging
         println(unimplemented)
         println(extra)
       }
-      unimplemented.foreach {
-        case (method, _, _) =>
-          // an unimplemented method is only a problem if it's abstract and isn't auto-implemented by Object
-          if (isAbstractMethod(method) && !isObjectMethod(method)) {
-            sctx.errors.add(NewObjectMissingMethod(clazz, method, loc))
-          }
-      }
+      missing.foreach { case (method, _, _) => sctx.errors.add(NewObjectMissingMethod(clazz, method, loc)) }
       extra.foreach { case (ident, name, _) => sctx.errors.add(NewObjectUndefinedMethod(clazz, name, ident.loc)) }
 
       // `methods` must not let control effects escape.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -1024,8 +1024,7 @@ object ConstraintGen {
                      else Type.mkNative(clazz, loc)
         c.unifyType(tvar, resTpe, loc)
 
-        // Constrain each method's params against the resolved Java method signature.
-        methods.foreach(m => visitNewObjectMethod(m, clazz, targs))
+        methods.foreach(visitJvmMethod)
 
         val resEff = Type.IO
         (tvar, resEff)
@@ -1342,59 +1341,6 @@ object ConstraintGen {
       val (bodyTpe, bodyEff) = visitExp(exp)
       c.expectType(expected = returnTpe, actual = bodyTpe, exp.loc)
       c.expectType(expected = eff, actual = bodyEff, exp.loc)
-  }
-
-  /**
-    * Generates constraints for a JVM method in a NewObject expression,
-    * including constraints that the Flix method's parameter and return types
-    * match the resolved Java method signature.
-    *
-    * For example, given `new Comparator[String]` with substMap `{T -> String}`,
-    * Java's `Comparator.compare(T, T) -> int` resolves to `compare(String, String) -> Int32`.
-    * If the Flix method declares `t: Int32` instead of `t: String`, the emitted
-    * constraint `Int32 ~ String` produces a type error.
-    */
-  private def visitNewObjectMethod(method: KindedAst.JvmMethod, clazz: Class[?], targs: List[Type])(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): Unit = method match {
-    case KindedAst.JvmMethod(_, ident, fparams, exp, returnTpe, eff, _) =>
-      // Constrain each formal param to its declared type.
-      fparams.foreach {
-        case KindedAst.FormalParam(sym, tpe, _, loc) =>
-          c.unifyType(sym.tvar, tpe, loc)
-      }
-
-      val (bodyTpe, bodyEff) = visitExp(exp)
-      c.expectType(expected = returnTpe, actual = bodyTpe, exp.loc)
-      c.expectType(expected = eff, actual = bodyEff, exp.loc)
-
-      // Find the matching Java method by name and arity (excluding 'this' param).
-      val flixParamCount = fparams.tail.length
-      val javaMethodOpt = JvmUtils.getOverridableInstanceMethods(clazz)
-        .find(m => m.getName == ident.name && m.getParameterCount == flixParamCount)
-      javaMethodOpt match {
-        case Some(jm) =>
-          // Build a substitution from the declaring class's type parameter names
-          // to the user-provided Flix type arguments. This correctly handles
-          // inherited methods where the declaring class differs from the
-          // instantiated class (e.g., UnaryOperator.apply is declared on Function).
-          val indexMapping = JvmUtils.resolveTypeParamMapping(jm, clazz)
-          val substMap: Map[String, Type] = indexMapping.flatMap { case (name, idx) =>
-            if (idx < targs.length) Some(name -> targs(idx)) else None
-          }
-
-          // Constrain each Flix param type against the resolved Java param type.
-          val resolvedParams = jm.getGenericParameterTypes.toList.map(resolveJavaType(_, substMap, ident.loc))
-          fparams.tail.zip(resolvedParams).foreach {
-            case (KindedAst.FormalParam(_, tpe, _, paramLoc), expectedType) =>
-              c.expectType(expected = expectedType, actual = tpe, paramLoc)
-          }
-
-          // Constrain the return type.
-          if (jm.getReturnType == java.lang.Void.TYPE)
-            c.expectType(expected = Type.Unit, actual = returnTpe, ident.loc)
-          else
-            c.expectType(expected = resolveJavaType(jm.getGenericReturnType, substMap, ident.loc), actual = returnTpe, ident.loc)
-        case None => // No matching Java method found; Safety will report the error.
-      }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -1344,28 +1344,6 @@ object ConstraintGen {
   }
 
   /**
-    * Resolves a `java.lang.reflect.Type` to a Flix [[Type]] using the given
-    * substitution map. Falls back to the erased (Object-filled) type.
-    */
-  private def resolveJavaType(javaType: java.lang.reflect.Type, substMap: Map[String, Type], loc: SourceLocation): Type = javaType match {
-    case tv: TypeVariable[_] =>
-      substMap.getOrElse(tv.getName, Type.instantiateJavaTypeWithObjectArgs(classOf[Object], loc))
-    case pt: ParameterizedType =>
-      pt.getRawType match {
-        case rawClazz: Class[_] =>
-          val base = Type.getFlixType(rawClazz)
-          val resolvedArgs = pt.getActualTypeArguments.toList.map(resolveJavaType(_, substMap, loc))
-          Type.mkApply(base, resolvedArgs, loc)
-        case _ =>
-          Type.instantiateJavaTypeWithObjectArgs(classOf[Object], loc)
-      }
-    case clazz: Class[_] =>
-      Type.instantiateJavaTypeWithObjectArgs(clazz, loc)
-    case _ =>
-      Type.instantiateJavaTypeWithObjectArgs(classOf[Object], loc)
-  }
-
-  /**
     * Generates constraints for the SelectChannelRule.
     *
     * Returns the type and effect of the rule.

--- a/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
@@ -149,7 +149,7 @@ object ListOps {
 
     val lone2 = dll2.asScala.toList
 
-    (pairs.result, lone1, lone2)
+    (pairs.result(), lone1, lone2)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
@@ -20,8 +20,6 @@ import ca.uwaterloo.flix.util.InternalCompilerException
 
 import java.util
 import scala.annotation.tailrec
-import scala.jdk.CollectionConverters
-import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 /**
   * Operations on lists.
@@ -127,42 +125,42 @@ object ListOps {
     *
     * Assumes f is an equivalence-like relation.
     */
-  def unorderedCorresponds[A, B](l1: List[A], l2: List[B])(f: (A, B) => Boolean): (List[(A, B)], List[A], List[B]) = {
-    val pairs = List.newBuilder[(A, B)]
+  def fullOuterJoin[A, B](l1: List[A], l2: List[B])(f: (A, B) => Boolean): (List[(A, B)], List[A], List[B]) = {
+    // pairs and unpaired1 are built up during iteration; unpaired2 is broken down during iteration
+    var pairs = List.empty[(A, B)]
+    var unpaired1 = List.empty[A]
+    var unpaired2 = l2
 
-    // build a linked list from l2 for fast removal
-    val dll2 = new util.LinkedList[B]()
-    l2.foreach(dll2.add)
-
-    val lone1 = l1.filter {
-      a =>
-        extractMatch(dll2)(f(a, _)) match {
-          // no match for this value; add it to the loners
-          case None => true
-
-          // found a match; add it to the pairs
-          case Some(b) =>
-            pairs.addOne((a, b))
-            false
-        }
+    for {
+      a <- l1
+    } {
+      extractMatch(l2)(f(a, _)) match {
+        case None =>
+          unpaired1 = a :: unpaired1
+        case Some((b, rest)) =>
+          unpaired2 = rest
+          pairs = (a, b) :: pairs
+      }
     }
 
-    val lone2 = dll2.asScala.toList
-
-    (pairs.result(), lone1, lone2)
-
+    (pairs.reverse, unpaired1.reverse, unpaired2)
   }
 
   /** Removes and returns the first element in the list matching the given predicate. */
-  private def extractMatch[A](l: util.LinkedList[A])(f: A => Boolean): Option[A] = {
-    val iter = l.iterator()
-    while (iter.hasNext) {
-      val next = iter.next()
-      if (f(next)) {
-        iter.remove()
-        return Some(next)
+  private def extractMatch[A](l: List[A])(f: A => Boolean): Option[(A, List[A])] = {
+    @tailrec
+    def helper(in: List[A], acc: List[A]): Option[(A, List[A])] = {
+      in match {
+        case Nil => None
+        case hd :: tl =>
+          if (f(hd)) {
+            Some((hd, acc reverse_::: tl))
+          } else {
+            helper(in, hd :: acc)
+          }
       }
     }
-    None
+
+    helper(l, Nil)
   }
 }

--- a/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
@@ -134,7 +134,7 @@ object ListOps {
     for {
       a <- l1
     } {
-      extractMatch(l2)(f(a, _)) match {
+      extractMatch(unpaired2)(f(a, _)) match {
         case None =>
           unpaired1 = a :: unpaired1
         case Some((b, rest)) =>
@@ -156,7 +156,7 @@ object ListOps {
           if (f(hd)) {
             Some((hd, acc reverse_::: tl))
           } else {
-            helper(in, hd :: acc)
+            helper(tl, hd :: acc)
           }
       }
     }

--- a/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
@@ -18,7 +18,10 @@ package ca.uwaterloo.flix.util.collection
 import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.util.InternalCompilerException
 
+import java.util
 import scala.annotation.tailrec
+import scala.jdk.CollectionConverters
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 /**
   * Operations on lists.
@@ -110,5 +113,56 @@ object ListOps {
       cur = cur.tail
     }
     if (changed) buf.result() else list
+  }
+
+  /**
+    * Identifies corresponding elements in the given lists according to the given function, disregarding order.
+    *
+    * Returns a 3-tuple:
+    * - the corresponding pairs
+    * - the unpaired items in the first list
+    * - the unpaired items in the second list
+    *
+    * Worst case O(n**2) time, but linear when the lists are ordered according to their correspondences.
+    *
+    * Assumes f is an equivalence-like relation.
+    */
+  def unorderedCorresponds[A, B](l1: List[A], l2: List[B])(f: (A, B) => Boolean): (List[(A, B)], List[A], List[B]) = {
+    val pairs = List.newBuilder[(A, B)]
+
+    // build a linked list from l2 for fast removal
+    val dll2 = new util.LinkedList[B]()
+    l2.foreach(dll2.add)
+
+    val lone1 = l1.filter {
+      a =>
+        extractMatch(dll2)(f(a, _)) match {
+          // no match for this value; add it to the loners
+          case None => true
+
+          // found a match; add it to the pairs
+          case Some(b) =>
+            pairs.addOne((a, b))
+            false
+        }
+    }
+
+    val lone2 = dll2.asScala.toList
+
+    (pairs.result, lone1, lone2)
+
+  }
+
+  /** Removes and returns the first element in the list matching the given predicate. */
+  private def extractMatch[A](l: util.LinkedList[A])(f: A => Boolean): Option[A] = {
+    val iter = l.iterator()
+    while (iter.hasNext) {
+      val next = iter.next()
+      if (f(next)) {
+        iter.remove()
+        return Some(next)
+      }
+    }
+    None
   }
 }

--- a/main/src/ca/uwaterloo/flix/util/collection/MapOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/MapOps.scala
@@ -38,6 +38,18 @@ object MapOps {
   }
 
   /**
+    * Applies `f` to each of the values in the given map, keeping only entries that return `Some(...)`.
+    */
+  def filterMapValues[K, V1, V2](m: Map[K, V1])(f: V1 => Option[V2]): Map[K, V2] = {
+    m.flatMap {
+      case (k, v1) => f(v1) match {
+        case None => None
+        case Some(v2) => Some((k, v2))
+      }
+    }
+  }
+
+  /**
     * Combines the two maps with the given function.
     *
     * If a key is present in only one of the maps, then that map's value is used.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -378,6 +378,74 @@ class TestSafety extends AnyFunSuite with TestUtils {
     expectError[SafetyError.NewObjectUndefinedMethod](result)
   }
 
+  test("TestExtraMethod.02") {
+    // Methods are matched by parameter type, not just by name and arity:
+    // `compare` on a `Comparator[String]` takes two Strings, not two Int32s.
+    val input =
+      """
+        |import java.util.Comparator
+        |
+        |def f(): Comparator[String] \ IO =
+        |  new Comparator[String] {
+        |    def compare(_this: Comparator[String], x: Int32, y: Int32): Int32 = x - y
+        |  }
+      """.stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[SafetyError.NewObjectUndefinedMethod](result)
+  }
+
+  test("TestExtraMethod.03") {
+    // The type parameter of an *inherited* method is resolved through the extends chain:
+    // TestGenericChildInterface[String] gives TestGenericInterface's T1 = String, so an
+    // implementation taking an Int32 does not match.
+    val input =
+      """
+        |import dev.flix.test.TestGenericChildInterface
+        |
+        |def f(): TestGenericChildInterface[String] \ IO =
+        |  new TestGenericChildInterface[String] {
+        |    def testMethod(_this: TestGenericChildInterface[String], x: Int32): Int32 = x
+        |    def describe(_this: TestGenericChildInterface[String]): String = "child"
+        |  }
+      """.stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[SafetyError.NewObjectUndefinedMethod](result)
+  }
+
+  test("TestExtraMethod.04") {
+    // Overloads are distinguished by parameter type: `append(char)` is implemented
+    // with an Int32, so it matches neither `append` overload of that arity.
+    val input =
+      """
+        |import java.lang.Appendable
+        |import java.lang.CharSequence
+        |
+        |def f(): Appendable \ IO =
+        |  new Appendable {
+        |    def append(_this: Appendable, seq: CharSequence): Appendable = ???
+        |    def append(_this: Appendable, x: Int32): Appendable = ???
+        |    def append(_this: Appendable, seq: CharSequence, start: Int32, end: Int32): Appendable = ???
+        |  }
+      """.stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[SafetyError.NewObjectUndefinedMethod](result)
+  }
+
+  test("TestUnimplementedMethod.03") {
+    // The inherited generic method `testMethod` is missing entirely.
+    val input =
+      """
+        |import dev.flix.test.TestGenericChildInterface
+        |
+        |def f(): TestGenericChildInterface[String] \ IO =
+        |  new TestGenericChildInterface[String] {
+        |    def describe(_this: TestGenericChildInterface[String]): String = "child"
+        |  }
+      """.stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[SafetyError.NewObjectMissingMethod](result)
+  }
+
   test("TestNonDefaultConstructor.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/util/TestJvmUtils.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestJvmUtils.scala
@@ -104,4 +104,55 @@ class TestJvmUtils extends AnyFunSuite {
     assert(result == Map.empty)
   }
 
+  // --- resolveTypeParamMapping: renamed type parameters ---
+
+  test("resolveTypeParamMapping.Renamed.TestGenericChildInterface.testMethod") {
+    // TestGenericChildInterface<T> extends TestGenericInterface<T1>, so the inherited
+    // method's type parameter is spelled differently from the instantiated class's.
+    val method = classOf[dev.flix.test.TestGenericChildInterface[_]].getMethod("testMethod", classOf[Object])
+    val result = JvmUtils.resolveTypeParamMapping(method, classOf[dev.flix.test.TestGenericChildInterface[_]])
+    assert(result == Map("T1" -> 0))
+  }
+
+  test("resolveTypeParamMapping.Renamed.TestGenericSubInterface.compareTo") {
+    // TestGenericSubInterface<T extends Comparable<T>> extends Comparable<T>.
+    val method = classOf[dev.flix.test.TestGenericSubInterface[_]].getMethod("compareTo", classOf[Object])
+    val result = JvmUtils.resolveTypeParamMapping(method, classOf[dev.flix.test.TestGenericSubInterface[_]])
+    assert(result == Map("T" -> 0))
+  }
+
+  // --- resolveTypeParamMapping: inherited through an intermediate supertype ---
+
+  test("resolveTypeParamMapping.TwoLevel.TestGenericGrandchildInterface.testMethod") {
+    // Grandchild<U> -> TestGenericChildInterface<U> -> TestGenericInterface<T1>.
+    // T1 must be traced through the intermediate interface back to index 0.
+    val method = classOf[dev.flix.test.TestGenericGrandchildInterface[_]].getMethod("testMethod", classOf[Object])
+    val result = JvmUtils.resolveTypeParamMapping(method, classOf[dev.flix.test.TestGenericGrandchildInterface[_]])
+    assert(result == Map("T1" -> 0))
+  }
+
+  test("resolveTypeParamMapping.TwoLevel.TestGenericGrandchildInterface.describe") {
+    // describe is declared one level up, on TestGenericChildInterface<T>.
+    val method = classOf[dev.flix.test.TestGenericGrandchildInterface[_]].getMethod("describe")
+    val result = JvmUtils.resolveTypeParamMapping(method, classOf[dev.flix.test.TestGenericGrandchildInterface[_]])
+    assert(result == Map("T" -> 0))
+  }
+
+  test("resolveTypeParamMapping.TwoLevel.TestGenericGrandchildInterface.identity") {
+    // identity is declared directly on the instantiated interface.
+    val method = classOf[dev.flix.test.TestGenericGrandchildInterface[_]].getMethod("identity", classOf[Object])
+    val result = JvmUtils.resolveTypeParamMapping(method, classOf[dev.flix.test.TestGenericGrandchildInterface[_]])
+    assert(result == Map("U" -> 0))
+  }
+
+  // --- resolveTypeParamMapping: reordered type parameters ---
+
+  test("resolveTypeParamMapping.Reordered.TestGenericSwappedInterface.apply") {
+    // TestGenericSwappedInterface<A, B> extends TestGenericInterface2<B, A>, so the
+    // declaring interface's A comes from index 1 and its B from index 0.
+    val method = classOf[dev.flix.test.TestGenericSwappedInterface[_, _]].getMethod("apply", classOf[Object])
+    val result = JvmUtils.resolveTypeParamMapping(method, classOf[dev.flix.test.TestGenericSwappedInterface[_, _]])
+    assert(result == Map("A" -> 1, "B" -> 0))
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/util/TestListOps.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestListOps.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Matthew Lutze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.util
+
+import ca.uwaterloo.flix.util.collection.ListOps
+import org.scalatest.funsuite.AnyFunSuite
+
+class TestListOps extends AnyFunSuite {
+
+  test("unorderedCorresponds.Empty.01") {
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List.empty[Int], List.empty[Int])(_ == _)
+    assert(pairs == Nil)
+    assert(lone1 == Nil)
+    assert(lone2 == Nil)
+  }
+
+  test("unorderedCorresponds.Empty.02") {
+    // Everything in the second list is unpaired.
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List.empty[Int], List(1, 2))(_ == _)
+    assert(pairs == Nil)
+    assert(lone1 == Nil)
+    assert(lone2 == List(1, 2))
+  }
+
+  test("unorderedCorresponds.Empty.03") {
+    // Everything in the first list is unpaired.
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2), List.empty[Int])(_ == _)
+    assert(pairs == Nil)
+    assert(lone1 == List(1, 2))
+    assert(lone2 == Nil)
+  }
+
+  test("unorderedCorresponds.SameOrder.01") {
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2, 3), List(1, 2, 3))(_ == _)
+    assert(pairs == List((1, 1), (2, 2), (3, 3)))
+    assert(lone1 == Nil)
+    assert(lone2 == Nil)
+  }
+
+  test("unorderedCorresponds.DifferentOrder.01") {
+    // The whole point: order must not affect which elements pair up.
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2, 3), List(3, 1, 2))(_ == _)
+    assert(pairs == List((1, 1), (2, 2), (3, 3)))
+    assert(lone1 == Nil)
+    assert(lone2 == Nil)
+  }
+
+  test("unorderedCorresponds.PartialOverlap.01") {
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2, 3), List(3, 4, 1))(_ == _)
+    assert(pairs == List((1, 1), (3, 3)))
+    assert(lone1 == List(2))
+    assert(lone2 == List(4))
+  }
+
+  test("unorderedCorresponds.Disjoint.01") {
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2), List(3, 4))(_ == _)
+    assert(pairs == Nil)
+    assert(lone1 == List(1, 2))
+    assert(lone2 == List(3, 4))
+  }
+
+  test("unorderedCorresponds.Duplicates.01") {
+    // Each element of the second list may be consumed at most once.
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 1), List(1))(_ == _)
+    assert(pairs == List((1, 1)))
+    assert(lone1 == List(1))
+    assert(lone2 == Nil)
+  }
+
+  test("unorderedCorresponds.Duplicates.02") {
+    // Symmetric case: a surplus duplicate in the second list is left over.
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1), List(1, 1))(_ == _)
+    assert(pairs == List((1, 1)))
+    assert(lone1 == Nil)
+    assert(lone2 == List(1))
+  }
+
+  test("unorderedCorresponds.Duplicates.03") {
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 1, 2), List(2, 1, 1))(_ == _)
+    assert(pairs == List((1, 1), (1, 1), (2, 2)))
+    assert(lone1 == Nil)
+    assert(lone2 == Nil)
+  }
+
+  test("unorderedCorresponds.HeterogeneousTypes.01") {
+    // The two lists need not have the same element type.
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2, 3), List("3", "1", "4")) {
+      case (i, s) => i.toString == s
+    }
+    assert(pairs == List((1, "1"), (3, "3")))
+    assert(lone1 == List(2))
+    assert(lone2 == List("4"))
+  }
+
+  test("unorderedCorresponds.CoarseRelation.01") {
+    // A relation coarser than equality: pair numbers by parity.
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2), List(4, 3, 5)) {
+      case (a, b) => a % 2 == b % 2
+    }
+    assert(pairs == List((1, 3), (2, 4)))
+    assert(lone1 == Nil)
+    assert(lone2 == List(5))
+  }
+
+  test("unorderedCorresponds.NeverMatches.01") {
+    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2), List(1, 2))((_, _) => false)
+    assert(pairs == Nil)
+    assert(lone1 == List(1, 2))
+    assert(lone2 == List(1, 2))
+  }
+
+}

--- a/main/test/ca/uwaterloo/flix/util/TestListOps.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestListOps.scala
@@ -21,84 +21,84 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class TestListOps extends AnyFunSuite {
 
-  test("unorderedCorresponds.Empty.01") {
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List.empty[Int], List.empty[Int])(_ == _)
+  test("fullOuterJoin.Empty.01") {
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List.empty[Int], List.empty[Int])(_ == _)
     assert(pairs == Nil)
     assert(lone1 == Nil)
     assert(lone2 == Nil)
   }
 
-  test("unorderedCorresponds.Empty.02") {
+  test("fullOuterJoin.Empty.02") {
     // Everything in the second list is unpaired.
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List.empty[Int], List(1, 2))(_ == _)
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List.empty[Int], List(1, 2))(_ == _)
     assert(pairs == Nil)
     assert(lone1 == Nil)
     assert(lone2 == List(1, 2))
   }
 
-  test("unorderedCorresponds.Empty.03") {
+  test("fullOuterJoin.Empty.03") {
     // Everything in the first list is unpaired.
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2), List.empty[Int])(_ == _)
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 2), List.empty[Int])(_ == _)
     assert(pairs == Nil)
     assert(lone1 == List(1, 2))
     assert(lone2 == Nil)
   }
 
-  test("unorderedCorresponds.SameOrder.01") {
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2, 3), List(1, 2, 3))(_ == _)
+  test("fullOuterJoin.SameOrder.01") {
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 2, 3), List(1, 2, 3))(_ == _)
     assert(pairs == List((1, 1), (2, 2), (3, 3)))
     assert(lone1 == Nil)
     assert(lone2 == Nil)
   }
 
-  test("unorderedCorresponds.DifferentOrder.01") {
+  test("fullOuterJoin.DifferentOrder.01") {
     // The whole point: order must not affect which elements pair up.
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2, 3), List(3, 1, 2))(_ == _)
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 2, 3), List(3, 1, 2))(_ == _)
     assert(pairs == List((1, 1), (2, 2), (3, 3)))
     assert(lone1 == Nil)
     assert(lone2 == Nil)
   }
 
-  test("unorderedCorresponds.PartialOverlap.01") {
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2, 3), List(3, 4, 1))(_ == _)
+  test("fullOuterJoin.PartialOverlap.01") {
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 2, 3), List(3, 4, 1))(_ == _)
     assert(pairs == List((1, 1), (3, 3)))
     assert(lone1 == List(2))
     assert(lone2 == List(4))
   }
 
-  test("unorderedCorresponds.Disjoint.01") {
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2), List(3, 4))(_ == _)
+  test("fullOuterJoin.Disjoint.01") {
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 2), List(3, 4))(_ == _)
     assert(pairs == Nil)
     assert(lone1 == List(1, 2))
     assert(lone2 == List(3, 4))
   }
 
-  test("unorderedCorresponds.Duplicates.01") {
+  test("fullOuterJoin.Duplicates.01") {
     // Each element of the second list may be consumed at most once.
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 1), List(1))(_ == _)
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 1), List(1))(_ == _)
     assert(pairs == List((1, 1)))
     assert(lone1 == List(1))
     assert(lone2 == Nil)
   }
 
-  test("unorderedCorresponds.Duplicates.02") {
+  test("fullOuterJoin.Duplicates.02") {
     // Symmetric case: a surplus duplicate in the second list is left over.
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1), List(1, 1))(_ == _)
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1), List(1, 1))(_ == _)
     assert(pairs == List((1, 1)))
     assert(lone1 == Nil)
     assert(lone2 == List(1))
   }
 
-  test("unorderedCorresponds.Duplicates.03") {
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 1, 2), List(2, 1, 1))(_ == _)
+  test("fullOuterJoin.Duplicates.03") {
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 1, 2), List(2, 1, 1))(_ == _)
     assert(pairs == List((1, 1), (1, 1), (2, 2)))
     assert(lone1 == Nil)
     assert(lone2 == Nil)
   }
 
-  test("unorderedCorresponds.HeterogeneousTypes.01") {
+  test("fullOuterJoin.HeterogeneousTypes.01") {
     // The two lists need not have the same element type.
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2, 3), List("3", "1", "4")) {
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 2, 3), List("3", "1", "4")) {
       case (i, s) => i.toString == s
     }
     assert(pairs == List((1, "1"), (3, "3")))
@@ -106,9 +106,9 @@ class TestListOps extends AnyFunSuite {
     assert(lone2 == List("4"))
   }
 
-  test("unorderedCorresponds.CoarseRelation.01") {
+  test("fullOuterJoin.CoarseRelation.01") {
     // A relation coarser than equality: pair numbers by parity.
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2), List(4, 3, 5)) {
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 2), List(4, 3, 5)) {
       case (a, b) => a % 2 == b % 2
     }
     assert(pairs == List((1, 3), (2, 4)))
@@ -116,8 +116,8 @@ class TestListOps extends AnyFunSuite {
     assert(lone2 == List(5))
   }
 
-  test("unorderedCorresponds.NeverMatches.01") {
-    val (pairs, lone1, lone2) = ListOps.unorderedCorresponds(List(1, 2), List(1, 2))((_, _) => false)
+  test("fullOuterJoin.NeverMatches.01") {
+    val (pairs, lone1, lone2) = ListOps.fullOuterJoin(List(1, 2), List(1, 2))((_, _) => false)
     assert(pairs == Nil)
     assert(lone1 == List(1, 2))
     assert(lone2 == List(1, 2))

--- a/main/test/ca/uwaterloo/flix/util/TestMapOps.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestMapOps.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Matthew Lutze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.util
+
+import ca.uwaterloo.flix.util.collection.MapOps
+import org.scalatest.funsuite.AnyFunSuite
+
+class TestMapOps extends AnyFunSuite {
+
+  test("filterMapValues.Empty.01") {
+    val actual = MapOps.filterMapValues(Map.empty[String, Int])(Some(_))
+    assert(actual == Map.empty[String, Int])
+  }
+
+  test("filterMapValues.KeepAll.01") {
+    val m = Map("a" -> 1, "b" -> 2)
+    val actual = MapOps.filterMapValues(m)(v => Some(v * 10))
+    assert(actual == Map("a" -> 10, "b" -> 20))
+  }
+
+  test("filterMapValues.DropAll.01") {
+    val m = Map("a" -> 1, "b" -> 2)
+    val actual = MapOps.filterMapValues(m)(_ => None: Option[Int])
+    assert(actual == Map.empty[String, Int])
+  }
+
+  test("filterMapValues.Mixed.01") {
+    val m = Map("a" -> 1, "b" -> 2, "c" -> 3)
+    val actual = MapOps.filterMapValues(m)(v => if (v % 2 == 1) Some(v) else None)
+    assert(actual == Map("a" -> 1, "c" -> 3))
+  }
+
+  test("filterMapValues.ChangesValueType.01") {
+    val m = Map(1 -> "a", 2 -> "bb")
+    val actual = MapOps.filterMapValues(m)(v => Some(v.length))
+    assert(actual == Map(1 -> 1, 2 -> 2))
+  }
+
+  test("filterMapValues.OutOfBoundsIndex.01") {
+    // The use site in Safety: indices that fall outside the type argument list are dropped
+    // rather than throwing.
+    val targs = List("X", "Y")
+    val m = Map("T" -> 0, "U" -> 1, "V" -> 5)
+    val actual = MapOps.filterMapValues(m)(targs.lift)
+    assert(actual == Map("T" -> "X", "U" -> "Y"))
+  }
+
+}

--- a/main/test/dev/flix/test/TestGenericGrandchildInterface.java
+++ b/main/test/dev/flix/test/TestGenericGrandchildInterface.java
@@ -1,0 +1,12 @@
+package dev.flix.test;
+
+/**
+ * A generic interface two levels below TestGenericInterface:
+ * TestGenericGrandchildInterface -> TestGenericChildInterface -> TestGenericInterface.
+ *
+ * Used to test that a type parameter is traced through an *intermediate* supertype,
+ * i.e. that `testMethod`'s `T1` resolves to `U` rather than being erased to Object.
+ */
+public interface TestGenericGrandchildInterface<U> extends TestGenericChildInterface<U> {
+    U identity(U x);
+}

--- a/main/test/dev/flix/test/TestGenericSwappedInterface.java
+++ b/main/test/dev/flix/test/TestGenericSwappedInterface.java
@@ -1,0 +1,12 @@
+package dev.flix.test;
+
+/**
+ * A generic interface that reorders its supertype's type parameters:
+ * TestGenericSwappedInterface<A, B> extends TestGenericInterface2<B, A>.
+ *
+ * Since TestGenericInterface2<X, Y> declares `Y apply(X x)`, the inherited method
+ * here is `A apply(B b)`. Used to test that type parameter *positions* are permuted
+ * rather than assumed to line up.
+ */
+public interface TestGenericSwappedInterface<A, B> extends TestGenericInterface2<B, A> {
+}

--- a/main/test/flix/Test.Exp.Jvm.Generic.NewObject.Inherited.flix
+++ b/main/test/flix/Test.Exp.Jvm.Generic.NewObject.Inherited.flix
@@ -3,7 +3,9 @@ mod Test.Exp.Jvm.Generic.NewObject.Inherited {
     use Assert.{assertEq, assertTrue}
 
     import dev.flix.test.TestGenericChildInterface
+    import dev.flix.test.TestGenericGrandchildInterface
     import dev.flix.test.TestGenericSubInterface
+    import dev.flix.test.TestGenericSwappedInterface
     import java.lang.{Comparable => JComparable}
     import java.lang.{Integer => JInteger}
 
@@ -25,6 +27,28 @@ mod Test.Exp.Jvm.Generic.NewObject.Inherited {
                 "hello"
             def compareTo(_this: TestGenericSubInterface[String], o: String): Int32 =
                 "hello".compareTo(o)
+        }
+
+    // `testMethod` is inherited two levels up, from TestGenericInterface, where its type
+    // parameter is spelled `T1` rather than `U`.
+    @CompileTest
+    def testGenericGrandchildInterfaceCompile01(): TestGenericGrandchildInterface[String] \ IO =
+        new TestGenericGrandchildInterface[String] {
+            def identity(_this: TestGenericGrandchildInterface[String], x: String): String =
+                x
+            def testMethod(_this: TestGenericGrandchildInterface[String], x: String): String =
+                x + x
+            def describe(_this: TestGenericGrandchildInterface[String]): String =
+                "grandchild"
+        }
+
+    // TestGenericSwappedInterface[A, B] extends TestGenericInterface2[B, A],
+    // so the inherited `apply` takes a B and returns an A.
+    @CompileTest
+    def testGenericSwappedInterfaceCompile01(): TestGenericSwappedInterface[String, JInteger] \ IO =
+        new TestGenericSwappedInterface[String, JInteger] {
+            def apply(_this: TestGenericSwappedInterface[String, JInteger], a: JInteger): String =
+                a.toString()
         }
 
     // Tests
@@ -106,5 +130,53 @@ mod Test.Exp.Jvm.Generic.NewObject.Inherited {
                 "hello".compareTo(o)
         };
         assertEq(expected = 0, obj.compareTo("hello"))
+
+    @Test
+    def testGenericGrandchildInterfaceInherited01(): Unit \ {Assert, IO} =
+        let obj = new TestGenericGrandchildInterface[String] {
+            def identity(_this: TestGenericGrandchildInterface[String], x: String): String =
+                x
+            def testMethod(_this: TestGenericGrandchildInterface[String], x: String): String =
+                x + "!"
+            def describe(_this: TestGenericGrandchildInterface[String]): String =
+                "grandchild"
+        };
+        let r: String = obj.testMethod("hi");
+        assertEq(expected = "hi!", r)
+
+    @Test
+    def testGenericGrandchildInterfaceInherited02(): Unit \ {Assert, IO} =
+        let obj = new TestGenericGrandchildInterface[String] {
+            def identity(_this: TestGenericGrandchildInterface[String], x: String): String =
+                x
+            def testMethod(_this: TestGenericGrandchildInterface[String], x: String): String =
+                x
+            def describe(_this: TestGenericGrandchildInterface[String]): String =
+                "two-levels-up"
+        };
+        let r: String = obj.describe();
+        assertEq(expected = "two-levels-up", r)
+
+    @Test
+    def testGenericGrandchildInterfaceOwnMethod01(): Unit \ {Assert, IO} =
+        let obj = new TestGenericGrandchildInterface[JInteger] {
+            def identity(_this: TestGenericGrandchildInterface[JInteger], x: JInteger): JInteger =
+                x
+            def testMethod(_this: TestGenericGrandchildInterface[JInteger], x: JInteger): JInteger =
+                x
+            def describe(_this: TestGenericGrandchildInterface[JInteger]): String =
+                "integer-grandchild"
+        };
+        let r: JInteger = obj.identity(JInteger.valueOf(7i32));
+        assertEq(expected = 7, r.intValue())
+
+    @Test
+    def testGenericSwappedInterfaceApply01(): Unit \ {Assert, IO} =
+        let obj = new TestGenericSwappedInterface[String, JInteger] {
+            def apply(_this: TestGenericSwappedInterface[String, JInteger], a: JInteger): String =
+                "n=" + a.toString()
+        };
+        let r: String = obj.apply(JInteger.valueOf(42i32));
+        assertEq(expected = "n=42", r)
 
 }

--- a/main/test/flix/Test.Exp.Jvm.NewObject.Overload.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.Overload.flix
@@ -1,0 +1,13 @@
+mod Test.Exp.Jvm.NewObject.Overload {
+    import java.lang.Appendable
+    import java.lang.CharSequence
+    
+    @CompileTest
+    def mk(): Appendable = {
+        new Appendable {
+            def append(_this: Appendable, seq: CharSequence): Appendable = ???
+            def append(_this: Appendable, char: Char): Appendable = ???
+            def append(_this: Appendable, seq: CharSequence, start: Int32, end: Int32): Appendable = ???
+        }
+    }
+}

--- a/main/test/flix/Test.Exp.Jvm.NewObject.Overload.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.Overload.flix
@@ -3,7 +3,7 @@ mod Test.Exp.Jvm.NewObject.Overload {
     import java.lang.CharSequence
     
     @CompileTest
-    def mk(): Appendable = {
+    def mk(): Appendable \ IO = {
         new Appendable {
             def append(_this: Appendable, seq: CharSequence): Appendable = ???
             def append(_this: Appendable, char: Char): Appendable = ???


### PR DESCRIPTION
fixes #12976 