### PR TITLE
refactor: use Nel for formal parameters

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LspUtil.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspUtil.scala
@@ -83,8 +83,8 @@ object LspUtil {
     */
   def mkSpecSnippet(label: String, spec: TypedAst.Spec, ectx: ExprContext): String = ectx match {
     case ExprContext.InsideApply => CompletionUtils.getApplySnippet(label, Nil)
-    case ExprContext.InsidePipeline => CompletionUtils.getApplySnippet(label, spec.fparams.dropRight(1))
-    case ExprContext.InsideRunWith => CompletionUtils.getApplySnippet(label, spec.fparams.dropRight(1))
-    case ExprContext.Unknown => CompletionUtils.getApplySnippet(label, spec.fparams)
+    case ExprContext.InsidePipeline => CompletionUtils.getApplySnippet(label, spec.fparams.toList.dropRight(1))
+    case ExprContext.InsideRunWith => CompletionUtils.getApplySnippet(label, spec.fparams.toList.dropRight(1))
+    case ExprContext.Unknown => CompletionUtils.getApplySnippet(label, spec.fparams.toList)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspUtil.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspUtil.scala
@@ -83,8 +83,8 @@ object LspUtil {
     */
   def mkSpecSnippet(label: String, spec: TypedAst.Spec, ectx: ExprContext): String = ectx match {
     case ExprContext.InsideApply => CompletionUtils.getApplySnippet(label, Nil)
-    case ExprContext.InsidePipeline => CompletionUtils.getApplySnippet(label, spec.fparams.toList.dropRight(1))
-    case ExprContext.InsideRunWith => CompletionUtils.getApplySnippet(label, spec.fparams.toList.dropRight(1))
+    case ExprContext.InsidePipeline => CompletionUtils.getApplySnippet(label, spec.fparams.init)
+    case ExprContext.InsideRunWith => CompletionUtils.getApplySnippet(label, spec.fparams.init)
     case ExprContext.Unknown => CompletionUtils.getApplySnippet(label, spec.fparams.toList)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/SignatureInformation.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SignatureInformation.scala
@@ -27,7 +27,7 @@ object SignatureInformation {
   def from(sym: Symbol, spec: TypedAst.Spec, activeParameter: Int)(implicit flix: Flix): SignatureInformation = {
     val label = sym.toString + LspUtil.getLabelForSpec(spec)
     val documentation = spec.doc.text
-    val parameters = spec.fparams.map(ParameterInformation.from)
+    val parameters = spec.fparams.toList.map(ParameterInformation.from)
     SignatureInformation(label, Some(documentation), parameters, activeParameter)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeLensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeLensProvider.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider
 import ca.uwaterloo.flix.api.lsp.{CodeLens, Command, Range, ResponseStatus}
 import ca.uwaterloo.flix.language.ast.TypedAst.{Root, Spec}
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.util.collection.Nel
 import org.json4s.JsonAST.{JArray, JObject, JString}
 import org.json4s.JsonDSL.*
 
@@ -76,7 +77,7 @@ object CodeLensProvider {
     * Returns `true` if the given `spec` is an entry point.
     */
   private def isEntryPoint(spec: Spec): Boolean = spec.fparams match {
-    case fparam :: Nil => isUnitType(fparam.tpe) && isPublic(spec) && isMonomorphic(spec)
+    case Nel(fparam, Nil) => isUnitType(fparam.tpe) && isPublic(spec) && isMonomorphic(spec)
     case _ => false
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -23,6 +23,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.{ApplyPosition, Expr, FormalParam
 import ca.uwaterloo.flix.language.ast.shared.{Decreasing, SymUse}
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.errors.TypeError
+import ca.uwaterloo.flix.util.collection.Nel
 
 import scala.collection.mutable
 
@@ -215,7 +216,7 @@ object InlayHintProvider {
     */
   private def getTailRecursionHints(uri: String)(implicit root: Root): List[InlayHint] = {
     var hints: List[InlayHint] = List.empty
-    val localDefFparams: mutable.Map[Symbol.VarSym, List[FormalParam]] = mutable.Map.empty
+    val localDefFparams: mutable.Map[Symbol.VarSym, Nel[FormalParam]] = mutable.Map.empty
 
     object c extends Consumer {
       override def consumeExpr(expr: Expr): Unit = {
@@ -265,7 +266,7 @@ object InlayHintProvider {
   /**
     * Creates inlay hints for arguments corresponding to structurally decreasing parameters.
     */
-  private def mkDecreasingArgHints(exps: List[Expr], fparams: List[FormalParam]): List[InlayHint] = {
+  private def mkDecreasingArgHints(exps: List[Expr], fparams: Nel[FormalParam]): List[InlayHint] = {
     exps.zip(fparams).collect {
       case (arg, fparam) if fparam.decreasing == Decreasing.StrictlyDecreasing =>
         InlayHint(

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.api.lsp.{Command, CompletionItem, CompletionItemKind, C
 import ca.uwaterloo.flix.language.ast.shared.AnchorPosition
 import ca.uwaterloo.flix.language.ast.{Name, ResolvedAst, SourceLocation, Symbol, Type, TypedAst}
 import ca.uwaterloo.flix.language.fmt.{FormatScheme, FormatType}
+import ca.uwaterloo.flix.util.collection.Nel
 
 import java.lang.reflect.{Field, Method}
 
@@ -518,7 +519,7 @@ sealed trait Completion {
 
     case Completion.HoleCompletion(sym, decl, priority, loc) =>
       val name = decl.sym.toString
-      val args = decl.spec.fparams.dropRight(1).zipWithIndex.map {
+      val args = decl.spec.fparams.toList.dropRight(1).zipWithIndex.map {
         case (fparam, idx) => "$" + s"{${idx + 1}:?${fparam.bnd.sym.text}}"
       } ::: sym.text :: Nil
       val params = args.mkString(", ")
@@ -690,7 +691,7 @@ object Completion {
     * @param range    the range of the completion.
     * @param priority the priority of the completion.
     */
-  case class LocalDefCompletion(sym: Symbol.VarSym, fparams: List[ResolvedAst.FormalParam], range: Range, priority: Priority) extends Completion
+  case class LocalDefCompletion(sym: Symbol.VarSym, fparams: Nel[ResolvedAst.FormalParam], range: Range, priority: Priority) extends Completion
 
   /**
     * Represents a Def completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -377,7 +377,7 @@ sealed trait Completion {
 
     case Completion.OpHandlerCompletion(op, range, priority) =>
       val name = op.sym.name
-      val snippet = CompletionUtils.getOpHandlerSnippet(name, op.spec.fparams.toList)
+      val snippet = CompletionUtils.getOpHandlerSnippet(name, op.spec.fparams)
       val description = Some(name)
       val labelDetails = CompletionItemLabelDetails(Some(CompletionUtils.getLabelForSpec(op.spec)(flix)), description)
       CompletionItem(
@@ -519,7 +519,7 @@ sealed trait Completion {
 
     case Completion.HoleCompletion(sym, decl, priority, loc) =>
       val name = decl.sym.toString
-      val args = decl.spec.fparams.toList.dropRight(1).zipWithIndex.map {
+      val args = decl.spec.fparams.init.zipWithIndex.map {
         case (fparam, idx) => "$" + s"{${idx + 1}:?${fparam.bnd.sym.text}}"
       } ::: sym.text :: Nil
       val params = args.mkString(", ")

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -377,7 +377,7 @@ sealed trait Completion {
 
     case Completion.OpHandlerCompletion(op, range, priority) =>
       val name = op.sym.name
-      val snippet = CompletionUtils.getOpHandlerSnippet(name, op.spec.fparams)
+      val snippet = CompletionUtils.getOpHandlerSnippet(name, op.spec.fparams.toList)
       val description = Some(name)
       val labelDetails = CompletionItemLabelDetails(Some(CompletionUtils.getLabelForSpec(op.spec)(flix)), description)
       CompletionItem(

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.Decl
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{Kind, Name, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.fmt.FormatType
+import ca.uwaterloo.flix.util.collection.Nel
 
 import scala.annotation.tailrec
 
@@ -69,12 +70,13 @@ object CompletionUtils {
   /**
     * Generate a snippet which represents defining an effect operation handler, with an extra `resume` as the last argument.
     */
-  def getOpHandlerSnippet(name: String, fparams: List[TypedAst.FormalParam]): String = {
-    val functionIsUnit = isUnitFunction(fparams)
+  def getOpHandlerSnippet(name: String, fparams: Nel[TypedAst.FormalParam]): String = {
+    val fps = fparams.toList
+    val functionIsUnit = isUnitFunction(fps)
 
-    val args = fparams.zipWithIndex.map {
+    val args = fps.zipWithIndex.map {
       case (fparam, idx) => "$" + s"{${idx + 1}:?${fparam.bnd.sym.text}}"
-    } :+ s"$${${fparams.length + 1}:resume}"
+    } :+ s"$${${fps.length + 1}:resume}"
     if (functionIsUnit)
       s"$name($${1:resume}) = "
     else
@@ -350,7 +352,7 @@ object CompletionUtils {
     * Formats the given Op
     */
   def fmtOp(op: TypedAst.Op): String = {
-    val fparamsString = (op.spec.fparams.toList.collect { case p if p.tpe != Type.Unit => p.bnd.sym.text } :+ "k").mkString(", ")
+    val fparamsString = (op.spec.fparams.collect { case p if p.tpe != Type.Unit => p.bnd.sym.text } :+ "k").mkString(", ")
     s"    def ${op.sym.name}($fparamsString) = ???"
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -28,7 +28,7 @@ object CompletionUtils {
 
   private def isUnitType(tpe: Type): Boolean = tpe == Type.Unit
 
-  private def isUnitFunction(fparams: List[TypedAst.FormalParam]): Boolean = fparams.length == 1 && isUnitType(fparams.head.tpe)
+  private def isUnitFunction(fparams: Iterable[TypedAst.FormalParam]): Boolean = fparams.size == 1 && isUnitType(fparams.head.tpe)
 
   def getLabelForSpec(spec: TypedAst.Spec)(implicit flix: Flix): String = spec match {
     case TypedAst.Spec(_, _, _, _, fparams, _, retTpe0, eff0, _, _) =>
@@ -52,7 +52,7 @@ object CompletionUtils {
   /**
     * Generate a snippet which represents calling a function.
     */
-  def getApplySnippet(name: String, fparams: List[TypedAst.FormalParam]): String = {
+  def getApplySnippet(name: String, fparams: Iterable[TypedAst.FormalParam]): String = {
     val functionIsUnit = isUnitFunction(fparams)
 
     val args = fparams.zipWithIndex.map {
@@ -69,12 +69,12 @@ object CompletionUtils {
   /**
     * Generate a snippet which represents defining an effect operation handler, with an extra `resume` as the last argument.
     */
-  def getOpHandlerSnippet(name: String, fparams: List[TypedAst.FormalParam]): String = {
+  def getOpHandlerSnippet(name: String, fparams: Iterable[TypedAst.FormalParam]): String = {
     val functionIsUnit = isUnitFunction(fparams)
 
-    val args = fparams.zipWithIndex.map {
+    val args = fparams.toList.zipWithIndex.map {
       case (fparam, idx) => "$" + s"{${idx + 1}:?${fparam.bnd.sym.text}}"
-    } :+ s"$${${fparams.length + 1}:resume}"
+    } :+ s"$${${fparams.size + 1}:resume}"
     if (functionIsUnit)
       s"$name($${1:resume}) = "
     else
@@ -350,7 +350,7 @@ object CompletionUtils {
     * Formats the given Op
     */
   def fmtOp(op: TypedAst.Op): String = {
-    val fparamsString = (op.spec.fparams.collect { case p if p.tpe != Type.Unit => p.bnd.sym.text } :+ "k").mkString(", ")
+    val fparamsString = (op.spec.fparams.toList.collect { case p if p.tpe != Type.Unit => p.bnd.sym.text } :+ "k").mkString(", ")
     s"    def ${op.sym.name}($fparamsString) = ???"
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -28,11 +28,11 @@ object CompletionUtils {
 
   private def isUnitType(tpe: Type): Boolean = tpe == Type.Unit
 
-  private def isUnitFunction(fparams: Iterable[TypedAst.FormalParam]): Boolean = fparams.size == 1 && isUnitType(fparams.head.tpe)
+  private def isUnitFunction(fparams: List[TypedAst.FormalParam]): Boolean = fparams.length == 1 && isUnitType(fparams.head.tpe)
 
   def getLabelForSpec(spec: TypedAst.Spec)(implicit flix: Flix): String = spec match {
     case TypedAst.Spec(_, _, _, _, fparams, _, retTpe0, eff0, _, _) =>
-      val args = if (isUnitFunction(fparams))
+      val args = if (isUnitFunction(fparams.toList))
         Nil
       else
         fparams.map {
@@ -52,7 +52,7 @@ object CompletionUtils {
   /**
     * Generate a snippet which represents calling a function.
     */
-  def getApplySnippet(name: String, fparams: Iterable[TypedAst.FormalParam]): String = {
+  def getApplySnippet(name: String, fparams: List[TypedAst.FormalParam]): String = {
     val functionIsUnit = isUnitFunction(fparams)
 
     val args = fparams.zipWithIndex.map {
@@ -69,12 +69,12 @@ object CompletionUtils {
   /**
     * Generate a snippet which represents defining an effect operation handler, with an extra `resume` as the last argument.
     */
-  def getOpHandlerSnippet(name: String, fparams: Iterable[TypedAst.FormalParam]): String = {
+  def getOpHandlerSnippet(name: String, fparams: List[TypedAst.FormalParam]): String = {
     val functionIsUnit = isUnitFunction(fparams)
 
-    val args = fparams.toList.zipWithIndex.map {
+    val args = fparams.zipWithIndex.map {
       case (fparam, idx) => "$" + s"{${idx + 1}:?${fparam.bnd.sym.text}}"
-    } :+ s"$${${fparams.size + 1}:resume}"
+    } :+ s"$${${fparams.length + 1}:resume}"
     if (functionIsUnit)
       s"$name($${1:resume}) = "
     else

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MagicDefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MagicDefCompleter.scala
@@ -92,7 +92,7 @@ object MagicDefCompleter {
     matchedDefs.map {
       case defn =>
         val label = baseExp + "." + defn.sym.text // VSCode requires the code to be a prefix of the label.
-        val snippet = getSnippet(defn.sym, defn.spec.fparams.toList.init, baseExp)
+        val snippet = getSnippet(defn.sym, defn.spec.fparams.init, baseExp)
         Completion.MagicDefCompletion(defn, label, snippet, range, Priority.Lower(0))
     }
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MagicDefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MagicDefCompleter.scala
@@ -92,7 +92,7 @@ object MagicDefCompleter {
     matchedDefs.map {
       case defn =>
         val label = baseExp + "." + defn.sym.text // VSCode requires the code to be a prefix of the label.
-        val snippet = getSnippet(defn.sym, defn.spec.fparams.init, baseExp)
+        val snippet = getSnippet(defn.sym, defn.spec.fparams.toList.init, baseExp)
         Completion.MagicDefCompletion(defn, label, snippet, range, Priority.Lower(0))
     }
   }
@@ -131,7 +131,7 @@ object MagicDefCompleter {
     *   A.B.C.f({1:?arg1}, {2:?arg2}, lastArg)
     * }}}
     */
-  private def getSnippet(sym: QualifiedSym, fparamsExceptLast: Iterable[TypedAst.FormalParam], lastArg: String): String = {
+  private def getSnippet(sym: QualifiedSym, fparamsExceptLast: List[TypedAst.FormalParam], lastArg: String): String = {
     if (fparamsExceptLast.isEmpty) {
       s"$sym($lastArg)"
     } else {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MagicDefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MagicDefCompleter.scala
@@ -120,11 +120,8 @@ object MagicDefCompleter {
     * Returns `true` if the given expression type `tpe` unifies with the last parameter type of the given `spec`.
     */
   private def expMatchesLastArgType(tpe: Type, spec: TypedAst.Spec, root: TypedAst.Root)(implicit flix: Flix): Boolean = {
-    spec.fparams.lastOption match {
-      case Some(lastParam) =>
-        ConstraintSolver2.fullyUnify(tpe, lastParam.tpe, RegionScope.Top, RigidityEnv.empty)(root.eqEnv, flix).isDefined
-      case None => false
-    }
+    val lastParam = spec.fparams.last
+    ConstraintSolver2.fullyUnify(tpe, lastParam.tpe, RegionScope.Top, RigidityEnv.empty)(root.eqEnv, flix).isDefined
   }
 
   /**
@@ -134,7 +131,7 @@ object MagicDefCompleter {
     *   A.B.C.f({1:?arg1}, {2:?arg2}, lastArg)
     * }}}
     */
-  private def getSnippet(sym: QualifiedSym, fparamsExceptLast: List[TypedAst.FormalParam], lastArg: String): String = {
+  private def getSnippet(sym: QualifiedSym, fparamsExceptLast: Iterable[TypedAst.FormalParam], lastArg: String): String = {
     if (fparamsExceptLast.isEmpty) {
       s"$sym($lastArg)"
     } else {

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -38,9 +38,9 @@ object DesugaredAst {
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: Name.QName, tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], loc: SourceLocation) extends Declaration
 
-    case class Sig(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Option[Expr], tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], loc: SourceLocation)
+    case class Sig(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: Nel[FormalParam], exp: Option[Expr], tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], loc: SourceLocation)
 
-    case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
+    case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: Nel[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
 
     case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], derives: Derivations, cases: List[Case], loc: SourceLocation) extends Declaration
 
@@ -56,7 +56,7 @@ object DesugaredAst {
 
     case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], ops: List[Declaration.Op], loc: SourceLocation) extends Declaration
 
-    case class Op(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, fparams: List[FormalParam], tpe: Type, tconstrs: List[TraitConstraint], loc: SourceLocation)
+    case class Op(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, fparams: Nel[FormalParam], tpe: Type, tconstrs: List[TraitConstraint], loc: SourceLocation)
 
   }
 
@@ -106,7 +106,7 @@ object DesugaredAst {
 
     case class Let(ident: Name.Ident, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
-    case class LocalDef(ann: Annotations, ident: Name.Ident, fparams: List[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(ann: Annotations, ident: Name.Ident, fparams: Nel[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
     case class Region(ident: Name.Ident, exp: Expr, loc: SourceLocation) extends Expr
 
@@ -409,11 +409,11 @@ object DesugaredAst {
 
   case class JvmAnnotation(name: Name.Ident, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
 
   case class CatchRule(ident: Name.Ident, className: Name.Ident, exp: Expr, loc: SourceLocation)
 
-  case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(op: Name.Ident, fparams: Nel[FormalParam], exp: Expr, loc: SourceLocation)
 
   case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -52,7 +52,7 @@ object KindedAst {
 
   case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
 
-  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], sc: Scheme, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
+  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: Nel[FormalParam], sc: Scheme, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
 
   case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], loc: SourceLocation)
 
@@ -112,7 +112,7 @@ object KindedAst {
 
     case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
-    case class LocalDef(ann: Annotations, sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(ann: Annotations, sym: Symbol.VarSym, fparams: Nel[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
     case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp1: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
@@ -348,11 +348,11 @@ object KindedAst {
 
   case class JvmConstructor(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr, loc: SourceLocation)
 
-  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr, tvar: Type.Var, loc: SourceLocation)
+  case class HandlerRule(symUse: OpSymUse, fparams: Nel[FormalParam], exp: Expr, tvar: Type.Var, loc: SourceLocation)
 
   case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -35,7 +35,7 @@ object MonoAst {
 
   case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
 
-  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, fparams: List[FormalParam], functionType: Type, retTpe: Type, eff: Type, defContext: DefContext)
+  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, fparams: Nel[FormalParam], functionType: Type, retTpe: Type, eff: Type, defContext: DefContext)
 
   case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EffSym, ops: List[Op], loc: SourceLocation)
 
@@ -79,7 +79,7 @@ object MonoAst {
 
     case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, occur: Occur, loc: SourceLocation) extends Expr
 
-    case class LocalDef(sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, tpe: Type, eff: Type, occur: Occur, loc: SourceLocation) extends Expr
+    case class LocalDef(sym: Symbol.VarSym, fparams: Nel[FormalParam], exp1: Expr, exp2: Expr, tpe: Type, eff: Type, occur: Occur, loc: SourceLocation) extends Expr
 
     case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
@@ -166,11 +166,11 @@ object MonoAst {
 
   case class JvmConstructor(exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr)
 
-  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
+  case class HandlerRule(op: OpSymUse, fparams: Nel[FormalParam], exp: Expr)
 
   case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -72,7 +72,7 @@ object NamedAst {
     case class RestrictableCase(sym: Symbol.RestrictableCaseSym, tpes: List[Type], loc: SourceLocation) extends Declaration
   }
 
-  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], retTpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
+  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: Nel[FormalParam], retTpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
 
   sealed trait UseOrImport {
     def alias: Name.Ident
@@ -123,7 +123,7 @@ object NamedAst {
 
     case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
-    case class LocalDef(ann: Annotations, sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(ann: Annotations, sym: Symbol.VarSym, fparams: Nel[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
     case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Expr, loc: SourceLocation) extends Expr
 
@@ -424,11 +424,11 @@ object NamedAst {
 
   case class JvmAnnotation(name: Name.Ident, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, className: Name.Ident, exp: Expr, loc: SourceLocation)
 
-  case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(op: Name.Ident, fparams: Nel[FormalParam], exp: Expr, loc: SourceLocation)
 
   case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -81,7 +81,7 @@ object ResolvedAst {
     case class Op(sym: Symbol.OpSym, spec: Spec, loc: SourceLocation) extends Declaration
   }
 
-  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], tpe: UnkindedType, eff: Option[UnkindedType], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
+  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: Nel[FormalParam], tpe: UnkindedType, eff: Option[UnkindedType], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
 
   sealed trait Expr {
     def loc: SourceLocation
@@ -125,7 +125,7 @@ object ResolvedAst {
 
     case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
-    case class LocalDef(ann: Annotations, sym: Symbol.VarSym, fparams: List[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(ann: Annotations, sym: Symbol.VarSym, fparams: Nel[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
     case class Region(sym: Symbol.VarSym, regSym: Symbol.RegionSym, exp: Expr, loc: SourceLocation) extends Expr
 
@@ -362,11 +362,11 @@ object ResolvedAst {
 
   case class JvmConstructor(exp: Expr, tpe: UnkindedType, eff: Option[UnkindedType], loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: UnkindedType, eff: Option[UnkindedType], loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, tpe: UnkindedType, eff: Option[UnkindedType], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr, loc: SourceLocation)
 
-  case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(symUse: OpSymUse, fparams: Nel[FormalParam], exp: Expr, loc: SourceLocation)
 
   case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -67,7 +67,7 @@ object TypedAst {
 
   case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
 
-  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint]) extends Decl
+  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: Nel[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint]) extends Decl
 
   case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], loc: SourceLocation) extends Decl
 
@@ -139,7 +139,7 @@ object TypedAst {
 
     case class Let(bnd: Binder, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class LocalDef(ann: Annotations, bnd: Binder, fparams: List[FormalParam], exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class LocalDef(ann: Annotations, bnd: Binder, fparams: Nel[FormalParam], exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class Region(bnd: Binder, regSym: Symbol.RegionSym, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
@@ -407,11 +407,11 @@ object TypedAst {
 
   case class JvmConstructor(exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
 
   case class CatchRule(bnd: Binder, clazz: java.lang.Class[?], exp: Expr, loc: SourceLocation)
 
-  case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(op: OpSymUse, fparams: Nel[FormalParam], exp: Expr, loc: SourceLocation)
 
   case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -40,11 +40,11 @@ object WeededAst {
 
     case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, clazz: Name.QName, tpe: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], redefs: List[Declaration.Redef], loc: SourceLocation) extends Declaration
 
-    case class Sig(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Option[Expr], tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], loc: SourceLocation)
+    case class Sig(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: Nel[FormalParam], exp: Option[Expr], tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint], loc: SourceLocation)
 
-    case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
+    case class Def(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: Nel[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
 
-    case class Redef(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
+    case class Redef(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], fparams: Nel[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], tconstrs: List[TraitConstraint], constrs: List[EqualityConstraint], loc: SourceLocation) extends Declaration
 
     case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], derives: Derivations, cases: List[Case], loc: SourceLocation) extends Declaration
 
@@ -60,7 +60,7 @@ object WeededAst {
 
     case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, tparams: List[TypeParam], ops: List[Declaration.Op], loc: SourceLocation) extends Declaration
 
-    case class Op(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, fparams: List[FormalParam], tpe: Type, tconstrs: List[TraitConstraint], loc: SourceLocation)
+    case class Op(doc: Doc, ann: Annotations, mod: Modifiers, ident: Name.Ident, fparams: Nel[FormalParam], tpe: Type, tconstrs: List[TraitConstraint], loc: SourceLocation)
 
   }
 
@@ -114,7 +114,7 @@ object WeededAst {
 
     case class Discard(exp: Expr, loc: SourceLocation) extends Expr
 
-    case class LocalDef(ann: Annotations, ident: Name.Ident, fparams: List[FormalParam], declaredTpe: Option[Type], declaredEff: Option[Type], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class LocalDef(ann: Annotations, ident: Name.Ident, fparams: Nel[FormalParam], declaredTpe: Option[Type], declaredEff: Option[Type], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
     case class Region(ident: Name.Ident, exp: Expr, loc: SourceLocation) extends Expr
 
@@ -434,11 +434,11 @@ object WeededAst {
 
   case class JvmAnnotation(name: Name.Ident, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
 
   case class CatchRule(ident: Name.Ident, className: Name.Ident, exp: Expr, loc: SourceLocation)
 
-  case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Expr, loc: SourceLocation)
+  case class HandlerRule(op: Name.Ident, fparams: Nel[FormalParam], exp: Expr, loc: SourceLocation)
 
   case class RestrictableChooseRule(pat: RestrictableChoosePattern, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -202,7 +202,7 @@ object TypedAstOps {
       (freeVars(exp1) ++ freeVars(exp2)) - bnd.sym
 
     case Expr.LocalDef(_, TypedAst.Binder(sym, _), fparams, exp1, exp2, _, _, _) =>
-      val bound = sym :: fparams.map(_.bnd.sym)
+      val bound = sym :: fparams.toList.map(_.bnd.sym)
       (freeVars(exp1) -- bound) ++ (freeVars(exp2) - sym)
 
     case Expr.Region(Binder(sym, _), _, exp, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/Resolution.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/Resolution.scala
@@ -16,6 +16,7 @@
 package ca.uwaterloo.flix.language.ast.shared
 
 import ca.uwaterloo.flix.language.ast.{NamedAst, ResolvedAst, Symbol}
+import ca.uwaterloo.flix.util.collection.Nel
 
 /**
  * Result of a name resolution.
@@ -29,7 +30,7 @@ object Resolution {
 
   case class Var(sym: Symbol.VarSym) extends Resolution
 
-  case class LocalDef(ann: Annotations, sym: Symbol.VarSym, fparams: List[ResolvedAst.FormalParam]) extends Resolution
+  case class LocalDef(ann: Annotations, sym: Symbol.VarSym, fparams: Nel[ResolvedAst.FormalParam]) extends Resolution
 
   case class TypeVar(sym: Symbol.UnkindedTypeVarSym) extends Resolution
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -14,7 +14,7 @@ object MonoAstPrinter {
     }.toList
     val defs = root.defs.values.map {
       case MonoAst.Def(sym, MonoAst.Spec(_, ann, mod, fparams, _, retTpe, eff, _), exp, _) =>
-        val fps = fparams.map(printFormalParam)
+        val fps = fparams.toList.map(printFormalParam)
         val rtpe = TypePrinter.print(retTpe)
         val ef = TypePrinter.print(eff)
         val e = print(exp)
@@ -33,7 +33,7 @@ object MonoAstPrinter {
     case Expr.ApplyLocalDef(sym, exps, _, _, _) => DocAst.Expr.ApplyLocalDef(sym, exps.map(print))
     case Expr.ApplyOp(sym, exps, _, _, _) => DocAst.Expr.ApplyOp(sym, exps.map(print))
     case Expr.Let(sym, exp1, exp2, _, _, _, _) => DocAst.Expr.Let(printVar(sym), Some(TypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
-    case Expr.LocalDef(sym, fparams, exp1, exp2, tpe, eff, _, _) => DocAst.Expr.LocalDef(printVar(sym), fparams.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
+    case Expr.LocalDef(sym, fparams, exp1, exp2, tpe, eff, _, _) => DocAst.Expr.LocalDef(printVar(sym), fparams.toList.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
     case Expr.Region(sym, _, exp, _, _, _) => DocAst.Expr.Region(printVar(sym), print(exp))
     case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Expr.IfThenElse(print(exp1), print(exp2), print(exp3))
     case Expr.Stm(exps, exp, _, _, _) => exps.foldRight(print(exp))((e, acc) => DocAst.Expr.Stm(print(e), acc))
@@ -55,12 +55,12 @@ object MonoAstPrinter {
   /** Returns the [[DocAst.JvmMethod]] representation of `method`. */
   private def printJvmMethod(method: MonoAst.JvmMethod): DocAst.JvmMethod = method match {
     case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
+      DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
   }
 
   /** Returns the [[DocAst]] representation of `rule`. */
   private def printHandlerRule(rule: MonoAst.HandlerRule): (Symbol.OpSym, List[DocAst.Expr.AscriptionTpe], DocAst.Expr) = rule match {
-    case MonoAst.HandlerRule(op, fparams, exp) => (op.sym, fparams.map(printFormalParam), print(exp))
+    case MonoAst.HandlerRule(op, fparams, exp) => (op.sym, fparams.toList.map(printFormalParam), print(exp))
   }
 
   /** Returns the [[DocAst]] representation of `rule`. */

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -32,7 +32,7 @@ object ResolvedAstPrinter {
           spec.ann,
           spec.mod,
           sym,
-          spec.fparams.map(printFormalParam),
+          spec.fparams.toList.map(printFormalParam),
           UnkindedTypePrinter.print(spec.tpe),
           spec.eff.map(UnkindedTypePrinter.print).getOrElse(DocAst.Type.Pure),
           print(exp)
@@ -61,7 +61,7 @@ object ResolvedAstPrinter {
     case Expr.Stm(exps, exp, _) => exps.foldRight(print(exp))((e, acc) => DocAst.Expr.Stm(print(e), acc))
     case Expr.Discard(exp, _) => DocAst.Expr.Discard(print(exp))
     case Expr.Let(sym, exp1, exp2, _) => DocAst.Expr.Let(printVarSym(sym), None, print(exp1), print(exp2))
-    case Expr.LocalDef(_, sym, fparams, exp1, exp2, _) => DocAst.Expr.LocalDef(DocAst.Expr.Var(sym), fparams.map(printFormalParam), None, None, print(exp1), print(exp2))
+    case Expr.LocalDef(_, sym, fparams, exp1, exp2, _) => DocAst.Expr.LocalDef(DocAst.Expr.Var(sym), fparams.toList.map(printFormalParam), None, None, print(exp1), print(exp2))
     case Expr.Region(sym, _, exp, _) => DocAst.Expr.Region(printVarSym(sym), print(exp))
     case Expr.Match(exp, rules, _) => DocAst.Expr.Match(print(exp), rules.map {
       case ResolvedAst.MatchRule(pat, guard, body, _) => (printPattern(pat), guard.map(print), print(body))
@@ -100,7 +100,7 @@ object ResolvedAstPrinter {
     })
     case Expr.Throw(exp, _) => DocAst.Expr.Throw(print(exp))
     case Expr.Handler(symUse, rules, _) => DocAst.Expr.Handler(symUse.sym, rules.map {
-      case ResolvedAst.HandlerRule(opSymUse, fparams, exp, _) => (opSymUse.sym, fparams.map(printFormalParam), print(exp))
+      case ResolvedAst.HandlerRule(opSymUse, fparams, exp, _) => (opSymUse.sym, fparams.toList.map(printFormalParam), print(exp))
     })
     case Expr.RunWith(exp1, exp2, _) => DocAst.Expr.RunWith(print(exp1), print(exp2))
     case Expr.InvokeConstructor(_, _, _) => DocAst.Expr.Unknown

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -18,7 +18,7 @@ object TypedAstPrinter {
     }.toList
     val defs = root.defs.values.map {
       case TypedAst.Def(sym, TypedAst.Spec(_, ann, mod, _, fparams, _, retTpe, eff, _, _), exp, _) =>
-        DocAst.Def(ann, mod, sym, fparams.map(printFormalParam), TypePrinter.print(retTpe), TypePrinter.print(eff), print(exp))
+        DocAst.Def(ann, mod, sym, fparams.toList.map(printFormalParam), TypePrinter.print(retTpe), TypePrinter.print(eff), print(exp))
     }.toList
     DocAst.Program(enums, defs, Nil)
   }
@@ -42,7 +42,7 @@ object TypedAstPrinter {
     case Expr.Unary(sop, exp, _, _, _) => DocAst.Expr.Unary(OpPrinter.print(sop), print(exp))
     case Expr.Binary(sop, exp1, exp2, _, _, _) => DocAst.Expr.Binary(print(exp1), OpPrinter.print(sop), print(exp2))
     case Expr.Let(bnd, exp1, exp2, _, _, _) => DocAst.Expr.Let(printVar(bnd.sym), Some(TypePrinter.print(exp1.tpe)), print(exp1), print(exp2))
-    case Expr.LocalDef(_, TypedAst.Binder(sym, _), fparams, exp1, exp2, tpe, eff, _) => DocAst.Expr.LocalDef(printVar(sym), fparams.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
+    case Expr.LocalDef(_, TypedAst.Binder(sym, _), fparams, exp1, exp2, tpe, eff, _) => DocAst.Expr.LocalDef(printVar(sym), fparams.toList.map(printFormalParam), Some(TypePrinter.print(tpe)), Some(TypePrinter.print(eff)), print(exp1), print(exp2))
     case Expr.Region(TypedAst.Binder(sym, _), _, exp, _, _, _) => DocAst.Expr.Region(printVar(sym), print(exp))
     case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Expr.IfThenElse(print(exp1), print(exp2), print(exp3))
     case Expr.Stm(exps, exp, _, _, _) => exps.foldRight(print(exp))((e, acc) => DocAst.Expr.Stm(print(e), acc))
@@ -119,14 +119,14 @@ object TypedAstPrinter {
     */
   private def printJvmMethod(method: TypedAst.JvmMethod): DocAst.JvmMethod = method match {
     case TypedAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
+      DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
   }
 
   /**
     * Returns the [[DocAst]] representation of `rule`.
     */
   private def printHandlerRule(rule: TypedAst.HandlerRule): (Symbol.OpSym, List[DocAst.Expr.AscriptionTpe], DocAst.Expr) = rule match {
-    case TypedAst.HandlerRule(op, fparams, exp, _) => (op.sym, fparams.map(printFormalParam), print(exp))
+    case TypedAst.HandlerRule(op, fparams, exp, _) => (op.sym, fparams.toList.map(printFormalParam), print(exp))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatSignature.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatSignature.scala
@@ -17,6 +17,7 @@ package ca.uwaterloo.flix.language.fmt
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.util.collection.Nel
 
 object FormatSignature {
 
@@ -52,9 +53,9 @@ object FormatSignature {
   /**
     * Returns a formatted string of the formal parameters.
     */
-  private def formatFormalParams(fparams0: List[TypedAst.FormalParam])(implicit flix: Flix): String = fparams0 match {
+  private def formatFormalParams(fparams0: Nel[TypedAst.FormalParam])(implicit flix: Flix): String = fparams0 match {
     // Case 1: Single Unit type parameter. This gets sugared into a nullary function: `foo()`
-    case fparam :: Nil if fparam.tpe == Type.Unit => ""
+    case Nel(fparam, Nil) if fparam.tpe == Type.Unit => ""
     // Case 2: Some list of parameters. Format each and join them: `foo(x: Int32, y: Bool)`
     case fparams =>
       val formattedArgs = fparams.map {

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -200,9 +200,9 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = List(
+        fparams = Nel(
           KindedAst.FormalParam(param1, tpe, TypeSource.Ascribed, loc),
-          KindedAst.FormalParam(param2, tpe, TypeSource.Ascribed, loc)
+          List(KindedAst.FormalParam(param2, tpe, TypeSource.Ascribed, loc))
         ),
         sc = Scheme(
           Nil,
@@ -385,9 +385,9 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = List(
+        fparams = Nel(
           KindedAst.FormalParam(param1, tpe, TypeSource.Ascribed, loc),
-          KindedAst.FormalParam(param2, tpe, TypeSource.Ascribed, loc)
+          List(KindedAst.FormalParam(param2, tpe, TypeSource.Ascribed, loc))
         ),
         sc = Scheme(
           Nil,
@@ -556,7 +556,7 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = List(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc)),
+        fparams = Nel(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc), Nil),
         sc = Scheme(
           Nil,
           List(TraitConstraint(TraitSymUse(toStringTraitSym, loc), tpe, loc)),
@@ -766,7 +766,7 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = List(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc)),
+        fparams = Nel(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc), Nil),
         sc = Scheme(
           Nil,
           List(TraitConstraint(TraitSymUse(hashTraitSym, loc), tpe, loc)),
@@ -923,7 +923,7 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = List(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc)),
+        fparams = Nel(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc), Nil),
         sc = Scheme(
           Nil,
           List(TraitConstraint(TraitSymUse(coerceTraitSym, loc), tpe, loc)),

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -23,6 +23,7 @@ import ca.uwaterloo.flix.language.ast.WeededAst.Predicate
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugDesugaredAst
 import ca.uwaterloo.flix.util.ParOps
+import ca.uwaterloo.flix.util.collection.Nel
 
 import scala.annotation.tailrec
 
@@ -373,9 +374,9 @@ object Desugar {
   }
 
   /**
-    * Desugars the given list of [[WeededAst.FormalParam]] `fparams0`.
+    * Desugars the given non-empty list of [[WeededAst.FormalParam]] `fparams0`.
     */
-  private def visitFormalParams(fparams0: List[WeededAst.FormalParam]): List[DesugaredAst.FormalParam] =
+  private def visitFormalParams(fparams0: Nel[WeededAst.FormalParam]): Nel[DesugaredAst.FormalParam] =
     fparams0.map(visitFormalParam)
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -22,8 +22,8 @@ import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeC
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.EntryPointError
 import ca.uwaterloo.flix.runtime.shell.Shell
-import ca.uwaterloo.flix.util.collection.CofiniteSet
-import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Result}
+import ca.uwaterloo.flix.util.collection.{CofiniteSet, Nel}
+import ca.uwaterloo.flix.util.{ParOps, Result}
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
@@ -306,7 +306,7 @@ object EntryPoints {
 
   /** Returns all the types in the signature of `defn`. */
   private def typesOf(defn: TypedAst.Def): List[Type] = {
-    defn.spec.fparams.map(_.tpe) ++
+    defn.spec.fparams.toList.map(_.tpe) ++
       List(defn.spec.retTpe) ++
       List(defn.spec.eff) ++
       defn.spec.tconstrs.map(_.arg) ++
@@ -317,7 +317,7 @@ object EntryPoints {
   private def checkUnitArg(defn: TypedAst.Def): Option[EntryPointError] = {
     defn.spec.fparams match {
       // One parameter of type Unit - valid.
-      case List(arg) =>
+      case Nel(arg, Nil) =>
         isUnitType(arg.tpe) match {
           case Result.Ok(true) => None
           case Result.Ok(false) =>
@@ -326,11 +326,9 @@ object EntryPoints {
             // Do not report an error, since previous phases should have done already.
             None
         }
-      // One parameter of a non-Unit type or more than two parameters - invalid.
-      case _ :: _ =>
+      // More than one parameter - invalid.
+      case _ =>
         Some(EntryPointError.IllegalRunnableEntryPointArgs(defn.sym.loc))
-      // Zero parameters.
-      case Nil => throw InternalCompilerException(s"Unexpected main with zero parameters ('${defn.sym}'", defn.sym.loc)
     }
   }
 
@@ -429,7 +427,7 @@ object EntryPoints {
 
   /** Returns an error for each type in `defn` that is not valid in Java. */
   private def checkJavaTypes(defn: TypedAst.Def)(implicit flix: Flix): List[EntryPointError] = {
-    val types = defn.spec.retTpe :: defn.spec.fparams.map(_.tpe)
+    val types = defn.spec.retTpe :: defn.spec.fparams.toList.map(_.tpe)
     types.flatMap(tpe => {
       isExportableType(tpe) match {
         case Result.Ok(true) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -22,6 +22,7 @@ import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeC
 import ca.uwaterloo.flix.language.fmt.{FormatType, DisplayType}
 import ca.uwaterloo.flix.tools.pkg.PackageModules
 import ca.uwaterloo.flix.util.LocalResource
+import ca.uwaterloo.flix.util.collection.Nel
 import org.commonmark.ext.gfm.tables.TablesExtension
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
@@ -1305,14 +1306,14 @@ object HtmlDocumentor {
     *
     * The result will be appended to the given `StringBuilder`, `sb`.
     */
-  private def docFormalParams(fparams: List[TypedAst.FormalParam])(implicit flix: Flix, sb: StringBuilder): Unit = {
+  private def docFormalParams(fparams: Nel[TypedAst.FormalParam])(implicit flix: Flix, sb: StringBuilder): Unit = {
     sb.append("<span class='fparams'>(")
     fparams match {
-      case List(TypedAst.FormalParam(_, Type.Cst(TypeConstructor.Unit, _), _, _, _)) =>
+      case Nel(TypedAst.FormalParam(_, Type.Cst(TypeConstructor.Unit, _), _, _, _), Nil) =>
       // For a function declared with zero formal parameters,
       // the compiler will introduce a single parameter of the unit type
       case _ =>
-        docList(fparams.sortBy(_.loc)) { p =>
+        docList(fparams.toList.sortBy(_.loc)) { p =>
           sb.append(s"<span><span>${esc(p.bnd.sym.text)}</span>: ")
           docType(p.tpe)
           sb.append("</span>")

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -374,7 +374,7 @@ object Kinder {
           visitEqualityConstraint(symUse, arg, tpe2, loc, kenv, root)
       }
       val allQuantifiers = quantifiers ::: tparams.map(_.sym)
-      val base = Type.mkUncurriedArrowWithEffect(fparams.map(_.tpe), eff.getOrElse(Type.Pure), tpe, tpe.loc)
+      val base = Type.mkUncurriedArrowWithEffect(fparams.toList.map(_.tpe), eff.getOrElse(Type.Pure), tpe, tpe.loc)
       val sc = Scheme(allQuantifiers, tconstrs, econstrs, base)
       KindedAst.Spec(doc, ann, mod, tparams, fparams, sc, tpe, eff, tconstrs, econstrs)
   }
@@ -514,7 +514,7 @@ object Kinder {
       case ResolvedAst.Expr.LocalDef(ann, sym, fparams0, exp10, exp20, loc) =>
         // we must infer the formal parameters because the may contain wildcard types
         // which would not appear in the function's kenv
-        val fparamKenvs = fparams0.map(inferFormalParam(_, kenv0, root))
+        val fparamKenvs = fparams0.toList.map(inferFormalParam(_, kenv0, root))
         val kenv1 = KindEnv.merge(kenv0 :: fparamKenvs)
         val fparams = fparams0.map(visitFormalParam(_, kenv1, root))
         val exp1 = visitExp(exp10, kenv1, root)
@@ -1478,7 +1478,7 @@ object Kinder {
     */
   private def inferSpec(spec0: ResolvedAst.Spec, kenv: KindEnv, root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, declKinds: DeclKinds, sctx: SharedContext): KindEnv = spec0 match {
     case ResolvedAst.Spec(_, _, _, _, fparams, tpe, eff0, tconstrs, econstrs) =>
-      val fparamKenv = KindEnv.merge(fparams.map(inferFormalParam(_, kenv, root)))
+      val fparamKenv = KindEnv.merge(fparams.toList.map(inferFormalParam(_, kenv, root)))
       val tpeKenv = inferType(tpe, Kind.Star, kenv, root)
       val effKenv = eff0.map(inferType(_, Kind.Eff, kenv, root)).getOrElse(KindEnv.empty)
       val tconstrsKenv = KindEnv.merge(tconstrs.map(inferTraitConstraint(_, kenv, root)))

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1725,7 +1725,7 @@ object Namer {
     */
   private def visitImplicitTypeParamsFromFormalParams(fparams: Nel[DesugaredAst.FormalParam], tpe: DesugaredAst.Type, eff: Option[DesugaredAst.Type], econstrs: List[DesugaredAst.EqualityConstraint])(implicit flix: Flix): List[NamedAst.TypeParam] = {
     // Compute the type variables that occur in the formal parameters.
-    val fparamTvars = fparams.toList.flatMap {
+    val fparamTvars = fparams.flatMap {
       case DesugaredAst.FormalParam(_, Some(tpe1), _) => freeTypeVars(tpe1)
       case DesugaredAst.FormalParam(_, None, _) => Nil
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{NamedAst, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.NameError
-import ca.uwaterloo.flix.util.collection.ListMap
+import ca.uwaterloo.flix.util.collection.{ListMap, Nel}
 import ca.uwaterloo.flix.util.{ChaosMonkey, InternalCompilerException, ParOps}
 
 import java.nio.file.{FileSystemNotFoundException, Path}
@@ -1689,7 +1689,7 @@ object Namer {
   /**
     * Performs naming on the given type parameters `tparams0` from the given formal params `fparams` and overall type `tpe`.
     */
-  private def getTypeParamsFromFormalParams(tparams0: List[DesugaredAst.TypeParam], fparams: List[DesugaredAst.FormalParam], tpe: DesugaredAst.Type, eff: Option[DesugaredAst.Type], econstrs: List[DesugaredAst.EqualityConstraint])(implicit flix: Flix): List[NamedAst.TypeParam] = {
+  private def getTypeParamsFromFormalParams(tparams0: List[DesugaredAst.TypeParam], fparams: Nel[DesugaredAst.FormalParam], tpe: DesugaredAst.Type, eff: Option[DesugaredAst.Type], econstrs: List[DesugaredAst.EqualityConstraint])(implicit flix: Flix): List[NamedAst.TypeParam] = {
     tparams0 match {
       case Nil => visitImplicitTypeParamsFromFormalParams(fparams, tpe, eff, econstrs)
       case tparams@(_ :: _) => visitExplicitTypeParams(tparams)
@@ -1723,9 +1723,9 @@ object Namer {
     *
     * Does not include wildcard parameters. These are handled by the Resolver.
     */
-  private def visitImplicitTypeParamsFromFormalParams(fparams: List[DesugaredAst.FormalParam], tpe: DesugaredAst.Type, eff: Option[DesugaredAst.Type], econstrs: List[DesugaredAst.EqualityConstraint])(implicit flix: Flix): List[NamedAst.TypeParam] = {
+  private def visitImplicitTypeParamsFromFormalParams(fparams: Nel[DesugaredAst.FormalParam], tpe: DesugaredAst.Type, eff: Option[DesugaredAst.Type], econstrs: List[DesugaredAst.EqualityConstraint])(implicit flix: Flix): List[NamedAst.TypeParam] = {
     // Compute the type variables that occur in the formal parameters.
-    val fparamTvars = fparams.flatMap {
+    val fparamTvars = fparams.toList.flatMap {
       case DesugaredAst.FormalParam(_, Some(tpe1), _) => freeTypeVars(tpe1)
       case DesugaredAst.FormalParam(_, None, _) => Nil
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -28,6 +28,7 @@ import ca.uwaterloo.flix.language.errors.RedundancyError.*
 import ca.uwaterloo.flix.language.phase.unification.TraitEnvironment
 import ca.uwaterloo.flix.util.ParOps
 import ca.uwaterloo.flix.util.collection.ListOps
+import ca.uwaterloo.flix.util.collection.Nel
 import ca.uwaterloo.flix.util.collection.SeqOps
 
 import java.util.concurrent.ConcurrentHashMap
@@ -294,8 +295,8 @@ object Redundancy {
   /**
     * Finds unused formal parameters.
     */
-  private def findUnusedFormalParameters(fparams: List[FormalParam], used: Used): List[UnusedFormalParam] = {
-    fparams.collect {
+  private def findUnusedFormalParameters(fparams: Nel[FormalParam], used: Used): List[UnusedFormalParam] = {
+    fparams.toList.collect {
       case fparam if deadVarSym(fparam.bnd.sym, used) => UnusedFormalParam(fparam.bnd.sym)
     }
   }
@@ -305,7 +306,7 @@ object Redundancy {
     */
   private def findUnusedTypeParameters(spec: Spec): List[UnusedTypeParamSignature] = spec match {
     case Spec(_, _, _, tparams, fparams, _, tpe, eff, tconstrs, econstrs) =>
-      val tpes = fparams.map(_.tpe) ::: tpe :: eff :: tconstrs.map(_.arg) ::: econstrs.map(_.tpe1) ::: econstrs.map(_.tpe2)
+      val tpes = fparams.toList.map(_.tpe) ::: tpe :: eff :: tconstrs.map(_.arg) ::: econstrs.map(_.tpe1) ::: econstrs.map(_.tpe2)
       val used = tpes.flatMap { t => t.typeVars.map(_.sym) }.toSet
       tparams.collect {
         case tparam if deadTypeVar(tparam.sym, used) => UnusedTypeParamSignature(tparam.name, tparam.loc)
@@ -455,7 +456,7 @@ object Redundancy {
         (used ++ shadowedVar) - sym
 
       // Check if the fparams are dead in exp1
-      val fparamVars = fparams.map(_.bnd.sym)
+      val fparamVars = fparams.toList.map(_.bnd.sym)
       val shadowedFparamVars = fparamVars.map(s => shadowing(s.text, s.loc, env0))
 
       ListOps.zip(fparamVars, shadowedFparamVars).foldLeft(res1) {
@@ -748,7 +749,7 @@ object Redundancy {
       sctx.effSyms.put(symUse.sym, ())
       rules.foldLeft(Used.empty) {
         case (acc, HandlerRule(_, fparams, body, _)) =>
-          val syms = fparams.map(_.bnd.sym)
+          val syms = fparams.toList.map(_.bnd.sym)
           val shadowedFparamVars = syms.map(s => shadowing(s.text, s.loc, env0))
           val env1 = env0 ++ syms
           val usedBody = visitExp(body, env1, rc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -296,7 +296,7 @@ object Redundancy {
     * Finds unused formal parameters.
     */
   private def findUnusedFormalParameters(fparams: Nel[FormalParam], used: Used): List[UnusedFormalParam] = {
-    fparams.toList.collect {
+    fparams.collect {
       case fparam if deadVarSym(fparam.bnd.sym, used) => UnusedFormalParam(fparam.bnd.sym)
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -893,7 +893,7 @@ object Resolver {
 
     case NamedAst.Expr.Lambda(fparam, exp, loc) =>
       val p = resolveFormalParam(fparam, Wildness.AllowWild, scp0, taenv, ns0, root)
-      val scp = (scp0 ++ mkFormalParamScp(List(p))).withSuperClass(None) // super calls not allowed inside lambdas
+      val scp = (scp0 ++ mkFormalParamScp(Nel(p, Nil))).withSuperClass(None) // super calls not allowed inside lambdas
       val e = resolveExp(exp, scp)
       ResolvedAst.Expr.Lambda(p, e, allowSubeffecting = true, loc)
 
@@ -929,7 +929,7 @@ object Resolver {
 
     case NamedAst.Expr.LocalDef(ann, sym, fparams0, exp1, exp2, loc) =>
       val fparams = fparams0.map(resolveFormalParam(_, Wildness.AllowWild, scp0, taenv, ns0, root))
-      val scp1 = scp0 ++ mkLocalDefScp(ann, sym, fparams) ++ mkFormalParamScp(fparams.toList)
+      val scp1 = scp0 ++ mkLocalDefScp(ann, sym, fparams) ++ mkFormalParamScp(fparams)
       val e1 = resolveExp(exp1, scp1)
       val scp2 = scp0 ++ mkLocalDefScp(ann, sym, fparams)
       val e2 = resolveExp(exp2, scp2)
@@ -1592,7 +1592,7 @@ object Resolver {
     case NamedAst.JvmMethod(ann0, ident, fparams0, exp, tpe, eff, loc) =>
       val ann = ann0.flatMap(resolveJvmAnnotation(_, scp0))
       val fparams = fparams0.map(resolveFormalParam(_, Wildness.AllowWild, scp0, taenv, ns0, root))
-      val scp = scp0 ++ mkFormalParamScp(fparams.toList)
+      val scp = scp0 ++ mkFormalParamScp(fparams)
       val e = resolveExp(exp, scp)
       val t = resolveType(tpe, Some(Kind.Star), Wildness.ForbidWild, scp, taenv, ns0, root)
       val p = eff.map(resolveType(_, Some(Kind.Eff), Wildness.ForbidWild, scp, taenv, ns0, root))
@@ -1751,7 +1751,7 @@ object Resolver {
             val fp = fparams.map(resolveFormalParam(_, Wildness.AllowWild, scp0, taenv, ns, root))
             findOpInEffect(ident, decl, ns, scp0) match {
               case Result.Ok(o) =>
-                val scp = scp0 ++ mkFormalParamScp(fp.toList)
+                val scp = scp0 ++ mkFormalParamScp(fp)
                 checkOpArity(o, fp.length - 1, ident.loc)
                 val b = resolveExp(body, scp)
                 Some(ResolvedAst.HandlerRule(OpSymUse(o.sym, ident.loc), fp, b, loc))
@@ -3378,7 +3378,7 @@ object Resolver {
   /**
     * Creates a use LocalScope from the given formal parameters.
     */
-  private def mkFormalParamScp(fparams: List[ResolvedAst.FormalParam]): LocalScope = {
+  private def mkFormalParamScp(fparams: Nel[ResolvedAst.FormalParam]): LocalScope = {
     fparams.foldLeft(LocalScope.empty) {
       case (acc, fparam) => acc + (fparam.sym.text -> Resolution.Var(fparam.sym))
     }
@@ -3398,7 +3398,7 @@ object Resolver {
     */
   private def mkSpecScp(spec: ResolvedAst.Spec): LocalScope = spec match {
     case ResolvedAst.Spec(_, _, _, tparams, fparams, _, _, _, _) =>
-      mkTypeParamScp(tparams) ++ mkFormalParamScp(fparams.toList)
+      mkTypeParamScp(tparams) ++ mkFormalParamScp(fparams)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -30,7 +30,7 @@ import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.Validation.*
-import ca.uwaterloo.flix.util.collection.{Chain, ListMap, ListOps, MapOps}
+import ca.uwaterloo.flix.util.collection.{Chain, ListMap, ListOps, MapOps, Nel}
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.unused
@@ -705,7 +705,7 @@ object Resolver {
     */
   private def checkSigSpec(sym: Symbol.SigSym, spec0: ResolvedAst.Spec, tvar: Symbol.UnkindedTypeVarSym)(implicit sctx: SharedContext): Unit = spec0 match {
     case ResolvedAst.Spec(_, _, _, _, fparams, tpe, _, _, _) =>
-      val tpes = tpe :: fparams.flatMap(_.tpe)
+      val tpes = tpe :: fparams.toList.flatMap(_.tpe)
       val tvars = tpes.flatMap(_.definiteTypeVars).to(SortedSet)
       if (!tvars.contains(tvar)) {
         val error = ResolutionError.IllegalSignature(sym, tvar, sym.loc)
@@ -3378,7 +3378,7 @@ object Resolver {
   /**
     * Creates a use LocalScope from the given formal parameters.
     */
-  private def mkFormalParamScp(fparams: List[ResolvedAst.FormalParam]): LocalScope = {
+  private def mkFormalParamScp(fparams: Iterable[ResolvedAst.FormalParam]): LocalScope = {
     fparams.foldLeft(LocalScope.empty) {
       case (acc, fparam) => acc + (fparam.sym.text -> Resolution.Var(fparam.sym))
     }
@@ -3433,7 +3433,7 @@ object Resolver {
   /**
     * Creates an LocalScope from the given local def symbol and formal parameters.
     */
-  private def mkLocalDefScp(ann: Annotations, sym: Symbol.VarSym, fparams: List[ResolvedAst.FormalParam]): LocalScope = {
+  private def mkLocalDefScp(ann: Annotations, sym: Symbol.VarSym, fparams: Nel[ResolvedAst.FormalParam]): LocalScope = {
     LocalScope.singleton(sym.text, Resolution.LocalDef(ann, sym, fparams))
   }
 
@@ -3525,7 +3525,7 @@ object Resolver {
 
     case class Def(defn: NamedAst.Declaration.Def) extends ResolvedQName
 
-    case class LocalDef(sym: Symbol.VarSym, fparams: List[ResolvedAst.FormalParam]) extends ResolvedQName
+    case class LocalDef(sym: Symbol.VarSym, fparams: Nel[ResolvedAst.FormalParam]) extends ResolvedQName
 
     case class Sig(sig: NamedAst.Declaration.Sig) extends ResolvedQName
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -705,7 +705,7 @@ object Resolver {
     */
   private def checkSigSpec(sym: Symbol.SigSym, spec0: ResolvedAst.Spec, tvar: Symbol.UnkindedTypeVarSym)(implicit sctx: SharedContext): Unit = spec0 match {
     case ResolvedAst.Spec(_, _, _, _, fparams, tpe, _, _, _) =>
-      val tpes = tpe :: fparams.toList.flatMap(_.tpe)
+      val tpes = tpe :: fparams.flatMap(_.tpe)
       val tvars = tpes.flatMap(_.definiteTypeVars).to(SortedSet)
       if (!tvars.contains(tvar)) {
         val error = ResolutionError.IllegalSignature(sym, tvar, sym.loc)
@@ -929,7 +929,7 @@ object Resolver {
 
     case NamedAst.Expr.LocalDef(ann, sym, fparams0, exp1, exp2, loc) =>
       val fparams = fparams0.map(resolveFormalParam(_, Wildness.AllowWild, scp0, taenv, ns0, root))
-      val scp1 = scp0 ++ mkLocalDefScp(ann, sym, fparams) ++ mkFormalParamScp(fparams)
+      val scp1 = scp0 ++ mkLocalDefScp(ann, sym, fparams) ++ mkFormalParamScp(fparams.toList)
       val e1 = resolveExp(exp1, scp1)
       val scp2 = scp0 ++ mkLocalDefScp(ann, sym, fparams)
       val e2 = resolveExp(exp2, scp2)
@@ -1592,7 +1592,7 @@ object Resolver {
     case NamedAst.JvmMethod(ann0, ident, fparams0, exp, tpe, eff, loc) =>
       val ann = ann0.flatMap(resolveJvmAnnotation(_, scp0))
       val fparams = fparams0.map(resolveFormalParam(_, Wildness.AllowWild, scp0, taenv, ns0, root))
-      val scp = scp0 ++ mkFormalParamScp(fparams)
+      val scp = scp0 ++ mkFormalParamScp(fparams.toList)
       val e = resolveExp(exp, scp)
       val t = resolveType(tpe, Some(Kind.Star), Wildness.ForbidWild, scp, taenv, ns0, root)
       val p = eff.map(resolveType(_, Some(Kind.Eff), Wildness.ForbidWild, scp, taenv, ns0, root))
@@ -1751,7 +1751,7 @@ object Resolver {
             val fp = fparams.map(resolveFormalParam(_, Wildness.AllowWild, scp0, taenv, ns, root))
             findOpInEffect(ident, decl, ns, scp0) match {
               case Result.Ok(o) =>
-                val scp = scp0 ++ mkFormalParamScp(fp)
+                val scp = scp0 ++ mkFormalParamScp(fp.toList)
                 checkOpArity(o, fp.length - 1, ident.loc)
                 val b = resolveExp(body, scp)
                 Some(ResolvedAst.HandlerRule(OpSymUse(o.sym, ident.loc), fp, b, loc))
@@ -3378,7 +3378,7 @@ object Resolver {
   /**
     * Creates a use LocalScope from the given formal parameters.
     */
-  private def mkFormalParamScp(fparams: Iterable[ResolvedAst.FormalParam]): LocalScope = {
+  private def mkFormalParamScp(fparams: List[ResolvedAst.FormalParam]): LocalScope = {
     fparams.foldLeft(LocalScope.empty) {
       case (acc, fparam) => acc + (fparam.sym.text -> Resolution.Var(fparam.sym))
     }
@@ -3398,7 +3398,7 @@ object Resolver {
     */
   private def mkSpecScp(spec: ResolvedAst.Spec): LocalScope = spec match {
     case ResolvedAst.Spec(_, _, _, tparams, fparams, _, _, _, _) =>
-      mkTypeParamScp(tparams) ++ mkFormalParamScp(fparams)
+      mkTypeParamScp(tparams) ++ mkFormalParamScp(fparams.toList)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -47,7 +47,7 @@ object Simplifier {
 
   private def visitDef(decl: MonoAst.Def)(implicit universe: Set[Symbol.EffSym], root: MonoAst.Root, flix: Flix): SimplifiedAst.Def = decl match {
     case MonoAst.Def(sym, spec, exp, _) =>
-      val fs = spec.fparams.map(visitFormalParam)
+      val fs = spec.fparams.toList.map(visitFormalParam)
       val e = visitExp(exp)
       val funType = spec.functionType
       val retType = visitType(funType.arrowResultType)
@@ -213,7 +213,7 @@ object Simplifier {
       SimplifiedAst.Expr.Let(sym, visitExp(e1), visitExp(e2), t, simplifyEffect(eff), loc)
 
     case MonoAst.Expr.LocalDef(sym, fparams, exp1, exp2, tpe, eff, _, loc) =>
-      val fps = fparams.map(visitFormalParam)
+      val fps = fparams.toList.map(visitFormalParam)
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val t = visitType(tpe)
@@ -252,7 +252,7 @@ object Simplifier {
       val e = visitExp(exp)
       val rs = rules map {
         case MonoAst.HandlerRule(sym, fparams, body) =>
-          val fps = fparams.map(visitFormalParam)
+          val fps = fparams.toList.map(visitFormalParam)
           val b = visitExp(body)
           SimplifiedAst.HandlerRule(sym, fps, b)
       }
@@ -635,7 +635,7 @@ object Simplifier {
 
   private def visitJvmMethod(method: MonoAst.JvmMethod)(implicit universe: Set[Symbol.EffSym], root: MonoAst.Root, flix: Flix): SimplifiedAst.JvmMethod = method match {
     case MonoAst.JvmMethod(ann, ident, fparams0, exp0, retTpe, eff, loc) =>
-      val fparams = fparams0 map visitFormalParam
+      val fparams = fparams0.toList.map(visitFormalParam)
       val exp = visitExp(exp0)
       val rt = visitType(retTpe)
       SimplifiedAst.JvmMethod(ann, ident, fparams, exp, rt, simplifyEffect(eff), loc)
@@ -1480,7 +1480,7 @@ object Simplifier {
 
   private def visitEffOp(op: MonoAst.Op)(implicit universe: Set[Symbol.EffSym]): SimplifiedAst.Op = op match {
     case MonoAst.Op(sym, MonoAst.Spec(_, ann, mod, fparams0, _, retTpe0, eff0, _), loc) =>
-      val fparams = fparams0.map(visitFormalParam)
+      val fparams = fparams0.toList.map(visitFormalParam)
       val retTpe = visitType(retTpe0)
       val eff = simplifyEffect(eff0)
       SimplifiedAst.Op(sym, ann, mod, fparams, retTpe, eff, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.{ChangeSet, SourceLocation, Symbol, Type, 
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.TerminationError
 import ca.uwaterloo.flix.util.ParOps
-import ca.uwaterloo.flix.util.collection.{ListOps, OptionOps}
+import ca.uwaterloo.flix.util.collection.{ListOps, Nel, OptionOps}
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.tailrec
@@ -169,7 +169,7 @@ object Terminator {
     * onto the front of the context list, so that calls to both the local def
     * ''and'' any enclosing `@Terminates` function are checked.
     */
-  private case class RecursionContext(selfSym: SelfSym, fparams: List[FormalParam], env: SubEnv)
+  private case class RecursionContext(selfSym: SelfSym, fparams: Nel[FormalParam], env: SubEnv)
 
   /**
     * Tracks the structural relationship between local variables and the formal parameters
@@ -209,7 +209,7 @@ object Terminator {
       * Each formal parameter is mapped to itself with `Alias` strictness,
       * meaning "this variable ''is'' the parameter, not a substructure of it".
       */
-    def init(fparams: List[FormalParam]): SubEnv =
+    def init(fparams: Nel[FormalParam]): SubEnv =
       SubEnv(fparams.map(fp => fp.bnd.sym -> ParamRelation(fp.bnd.sym, Alias)).toMap)
   }
 
@@ -300,11 +300,11 @@ object Terminator {
     *
     * Returns `fparams` itself when `decreasingIndices` is empty.
     */
-  private def mkDecreasingFparams(fparams: List[FormalParam], decreasingIndices: Set[Int]): List[FormalParam] =
+  private def mkDecreasingFparams(fparams: Nel[FormalParam], decreasingIndices: Set[Int]): Nel[FormalParam] =
     if (decreasingIndices.isEmpty) fparams
-    else fparams.zipWithIndex.map { case (fp, i) =>
+    else Nel.unsafeFrom(fparams.toList.zipWithIndex.map { case (fp, i) =>
       if (decreasingIndices.contains(i)) fp.copy(decreasing = Decreasing.StrictlyDecreasing) else fp
-    }
+    })
 
   ////////////////////////////////////////////////////////////////////////////
   // Self-call matching
@@ -1004,7 +1004,7 @@ object Terminator {
   /**
     * Checks that the types of formal parameters are strictly positive.
     */
-  private def checkStrictPositivity(fparams: List[FormalParam], sym: QualifiedSym)(implicit sctx: SharedContext, root: Root): Unit = {
+  private def checkStrictPositivity(fparams: Nel[FormalParam], sym: QualifiedSym)(implicit sctx: SharedContext, root: Root): Unit = {
     for (fparam <- fparams) {
       fparam.tpe.typeConstructor match {
         case Some(TypeConstructor.Enum(enumSym, _)) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
@@ -302,9 +302,9 @@ object Terminator {
     */
   private def mkDecreasingFparams(fparams: Nel[FormalParam], decreasingIndices: Set[Int]): Nel[FormalParam] =
     if (decreasingIndices.isEmpty) fparams
-    else Nel.unsafeFrom(fparams.toList.zipWithIndex.map { case (fp, i) =>
+    else fparams.zipWithIndex.map { case (fp, i) =>
       if (decreasingIndices.contains(i)) fp.copy(decreasing = Decreasing.StrictlyDecreasing) else fp
-    })
+    }
 
   ////////////////////////////////////////////////////////////////////////////
   // Self-call matching

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -193,7 +193,7 @@ object TypeReconstruction {
       val e2 = visitExp(exp2)
       val tpe = e2.tpe
       val eff = e2.eff
-      val boundType = Type.mkUncurriedArrowWithEffect(fps.map(_.tpe), e1.tpe, e1.eff, SourceLocation.Unknown)
+      val boundType = Type.mkUncurriedArrowWithEffect(fps.toList.map(_.tpe), e1.tpe, e1.eff, SourceLocation.Unknown)
       val bnd = TypedAst.Binder(sym, boundType)
       TypedAst.Expr.LocalDef(ann, bnd, fps, e1, e2, tpe, eff, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -431,7 +431,7 @@ object Typer {
   private def checkSpecAssocTypes(spec0: KindedAst.Spec, extraTconstrs: List[TraitConstraint], tenv: TraitEnv)(implicit sctx: SharedContext, flix: Flix): Unit = spec0 match {
     case KindedAst.Spec(_, _, _, tparams, fparams, _, tpe, eff, tconstrs, econstrs) =>
       // get all the associated types in the spec
-      val tpes = fparams.map(_.tpe) ::: tpe :: eff.getOrElse(Type.Pure) :: econstrs.flatMap(getTypes)
+      val tpes = fparams.toList.map(_.tpe) ::: tpe :: eff.getOrElse(Type.Pure) :: econstrs.flatMap(getTypes)
 
       // check that they are all covered by the type constraints
       for {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -686,12 +686,12 @@ object Weeder2 {
       loc
     )
 
-    def pickFormalParameters(tree: Tree, presence: Presence = Presence.Required)(implicit sctx: SharedContext): List[FormalParam] = {
+    def pickFormalParameters(tree: Tree, presence: Presence = Presence.Required)(implicit sctx: SharedContext): Nel[FormalParam] = {
       tryPick(TreeKind.ParameterList, tree) match {
         case Some(t) =>
           val params = pickAll(TreeKind.Parameter, t)
           if (params.isEmpty) {
-            List(unitFormalParameter(t.loc))
+            Nel(unitFormalParameter(t.loc), Nil)
           } else {
             val fparams = params.map(visitParameter(_, presence))
             // Check for duplicates
@@ -701,12 +701,12 @@ object Weeder2 {
             errors.foreach(sctx.errors.add)
 
             // Check missing or illegal type ascription
-            fparams
+            Nel.unsafeFrom(fparams)
           }
         case None =>
           val error = UnexpectedToken(NamedTokenSet.FromKinds(Set(TokenKind.ParenL)), actual = None, SyntacticContext.Decl.Module, loc = tree.loc)
           sctx.errors.add(error)
-          List(unitFormalParameter(tree.loc))
+          Nel(unitFormalParameter(tree.loc), Nil)
       }
     }
 
@@ -1820,14 +1820,14 @@ object Weeder2 {
       // `def f(x)` becomes `def f(_unit: Unit, x)`.
       // `def f(x, y, ..)` is unchanged.
       fparams0 match {
-        case fparam :: Nil =>
+        case Nel(fparam, Nil) =>
           // Since a continuation argument must always be there, the underlying function needs a
           // unit param. For example `def f(k)` becomes `def f(_unit: Unit, k)`.
 
           // The new param has the zero-width location of the actual argument.
           val loc = SourceLocation.zeroPoint(isReal = false, fparam.loc.source, fparam.loc.start)
           val unitParam = Decls.unitFormalParameter(loc)
-          HandlerRule(ident, List(unitParam, fparam), expr, tree.loc)
+          HandlerRule(ident, Nel(unitParam, List(fparam)), expr, tree.loc)
         case fparams =>
           HandlerRule(ident, fparams, expr, tree.loc)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -913,7 +913,7 @@ object Lowering {
     // by just checking the length of the handlers and if it is greater than 0
     // just adding IO. However, that would only work while default handlers can only generate IO.
     val eff = Type.mkUnion(effDif, Type.IO, effLoc)
-    val tpe = Type.mkCurriedArrowWithEffect(defn.spec.fparams.map(_.tpe), eff, defn.spec.retTpe, baseTypeLoc)
+    val tpe = Type.mkCurriedArrowWithEffect(defn.spec.fparams.toList.map(_.tpe), eff, defn.spec.retTpe, baseTypeLoc)
     val spec = defn.spec.copy(
       declaredScheme = defn.spec.declaredScheme.copy(base = tpe),
       eff = eff,

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -1295,7 +1295,7 @@ object Specialization {
     * Specializes `fparams0` w.r.t. `subst0` and returns a mapping from variable symbols to fresh
     * variable symbols.
     */
-  private def specializeFormalParams(fparams0: List[TypedAst.FormalParam], subst0: StrictSubstitution)(implicit root: TypedAst.Root, flix: Flix): (List[TypedAst.FormalParam], Map[Symbol.VarSym, Symbol.VarSym]) = {
+  private def specializeFormalParams(fparams0: Nel[TypedAst.FormalParam], subst0: StrictSubstitution)(implicit root: TypedAst.Root, flix: Flix): (Nel[TypedAst.FormalParam], Map[Symbol.VarSym, Symbol.VarSym]) = {
     // Specialize each formal parameter and recombine the results.
     val (params, envs) = fparams0.map(p => specializeFormalParam(p, subst0)).unzip
     (params, combineEnvs(envs))

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -187,7 +187,7 @@ object Inliner {
         case Expr.Lambda(fparam, e1, _, _) =>
           sctx.changed.putIfAbsent(sym0, ())
           val e2 = visitExp(exp2, ctx0)
-          val letBinding = bindArgs(e1, List(fparam), List(e2), loc)
+          val letBinding = bindArgs(e1, Nel(fparam, Nil), List(e2), loc)
           visitExp(letBinding, ctx0)
 
         case e1 =>
@@ -290,7 +290,7 @@ object Inliner {
         val ctx1 = ctx0.addVarSubst(sym, freshVarSym)
         val e2 = visitExp(exp2, ctx1)
         val (fps, varSubsts) = fparams.map(freshFormalParam).unzip
-        val ctx2 = ctx1.addVarSubsts(varSubsts)
+        val ctx2 = ctx1.addVarSubsts(varSubsts.toList)
           .addInScopeVar(sym, BoundKind.ParameterOrPattern)
           .addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
         val e1 = visitExp(exp1, ctx2)
@@ -720,7 +720,7 @@ object Inliner {
   private def visitHandlerRule(rule: MonoAst.HandlerRule, ctx0: LocalContext)(implicit sym0: Symbol.DefnSym, sctx: SharedContext, root: MonoAst.Root, flix: Flix): MonoAst.HandlerRule = rule match {
     case MonoAst.HandlerRule(op, fparams, exp1) =>
       val (fps, varSubsts) = fparams.map(freshFormalParam).unzip
-      val ctx = ctx0.addVarSubsts(varSubsts).addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
+      val ctx = ctx0.addVarSubsts(varSubsts.toList).addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
       val e1 = visitExp(exp1, ctx)
       MonoAst.HandlerRule(op, fps, e1)
   }
@@ -734,7 +734,7 @@ object Inliner {
   private def visitJvmMethod(method: MonoAst.JvmMethod, ctx0: LocalContext)(implicit sym0: Symbol.DefnSym, sctx: SharedContext, root: MonoAst.Root, flix: Flix): MonoAst.JvmMethod = method match {
     case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, eff1, loc1) =>
       val (fps, varSubsts) = fparams.map(freshFormalParam).unzip
-      val ctx = ctx0.addVarSubsts(varSubsts).addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
+      val ctx = ctx0.addVarSubsts(varSubsts.toList).addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
       val e = visitExp(exp, ctx)
       MonoAst.JvmMethod(ann, ident, fps, e, retTpe, eff1, loc1)
   }
@@ -1028,7 +1028,7 @@ object Inliner {
     }
 
     /** Returns a [[LocalContext]] with the mappings of `l` added to [[varSubst]]. */
-    def addVarSubsts(l: Iterable[Map[Symbol.VarSym, Symbol.VarSym]]): LocalContext = {
+    def addVarSubsts(l: List[Map[Symbol.VarSym, Symbol.VarSym]]): LocalContext = {
       this.copy(varSubst = l.foldLeft(this.varSubst)(_ ++ _))
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -23,6 +23,7 @@ import ca.uwaterloo.flix.language.ast.shared.Constant
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoAst, SourceLocation, Symbol, Type}
 import ca.uwaterloo.flix.util.collection.Chain
 import ca.uwaterloo.flix.util.collection.ListOps
+import ca.uwaterloo.flix.util.collection.Nel
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 import java.util.concurrent.ConcurrentHashMap
@@ -753,8 +754,8 @@ object Inliner {
     * where `symi` is the symbol of the i-th formal parameter and `exp` is the body of the function.
     *
     */
-  private def bindArgs(exp: Expr, fparams: List[FormalParam], exps: List[Expr], loc: SourceLocation): Expr = {
-    ListOps.zip(fparams, exps).foldRight(exp) {
+  private def bindArgs(exp: Expr, fparams: Nel[FormalParam], exps: List[Expr], loc: SourceLocation): Expr = {
+    ListOps.zip(fparams.toList, exps).foldRight(exp) {
       case ((fparam, arg), acc) =>
         val eff = Type.mkUnion(arg.eff, acc.eff, loc)
         Expr.Let(fparam.sym, arg, acc, acc.tpe, eff, fparam.occur, loc)
@@ -1027,7 +1028,7 @@ object Inliner {
     }
 
     /** Returns a [[LocalContext]] with the mappings of `l` added to [[varSubst]]. */
-    def addVarSubsts(l: List[Map[Symbol.VarSym, Symbol.VarSym]]): LocalContext = {
+    def addVarSubsts(l: Iterable[Map[Symbol.VarSym, Symbol.VarSym]]): LocalContext = {
       this.copy(varSubst = l.foldLeft(this.varSubst)(_ ++ _))
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -290,7 +290,7 @@ object Inliner {
         val ctx1 = ctx0.addVarSubst(sym, freshVarSym)
         val e2 = visitExp(exp2, ctx1)
         val (fps, varSubsts) = fparams.map(freshFormalParam).unzip
-        val ctx2 = ctx1.addVarSubsts(varSubsts.toList)
+        val ctx2 = ctx1.addVarSubsts(varSubsts)
           .addInScopeVar(sym, BoundKind.ParameterOrPattern)
           .addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
         val e1 = visitExp(exp1, ctx2)
@@ -720,7 +720,7 @@ object Inliner {
   private def visitHandlerRule(rule: MonoAst.HandlerRule, ctx0: LocalContext)(implicit sym0: Symbol.DefnSym, sctx: SharedContext, root: MonoAst.Root, flix: Flix): MonoAst.HandlerRule = rule match {
     case MonoAst.HandlerRule(op, fparams, exp1) =>
       val (fps, varSubsts) = fparams.map(freshFormalParam).unzip
-      val ctx = ctx0.addVarSubsts(varSubsts.toList).addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
+      val ctx = ctx0.addVarSubsts(varSubsts).addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
       val e1 = visitExp(exp1, ctx)
       MonoAst.HandlerRule(op, fps, e1)
   }
@@ -734,7 +734,7 @@ object Inliner {
   private def visitJvmMethod(method: MonoAst.JvmMethod, ctx0: LocalContext)(implicit sym0: Symbol.DefnSym, sctx: SharedContext, root: MonoAst.Root, flix: Flix): MonoAst.JvmMethod = method match {
     case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, eff1, loc1) =>
       val (fps, varSubsts) = fparams.map(freshFormalParam).unzip
-      val ctx = ctx0.addVarSubsts(varSubsts.toList).addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
+      val ctx = ctx0.addVarSubsts(varSubsts).addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
       val e = visitExp(exp, ctx)
       MonoAst.JvmMethod(ann, ident, fps, e, retTpe, eff1, loc1)
   }
@@ -1028,7 +1028,7 @@ object Inliner {
     }
 
     /** Returns a [[LocalContext]] with the mappings of `l` added to [[varSubst]]. */
-    def addVarSubsts(l: List[Map[Symbol.VarSym, Symbol.VarSym]]): LocalContext = {
+    def addVarSubsts(l: Nel[Map[Symbol.VarSym, Symbol.VarSym]]): LocalContext = {
       this.copy(varSubst = l.foldLeft(this.varSubst)(_ ++ _))
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.MonoAst.{Expr, Occur}
 import ca.uwaterloo.flix.language.ast.shared.{BoundBy, RegionScope}
 import ca.uwaterloo.flix.language.ast.{MonoAst, SourceLocation, Symbol, TypeConstructor}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugMonoAst
-import ca.uwaterloo.flix.util.collection.ListOps
+import ca.uwaterloo.flix.util.collection.{ListOps, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 import scala.collection.mutable
@@ -77,16 +77,17 @@ object LambdaDrop {
     * (a) it contains at least one recursive call and
     * (b) is a higher-order function, i.e., it has at least one formal parameter
     * with a function type and
-    * (c) has at least one constant parameter.
+    * (c) has at least one constant parameter and
+    * (d) has at least one non-constant parameter.
     *
-    * The latter condition can be checked by the [[isHigherOrder]] predicate.
+    * Condition (b) can be checked by the [[isHigherOrder]] predicate.
     */
   private def isDroppable(defn: MonoAst.Def)(implicit lctx: LocalContext): Boolean = {
     if (!isHigherOrder(defn)) {
       return false
     }
     visitExp(defn.exp)(defn.sym, lctx)
-    lctx.recursiveCalls.nonEmpty && hasConstantParameter(lctx.recursiveCalls.toList, defn.spec.fparams)
+    lctx.recursiveCalls.nonEmpty && hasDroppableParameters(lctx.recursiveCalls.toList, defn.spec.fparams)
   }
 
   /** Returns `true` if at least one formal parameter of `defn` has an arrow type. */
@@ -365,8 +366,8 @@ object LambdaDrop {
     *
     * Otherwise, it is marked [[ParamKind.NonConst]]
     */
-  private def paramKinds(calls: List[Expr.ApplyDef], fparams: List[MonoAst.FormalParam]): List[(MonoAst.FormalParam, ParamKind)] = {
-    val matrix = calls.map(call => ListOps.zip(fparams, call.exps)).transpose
+  private def paramKinds(calls: List[Expr.ApplyDef], fparams: Nel[MonoAst.FormalParam]): List[(MonoAst.FormalParam, ParamKind)] = {
+    val matrix = calls.map(call => ListOps.zip(fparams.toList, call.exps)).transpose
     matrix.map {
       case invocations =>
         val allConstant = invocations.forall {
@@ -381,11 +382,17 @@ object LambdaDrop {
     }
   }
 
-  /** Returns `true` if there exists at least one constant parameter. */
-  private def hasConstantParameter(calls: List[Expr.ApplyDef], fparams: List[MonoAst.FormalParam]): Boolean = {
-    paramKinds(calls, fparams).exists {
-      case (_, pkind) => pkind == ParamKind.Const
-    }
+  /**
+    * Returns `true` if there exists at least one constant parameter and at least one
+    * non-constant parameter.
+    *
+    * The latter is required because the introduced local def takes the non-constant
+    * parameters as its formal parameters, and a def must have at least one.
+    */
+  private def hasDroppableParameters(calls: List[Expr.ApplyDef], fparams: Nel[MonoAst.FormalParam]): Boolean = {
+    val kinds = paramKinds(calls, fparams)
+    kinds.exists { case (_, pkind) => pkind == ParamKind.Const } &&
+      kinds.exists { case (_, pkind) => pkind == ParamKind.NonConst }
   }
 
   /** Returns a fresh [[Symbol.VarSym]] for a local def. */
@@ -414,9 +421,10 @@ object LambdaDrop {
     }
     val applyLocalDefExpr = Expr.ApplyLocalDef(sym, args, exp0.tpe, exp0.eff, exp0.loc.asSynthetic)
 
-    val localDefParams = nonConstantParams.map {
+    // Non-empty by the (d) condition of `isDroppable`.
+    val localDefParams = Nel.unsafeFrom(nonConstantParams.map {
       case (fp, _) => fp.copy(sym = subst(fp.sym), loc = fp.loc.asSynthetic)
-    }
+    })
     val tpe = applyLocalDefExpr.tpe
     val eff = applyLocalDefExpr.eff
     val loc = applyLocalDefExpr.loc.asSynthetic

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -146,7 +146,7 @@ object OccurrenceAnalyzer {
         val ctx5 = combineSeq(ctx3, ctx4)
         val occur = ctx5.get(sym)
         val ctx6 = ctx5.removeVar(sym)
-        if ((e1 eq exp1) && (e2 eq exp2) && ListOps.zip(fparams.toList, fps.toList).forall { case (fp1, fp2) => fp1 eq fp2 } && (occur eq occur0)) {
+        if ((e1 eq exp1) && (e2 eq exp2) && fparams.zip(fps).forall { case (fp1, fp2) => fp1 eq fp2 } && (occur eq occur0)) {
           (exp0, ctx6) // Reuse exp0.
         } else {
           (Expr.LocalDef(sym, fps, e1, e2, tpe, eff, occur, loc), ctx6)
@@ -296,7 +296,7 @@ object OccurrenceAnalyzer {
       val (e, ctx1) = visitExp(exp)
       val fps = fparams.map(visitFormalParam(_, ctx1))
       val ctx2 = ctx1.removeVars(fps.map(_.sym))
-      if ((e eq exp) && ListOps.zip(fparams.toList, fps.toList).forall { case (fp1, fp2) => fp1 eq fp2 }) {
+      if ((e eq exp) && fparams.zip(fps).forall { case (fp1, fp2) => fp1 eq fp2 }) {
         (rule, ctx2) // Reuse rule.
       } else {
         (MonoAst.HandlerRule(op, fps, e), ctx2)
@@ -318,7 +318,7 @@ object OccurrenceAnalyzer {
       val (e, ctx1) = visitExp(exp)
       val fps = fparams.map(visitFormalParam(_, ctx1))
       val ctx2 = ctx1.removeVars(fps.map(_.sym))
-      if ((e eq exp) && ListOps.zip(fparams.toList, fps.toList).forall { case (fp1, fp2) => fp1 eq fp2 }) {
+      if ((e eq exp) && fparams.zip(fps).forall { case (fp1, fp2) => fp1 eq fp2 }) {
         (method, ctx2) // Reuse method.
       } else {
         (MonoAst.JvmMethod(ann, ident, fparams, e, retTpe, eff, loc), ctx2)

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -146,7 +146,7 @@ object OccurrenceAnalyzer {
         val ctx5 = combineSeq(ctx3, ctx4)
         val occur = ctx5.get(sym)
         val ctx6 = ctx5.removeVar(sym)
-        if ((e1 eq exp1) && (e2 eq exp2) && ListOps.zip(fparams, fps).forall { case (fp1, fp2) => fp1 eq fp2 } && (occur eq occur0)) {
+        if ((e1 eq exp1) && (e2 eq exp2) && ListOps.zip(fparams.toList, fps.toList).forall { case (fp1, fp2) => fp1 eq fp2 } && (occur eq occur0)) {
           (exp0, ctx6) // Reuse exp0.
         } else {
           (Expr.LocalDef(sym, fps, e1, e2, tpe, eff, occur, loc), ctx6)
@@ -296,7 +296,7 @@ object OccurrenceAnalyzer {
       val (e, ctx1) = visitExp(exp)
       val fps = fparams.map(visitFormalParam(_, ctx1))
       val ctx2 = ctx1.removeVars(fps.map(_.sym))
-      if ((e eq exp) && ListOps.zip(fparams, fps).forall { case (fp1, fp2) => fp1 eq fp2 }) {
+      if ((e eq exp) && ListOps.zip(fparams.toList, fps.toList).forall { case (fp1, fp2) => fp1 eq fp2 }) {
         (rule, ctx2) // Reuse rule.
       } else {
         (MonoAst.HandlerRule(op, fps, e), ctx2)
@@ -318,7 +318,7 @@ object OccurrenceAnalyzer {
       val (e, ctx1) = visitExp(exp)
       val fps = fparams.map(visitFormalParam(_, ctx1))
       val ctx2 = ctx1.removeVars(fps.map(_.sym))
-      if ((e eq exp) && ListOps.zip(fparams, fps).forall { case (fp1, fp2) => fp1 eq fp2 }) {
+      if ((e eq exp) && ListOps.zip(fparams.toList, fps.toList).forall { case (fp1, fp2) => fp1 eq fp2 }) {
         (method, ctx2) // Reuse method.
       } else {
         (MonoAst.JvmMethod(ann, ident, fparams, e, retTpe, eff, loc), ctx2)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -1296,7 +1296,9 @@ object ConstraintGen {
       val ops = effect.ops.map(op => op.sym -> op).toMap
       // Don't need to generalize since ops are monomorphic
       // Don't need to handle unknown op because resolver would have caught this
-      val (actualFparams, List(resumptionFparam)) = actualFparams0.toList.splitAt(actualFparams0.length - 1)
+      // The last formal parameter is the resumption, the rest correspond to the operation's parameters.
+      val actualFparams = actualFparams0.init
+      val resumptionFparam = actualFparams0.last
       ops(symUse.sym) match {
         case KindedAst.Op(_, KindedAst.Spec(_, _, _, _, expectedFparams, _, opTpe, _, _, _), _) =>
           val resumptionArgType = opTpe

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -104,7 +104,7 @@ object ConstraintGen {
         // If no effect specified, we assume the function is pure
         val declaredEff = subst(defn.spec.eff.getOrElse(Type.Pure))
         val declaredResultType = generalizeVoid(subst(defn.spec.tpe))
-        val declaredArgumentTypes = defn.spec.fparams.map(_.tpe).map(subst.apply)
+        val declaredArgumentTypes = defn.spec.fparams.toList.map(_.tpe).map(subst.apply)
         val declaredType = Type.mkUncurriedArrowWithEffect(declaredArgumentTypes, declaredEff, declaredResultType, loc2)
 
         val (tpes, effs) = exps.map(visitExp).unzip
@@ -160,7 +160,7 @@ object ConstraintGen {
 
         val declaredEff = subst(sig.spec.eff.getOrElse(Type.Pure))
         val declaredResultType = subst(sig.spec.tpe)
-        val declaredArgumentTypes = sig.spec.fparams.map(_.tpe).map(subst.apply)
+        val declaredArgumentTypes = sig.spec.fparams.toList.map(_.tpe).map(subst.apply)
         val declaredType = Type.mkUncurriedArrowWithEffect(declaredArgumentTypes, declaredEff, declaredResultType, loc1)
 
         val (tpes, effs) = exps.map(visitExp).unzip
@@ -489,7 +489,7 @@ object ConstraintGen {
           enabled && !useless
         }
         val defEff = if (shouldSubeffect) Type.mkUnion(eff1, Type.freshEffSlackVar(loc), loc) else eff1
-        val defTpe = Type.mkUncurriedArrowWithEffect(fparams.map(_.tpe), defEff, tpe1, sym.loc)
+        val defTpe = Type.mkUncurriedArrowWithEffect(fparams.toList.map(_.tpe), defEff, tpe1, sym.loc)
         c.unifyType(sym.tvar, defTpe, sym.loc)
         val (tpe2, eff2) = visitExp(exp2)
         val resTpe = tpe2
@@ -1296,14 +1296,14 @@ object ConstraintGen {
       val ops = effect.ops.map(op => op.sym -> op).toMap
       // Don't need to generalize since ops are monomorphic
       // Don't need to handle unknown op because resolver would have caught this
-      val (actualFparams, List(resumptionFparam)) = actualFparams0.splitAt(actualFparams0.length - 1)
+      val (actualFparams, List(resumptionFparam)) = actualFparams0.toList.splitAt(actualFparams0.length - 1)
       ops(symUse.sym) match {
         case KindedAst.Op(_, KindedAst.Spec(_, _, _, _, expectedFparams, _, opTpe, _, _, _), _) =>
           val resumptionArgType = opTpe
           val resumptionResType = tryBlockTpe
           val resumptionEff = continuationEffect
           val expectedResumptionType = Type.mkArrowWithEffect(resumptionArgType, resumptionEff, resumptionResType, loc.asSynthetic)
-          unifyFormalParams(symUse.sym, expected = expectedFparams, actual = actualFparams)
+          unifyFormalParams(symUse.sym, expected = expectedFparams.toList, actual = actualFparams)
           c.expectType(expected = expectedResumptionType, actual = resumptionFparam.tpe, resumptionFparam.loc)
           val (actualTpe, actualEff) = visitExp(body)
 

--- a/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
@@ -36,11 +36,17 @@ case class Nel[T](x: T, xs: List[T]) extends Iterable[T] {
   /** Returns all elements of `this` except the first. */
   override def tail: List[T] = xs
 
+  /** Returns all elements of `this` except the last. */
+  override def init: List[T] = if (xs.isEmpty) Nil else x :: xs.init
+
   /** Builds a new [[Nel]] by applying `f` to all elements of `this`. */
   override def map[S](f: T => S): Nel[S] = Nel(f(x), xs.map(f))
 
   /** Builds a new [[List]] by applying `f` to all elements of `this` and concatenating the results. */
   override def flatMap[S](f: T => IterableOnce[S]): List[S] = toList.flatMap(f)
+
+  /** Builds a new [[List]] by applying `pf` to all elements of `this` on which it is defined. */
+  override def collect[S](pf: PartialFunction[T, S]): List[S] = toList.collect(pf)
 
   /** Returns a [[Nel]] of pairs of the elements of `this` and their indices. */
   override def zipWithIndex: Nel[(T, Int)] = Nel((x, 0), xs.zipWithIndex.map { case (y, i) => (y, i + 1) })

--- a/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
@@ -15,6 +15,9 @@
  */
 package ca.uwaterloo.flix.util.collection
 
+import ca.uwaterloo.flix.language.ast.SourceLocation
+import ca.uwaterloo.flix.util.InternalCompilerException
+
 /**
   * A non-empty list (Nel) - always has at least one element.
   *
@@ -26,6 +29,12 @@ case class Nel[T](x: T, xs: List[T]) extends Iterable[T] {
 
   /** Returns the number of elements in `this` (always at least 1). */
   def length: Int = 1 + xs.length
+
+  /** Returns the first element of `this`. */
+  override def head: T = x
+
+  /** Returns all elements of `this` except the first. */
+  override def tail: List[T] = xs
 
   /** Builds a new [[Nel]] by applying `f` to all elements of `this`. */
   override def map[S](f: T => S): Nel[S] = Nel(f(x), xs.map(f))
@@ -45,5 +54,19 @@ case class Nel[T](x: T, xs: List[T]) extends Iterable[T] {
 
   /** Returns `this` as a [[List]]. */
   override def toList: List[T] = x :: xs
+
+}
+
+object Nel {
+
+  /**
+    * Returns `l` as a [[Nel]].
+    *
+    * Throws an [[InternalCompilerException]] if `l` is empty.
+    */
+  def unsafeFrom[T](l: List[T]): Nel[T] = l match {
+    case Nil => throw InternalCompilerException("Unexpected empty list", SourceLocation.Unknown)
+    case x :: xs => Nel(x, xs)
+  }
 
 }

--- a/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
@@ -39,6 +39,19 @@ case class Nel[T](x: T, xs: List[T]) extends Iterable[T] {
   /** Builds a new [[Nel]] by applying `f` to all elements of `this`. */
   override def map[S](f: T => S): Nel[S] = Nel(f(x), xs.map(f))
 
+  /** Builds a new [[List]] by applying `f` to all elements of `this` and concatenating the results. */
+  override def flatMap[S](f: T => IterableOnce[S]): List[S] = toList.flatMap(f)
+
+  /** Returns a [[Nel]] of pairs of the elements of `this` and their indices. */
+  override def zipWithIndex: Nel[(T, Int)] = Nel((x, 0), xs.zipWithIndex.map { case (y, i) => (y, i + 1) })
+
+  /**
+    * Returns a [[Nel]] of pairs of corresponding elements of `this` and `that`.
+    *
+    * Throws an [[InternalCompilerException]] if `this` and `that` have different lengths.
+    */
+  def zip[S](that: Nel[S]): Nel[(T, S)] = Nel((x, that.x), ListOps.zip(xs, that.xs))
+
   /** Returns two lists from a list of tuples. */
   override def unzip[A1, A2](implicit asPair: T => (A1, A2)): (Nel[A1], Nel[A2]) = {
     val (a, b) = asPair(x)


### PR DESCRIPTION
_Below generated by Claude_

Closes #12980.
Related to #13009 

Formal parameters are never empty — `Weeder2.pickFormalParameters` inserts a synthetic `_unit: Unit` parameter for zero-parameter declarations. This encodes that invariant in the types.

`fparams` changes from `List[FormalParam]` to `Nel[FormalParam]` in `WeededAst`, `DesugaredAst`, `NamedAst`, `ResolvedAst`, `KindedAst`, `TypedAst`, and `MonoAst` — on `Spec`/`Def`/`Sig`/`Redef`/`Op`, `Expr.LocalDef`, `JvmMethod`, and `HandlerRule`. `Resolution.LocalDef`, `ResolvedQName.LocalDef`, and `Completion.LocalDefCompletion` follow suit.

The backend ASTs (`SimplifiedAst`, `LiftedAst`, `ReducedAst`, `ErasedAst`, `JvmAst`) keep `List`; the `Simplifier` converts at the boundary. Closure parameters (`cparams`) can legitimately be empty and are untouched.

### `Nel` additions

Length-preserving operations return a `Nel`; the rest return a `List`, so callers rarely need to convert:

- `head`, `tail`, and `init` overrides, returning `T`, `List`, and `List`.
- `flatMap` and `collect`, returning a `List`.
- `map` (already present) and `zipWithIndex`, returning a `Nel`.
- `zip`, returning a `Nel` and matching `ListOps.zip` in crashing on length mismatch.
- `Nel.unsafeFrom`, which throws an `InternalCompilerException` on an empty list.

Helpers that take a declaration's formal parameters now take a `Nel` — `Resolver.mkFormalParamScp`, `CompletionUtils.getOpHandlerSnippet`, `Redundancy.findUnusedFormalParameters`, `Terminator.checkStrictPositivity`/`mkDecreasingFparams`, `Inliner.bindArgs`, `LambdaDrop.paramKinds`, `InlayHintProvider.mkDecreasingArgHints`, `FormatSignature.formatFormalParams`, `HtmlDocumentor.docFormalParams`. Helpers that receive a *truncated* parameter list keep `List`: `CompletionUtils.getApplySnippet` (drops the piped argument), `ConstraintGen.unifyFormalParams` (the handler rule's resumption is stripped), and the `DocAst` printers (shared with the backend ASTs, which keep `List`).

### Dead branches removed

Three places had a branch for the impossible empty case, now gone:

- `EntryPoints.checkUnitArg` threw an `InternalCompilerException` on zero parameters.
- `MagicDefCompleter.expMatchesLastArgType` returned `false` for `fparams.lastOption == None`.
- `Safety` and `Lowering` call `fparams.head` on `JvmMethod`, which is now total.

### Behaviour change in `LambdaDrop`

`LambdaDrop` splits a recursive higher-order function's parameters into *constant* ones (same value in every recursive call, so they can be closure-captured) and *non-constant* ones (which become the parameters of the introduced local def).

`isDroppable` only required at least one **constant** parameter. But if *every* parameter is constant — e.g. `def f(g: Int32 -> Int32): Int32 = f(g)` — then there are no non-constant parameters left, and `mkLocalDefExpr` built a `LocalDef` with an empty parameter list. That is an invalid AST today; `Nel` merely turns it into a type error.

So `isDroppable` now also requires at least one non-constant parameter, and `hasConstantParameter` was renamed to `hasDroppableParameters` to reflect that it checks both. Such definitions are now left alone instead of being rewritten.

I could not construct a `.flix` regression test for it: a function whose recursive call passes every parameter unchanged never terminates, so it cannot be exercised from a test. Happy to add one if you see an angle I missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
