### PR TITLE
refactor: split and rename files

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
@@ -186,14 +186,14 @@ object ConstraintGen {
 
   /**
     * Emits flow constraints for the default-handler calls that
-    * `SolutionLowering.wrapDefWithDefaultHandlers` synthesizes around entry points.
+    * `SpecializeAndLower.wrapDefWithDefaultHandlers` synthesizes around entry points.
     */
   private def entryPointHandlerFlows(defn: TypedAst.Def)(implicit sctx: SharedContext, tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg], root: TypedAst.Root, flix: Flix): Unit = ???
 
   /**
     * Emits flow constraints for all call sites and enum/struct construction sites in `exp`.
     * Datalog and channel nodes additionally emit constraints for the stdlib calls
-    * [[SolutionLowering]] will synthesize for them.
+    * [[SpecializeAndLower]] will synthesize for them.
     */
   private def visitExp(exp0: Expr)(implicit sctx: SharedContext, tparamEnv: Map[Symbol.KindedTypeVarSym, MonoArg], root: TypedAst.Root, flix: Flix): Unit = exp0 match {
     case Expr.Cst(_, _, _) => ()

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable
   * Constraint generation for constraint-based monomorphization: emits `Flow` constraints
   * describing how concrete types propagate through the program, for [[ConstraintSolver]] to solve.
   */
-object ConstraintCollection {
+object ConstraintGen {
 
   /**
     * The mutable data used throughout constraint generation.

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintMonomorphization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintMonomorphization.scala
@@ -33,7 +33,7 @@ import ca.uwaterloo.flix.language.ast.{MonoAst, TypedAst}
   *     recursion) before solving, so the next step cannot loop forever.
   *   - 3. [[ConstraintSolver]] solves the flow constraints to a fixpoint, producing the set of
   *     concrete type-argument tuples each polymorphic symbol must be specialized at.
-  *   - 4. [[SolutionSpecialization]] specializes (and lowers) every def/enum/struct/
+  *   - 4. [[Specialize]] specializes (and lowers) every def/enum/struct/
   *     restrictable-enum accordingly.
   *
   * Caution: step 4's lowering can synthesize references to specific stdlib defs/enums that step 1
@@ -47,6 +47,6 @@ object ConstraintMonomorphization {
     val constraints = ConstraintGen.generate(root)
     NonMonomorphizableCheck.checkMonomorphizable(constraints)
     val solution = ConstraintSolver.solve(constraints, root)
-    SolutionSpecialization.run(root, solution)
+    Specialize.run(root, solution)
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintMonomorphization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintMonomorphization.scala
@@ -26,7 +26,7 @@ import ca.uwaterloo.flix.language.ast.{MonoAst, TypedAst}
   *
   * At a high level, this pipeline works as follows:
   *
-  *   - 1. [[ConstraintCollection]] generates flow constraints describing how concrete types and
+  *   - 1. [[ConstraintGen]] generates flow constraints describing how concrete types and
   *     type shapes propagate into the type-parameter slots of every polymorphic def/enum/struct/
   *     restrictable-enum.
   *   - 2. [[NonMonomorphizableCheck]] rejects programs with no finite solution (e.g. polymorphic
@@ -44,7 +44,7 @@ object ConstraintMonomorphization {
 
   /** Performs constraint-based monomorphization of the given AST `root`. */
   def run(root: TypedAst.Root)(implicit flix: Flix): MonoAst.Root = {
-    val constraints = ConstraintCollection.generate(root)
+    val constraints = ConstraintGen.generate(root)
     NonMonomorphizableCheck.checkMonomorphizable(constraints)
     val solution = ConstraintSolver.solve(constraints, root)
     SolutionSpecialization.run(root, solution)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.TypedAst
 
 /**
-  * Solves the flow constraints produced by [[ConstraintCollection]] to a fixpoint: starting from
+  * Solves the flow constraints produced by [[ConstraintGen]] to a fixpoint: starting from
   * the ground (all-constant) flows, each newly solved tuple is substituted into the flows that
   * depend on it until no new tuples appear. Sig destinations are additionally dispatched to their
   * implementing (or default) def. The result is, per polymorphic symbol, exactly the ground

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Flow.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Flow.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Simon Lykke Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.monomorph2
+
+/**
+  * A component-wise flow constraint.
+  * Read as: "The type-argument tuple `args` flows into the parameter slots of `dst`."
+  */
+case class Flow(args: List[MonoArg], dst: MonoVar)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonoArg.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonoArg.scala
@@ -18,25 +18,6 @@ package ca.uwaterloo.flix.language.phase.monomorph2
 
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type}
 
-/**
-  * A monomorphization target-variable (def/enum/sig/struct/restrictable-enum) whose concrete
-  * type-argument tuple the solver determines, then substitutes back wherever `MonoArg.Param`
-  * references it.
-  */
-sealed trait MonoVar
-
-object MonoVar {
-  case class Def(sym: Symbol.DefnSym) extends MonoVar
-
-  case class Enum(sym: Symbol.EnumSym) extends MonoVar
-
-  case class Sig(sym: Symbol.SigSym) extends MonoVar
-
-  case class RestrictableEnum(sym: Symbol.RestrictableEnumSym) extends MonoVar
-
-  case class Struct(sym: Symbol.StructSym) extends MonoVar
-}
-
 /** A type argument that flows into a `MonoVar`. */
 sealed trait MonoArg
 
@@ -73,21 +54,3 @@ object MonoArg {
     case MonoArg.Assoc(_, a, _, _) => collectParams(a)
   }
 }
-
-/**
-  * A component-wise flow constraint.
-  * Read as: "The type-argument tuple `args` flows into the parameter slots of `dst`."
-  */
-case class Flow(args: List[MonoArg], dst: MonoVar)
-
-/**
-  * The result of constraint solving: for each polymorphic def/enum/struct/restrictable-enum
-  * symbol, the set of concrete type-argument tuples it must be specialized at. A restrictable
-  * enum's tuple always starts with its case-set index (`Kind.CaseSet`).
-  */
-case class Solution(
-  defs: Map[Symbol.DefnSym, Set[List[Type]]],
-  enums: Map[Symbol.EnumSym, Set[List[Type]]],
-  structs: Map[Symbol.StructSym, Set[List[Type]]],
-  restrictableEnums: Map[Symbol.RestrictableEnumSym, Set[List[Type]]]
-)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonoVar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonoVar.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Simon Lykke Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.monomorph2
+
+import ca.uwaterloo.flix.language.ast.Symbol
+
+/**
+  * A monomorphization target-variable (def/enum/sig/struct/restrictable-enum) whose concrete
+  * type-argument tuple the solver determines, then substitutes back wherever `MonoArg.Param`
+  * references it.
+  */
+sealed trait MonoVar
+
+object MonoVar {
+  case class Def(sym: Symbol.DefnSym) extends MonoVar
+
+  case class Enum(sym: Symbol.EnumSym) extends MonoVar
+
+  case class Sig(sym: Symbol.SigSym) extends MonoVar
+
+  case class RestrictableEnum(sym: Symbol.RestrictableEnumSym) extends MonoVar
+
+  case class Struct(sym: Symbol.StructSym) extends MonoVar
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonomorphCanon.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonomorphCanon.scala
@@ -27,7 +27,7 @@ import ca.uwaterloo.flix.util.collection.CofiniteSet
   * Shared definition of what a given (possibly non-ground) monomorph type becomes:
   * effect canonicalization and associated-type reduction.
   *
-  * Both [[ConstraintSolver]] and [[SolutionSpecialization]] must agree on this, or
+  * Both [[ConstraintSolver]] and [[Specialize]] must agree on this, or
   * their `(sym, type)` defTable keys diverge for the same instantiation.
   */
 private[monomorph2] object MonomorphCanon {

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Solution.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Solution.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Simon Lykke Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.monomorph2
+
+import ca.uwaterloo.flix.language.ast.{Symbol, Type}
+
+/**
+  * The result of constraint solving: for each polymorphic def/enum/struct/restrictable-enum
+  * symbol, the set of concrete type-argument tuples it must be specialized at. A restrictable
+  * enum's tuple always starts with its case-set index (`Kind.CaseSet`).
+  */
+case class Solution(
+  defs: Map[Symbol.DefnSym, Set[List[Type]]],
+  enums: Map[Symbol.EnumSym, Set[List[Type]]],
+  structs: Map[Symbol.StructSym, Set[List[Type]]],
+  restrictableEnums: Map[Symbol.RestrictableEnumSym, Set[List[Type]]]
+)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -23,12 +23,12 @@ import ca.uwaterloo.flix.language.ast.{MonoAst, TypedAst}
   * Solution-driven specialization: uses the solver's solution to specialize all def/enum/struct/
   * restrictable-enum in a single parallel pass.
   *
-  * `run` and [[SolutionLowering]] have different responsibilities: `run` builds the tables mapping
+  * `run` and [[SpecializeAndLower]] have different responsibilities: `run` builds the tables mapping
   * each original polymorphic symbol/instantiation to its fresh specialized symbol, and
-  * [[SolutionLowering]] does the actual `TypedAst`-to-`MonoAst` transformation, using those tables
+  * [[SpecializeAndLower]] does the actual `TypedAst`-to-`MonoAst` transformation, using those tables
   * to resolve which fresh symbol each call/tag/struct-access site should point to.
   */
-object SolutionSpecialization {
+object Specialize {
 
   /** Specializes `root` per `solution`, the constraint solver's output. */
   def run(root: TypedAst.Root, solution: Solution)(implicit flix: Flix): MonoAst.Root = ???


### PR DESCRIPTION
https://github.com/flix/flix/issues/12968 proposed changing `SolutionSpecialization.scala` -> `Specialize.scala`.
In the full code though the actual specialization step is split across two files:
1. `SolutionSpecialization.scala`: Responsible for setting up the substitutions and calling the AST-transformations in `SolutionLowering.scala`
2. `SolutionLowering.scala`: Responsible for doing the actual AST transformation (both specialization and lowering)
Right now I have renamed `SolutionSpecialization.scala` -> `Specialize.scala` and then changed the references to `SolutionLowering.scala` -> `SpecializeAndLower.scala` (pending its eventual inclusion where the file would be called that).

But I feel that these names are not very good but I have not been able to come up with any better ones.