### PR TITLE
refactor: comments, renaming and formatting of MonomorphCanon (renamed to Cannonicalization)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
@@ -41,13 +41,13 @@ private[monomorph2] object Canonicalization {
     * N.B.: `eff` must be simplified and ground.
     */
   def evalEff(eff: Type): CofiniteSet[Symbol.EffSym] = eff match {
-    case Type.Univ                                                                        => CofiniteSet.universe
-    case Type.Pure                                                                        => CofiniteSet.empty
-    case Type.Cst(TypeConstructor.Effect(sym, _), _)                                     => CofiniteSet.mkSet(sym)
-    case Type.Cst(TypeConstructor.Region(_), _)                                          => CofiniteSet.mkSet(Symbol.IO)
-    case Type.Alias(_, _, inner, _)                                                      => evalEff(inner)
-    case Type.Apply(Type.Cst(TypeConstructor.Complement, _), y, _)                       => CofiniteSet.complement(evalEff(y))
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Union, _), x, _), y, _)          => CofiniteSet.union(evalEff(x), evalEff(y))
+    case Type.Univ                                                                      => CofiniteSet.universe
+    case Type.Pure                                                                      => CofiniteSet.empty
+    case Type.Cst(TypeConstructor.Effect(sym, _), _)                                    => CofiniteSet.mkSet(sym)
+    case Type.Cst(TypeConstructor.Region(_), _)                                         => CofiniteSet.mkSet(Symbol.IO)
+    case Type.Alias(_, _, inner, _)                                                     => evalEff(inner)
+    case Type.Apply(Type.Cst(TypeConstructor.Complement, _), y, _)                      => CofiniteSet.complement(evalEff(y))
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Union, _), x, _), y, _)         => CofiniteSet.union(evalEff(x), evalEff(y))
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Intersection, _), x, _), y, _)  => CofiniteSet.intersection(evalEff(x), evalEff(y))
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Difference, _), x, _), y, _)    => CofiniteSet.difference(evalEff(x), evalEff(y))
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y, _) => CofiniteSet.xor(evalEff(x), evalEff(y))

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
@@ -32,11 +32,9 @@ import ca.uwaterloo.flix.util.collection.CofiniteSet
   */
 private[monomorph2] object Canonicalization {
 
-  // Copied from monomorph.Specialization.canonicalEffect
   /** Returns the canonical effect equivalent to `eff`. */
   def canonicalEffect(eff: Type): Type = coSetToType(evalEffect(eff), eff.loc)
 
-  // Copied from monomorph.Specialization.eval
   /**
     * Evaluates `eff`.
     *
@@ -56,14 +54,12 @@ private[monomorph2] object Canonicalization {
     case other => throw InternalCompilerException(s"Unexpected effect $other", other.loc)
   }
 
-  // Copied from monomorph.Specialization.coSetToType
   /** Returns the [[Type]] representation of `set` with `loc`. */
   def coSetToType(set: CofiniteSet[Symbol.EffSym], loc: SourceLocation): Type = set match {
     case CofiniteSet.Set(s)   => Type.mkUnion(s.toList.map(sym => Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc)), loc)
     case CofiniteSet.Compl(s) => Type.mkComplement(Type.mkUnion(s.toList.map(sym => Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc)), loc), loc)
   }
 
-  // Copied from monomorph.Specialization.reduceAssocType
   /** Reduces the given associated into its definition, will crash if not able to. */
   def reduceAssocType(assoc: Type.AssocType)(implicit root: TypedAst.Root, flix: Flix): Type = {
     val progress = Progress()
@@ -73,7 +69,6 @@ private[monomorph2] object Canonicalization {
     else throw InternalCompilerException(s"Could not reduce associated type $assoc", assoc.loc)
   }
 
-  // Ported from monomorph.Specialization.normalizeApply, with a small difference
   /**
     * Rebuilds `Type.Apply(normalize(tpe1), normalize(tpe2), loc)`, folding ground effect,
     * bool, and case-set/record-row/schema-row formulas via the same smart constructors used
@@ -110,7 +105,6 @@ private[monomorph2] object Canonicalization {
     }
   }
 
-  // Copied from monomorph.Specialization.simplify
   /**
     * Removes [[Type.Alias]] and [[Type.AssocType]], or crashes if some [[Type.AssocType]] is not
     * reducible.
@@ -130,7 +124,6 @@ private[monomorph2] object Canonicalization {
     case Type.UnresolvedJvmType(_, loc) => throw InternalCompilerException("unexpected JVM type", loc)
   }
 
-  // Copied from monomorph.Specialization.mkRecordExtendSorted
   /**
     * Returns a sorted record, assuming that `rest` is sorted.
     *
@@ -152,7 +145,6 @@ private[monomorph2] object Canonicalization {
     case Type.UnresolvedJvmType(_, _)  => throw InternalCompilerException(s"Unexpected JVM type '$rest'", rest.loc)
   }
 
-  // Copied from monomorph.Specialization.mkSchemaExtendSorted
   /**
     * Returns a sorted schema, assuming that `rest` is sorted.
     *

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
@@ -30,7 +30,7 @@ import ca.uwaterloo.flix.util.collection.CofiniteSet
   * Both [[ConstraintSolver]] and [[Specialize]] must agree on this, or
   * their `(sym, type)` defTable keys diverge for the same instantiation.
   */
-private[monomorph2] object MonomorphCanon {
+private[monomorph2] object Canonicalization {
 
   // Copied from monomorph.Specialization.canonicalEffect
   /** Returns the canonical effect equivalent to `eff`. */

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
@@ -33,24 +33,24 @@ import ca.uwaterloo.flix.util.collection.CofiniteSet
 private[monomorph2] object Canonicalization {
 
   /** Returns the canonical effect equivalent to `eff`. */
-  def canonicalEffect(eff: Type): Type = coSetToType(evalEffect(eff), eff.loc)
+  def canonicalEffect(eff: Type): Type = coSetToType(evalEff(eff), eff.loc)
 
   /**
     * Evaluates `eff`.
     *
     * N.B.: `eff` must be simplified and ground.
     */
-  def evalEffect(eff: Type): CofiniteSet[Symbol.EffSym] = eff match {
+  def evalEff(eff: Type): CofiniteSet[Symbol.EffSym] = eff match {
     case Type.Univ                                                                        => CofiniteSet.universe
     case Type.Pure                                                                        => CofiniteSet.empty
     case Type.Cst(TypeConstructor.Effect(sym, _), _)                                     => CofiniteSet.mkSet(sym)
     case Type.Cst(TypeConstructor.Region(_), _)                                          => CofiniteSet.mkSet(Symbol.IO)
-    case Type.Alias(_, _, inner, _)                                                      => evalEffect(inner)
-    case Type.Apply(Type.Cst(TypeConstructor.Complement, _), y, _)                       => CofiniteSet.complement(evalEffect(y))
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Union, _), x, _), y, _)          => CofiniteSet.union(evalEffect(x), evalEffect(y))
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Intersection, _), x, _), y, _)  => CofiniteSet.intersection(evalEffect(x), evalEffect(y))
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Difference, _), x, _), y, _)    => CofiniteSet.difference(evalEffect(x), evalEffect(y))
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y, _) => CofiniteSet.xor(evalEffect(x), evalEffect(y))
+    case Type.Alias(_, _, inner, _)                                                      => evalEff(inner)
+    case Type.Apply(Type.Cst(TypeConstructor.Complement, _), y, _)                       => CofiniteSet.complement(evalEff(y))
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Union, _), x, _), y, _)          => CofiniteSet.union(evalEff(x), evalEff(y))
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Intersection, _), x, _), y, _)  => CofiniteSet.intersection(evalEff(x), evalEff(y))
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Difference, _), x, _), y, _)    => CofiniteSet.difference(evalEff(x), evalEff(y))
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y, _) => CofiniteSet.xor(evalEff(x), evalEff(y))
     case other => throw InternalCompilerException(s"Unexpected effect $other", other.loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
@@ -32,13 +32,13 @@ import ca.uwaterloo.flix.util.collection.CofiniteSet
   */
 private[monomorph2] object Canonicalization {
 
-  /** Returns the canonical effect equivalent to `eff`. */
+  /** Puts the effect formula `eff` into canonical form. */
   def canonicalEffect(eff: Type): Type = coSetToType(evalEff(eff), eff.loc)
 
   /**
-    * Evaluates `eff`.
+    * Evaluates the effect formula `eff` to a set of atomic effects.
     *
-    * N.B.: `eff` must be simplified and ground.
+    * N.B. Throws [[InternalCompilerException]] if `eff` is not simplified and ground.
     */
   def evalEff(eff: Type): CofiniteSet[Symbol.EffSym] = eff match {
     case Type.Univ                                                                      => CofiniteSet.universe
@@ -54,13 +54,21 @@ private[monomorph2] object Canonicalization {
     case other => throw InternalCompilerException(s"Unexpected effect $other", other.loc)
   }
 
-  /** Returns the [[Type]] representation of `set` with `loc`. */
+  /**
+    * Renders `set` as a [[Type]] (the inverse of [[evalEff]]).
+    * - A finite [[CofiniteSet.Set]] becomes a union of `Effect` constants.
+    * - A [[CofiniteSet.Compl]] becomes the complement of one.
+    */
   def coSetToType(set: CofiniteSet[Symbol.EffSym], loc: SourceLocation): Type = set match {
     case CofiniteSet.Set(s)   => Type.mkUnion(s.toList.map(sym => Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc)), loc)
     case CofiniteSet.Compl(s) => Type.mkComplement(Type.mkUnion(s.toList.map(sym => Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc)), loc), loc)
   }
 
-  /** Reduces the given associated into its definition, will crash if not able to. */
+  /**
+    * Reduces the associated type `assoc` (e.g. `Foo.Assoc[a]`) to its concrete definition.
+    *
+    * N.B. Throws [[InternalCompilerException]] if `assoc` is not actually reducible.
+    */
   def reduceAssocType(assoc: Type.AssocType)(implicit root: TypedAst.Root, flix: Flix): Type = {
     val progress = Progress()
     val (res, cs) = TypeReduction2.reduce(assoc)(RegionScope.Top, RigidityEnv.empty, progress, root.eqEnv, flix)
@@ -70,11 +78,11 @@ private[monomorph2] object Canonicalization {
   }
 
   /**
-    * Rebuilds `Type.Apply(normalize(tpe1), normalize(tpe2), loc)`, folding ground effect,
-    * bool, and case-set/record-row/schema-row formulas via the same smart constructors used
-    * elsewhere, so the result matches what the specializer's query is built from (e.g. `{Cst} + {}`
-    * collapses to `{Cst}`, not a raw `CaseUnion` node; a ground effect formula collapses to its
-    * canonical union-of-constants form).
+    * Normalizes `app` by rebuilding it via the matching `Type.mk*` function for its head (e.g.
+    * `Type.mkUnion`, `Type.mkCaseUnion`, `Type.mkRecordRowExtend`).
+    *
+    * N.B. If `isGround` and the result has effect kind, it is further canonicalized via
+    * [[canonicalEffect]].
     */
   def normalizeApply(normalize: Type => Type, app: Type.Apply, isGround: Boolean): Type = {
     val Type.Apply(tpe1, tpe2, loc) = app
@@ -106,14 +114,17 @@ private[monomorph2] object Canonicalization {
   }
 
   /**
-    * Removes [[Type.Alias]] and [[Type.AssocType]], or crashes if some [[Type.AssocType]] is not
-    * reducible.
+    * Removes [[Type.Alias]] and [[Type.AssocType]] from `tpe`.
     *
-    * @param isGround If true, then `tpe` will be normalized.
+    * N.B. Throws [[InternalCompilerException]] if `tpe` contains a non-reducible [[Type.AssocType]]
+    * or an unresolved JVM type.
+    *
+    * N.B. If `isGround`, `tpe` is also put into canonical form. Only pass `true` once `tpe` has no
+    * free type variables left.
     */
   def simplify(tpe: Type, isGround: Boolean)(implicit root: TypedAst.Root, flix: Flix): Type = tpe match {
-    case v@Type.Var(_, _)          => v
-    case c@Type.Cst(_, _)          => c
+    case Type.Var(_, _)            => tpe
+    case Type.Cst(_, _)            => tpe
     case app@Type.Apply(_, _, _)   => normalizeApply(simplify(_, isGround), app, isGround)
     case Type.Alias(_, _, t, _)    => simplify(t, isGround)
     case Type.AssocType(symUse, arg0, kind, loc) =>
@@ -129,7 +140,7 @@ private[monomorph2] object Canonicalization {
     *
     * labels of the same name are not reordered.
     *
-    * N.B: `rest` must not contain [[Type.AssocType]] or [[Type.Alias]].
+    * N.B. `rest` must not contain [[Type.AssocType]] or [[Type.Alias]].
     */
   private def mkRecordExtendSorted(label: Name.Label, tpe: Type, rest: Type, loc: SourceLocation): Type = rest match {
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(l), loc1), t, loc2), r, loc3) if l.name < label.name =>
@@ -150,7 +161,7 @@ private[monomorph2] object Canonicalization {
     *
     * Sorting is stable on duplicate predicates.
     *
-    * Assumes that rest does not contain variables, aliases, or associated types.
+    * N.B. `rest` must not contain variables, aliases, or associated types.
     */
   private def mkSchemaExtendSorted(label: Name.Pred, tpe: Type, rest: Type, loc: SourceLocation): Type = rest match {
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(l), loc1), t, loc2), r, loc3) if l.name < label.name =>

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
@@ -137,7 +137,7 @@ object ConstraintGen {
     def dealiasedVisitType(tpe: Type): Unit = tpe match {
       case at @ Type.AssocType(_, arg, _, _) =>
         if (at.typeVars.isEmpty)
-          visitType(MonomorphCanon.reduceAssocType(at)(root, flix))
+          visitType(Canonicalization.reduceAssocType(at)(root, flix))
         else
           dealiasedVisitType(arg)
       case app @ Type.Apply(_, _, _)    =>
@@ -513,14 +513,14 @@ object ConstraintGen {
         tparamEnv.get(sym).getOrElse(MonoArg.Const(tpe))
       case at @ Type.AssocType(symUse, arg, kind, assocLoc) =>
         if (tpe.typeVars.isEmpty)
-          MonoArg.Const(MonomorphCanon.reduceAssocType(at)(root, flix))
+          MonoArg.Const(Canonicalization.reduceAssocType(at)(root, flix))
         else
           MonoArg.Assoc(symUse.sym, dealiasedTypeToMonoArg(arg), kind, assocLoc)
       case Type.Cst(_, _) =>
         MonoArg.Const(tpe)
       case Type.Apply(_, _, _) =>
         if (tpe.kind == Kind.Eff && tpe.typeVars.isEmpty)
-          MonoArg.Const(MonomorphCanon.simplify(tpe, isGround = true)(root, flix))
+          MonoArg.Const(Canonicalization.simplify(tpe, isGround = true)(root, flix))
         else {
           MonoArg.App(dealiasedTypeToMonoArg(tpe.baseType), tpe.typeArguments.map(arg => dealiasedTypeToMonoArg(arg)))
         }


### PR DESCRIPTION
Addresses some of the remarks made in https://github.com/flix/flix/issues/12968.
