### PR TITLE
refactor: take Nel of parameter types in the arrow constructors

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{AssocTypeSymUse, TypeAliasSymUse}
 import ca.uwaterloo.flix.language.ast.shared.VarText.Absent
 import ca.uwaterloo.flix.language.fmt.{FormatOptions, FormatType}
-import ca.uwaterloo.flix.util.collection.CofiniteSet
+import ca.uwaterloo.flix.util.collection.{CofiniteSet, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
 
 import java.util.Objects
@@ -851,72 +851,48 @@ object Type {
 
   /**
     * Constructs the pure curried arrow type A_1 -> (A_2  -> ... -> A_n) -> B.
-    *
-    * Returns `b` if `as` is empty.
     */
-  def mkPureCurriedArrow(as: List[Type], b: Type, loc: SourceLocation): Type = mkCurriedArrowWithEffect(as, Pure, b, loc)
+  def mkPureCurriedArrow(as: Nel[Type], b: Type, loc: SourceLocation): Type = mkCurriedArrowWithEffect(as, Pure, b, loc)
 
   /**
     * Constructs the curried arrow type A_1 -> (A_2  -> ... -> A_n) -> B \ e.
-    *
-    * Returns `b` if `as` is empty.
     */
-  def mkCurriedArrowWithEffect(as: List[Type], p: Type, b: Type, loc: SourceLocation): Type = {
-    if (as.isEmpty) {
-      b
-    } else {
-      val a = as.last
-      val base = mkArrowWithEffect(a, p, b, loc)
-      as.init.foldRight(base)(mkPureArrow(_, _, loc))
-    }
+  def mkCurriedArrowWithEffect(as: Nel[Type], p: Type, b: Type, loc: SourceLocation): Type = {
+    val a = as.last
+    val base = mkArrowWithEffect(a, p, b, loc)
+    as.init.foldRight(base)(mkPureArrow(_, _, loc))
   }
 
   /**
     * Constructs the pure uncurried arrow type (A_1, ..., A_n) -> B.
-    *
-    * Returns `b` if `as` is empty.
     */
-  def mkPureUncurriedArrow(as: List[Type], b: Type, loc: SourceLocation): Type = mkUncurriedArrowWithEffect(as, Pure, b, loc)
+  def mkPureUncurriedArrow(as: Nel[Type], b: Type, loc: SourceLocation): Type = mkUncurriedArrowWithEffect(as, Pure, b, loc)
 
   /**
     * Constructs the IO uncurried arrow type (A_1, ..., A_n) -> B \ IO.
-    *
-    * Returns `b` if `as` is empty.
     */
-  def mkIoUncurriedArrow(as: List[Type], b: Type, loc: SourceLocation): Type = mkUncurriedArrowWithEffect(as, IO, b, loc)
+  def mkIoUncurriedArrow(as: Nel[Type], b: Type, loc: SourceLocation): Type = mkUncurriedArrowWithEffect(as, IO, b, loc)
 
   /**
     * Constructs the uncurried arrow type (A_1, ..., A_n) -> B \ p.
-    *
-    * Returns `b` if `as` is empty.
     */
-  def mkUncurriedArrowWithEffect(as: List[Type], p: Type, b: Type, loc: SourceLocation): Type = {
-    if (as.isEmpty) {
-      b
-    } else {
-      val arrow = mkApply(Type.Cst(TypeConstructor.Arrow(as.length + 1), loc), List(p), loc)
-      val inner = as.foldLeft(arrow: Type) {
-        case (acc, x) => Apply(acc, x, loc)
-      }
-      Apply(inner, b, loc)
+  def mkUncurriedArrowWithEffect(as: Nel[Type], p: Type, b: Type, loc: SourceLocation): Type = {
+    val arrow = mkApply(Type.Cst(TypeConstructor.Arrow(as.length + 1), loc), List(p), loc)
+    val inner = as.foldLeft(arrow: Type) {
+      case (acc, x) => Apply(acc, x, loc)
     }
+    Apply(inner, b, loc)
   }
 
   /**
     * Constructs the backend arrow type (A_1, ..., A_n) -> B.
-    *
-    * Returns `b` if `as` is empty.
     */
-  def mkArrowWithoutEffect(as: List[Type], b: Type, loc: SourceLocation): Type = {
-    if (as.isEmpty) {
-      b
-    } else {
-      val arrow = Type.Cst(TypeConstructor.ArrowWithoutEffect(as.length + 1), loc)
-      val inner = as.foldLeft(arrow: Type) {
-        case (acc, x) => Apply(acc, x, loc)
-      }
-      Apply(inner, b, loc)
+  def mkArrowWithoutEffect(as: Nel[Type], b: Type, loc: SourceLocation): Type = {
+    val arrow = Type.Cst(TypeConstructor.ArrowWithoutEffect(as.length + 1), loc)
+    val inner = as.foldLeft(arrow: Type) {
+      case (acc, x) => Apply(acc, x, loc)
     }
+    Apply(inner, b, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -208,7 +208,7 @@ object Deriver {
           Nil,
           List(TraitConstraint(TraitSymUse(eqTraitSym, loc), tpe, loc)),
           Nil,
-          Type.mkPureUncurriedArrow(List(tpe, tpe), Type.mkBool(loc), loc)
+          Type.mkPureUncurriedArrow(Nel(tpe, List(tpe)), Type.mkBool(loc), loc)
         ),
         tpe = Type.mkBool(loc),
         eff = Some(Type.Cst(TypeConstructor.Pure, loc)),
@@ -393,7 +393,7 @@ object Deriver {
           Nil,
           List(TraitConstraint(TraitSymUse(orderTraitSym, loc), tpe, loc)),
           Nil,
-          Type.mkPureUncurriedArrow(List(tpe, tpe), Type.mkEnum(comparisonEnumSym, Kind.Star, loc), loc)
+          Type.mkPureUncurriedArrow(Nel(tpe, List(tpe)), Type.mkEnum(comparisonEnumSym, Kind.Star, loc), loc)
         ),
         tpe = Type.mkEnum(comparisonEnumSym, Kind.Star, loc),
         eff = Some(Type.Cst(TypeConstructor.Pure, loc)),

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.{AssocTypeSymUse, DefSymUse,
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.KindError
 import ca.uwaterloo.flix.language.phase.unification.KindUnification.unify
-import ca.uwaterloo.flix.util.collection.ListOps
+import ca.uwaterloo.flix.util.collection.{ListOps, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -189,7 +189,11 @@ object Kinder {
     case ResolvedAst.Declaration.Case(sym, tpes0, loc) =>
       val ts = tpes0.map(visitType(_, Kind.Star, kenv, root))
       val quants = tparams.map(_.sym)
-      val schemeBase = Type.mkPureUncurriedArrow(ts, resTpe, sym.loc.asSynthetic)
+      // A nullary case is not a function, but the enum type itself.
+      val schemeBase = ts match {
+        case Nil => resTpe
+        case t :: tail => Type.mkPureUncurriedArrow(Nel(t, tail), resTpe, sym.loc.asSynthetic)
+      }
       val sc = Scheme(quants, Nil, Nil, schemeBase)
       KindedAst.Case(sym, ts, sc, loc)
   }
@@ -210,7 +214,11 @@ object Kinder {
     case ResolvedAst.Declaration.RestrictableCase(sym, tpes0, loc) =>
       val ts = tpes0.map(visitType(_, Kind.Star, kenv, root))
       val quants = (index :: tparams).map(_.sym)
-      val schemeBase = Type.mkPureUncurriedArrow(ts, resTpe, sym.loc.asSynthetic)
+      // A nullary case is not a function, but the enum type itself.
+      val schemeBase = ts match {
+        case Nil => resTpe
+        case t :: tail => Type.mkPureUncurriedArrow(Nel(t, tail), resTpe, sym.loc.asSynthetic)
+      }
       val sc = Scheme(quants, Nil, Nil, schemeBase)
       KindedAst.RestrictableCase(sym, ts, sc, loc) // TODO RESTR-VARS the scheme is different for these. REVISIT
   }
@@ -374,7 +382,7 @@ object Kinder {
           visitEqualityConstraint(symUse, arg, tpe2, loc, kenv, root)
       }
       val allQuantifiers = quantifiers ::: tparams.map(_.sym)
-      val base = Type.mkUncurriedArrowWithEffect(fparams.toList.map(_.tpe), eff.getOrElse(Type.Pure), tpe, tpe.loc)
+      val base = Type.mkUncurriedArrowWithEffect(fparams.map(_.tpe), eff.getOrElse(Type.Pure), tpe, tpe.loc)
       val sc = Scheme(allQuantifiers, tconstrs, econstrs, base)
       KindedAst.Spec(doc, ann, mod, tparams, fparams, sc, tpe, eff, tconstrs, econstrs)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.CaseSymUse
 import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Modifiers, Mutability, RegionScope}
 import ca.uwaterloo.flix.language.ast.{Purity, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
-import ca.uwaterloo.flix.util.collection.{ListOps, MapOps}
+import ca.uwaterloo.flix.util.collection.{ListOps, MapOps, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 import scala.annotation.tailrec
@@ -540,7 +540,7 @@ object Simplifier {
             // Arrow type arguments are ordered (effect, args.., result type).
             val _ :: targs = tpe.typeArguments
             val (args, List(res)) = targs.splitAt(targs.length - 1)
-            Type.mkArrowWithoutEffect(args.map(visitPolyType), visitPolyType(res), loc)
+            Type.mkArrowWithoutEffect(Nel.unsafeFrom(args.map(visitPolyType)), visitPolyType(res), loc)
 
           case TypeConstructor.RecordRowExtend(label) =>
             val List(labelType, restType) = tpe.typeArguments

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -193,7 +193,7 @@ object TypeReconstruction {
       val e2 = visitExp(exp2)
       val tpe = e2.tpe
       val eff = e2.eff
-      val boundType = Type.mkUncurriedArrowWithEffect(fps.toList.map(_.tpe), e1.tpe, e1.eff, SourceLocation.Unknown)
+      val boundType = Type.mkUncurriedArrowWithEffect(fps.map(_.tpe), e1.tpe, e1.eff, SourceLocation.Unknown)
       val bnd = TypedAst.Binder(sym, boundType)
       TypedAst.Expr.LocalDef(ann, bnd, fps, e1, e2, tpe, eff, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -913,7 +913,7 @@ object Lowering {
     // by just checking the length of the handlers and if it is greater than 0
     // just adding IO. However, that would only work while default handlers can only generate IO.
     val eff = Type.mkUnion(effDif, Type.IO, effLoc)
-    val tpe = Type.mkCurriedArrowWithEffect(defn.spec.fparams.toList.map(_.tpe), eff, defn.spec.retTpe, baseTypeLoc)
+    val tpe = Type.mkCurriedArrowWithEffect(defn.spec.fparams.map(_.tpe), eff, defn.spec.retTpe, baseTypeLoc)
     val spec = defn.spec.copy(
       declaredScheme = defn.spec.declaredScheme.copy(base = tpe),
       eff = eff,
@@ -1188,7 +1188,7 @@ object Lowering {
     val valueSym = mkLetSym("value", loc)
     val chanVar = MonoAst.Expr.Var(chanSym, exp1.tpe, loc)
     val valueVar = MonoAst.Expr.Var(valueSym, exp2.tpe, loc)
-    val itpe = lowerType(Type.mkIoUncurriedArrow(List(exp2.tpe, exp1.tpe), Type.Unit, loc))
+    val itpe = lowerType(Type.mkIoUncurriedArrow(Nel(exp2.tpe, List(exp1.tpe)), Type.Unit, loc))
     val defnSym = lookup(Defs.ChannelPut, itpe)
     val putExp = MonoAst.Expr.ApplyDef(defnSym, List(valueVar, chanVar), itpe, Type.Unit, eff, loc)
     // The channel binding is the outermost let, so the channel is evaluated before the value.
@@ -1270,7 +1270,7 @@ object Lowering {
     val locksType = Types.mkList(Types.ConcurrentReentrantLock, loc)
 
     val selectRetTpe = Type.mkTuple(List(Type.Int32, locksType), loc)
-    val itpe = Type.mkIoUncurriedArrow(List(admins.tpe, Type.Bool), selectRetTpe, loc)
+    val itpe = Type.mkIoUncurriedArrow(Nel(admins.tpe, List(Type.Bool)), selectRetTpe, loc)
     val blocking = default match {
       case Some(_) => MonoAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc)
       case None => MonoAst.Expr.Cst(Constant.Bool(true), Type.Bool, loc)
@@ -1299,7 +1299,7 @@ object Lowering {
         val locksSym = mkLetSym("locks", loc)
         val pat = mkTuplePattern(Nel(MonoAst.Pattern.Cst(Constant.Int32(i), Type.Int32, loc), List(MonoAst.Pattern.Var(locksSym, locksType, Occur.Unknown, loc))), loc)
         val getTpe = extractChannelTpe(chan.tpe)
-        val itpe = lowerType(Type.mkIoUncurriedArrow(List(chan.tpe, locksType), getTpe, loc))
+        val itpe = lowerType(Type.mkIoUncurriedArrow(Nel(chan.tpe, List(locksType)), getTpe, loc))
         val args = List(MonoAst.Expr.Var(chSym, lowerType(chan.tpe), loc), MonoAst.Expr.Var(locksSym, locksType, loc))
         val defnSym = lookup(Defs.ChannelUnsafeGetAndUnlock, itpe)
         val getExp = MonoAst.Expr.ApplyDef(defnSym, args, lowerType(itpe), lowerType(getTpe), eff, loc)
@@ -1564,7 +1564,7 @@ object Lowering {
     val predArity = selects.length
 
     // Define the name and type of the appropriate factsX function in Solver.flix
-    val defTpe = Type.mkPureUncurriedArrow(List(Types.PredSym, Types.Datalog), tpe, loc)
+    val defTpe = Type.mkPureUncurriedArrow(Nel(Types.PredSym, List(Types.Datalog)), tpe, loc)
     val sym = lookup(Defs.Facts(predArity), defTpe)
 
     // Merge and solve exps
@@ -1615,7 +1615,7 @@ object Lowering {
     val loweredExps = exps.zip(predsAndArities).map {
       case (exp, PredicateAndArity(pred, arity)) =>
         // The type of the function.
-        val defTpe = Type.mkPureUncurriedArrow(List(Types.PredSym, lowerType(exp.tpe)), Types.Datalog, loc)
+        val defTpe = Type.mkPureUncurriedArrow(Nel(Types.PredSym, List(lowerType(exp.tpe))), Types.Datalog, loc)
 
         // Compute the symbol of the function.
         val sym = lookup(Defs.ProjectInto(arity), defTpe)
@@ -1776,7 +1776,7 @@ object Lowering {
     *
     * Note: liftX and liftXb are similar and should probably be maintained together.
     */
-  private def liftX(exp0: MonoAst.Expr, argTypes: List[Type], resultType: Type)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.Expr = {
+  private def liftX(exp0: MonoAst.Expr, argTypes: Nel[Type], resultType: Type)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.Expr = {
     //
     // The liftX family of functions are of the form: a -> b -> c -> `resultType` and
     // returns a function of the form Boxed -> Boxed -> Boxed -> Boxed -> Boxed`.
@@ -1802,7 +1802,7 @@ object Lowering {
   /**
     * Lifts the given Boolean-valued lambda expression `exp0` with the given argument types `argTypes`.
     */
-  private def liftXb(exp0: MonoAst.Expr, argTypes: List[Type])(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.Expr = {
+  private def liftXb(exp0: MonoAst.Expr, argTypes: Nel[Type])(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.Expr = {
     //
     // The liftX family of functions are of the form: a -> b -> c -> Bool and
     // returns a function of the form Boxed -> Boxed -> Boxed -> Boxed -> Bool.
@@ -1837,7 +1837,11 @@ object Lowering {
     //
 
     // The type of the function argument, i.e. i1 -> i2 -> i3 -> Vector[(o1, o2, o3, ...)].
-    val argType = Type.mkPureCurriedArrow(argTypes, resultType, loc)
+    // With no in variables the `lift0XY` functions take the vector directly, rather than a function.
+    val argType = argTypes match {
+      case Nil => resultType
+      case t :: ts => Type.mkPureCurriedArrow(Nel(t, ts), resultType, loc)
+    }
 
     // The type of the returned function, i.e. Vector[Boxed] -> Vector[Vector[Boxed]].
     val returnType = Type.mkPureArrow(Type.mkVector(Types.Boxed, loc), Type.mkVector(Type.mkVector(Types.Boxed, loc), loc), loc)
@@ -1994,7 +1998,7 @@ object Lowering {
     }
 
     // Lift the lambda expression to operate on boxed values.
-    val liftedExp = liftXb(lambdaExp, fvs.map(_._2))
+    val liftedExp = liftXb(lambdaExp, Nel.unsafeFrom(fvs.map(_._2)))
 
     // Construct the `Fixpoint/Ast/Datalog.BodyPredicate` value.
     val varExps = fvs.map(kv => mkVarSym(kv._1))
@@ -2077,7 +2081,8 @@ object Lowering {
     }
 
     // Lift the lambda expression to operate on boxed values.
-    val liftedExp = liftX(lambdaExp, fvs.map(_._2), exp.tpe)
+    // `fvs` is non-empty since the caller falls back to a literal head term when there are no free variables.
+    val liftedExp = liftX(lambdaExp, Nel.unsafeFrom(fvs.map(_._2)), exp.tpe)
 
     // Construct the `Fixpoint/Ast/Datalog.BodyPredicate` value.
     val varExps = fvs.map(kv => mkVarSym(kv._1))
@@ -2494,8 +2499,8 @@ object Lowering {
     * where `"terms" == termsVar.text`.
     */
   private def mkUnboxedTerm(termsVar: Symbol.VarSym, tpe: Type, i: Int, loc: SourceLocation)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.Expr = {
-    val outerItpe = Type.mkPureUncurriedArrow(List(Types.Boxed), tpe, loc)
-    val innerItpe = Type.mkPureUncurriedArrow(List(Type.Int32, Types.VectorOfBoxed), Types.Boxed, loc)
+    val outerItpe = Type.mkPureUncurriedArrow(Nel(Types.Boxed, Nil), tpe, loc)
+    val innerItpe = Type.mkPureUncurriedArrow(Nel(Type.Int32, List(Types.VectorOfBoxed)), Types.Boxed, loc)
     MonoAst.Expr.ApplyDef(
       sym = lookup(Defs.Unbox, outerItpe),
       exps = List(

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Symbols.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Symbols.scala
@@ -18,6 +18,7 @@
 package ca.uwaterloo.flix.language.phase.monomorph
 
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.util.collection.Nel
 
 object Symbols {
   protected[monomorph] object Defs {
@@ -107,18 +108,20 @@ object Symbols {
     // Function Types.
     //
     lazy val SolveType: Type = Type.mkPureArrow(Datalog, Datalog, SourceLocation.Unknown)
-    lazy val MergeType: Type = Type.mkPureUncurriedArrow(List(Datalog, Datalog), Datalog, SourceLocation.Unknown)
-    lazy val FilterType: Type = Type.mkPureUncurriedArrow(List(PredSym, Datalog), Datalog, SourceLocation.Unknown)
-    lazy val RenameType: Type = Type.mkPureUncurriedArrow(List(mkList(PredSym, SourceLocation.Unknown), Datalog), Datalog, SourceLocation.Unknown)
+    lazy val MergeType: Type = Type.mkPureUncurriedArrow(Nel(Datalog, List(Datalog)), Datalog, SourceLocation.Unknown)
+    lazy val FilterType: Type = Type.mkPureUncurriedArrow(Nel(PredSym, List(Datalog)), Datalog, SourceLocation.Unknown)
+    lazy val RenameType: Type = Type.mkPureUncurriedArrow(Nel(mkList(PredSym, SourceLocation.Unknown), List(Datalog)), Datalog, SourceLocation.Unknown)
 
     def mkProvenanceOf(t: Type, loc: SourceLocation): Type =
       Type.mkPureUncurriedArrow(
-        List(
+        Nel(
           PredSym,
-          Type.mkVector(Boxed, loc),
-          Type.mkVector(PredSym, loc),
-          Type.mkPureCurriedArrow(List(PredSym, Type.mkVector(Boxed, loc)), t, loc),
-          Datalog
+          List(
+            Type.mkVector(Boxed, loc),
+            Type.mkVector(PredSym, loc),
+            Type.mkPureCurriedArrow(Nel(PredSym, List(Type.mkVector(Boxed, loc))), t, loc),
+            Datalog
+          )
         ),
         Type.mkVector(t, loc), loc
       )

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Symbols.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Symbols.scala
@@ -18,6 +18,7 @@
 package ca.uwaterloo.flix.language.phase.monomorph2
 
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.util.collection.Nel
 
 /**
   * A collection of symbols defined in the Flix Standard Library that this pipeline's Channel and
@@ -144,18 +145,20 @@ private[monomorph2] object Symbols {
       object Solver {
         // Synthetic, these are not real stdlib declarations, just the corresponding def's arrow type.
         lazy val SolveType: Type = Type.mkPureArrow(Types.Fixpoint.Ast.Datalog.Datalog, Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
-        lazy val MergeType: Type = Type.mkPureUncurriedArrow(scala.collection.immutable.List(Types.Fixpoint.Ast.Datalog.Datalog, Types.Fixpoint.Ast.Datalog.Datalog), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
-        lazy val FilterType: Type = Type.mkPureUncurriedArrow(scala.collection.immutable.List(Types.Fixpoint.Ast.Shared.PredSym, Types.Fixpoint.Ast.Datalog.Datalog), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
-        lazy val RenameType: Type = Type.mkPureUncurriedArrow(scala.collection.immutable.List(Types.List.mkList(Types.Fixpoint.Ast.Shared.PredSym, SourceLocation.Unknown), Types.Fixpoint.Ast.Datalog.Datalog), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
+        lazy val MergeType: Type = Type.mkPureUncurriedArrow(Nel(Types.Fixpoint.Ast.Datalog.Datalog, scala.collection.immutable.List(Types.Fixpoint.Ast.Datalog.Datalog)), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
+        lazy val FilterType: Type = Type.mkPureUncurriedArrow(Nel(Types.Fixpoint.Ast.Shared.PredSym, scala.collection.immutable.List(Types.Fixpoint.Ast.Datalog.Datalog)), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
+        lazy val RenameType: Type = Type.mkPureUncurriedArrow(Nel(Types.List.mkList(Types.Fixpoint.Ast.Shared.PredSym, SourceLocation.Unknown), scala.collection.immutable.List(Types.Fixpoint.Ast.Datalog.Datalog)), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
 
         def mkProvenanceOf(t: Type, loc: SourceLocation): Type =
           Type.mkPureUncurriedArrow(
-            scala.collection.immutable.List(
+            Nel(
               Types.Fixpoint.Ast.Shared.PredSym,
-              Type.mkVector(Types.Fixpoint.Boxed, loc),
-              Type.mkVector(Types.Fixpoint.Ast.Shared.PredSym, loc),
-              Type.mkPureCurriedArrow(scala.collection.immutable.List(Types.Fixpoint.Ast.Shared.PredSym, Type.mkVector(Boxed, loc)), t, loc),
-              Types.Fixpoint.Ast.Datalog.Datalog
+              scala.collection.immutable.List(
+                Type.mkVector(Types.Fixpoint.Boxed, loc),
+                Type.mkVector(Types.Fixpoint.Ast.Shared.PredSym, loc),
+                Type.mkPureCurriedArrow(Nel(Types.Fixpoint.Ast.Shared.PredSym, scala.collection.immutable.List(Type.mkVector(Boxed, loc))), t, loc),
+                Types.Fixpoint.Ast.Datalog.Datalog
+              )
             ),
             Type.mkVector(t, loc), loc
           )

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.{DefSymUse, LocalDefSymUse, 
 import ca.uwaterloo.flix.language.ast.shared.{CheckedCastType, RegionScope, VarText}
 import ca.uwaterloo.flix.language.ast.{Kind, KindedAst, Name, Scheme, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.unification.Substitution
-import ca.uwaterloo.flix.util.collection.ListOps
+import ca.uwaterloo.flix.util.collection.{ListOps, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils, Subeffecting}
 
 import java.lang.reflect.{Modifier, ParameterizedType, TypeVariable}
@@ -104,13 +104,13 @@ object ConstraintGen {
         // If no effect specified, we assume the function is pure
         val declaredEff = subst(defn.spec.eff.getOrElse(Type.Pure))
         val declaredResultType = generalizeVoid(subst(defn.spec.tpe))
-        val declaredArgumentTypes = defn.spec.fparams.toList.map(_.tpe).map(subst.apply)
+        val declaredArgumentTypes = defn.spec.fparams.map(_.tpe).map(subst.apply)
         val declaredType = Type.mkUncurriedArrowWithEffect(declaredArgumentTypes, declaredEff, declaredResultType, loc2)
 
         val (tpes, effs) = exps.map(visitExp).unzip
 
         c.unifyType(itvar, declaredType, loc2)
-        c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
+        c.expectTypeArguments(sym, declaredArgumentTypes.toList, tpes, exps.map(_.loc))
         c.addClassConstraints(tconstrs, loc2)
         c.addEqualityConstraints(econstrs, loc2)
         c.unifyType(tvar, declaredResultType, loc2)
@@ -123,7 +123,7 @@ object ConstraintGen {
       case Expr.ApplyLocalDef(LocalDefSymUse(sym, loc1), exps, arrowTvar, tvar, evar, loc2) =>
         val (tpes, effs) = exps.map(visitExp).unzip
         val defEff = freshVar(Kind.Eff, loc1)
-        val actualDefTpe = Type.mkUncurriedArrowWithEffect(tpes, defEff, tvar, loc1)
+        val actualDefTpe = Type.mkUncurriedArrowWithEffect(Nel.unsafeFrom(tpes), defEff, tvar, loc1)
         c.unifyType(actualDefTpe, arrowTvar, loc1)
         c.expectType(sym.tvar, actualDefTpe, loc1)
         c.unifyType(evar, Type.mkUnion(defEff :: effs, loc2), loc2)
@@ -160,11 +160,11 @@ object ConstraintGen {
 
         val declaredEff = subst(sig.spec.eff.getOrElse(Type.Pure))
         val declaredResultType = subst(sig.spec.tpe)
-        val declaredArgumentTypes = sig.spec.fparams.toList.map(_.tpe).map(subst.apply)
+        val declaredArgumentTypes = sig.spec.fparams.map(_.tpe).map(subst.apply)
         val declaredType = Type.mkUncurriedArrowWithEffect(declaredArgumentTypes, declaredEff, declaredResultType, loc1)
 
         val (tpes, effs) = exps.map(visitExp).unzip
-        c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
+        c.expectTypeArguments(sym, declaredArgumentTypes.toList, tpes, exps.map(_.loc))
         c.addClassConstraints(tconstrs, loc2)
         c.addEqualityConstraints(econstrs, loc2)
         c.unifyType(itvar, declaredType, loc2)
@@ -489,7 +489,7 @@ object ConstraintGen {
           enabled && !useless
         }
         val defEff = if (shouldSubeffect) Type.mkUnion(eff1, Type.freshEffSlackVar(loc), loc) else eff1
-        val defTpe = Type.mkUncurriedArrowWithEffect(fparams.toList.map(_.tpe), defEff, tpe1, sym.loc)
+        val defTpe = Type.mkUncurriedArrowWithEffect(fparams.map(_.tpe), defEff, tpe1, sym.loc)
         c.unifyType(sym.tvar, defTpe, sym.loc)
         val (tpe2, eff2) = visitExp(exp2)
         val resTpe = tpe2
@@ -582,7 +582,11 @@ object ConstraintGen {
 
         // The tag type is a function from the types of terms to the type of the enum.
         val (tpes, effs) = exps.map(visitExp).unzip
-        val constructorBase = Type.mkPureUncurriedArrow(tpes, tvar, loc)
+        // A nullary tag is not a function, but the enum type itself.
+        val constructorBase = tpes match {
+          case Nil => tvar
+          case t :: ts => Type.mkPureUncurriedArrow(Nel(t, ts), tvar, loc)
+        }
         c.unifyType(tagType, constructorBase, loc)
         val resTpe = tvar
         val resEff = Type.mkUnion(effs, loc)
@@ -1152,7 +1156,11 @@ object ConstraintGen {
 
         // The tag type is a function from the type of variant to the type of the enum.
         val tpes = pats.map(visitPattern)
-        val constructorBase = if (tpes.nonEmpty) Type.mkPureUncurriedArrow(tpes, tvar, loc) else tvar
+        // A nullary tag is not a function, but the enum type itself.
+        val constructorBase = tpes match {
+          case Nil => tvar
+          case t :: ts => Type.mkPureUncurriedArrow(Nel(t, ts), tvar, loc)
+        }
         c.unifyType(tagType, constructorBase, loc)
         tvar
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/RestrictableChooseConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/RestrictableChooseConstraintGen.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.RestrictableEnumSymUse
 import ca.uwaterloo.flix.language.ast.{Kind, KindedAst, Scheme, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.typer.ConstraintGen.visitExp
 import ca.uwaterloo.flix.util.InternalCompilerException
-import ca.uwaterloo.flix.util.collection.ListOps
+import ca.uwaterloo.flix.util.collection.{ListOps, Nel}
 
 import scala.collection.immutable.SortedSet
 
@@ -246,7 +246,11 @@ object RestrictableChooseConstraintGen {
         //
         // Γ ⊢ e: τ
         val (tpes, effs) = exps.map(visitExp).unzip
-        val constructorBase = Type.mkPureUncurriedArrow(tpes, enumType, loc)
+        // A nullary tag is not a function, but the enum type itself.
+        val constructorBase = tpes match {
+          case Nil => enumType
+          case t :: ts => Type.mkPureUncurriedArrow(Nel(t, ts), enumType, loc)
+        }
         c.unifyType(tagType, constructorBase, loc)
         ListOps.zip(targs, targsOut).foreach { case (targ, targOut) => c.unifyType(targ, targOut, loc) }
         //        _ <- indexUnification // TODO ASSOC-TYPES here is where we did the index unification before
@@ -354,7 +358,11 @@ object RestrictableChooseConstraintGen {
         // The tag type is a function from the type of variant to the type of the enum.
         //
         val tpes = pat.map(visitVarOrWild)
-        val constructorBase = Type.mkPureUncurriedArrow(tpes, tvar, loc)
+        // A nullary tag is not a function, but the enum type itself.
+        val constructorBase = tpes match {
+          case Nil => tvar
+          case t :: ts => Type.mkPureUncurriedArrow(Nel(t, ts), tvar, loc)
+        }
         c.unifyType(tagType, constructorBase, loc)
         val resTpe = tvar
         resTpe

--- a/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
@@ -39,6 +39,9 @@ case class Nel[T](x: T, xs: List[T]) extends Iterable[T] {
   /** Returns all elements of `this` except the last. */
   override def init: List[T] = if (xs.isEmpty) Nil else x :: xs.init
 
+  /** Returns the last element of `this`. */
+  override def last: T = if (xs.isEmpty) x else xs.last
+
   /** Builds a new [[Nel]] by applying `f` to all elements of `this`. */
   override def map[S](f: T => S): Nel[S] = Nel(f(x), xs.map(f))
 

--- a/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.ast.shared.SymUse.TypeAliasSymUse
 import ca.uwaterloo.flix.language.ast.shared.{RegionScope, VarText}
 import ca.uwaterloo.flix.language.ast.{Kind, Name, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.util.collection.Nel
 import org.scalatest.funsuite.AnyFunSuite
 
 class TestFormatType extends AnyFunSuite with TestUtils {
@@ -130,7 +131,7 @@ class TestFormatType extends AnyFunSuite with TestUtils {
   }
 
   test("FormatType.Arrow.External.04") {
-    val tpe = Type.mkIoUncurriedArrow(Type.Int8 :: Type.Int16 :: Nil, Type.Int32, loc)
+    val tpe = Type.mkIoUncurriedArrow(Nel(Type.Int8, Type.Int16 :: Nil), Type.Int32, loc)
 
     val expected = raw"Int8 -> (Int16 -> Int32 \ IO)"
     val actual = FormatType.formatTypeWithOptions(tpe, standardFormat)


### PR DESCRIPTION
_Below generated by Claude_

Follow-up to #12981.
Related to #13009 

The `Type.mk*Arrow*` constructors took a `List` of parameter types and silently returned the result type `b` when that list was empty. That fallback is right for a nullary enum case, but it quietly produces a non-arrow type everywhere else — including for formal parameters, which are never empty.

This changes them to take a `Nel`:

- `mkPureCurriedArrow`, `mkCurriedArrowWithEffect`
- `mkPureUncurriedArrow`, `mkIoUncurriedArrow`, `mkUncurriedArrowWithEffect`
- `mkArrowWithoutEffect`

Each loses its `if (as.isEmpty) b` branch, and the "Returns `b` if `as` is empty" line is dropped from the docs.

Most call sites already have a `Nel` on hand — the `fparams` of a `Spec` or a `LocalDef` — so several `.toList` conversions go away. Four sites genuinely pass a possibly-empty list and now say so:

- `Kinder.visitCase` and `Kinder.visitRestrictableCase` — a nullary enum case's scheme is the enum type, not a function.
- `ConstraintGen` and `RestrictableChooseConstraintGen`, for tag expressions and tag patterns — same reason. One of these already had an explicit `if (tpes.nonEmpty)` guard.
- `Lowering.liftXY` — the `lift0X1`..`lift0X5` functions in `Fixpoint3.Boxable` take a vector directly rather than a function, so no in variables means no arrow.

Two sites use `Nel.unsafeFrom` where the non-emptiness holds but is not in the type: `Simplifier.visitPolyType` for `TypeConstructor.Arrow` (whose arity is at least 2) and `ConstraintGen` for `ApplyLocalDef` (whose argument list is padded to the local def's arity in the `Resolver`).

`Lowering.liftX` and `liftXb` now take a `Nel` too — `Fixpoint3.Boxable` has no `lift0` or `lift0b`, and their callers already establish that the free-variable list is non-empty.

`UnkindedType.mkUncurriedArrowWithEffect` is left alone; it builds an arrow from a source-level type annotation rather than from formal parameters.

### `Nel`

- `last`, so callers do not have to convert first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
