### PR TITLE
refactor: introduce Nel.of

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -200,15 +200,15 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = Nel(
+        fparams = Nel.of(
           KindedAst.FormalParam(param1, tpe, TypeSource.Ascribed, loc),
-          List(KindedAst.FormalParam(param2, tpe, TypeSource.Ascribed, loc))
+          KindedAst.FormalParam(param2, tpe, TypeSource.Ascribed, loc)
         ),
         sc = Scheme(
           Nil,
           List(TraitConstraint(TraitSymUse(eqTraitSym, loc), tpe, loc)),
           Nil,
-          Type.mkPureUncurriedArrow(Nel(tpe, List(tpe)), Type.mkBool(loc), loc)
+          Type.mkPureUncurriedArrow(Nel.of(tpe, tpe), Type.mkBool(loc), loc)
         ),
         tpe = Type.mkBool(loc),
         eff = Some(Type.Cst(TypeConstructor.Pure, loc)),
@@ -385,15 +385,15 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = Nel(
+        fparams = Nel.of(
           KindedAst.FormalParam(param1, tpe, TypeSource.Ascribed, loc),
-          List(KindedAst.FormalParam(param2, tpe, TypeSource.Ascribed, loc))
+          KindedAst.FormalParam(param2, tpe, TypeSource.Ascribed, loc)
         ),
         sc = Scheme(
           Nil,
           List(TraitConstraint(TraitSymUse(orderTraitSym, loc), tpe, loc)),
           Nil,
-          Type.mkPureUncurriedArrow(Nel(tpe, List(tpe)), Type.mkEnum(comparisonEnumSym, Kind.Star, loc), loc)
+          Type.mkPureUncurriedArrow(Nel.of(tpe, tpe), Type.mkEnum(comparisonEnumSym, Kind.Star, loc), loc)
         ),
         tpe = Type.mkEnum(comparisonEnumSym, Kind.Star, loc),
         eff = Some(Type.Cst(TypeConstructor.Pure, loc)),
@@ -416,7 +416,7 @@ object Deriver {
       // `case (C2(x0, x1), C2(y0, y1))
       val (pat1, varSyms1) = mkPattern(sym, tpes, "x", loc)
       val (pat2, varSyms2) = mkPattern(sym, tpes, "y", loc)
-      val pat = KindedAst.Pattern.Tuple(Nel(pat1, List(pat2)), loc)
+      val pat = KindedAst.Pattern.Tuple(Nel.of(pat1, pat2), loc)
 
       // Call compare on each variable pair
       // `compare(x0, y0)`, `compare(x1, y1)`
@@ -556,7 +556,7 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = Nel(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc), Nil),
+        fparams = Nel.of(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc)),
         sc = Scheme(
           Nil,
           List(TraitConstraint(TraitSymUse(toStringTraitSym, loc), tpe, loc)),
@@ -766,7 +766,7 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = Nel(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc), Nil),
+        fparams = Nel.of(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc)),
         sc = Scheme(
           Nil,
           List(TraitConstraint(TraitSymUse(hashTraitSym, loc), tpe, loc)),
@@ -923,7 +923,7 @@ object Deriver {
         ann = Annotations.Empty,
         mod = Modifiers.Empty,
         tparams = Nil,
-        fparams = Nel(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc), Nil),
+        fparams = Nel.of(KindedAst.FormalParam(param, tpe, TypeSource.Ascribed, loc)),
         sc = Scheme(
           Nil,
           List(TraitConstraint(TraitSymUse(coerceTraitSym, loc), tpe, loc)),

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -893,7 +893,7 @@ object Resolver {
 
     case NamedAst.Expr.Lambda(fparam, exp, loc) =>
       val p = resolveFormalParam(fparam, Wildness.AllowWild, scp0, taenv, ns0, root)
-      val scp = (scp0 ++ mkFormalParamScp(Nel(p, Nil))).withSuperClass(None) // super calls not allowed inside lambdas
+      val scp = (scp0 ++ mkFormalParamScp(Nel.of(p))).withSuperClass(None) // super calls not allowed inside lambdas
       val e = resolveExp(exp, scp)
       ResolvedAst.Expr.Lambda(p, e, allowSubeffecting = true, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -691,7 +691,7 @@ object Weeder2 {
         case Some(t) =>
           val params = pickAll(TreeKind.Parameter, t)
           if (params.isEmpty) {
-            Nel(unitFormalParameter(t.loc), Nil)
+            Nel.of(unitFormalParameter(t.loc))
           } else {
             val fparams = params.map(visitParameter(_, presence))
             // Check for duplicates
@@ -706,7 +706,7 @@ object Weeder2 {
         case None =>
           val error = UnexpectedToken(NamedTokenSet.FromKinds(Set(TokenKind.ParenL)), actual = None, SyntacticContext.Decl.Module, loc = tree.loc)
           sctx.errors.add(error)
-          Nel(unitFormalParameter(tree.loc), Nil)
+          Nel.of(unitFormalParameter(tree.loc))
       }
     }
 
@@ -1827,7 +1827,7 @@ object Weeder2 {
           // The new param has the zero-width location of the actual argument.
           val loc = SourceLocation.zeroPoint(isReal = false, fparam.loc.source, fparam.loc.start)
           val unitParam = Decls.unitFormalParameter(loc)
-          HandlerRule(ident, Nel(unitParam, List(fparam)), expr, tree.loc)
+          HandlerRule(ident, Nel.of(unitParam, fparam), expr, tree.loc)
         case fparams =>
           HandlerRule(ident, fparams, expr, tree.loc)
       }
@@ -2402,7 +2402,7 @@ object Weeder2 {
       expect(tree, TreeKind.Pattern.TagBody)
       val patterns = pickAll(TreeKind.Pattern.Pattern, tree)
       patterns.map(visitPattern(_, seen)) match {
-        case Nil => Nel(Pattern.Cst(Constant.Unit, tree.loc), Nil)
+        case Nil => Nel.of(Pattern.Cst(Constant.Unit, tree.loc))
         case x :: xs => Nel(x, xs)
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -1188,7 +1188,7 @@ object Lowering {
     val valueSym = mkLetSym("value", loc)
     val chanVar = MonoAst.Expr.Var(chanSym, exp1.tpe, loc)
     val valueVar = MonoAst.Expr.Var(valueSym, exp2.tpe, loc)
-    val itpe = lowerType(Type.mkIoUncurriedArrow(Nel(exp2.tpe, List(exp1.tpe)), Type.Unit, loc))
+    val itpe = lowerType(Type.mkIoUncurriedArrow(Nel.of(exp2.tpe, exp1.tpe), Type.Unit, loc))
     val defnSym = lookup(Defs.ChannelPut, itpe)
     val putExp = MonoAst.Expr.ApplyDef(defnSym, List(valueVar, chanVar), itpe, Type.Unit, eff, loc)
     // The channel binding is the outermost let, so the channel is evaluated before the value.
@@ -1270,7 +1270,7 @@ object Lowering {
     val locksType = Types.mkList(Types.ConcurrentReentrantLock, loc)
 
     val selectRetTpe = Type.mkTuple(List(Type.Int32, locksType), loc)
-    val itpe = Type.mkIoUncurriedArrow(Nel(admins.tpe, List(Type.Bool)), selectRetTpe, loc)
+    val itpe = Type.mkIoUncurriedArrow(Nel.of(admins.tpe, Type.Bool), selectRetTpe, loc)
     val blocking = default match {
       case Some(_) => MonoAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc)
       case None => MonoAst.Expr.Cst(Constant.Bool(true), Type.Bool, loc)
@@ -1297,9 +1297,9 @@ object Lowering {
     ListOps.zip(rs, channels).zipWithIndex map {
       case (((sym, chan, exp), (chSym, _)), i) =>
         val locksSym = mkLetSym("locks", loc)
-        val pat = mkTuplePattern(Nel(MonoAst.Pattern.Cst(Constant.Int32(i), Type.Int32, loc), List(MonoAst.Pattern.Var(locksSym, locksType, Occur.Unknown, loc))), loc)
+        val pat = mkTuplePattern(Nel.of(MonoAst.Pattern.Cst(Constant.Int32(i), Type.Int32, loc), MonoAst.Pattern.Var(locksSym, locksType, Occur.Unknown, loc)), loc)
         val getTpe = extractChannelTpe(chan.tpe)
-        val itpe = lowerType(Type.mkIoUncurriedArrow(Nel(chan.tpe, List(locksType)), getTpe, loc))
+        val itpe = lowerType(Type.mkIoUncurriedArrow(Nel.of(chan.tpe, locksType), getTpe, loc))
         val args = List(MonoAst.Expr.Var(chSym, lowerType(chan.tpe), loc), MonoAst.Expr.Var(locksSym, locksType, loc))
         val defnSym = lookup(Defs.ChannelUnsafeGetAndUnlock, itpe)
         val getExp = MonoAst.Expr.ApplyDef(defnSym, args, lowerType(itpe), lowerType(getTpe), eff, loc)
@@ -1319,7 +1319,7 @@ object Lowering {
     default match {
       case Some(defaultExp) =>
         val locksType = Types.mkList(Types.ConcurrentReentrantLock, loc)
-        val pat = mkTuplePattern(Nel(MonoAst.Pattern.Cst(Constant.Int32(-1), Type.Int32, loc), List(MonoAst.Pattern.Wild(locksType, loc))), loc)
+        val pat = mkTuplePattern(Nel.of(MonoAst.Pattern.Cst(Constant.Int32(-1), Type.Int32, loc), MonoAst.Pattern.Wild(locksType, loc)), loc)
         val defaultMatch = MonoAst.MatchRule(pat, None, defaultExp)
         List(defaultMatch)
       case _ =>
@@ -1564,7 +1564,7 @@ object Lowering {
     val predArity = selects.length
 
     // Define the name and type of the appropriate factsX function in Solver.flix
-    val defTpe = Type.mkPureUncurriedArrow(Nel(Types.PredSym, List(Types.Datalog)), tpe, loc)
+    val defTpe = Type.mkPureUncurriedArrow(Nel.of(Types.PredSym, Types.Datalog), tpe, loc)
     val sym = lookup(Defs.Facts(predArity), defTpe)
 
     // Merge and solve exps
@@ -1615,7 +1615,7 @@ object Lowering {
     val loweredExps = exps.zip(predsAndArities).map {
       case (exp, PredicateAndArity(pred, arity)) =>
         // The type of the function.
-        val defTpe = Type.mkPureUncurriedArrow(Nel(Types.PredSym, List(lowerType(exp.tpe))), Types.Datalog, loc)
+        val defTpe = Type.mkPureUncurriedArrow(Nel.of(Types.PredSym, lowerType(exp.tpe)), Types.Datalog, loc)
 
         // Compute the symbol of the function.
         val sym = lookup(Defs.ProjectInto(arity), defTpe)
@@ -2499,8 +2499,8 @@ object Lowering {
     * where `"terms" == termsVar.text`.
     */
   private def mkUnboxedTerm(termsVar: Symbol.VarSym, tpe: Type, i: Int, loc: SourceLocation)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.Expr = {
-    val outerItpe = Type.mkPureUncurriedArrow(Nel(Types.Boxed, Nil), tpe, loc)
-    val innerItpe = Type.mkPureUncurriedArrow(Nel(Type.Int32, List(Types.VectorOfBoxed)), Types.Boxed, loc)
+    val outerItpe = Type.mkPureUncurriedArrow(Nel.of(Types.Boxed), tpe, loc)
+    val innerItpe = Type.mkPureUncurriedArrow(Nel.of(Type.Int32, Types.VectorOfBoxed), Types.Boxed, loc)
     MonoAst.Expr.ApplyDef(
       sym = lookup(Defs.Unbox, outerItpe),
       exps = List(

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Symbols.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Symbols.scala
@@ -108,20 +108,18 @@ object Symbols {
     // Function Types.
     //
     lazy val SolveType: Type = Type.mkPureArrow(Datalog, Datalog, SourceLocation.Unknown)
-    lazy val MergeType: Type = Type.mkPureUncurriedArrow(Nel(Datalog, List(Datalog)), Datalog, SourceLocation.Unknown)
-    lazy val FilterType: Type = Type.mkPureUncurriedArrow(Nel(PredSym, List(Datalog)), Datalog, SourceLocation.Unknown)
-    lazy val RenameType: Type = Type.mkPureUncurriedArrow(Nel(mkList(PredSym, SourceLocation.Unknown), List(Datalog)), Datalog, SourceLocation.Unknown)
+    lazy val MergeType: Type = Type.mkPureUncurriedArrow(Nel.of(Datalog, Datalog), Datalog, SourceLocation.Unknown)
+    lazy val FilterType: Type = Type.mkPureUncurriedArrow(Nel.of(PredSym, Datalog), Datalog, SourceLocation.Unknown)
+    lazy val RenameType: Type = Type.mkPureUncurriedArrow(Nel.of(mkList(PredSym, SourceLocation.Unknown), Datalog), Datalog, SourceLocation.Unknown)
 
     def mkProvenanceOf(t: Type, loc: SourceLocation): Type =
       Type.mkPureUncurriedArrow(
-        Nel(
+        Nel.of(
           PredSym,
-          List(
-            Type.mkVector(Boxed, loc),
-            Type.mkVector(PredSym, loc),
-            Type.mkPureCurriedArrow(Nel(PredSym, List(Type.mkVector(Boxed, loc))), t, loc),
-            Datalog
-          )
+          Type.mkVector(Boxed, loc),
+          Type.mkVector(PredSym, loc),
+          Type.mkPureCurriedArrow(Nel.of(PredSym, Type.mkVector(Boxed, loc)), t, loc),
+          Datalog
         ),
         Type.mkVector(t, loc), loc
       )

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Symbols.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Symbols.scala
@@ -145,20 +145,18 @@ private[monomorph2] object Symbols {
       object Solver {
         // Synthetic, these are not real stdlib declarations, just the corresponding def's arrow type.
         lazy val SolveType: Type = Type.mkPureArrow(Types.Fixpoint.Ast.Datalog.Datalog, Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
-        lazy val MergeType: Type = Type.mkPureUncurriedArrow(Nel(Types.Fixpoint.Ast.Datalog.Datalog, scala.collection.immutable.List(Types.Fixpoint.Ast.Datalog.Datalog)), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
-        lazy val FilterType: Type = Type.mkPureUncurriedArrow(Nel(Types.Fixpoint.Ast.Shared.PredSym, scala.collection.immutable.List(Types.Fixpoint.Ast.Datalog.Datalog)), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
-        lazy val RenameType: Type = Type.mkPureUncurriedArrow(Nel(Types.List.mkList(Types.Fixpoint.Ast.Shared.PredSym, SourceLocation.Unknown), scala.collection.immutable.List(Types.Fixpoint.Ast.Datalog.Datalog)), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
+        lazy val MergeType: Type = Type.mkPureUncurriedArrow(Nel.of(Types.Fixpoint.Ast.Datalog.Datalog, Types.Fixpoint.Ast.Datalog.Datalog), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
+        lazy val FilterType: Type = Type.mkPureUncurriedArrow(Nel.of(Types.Fixpoint.Ast.Shared.PredSym, Types.Fixpoint.Ast.Datalog.Datalog), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
+        lazy val RenameType: Type = Type.mkPureUncurriedArrow(Nel.of(Types.List.mkList(Types.Fixpoint.Ast.Shared.PredSym, SourceLocation.Unknown), Types.Fixpoint.Ast.Datalog.Datalog), Types.Fixpoint.Ast.Datalog.Datalog, SourceLocation.Unknown)
 
         def mkProvenanceOf(t: Type, loc: SourceLocation): Type =
           Type.mkPureUncurriedArrow(
-            Nel(
+            Nel.of(
               Types.Fixpoint.Ast.Shared.PredSym,
-              scala.collection.immutable.List(
-                Type.mkVector(Types.Fixpoint.Boxed, loc),
-                Type.mkVector(Types.Fixpoint.Ast.Shared.PredSym, loc),
-                Type.mkPureCurriedArrow(Nel(Types.Fixpoint.Ast.Shared.PredSym, scala.collection.immutable.List(Type.mkVector(Boxed, loc))), t, loc),
-                Types.Fixpoint.Ast.Datalog.Datalog
-              )
+              Type.mkVector(Types.Fixpoint.Boxed, loc),
+              Type.mkVector(Types.Fixpoint.Ast.Shared.PredSym, loc),
+              Type.mkPureCurriedArrow(Nel.of(Types.Fixpoint.Ast.Shared.PredSym, Type.mkVector(Boxed, loc)), t, loc),
+              Types.Fixpoint.Ast.Datalog.Datalog
             ),
             Type.mkVector(t, loc), loc
           )

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -187,7 +187,7 @@ object Inliner {
         case Expr.Lambda(fparam, e1, _, _) =>
           sctx.changed.putIfAbsent(sym0, ())
           val e2 = visitExp(exp2, ctx0)
-          val letBinding = bindArgs(e1, Nel(fparam, Nil), List(e2), loc)
+          val letBinding = bindArgs(e1, Nel.of(fparam), List(e2), loc)
           visitExp(letBinding, ctx0)
 
         case e1 =>

--- a/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Nel.scala
@@ -91,4 +91,9 @@ object Nel {
     case x :: xs => Nel(x, xs)
   }
 
+  /**
+    * Returns a [[Nel]] containing the given elements.
+    */
+  def of[T](x: T, xs: T*): Nel[T] = Nel(x, xs.toList)
+
 }

--- a/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
@@ -131,7 +131,7 @@ class TestFormatType extends AnyFunSuite with TestUtils {
   }
 
   test("FormatType.Arrow.External.04") {
-    val tpe = Type.mkIoUncurriedArrow(Nel(Type.Int8, Type.Int16 :: Nil), Type.Int32, loc)
+    val tpe = Type.mkIoUncurriedArrow(Nel.of(Type.Int8, Type.Int16), Type.Int32, loc)
 
     val expected = raw"Int8 -> (Int16 -> Int32 \ IO)"
     val actual = FormatType.formatTypeWithOptions(tpe, standardFormat)

--- a/main/test/ca/uwaterloo/flix/util/TestNel.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestNel.scala
@@ -5,62 +5,68 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class TestNel extends AnyFunSuite {
 
-  private def mkNel[T](x: T, xs: T*): Nel[T] = Nel(x, xs.toList)
+  test("of.01") {
+    assert(Nel.of(1) == Nel(1, Nil))
+  }
+
+  test("of.02") {
+    assert(Nel.of(1, 2, 3) == Nel(1, List(2, 3)))
+  }
 
   test("length.01") {
-    assert(mkNel(1).length == 1)
+    assert(Nel.of(1).length == 1)
   }
 
   test("length.02") {
-    assert(mkNel(1, 2).length == 2)
+    assert(Nel.of(1, 2).length == 2)
   }
 
   test("length.03") {
-    assert(mkNel('a', 'b', 'c').length == 3)
+    assert(Nel.of('a', 'b', 'c').length == 3)
   }
 
   test("map.01") {
-    assert(Nel("a", List("bb", "ccc")).map(_.length) == mkNel(1, 2, 3))
+    assert(Nel.of("a", "bb", "ccc").map(_.length) == Nel.of(1, 2, 3))
   }
 
   test("map.02") {
-    assert(Nel("asd", Nil).map(_.length) == mkNel(3))
+    assert(Nel.of("asd").map(_.length) == Nel.of(3))
   }
 
   test("map.03") {
-    assert(mkNel(1, 2, 3, 4).map(x => -x) == mkNel(-1, -2, -3, -4))
+    assert(Nel.of(1, 2, 3, 4).map(x => -x) == Nel.of(-1, -2, -3, -4))
   }
 
   test("unzip.01") {
-    assert(mkNel((1, 2), (3, 4), (5, 6)).unzip == (mkNel(1, 3, 5), mkNel(2, 4, 6)))
+    assert(Nel.of((1, 2), (3, 4), (5, 6)).unzip == (Nel.of(1, 3, 5), Nel.of(2, 4, 6)))
   }
 
   test("unzip.02") {
-    assert(mkNel(("1", "2")).unzip == (mkNel("1"), mkNel("2")))
+    assert(Nel.of(("1", "2")).unzip == (Nel.of("1"), Nel.of("2")))
   }
 
   test("toString.01") {
-    assert(mkNel(1, 2, 3, 4).toString == "Nel(1, 2, 3, 4)")
+    assert(Nel.of(1, 2, 3, 4).toString == "Nel(1, 2, 3, 4)")
   }
 
   test("toString.02") {
-    assert(mkNel(1).toString == "Nel(1)")
+    assert(Nel.of(1).toString == "Nel(1)")
   }
 
   test("iterator.01") {
-    assert(mkNel(1, 2, 3, 4).iterator.sum == 10)
+    assert(Nel.of(1, 2, 3, 4).iterator.sum == 10)
   }
 
   test("iterator.02") {
-    assert(mkNel(1, 2, 3, 4).iterator.toList == List(1, 2, 3 ,4))
+    assert(Nel.of(1, 2, 3, 4).iterator.toList == List(1, 2, 3 ,4))
   }
 
   test("toList.01") {
-    assert(mkNel(1, 2, 3, 4).toList.sum == 10)
+    assert(Nel.of(1, 2, 3, 4).toList.sum == 10)
   }
 
   test("toList.02") {
-    assert(mkNel(1, 2, 3, 4).toList == List(1, 2, 3, 4))
+    assert(Nel.of(1, 2, 3, 4).toList == List(1, 2, 3, 4))
   }
 
 }


### PR DESCRIPTION
related to #13009 

Really simple: just introduces `Nel.of` so that we don't have to do `Nel(x, List(x, y, z))` everywhere.


An alternative might be to actually make Nel have the shape `Nel(X, XS*)`, which might allow pattern matching. But variadics in case classes like that seems controversial, so I'm sticking with this basic implementation.