### PR TITLE
fix: reject associated types in enums and structs

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -207,6 +207,7 @@ object ErrorCode {
   case object E6216 extends ErrorCode
   case object E6217 extends ErrorCode
   case object E6218 extends ErrorCode
+  case object E6221 extends ErrorCode
   case object E6247 extends ErrorCode
   case object E6285 extends ErrorCode
   case object E6289 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -327,6 +327,24 @@ object TypeError {
     }
   }
 
+  // MATT docs
+  case class IllegalAssocType(sym: Symbol.AssocTypeSym, loc: SourceLocation) extends TypeError {
+    def code: ErrorCode = ErrorCode.E6221
+
+    def summary: String = s"Illegal associated type '$sym'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Illegal associated type '${red(sym.toString)}'.
+         |
+         |${highlight(loc, "associated type not allowed here", fmt)}
+         |
+         |${underline("Explanation:")} An associated type is not allowed in an enum,
+         |struct, or type alias.
+         |""".stripMargin
+    }
+  }
+
   /**
     * An error raised to indicate that the signature of a default handler is illegal.
     *

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -327,7 +327,12 @@ object TypeError {
     }
   }
 
-  // MATT docs
+  /**
+    * Associated type used where not allowed.
+    *
+    * @param sym the symbol of the associated type.
+    * @param loc the location where the error occurred.
+    */
   case class IllegalAssocType(sym: Symbol.AssocTypeSym, loc: SourceLocation) extends TypeError {
     def code: ErrorCode = ErrorCode.E6221
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -323,65 +323,77 @@ object Typer {
   /**
     * Reconstructs types in the given enums.
     */
-  private def visitEnums(root: KindedAst.Root): Map[Symbol.EnumSym, TypedAst.Enum] = {
+  private def visitEnums(root: KindedAst.Root)(implicit sctx: SharedContext): Map[Symbol.EnumSym, TypedAst.Enum] = {
     MapOps.mapValues(root.enums)(visitEnum)
   }
 
   /**
     * Reconstructs types in the given enum.
     */
-  private def visitEnum(enum0: KindedAst.Enum): TypedAst.Enum = enum0 match {
+  private def visitEnum(enum0: KindedAst.Enum)(implicit sctx: SharedContext): TypedAst.Enum = enum0 match {
     case KindedAst.Enum(doc, ann, mod, enumSym, tparams0, derives, cases0, loc) =>
       val tparams = tparams0.map(visitTypeParam)
-      val cases = MapOps.mapValues(cases0) {
-        case KindedAst.Case(caseSym, tagTypes, sc, caseLoc) =>
-          TypedAst.Case(caseSym, tagTypes, sc, caseLoc)
-      }
+      val cases = MapOps.mapValues(cases0)(visitCase)
 
       TypedAst.Enum(doc, ann, mod, enumSym, tparams, derives, cases, loc)
+  }
+
+  // MATT docs
+  private def visitCase(caze: KindedAst.Case)(implicit sctx: SharedContext): TypedAst.Case = caze match {
+    case KindedAst.Case(caseSym, tagTypes, sc, caseLoc) =>
+      tagTypes.foreach(checkNoAssocTypes)
+      TypedAst.Case(caseSym, tagTypes, sc, caseLoc)
   }
 
   /**
     * Reconstructs types in the given structs.
     */
-  private def visitStructs(root: KindedAst.Root): Map[Symbol.StructSym, TypedAst.Struct] = {
+  private def visitStructs(root: KindedAst.Root)(implicit sctx: SharedContext): Map[Symbol.StructSym, TypedAst.Struct] = {
     MapOps.mapValues(root.structs)(visitStruct)
   }
 
   /**
     * Reconstructs types in the given struct.
     */
-  private def visitStruct(struct0: KindedAst.Struct): TypedAst.Struct = struct0 match {
+  private def visitStruct(struct0: KindedAst.Struct)(implicit sctx: SharedContext): TypedAst.Struct = struct0 match {
     case KindedAst.Struct(doc, ann, mod, sym, tparams0, sc, fields0, loc) =>
       val tparams = tparams0.map(visitTypeParam)
-      val fields = fields0.zipWithIndex.map {
-        case (field, _) =>
-          field.sym -> TypedAst.StructField(field.sym, field.tpe, field.loc)
-      }
+      val fields = fields0.map(field => field.sym -> visitStructField(field))
 
       TypedAst.Struct(doc, ann, mod, sym, tparams, sc, fields.toMap, loc)
+  }
+
+  // MATT docs
+  private def visitStructField(field: KindedAst.StructField)(implicit sctx: SharedContext): TypedAst.StructField = field match {
+    case KindedAst.StructField(_, sym, tpe, loc) =>
+      checkNoAssocTypes(tpe)
+      TypedAst.StructField(sym, tpe, loc)
   }
 
   /**
     * Reconstructs types in the given restrictable enums.
     */
-  private def visitRestrictableEnums(root: KindedAst.Root): Map[Symbol.RestrictableEnumSym, TypedAst.RestrictableEnum] = {
+  private def visitRestrictableEnums(root: KindedAst.Root)(implicit sctx: SharedContext): Map[Symbol.RestrictableEnumSym, TypedAst.RestrictableEnum] = {
     MapOps.mapValues(root.restrictableEnums)(visitRestrictableEnum)
   }
 
   /**
     * Reconstructs types in the given restrictable enum.
     */
-  private def visitRestrictableEnum(enum0: KindedAst.RestrictableEnum): TypedAst.RestrictableEnum = enum0 match {
+  private def visitRestrictableEnum(enum0: KindedAst.RestrictableEnum)(implicit sctx: SharedContext): TypedAst.RestrictableEnum = enum0 match {
     case KindedAst.RestrictableEnum(doc, ann, mod, enumSym, index0, tparams0, derives, cases0, _, loc) =>
       val index = TypedAst.TypeParam(index0.name, index0.sym, index0.loc)
       val tparams = tparams0.map(visitTypeParam)
-      val cases = MapOps.mapValues(cases0) {
-        case KindedAst.RestrictableCase(caseSym, tagTypes, sc, caseLoc) =>
-          TypedAst.RestrictableCase(caseSym, tagTypes, sc, caseLoc)
-      }
+      val cases = MapOps.mapValues(cases0)(visitRestrictableCase)
 
       TypedAst.RestrictableEnum(doc, ann, mod, enumSym, index, tparams, derives, cases, loc)
+  }
+
+  // MATT docs
+  private def visitRestrictableCase(caze: KindedAst.RestrictableCase)(implicit sctx: SharedContext): TypedAst.RestrictableCase = caze match {
+    case KindedAst.RestrictableCase(caseSym, tagTypes, sc, caseLoc) =>
+      tagTypes.foreach(checkNoAssocTypes)
+      TypedAst.RestrictableCase(caseSym, tagTypes, sc, caseLoc)
   }
 
   /**
@@ -404,15 +416,16 @@ object Typer {
   /**
     * Reconstructs types in the given type aliases.
     */
-  private def visitTypeAliases(root: KindedAst.Root): Map[Symbol.TypeAliasSym, TypedAst.TypeAlias] = {
+  private def visitTypeAliases(root: KindedAst.Root)(implicit sctx: SharedContext): Map[Symbol.TypeAliasSym, TypedAst.TypeAlias] = {
     MapOps.mapValues(root.typeAliases)(visitTypeAlias)
   }
 
   /**
     * Reconstructs types in the given type alias.
     */
-  private def visitTypeAlias(alias: KindedAst.TypeAlias): TypedAst.TypeAlias = alias match {
+  private def visitTypeAlias(alias: KindedAst.TypeAlias)(implicit sctx: SharedContext): TypedAst.TypeAlias = alias match {
     case KindedAst.TypeAlias(doc, ann, mod, sym, tparams0, tpe, loc) =>
+      checkNoAssocTypes(tpe)
       val tparams = tparams0.map(visitTypeParam)
       TypedAst.TypeAlias(doc, ann, mod, sym, tparams, tpe, loc)
   }
@@ -459,6 +472,13 @@ object Typer {
       }
   }
 
+  // MATT docs
+  private def checkNoAssocTypes(tpe: Type)(implicit sctx: SharedContext): Unit = {
+    for (assoc <- getAssocTypes(tpe)) {
+      sctx.errors.add(TypeError.IllegalAssocType(assoc.symUse.sym, assoc.loc))
+    }
+  }
+
   /**
     * Collects all associated types from the type.
     */
@@ -466,7 +486,7 @@ object Typer {
     case Type.Var(_, _) => Nil
     case Type.Cst(_, _) => Nil
     case Type.Apply(tpe1, tpe2, _) => getAssocTypes(tpe1) ::: getAssocTypes(tpe2)
-    case Type.Alias(_, args, _, _) => args.flatMap(getAssocTypes) // TODO ASSOC-TYPES what to do about alias
+    case Type.Alias(_, args, _, _) => args.flatMap(getAssocTypes)
     case assoc: Type.AssocType => List(assoc)
     case Type.JvmToType(tpe, _) => getAssocTypes(tpe)
     case Type.JvmToEff(tpe, _) => getAssocTypes(tpe)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -338,7 +338,9 @@ object Typer {
       TypedAst.Enum(doc, ann, mod, enumSym, tparams, derives, cases, loc)
   }
 
-  // MATT docs
+  /**
+    * Reconstructs types in the given case.
+    */
   private def visitCase(caze: KindedAst.Case)(implicit sctx: SharedContext): TypedAst.Case = caze match {
     case KindedAst.Case(caseSym, tagTypes, sc, caseLoc) =>
       tagTypes.foreach(checkNoAssocTypes)
@@ -363,7 +365,9 @@ object Typer {
       TypedAst.Struct(doc, ann, mod, sym, tparams, sc, fields.toMap, loc)
   }
 
-  // MATT docs
+  /**
+    * Reconstructs types in the given struct field.
+    */
   private def visitStructField(field: KindedAst.StructField)(implicit sctx: SharedContext): TypedAst.StructField = field match {
     case KindedAst.StructField(_, sym, tpe, loc) =>
       checkNoAssocTypes(tpe)
@@ -389,7 +393,9 @@ object Typer {
       TypedAst.RestrictableEnum(doc, ann, mod, enumSym, index, tparams, derives, cases, loc)
   }
 
-  // MATT docs
+  /**
+    * Reconstructs types in the given restrictable case.
+    */
   private def visitRestrictableCase(caze: KindedAst.RestrictableCase)(implicit sctx: SharedContext): TypedAst.RestrictableCase = caze match {
     case KindedAst.RestrictableCase(caseSym, tagTypes, sc, caseLoc) =>
       tagTypes.foreach(checkNoAssocTypes)
@@ -472,7 +478,9 @@ object Typer {
       }
   }
 
-  // MATT docs
+  /**
+    * Issues an error for each associated type found in the given type.
+    */
   private def checkNoAssocTypes(tpe: Type)(implicit sctx: SharedContext): Unit = {
     for (assoc <- getAssocTypes(tpe)) {
       sctx.errors.add(TypeError.IllegalAssocType(assoc.symUse.sym, assoc.loc))

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1669,6 +1669,79 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.MissingTraitConstraint](result)
   }
 
+  test("TypeError.IllegalAssocType.Enum.01") {
+    val input =
+      """
+        |trait C[a] {
+        |    type T
+        |}
+        |
+        |enum E[a] {
+        |    case D(C.T[a])
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.IllegalAssocType](result)
+  }
+
+  test("TypeError.IllegalAssocType.Enum.02") {
+    val input =
+      """
+        |trait C[a] {
+        |    type T
+        |}
+        |
+        |enum E[a] {
+        |    case D(C.T[a] -> Int32)
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.IllegalAssocType](result)
+  }
+
+  test("TypeError.IllegalAssocType.Struct.01") {
+    val input =
+      """
+        |trait C[a] {
+        |    type T
+        |}
+        |
+        |struct S[a, r] {
+        |    f: C.T[a]
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.IllegalAssocType](result)
+  }
+
+  test("TypeError.IllegalAssocType.TypeAlias.01") {
+    val input =
+      """
+        |trait C[a] {
+        |    type T
+        |}
+        |
+        |type alias A[a] = C.T[a]
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.IllegalAssocType](result)
+  }
+
+  test("TypeError.IllegalAssocType.RestrictableEnum.01") {
+    val input =
+      """
+        |trait C[a] {
+        |    type T
+        |}
+        |
+        |restrictable enum E[s][a] {
+        |    case D(C.T[a])
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.IllegalAssocType](result)
+  }
+
   test("TypeError.NewStruct.01") {
     val input =
       """


### PR DESCRIPTION
Fixes #13007.

We don't allow associated types anywhere there is no context to check that they are valid, so not in enums, structs, or type aliases.

Code written by Claude. Documentation written by Matt.
