### PR TITLE
fix: Datalog select-clause terms silently unconstrained by the type checker

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -859,12 +859,16 @@ object Kinder {
         val s = visitHeadPredicate(select, kenv0, root)
         KindedAst.Expr.FixpointQueryWithProvenance(es, s, withh, Type.freshVar(Kind.Star, loc), loc)
 
-      case ResolvedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
+      case ResolvedAst.Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, pred, loc) =>
         val es = exps.map(visitExp(_, kenv0, root))
         val qe = visitExp(queryExp, kenv0, root)
-        val ss = selects.map(visitExp(_, kenv0, root))
-        val f = from.map(visitBodyPredicate(_, kenv0, root))
-        val w = where.map(visitExp(_, kenv0, root))
+        val (ss, f, w) = qe match {
+          case KindedAst.Expr.FixpointConstraintSet(List(KindedAst.Constraint(_, KindedAst.Predicate.Head.Atom(_, _, terms, _, _), body, _)), _, _) =>
+            val guards = body.collect { case KindedAst.Predicate.Body.Guard(exp, _) => exp }
+            val atoms = body.collect { case a: KindedAst.Predicate.Body.Atom => a }
+            (terms, atoms, guards)
+          case _ => throw InternalCompilerException("Unexpected FixpointQueryWithSelect pseudo-query shape", loc)
+        }
         KindedAst.Expr.FixpointQueryWithSelect(es, qe, ss, f, w, pred, Type.freshVar(Kind.Star, loc), loc)
 
       case ResolvedAst.Expr.FixpointSolveWithProject(exps, optPreds, mode, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1158,12 +1158,16 @@ object Namer {
       val es = exps.map(visitExp)
       NamedAst.Expr.FixpointSolveWithProject(es, optPreds, mode, loc)
 
-    case DesugaredAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
+    case DesugaredAst.Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, pred, loc) =>
       val es = exps.map(visitExp)
       val qe = visitExp(queryExp)
-      val ss = selects.map(visitExp)
-      val f = from.map(visitBodyPredicate)
-      val w = where.map(visitExp)
+      val (ss, f, w) = qe match {
+        case NamedAst.Expr.FixpointConstraintSet(List(NamedAst.Constraint(_, NamedAst.Predicate.Head.Atom(_, _, terms, _), body, _)), _) =>
+          val guards = body.collect { case NamedAst.Predicate.Body.Guard(exp, _) => exp }
+          val atoms = body.collect { case a: NamedAst.Predicate.Body.Atom => a }
+          (terms, atoms, guards)
+        case _ => throw InternalCompilerException("Unexpected FixpointQueryWithSelect pseudo-query shape", loc)
+      }
       NamedAst.Expr.FixpointQueryWithSelect(es, qe, ss, f, w, pred, loc)
 
     case DesugaredAst.Expr.FixpointInjectInto(exps, predsAndArities, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1280,27 +1280,16 @@ object Resolver {
       val s = resolvePredicateHead(select, scp0)
       ResolvedAst.Expr.FixpointQueryWithProvenance(es, s, withh, loc)
 
-    case NamedAst.Expr.FixpointQueryWithSelect(exps, queryExp, selects, from, where, pred, loc) =>
+    case NamedAst.Expr.FixpointQueryWithSelect(exps, queryExp, _, _, _, pred, loc) =>
       val es = exps.map(resolveExp(_, scp0))
       val qe = resolveExp(queryExp, scp0)
-      // We cannot call resolvePredicateBody as it does not allow new variables to be introduced
-      val f = from.map {
-        case NamedAst.Predicate.Body.Atom(pred0, den, polarity, fixity, terms, loc1) =>
-          val ts = terms.map(resolvePattern(_, scp0, ns0, root))
-          ResolvedAst.Predicate.Body.Atom(pred0, den, polarity, fixity, ts, loc1)
-        case _ => throw InternalCompilerException("Unexpected predicate body when expecting body atom", loc)
+      val (s, f, w) = qe match {
+        case ResolvedAst.Expr.FixpointConstraintSet(List(ResolvedAst.Constraint(_, ResolvedAst.Predicate.Head.Atom(_, _, terms, _), body, _)), _) =>
+          val guards = body.collect { case ResolvedAst.Predicate.Body.Guard(exp, _) => exp }
+          val atoms = body.collect { case a: ResolvedAst.Predicate.Body.Atom => a }
+          (terms, atoms, guards)
+        case _ => throw InternalCompilerException("Unexpected FixpointQueryWithSelect pseudo-query shape", loc)
       }
-      // We have to bind variables appearing in the atoms before resolving the select and where exps
-      // Collect all variables appearing in atoms and bind them
-      val ts = f.flatMap(_.terms)
-      val scp1 = ts.foldLeft(scp0)(
-        (acc, t) => t match {
-          case ResolvedAst.Pattern.Var(sym, _) => acc ++ mkVarScp(sym)
-          case _ => acc
-        })
-      // Resolve select and where exps
-      val s = selects.map(resolveExp(_, scp1))
-      val w = where.map(resolveExp(_, scp1))
       ResolvedAst.Expr.FixpointQueryWithSelect(es, qe, s, f, w, pred, loc)
 
     case NamedAst.Expr.FixpointSolveWithProject(exps, optPreds, mode, loc) =>


### PR DESCRIPTION
Fixes https://github.com/flix/flix/issues/13015.