### PR TITLE
perf: build jars directly from in-memory class files

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.ast.{Scheme, SourceLocation, Symbol, TypedAst}
 import ca.uwaterloo.flix.language.phase.HtmlDocumentor
-import ca.uwaterloo.flix.language.phase.jvm.JvmClass
+import ca.uwaterloo.flix.language.phase.jvm.{JvmClass, JvmName}
 import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.runtime.shell.FileWatcher
 import ca.uwaterloo.flix.tools.Tester
@@ -466,7 +466,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       result <- Steps.compile(flix)
       _ <- Steps.validateJarFile(jarFile)
       contents = (zip: ZipOutputStream) => {
-        Steps.addClassesToZip(result.getClasses.values, zip)
+        Steps.addClassesToZip(result.getClasses, zip)
         Steps.addResourcesFromDirToZip(Bootstrap.getResourcesDirectory(projectPath), zip)
       }
       _ <- Steps.createJar(jarFile, contents)
@@ -489,7 +489,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       _ <- Steps.validateDirectory(libDir)
       _ <- Steps.validateJarFilesIn(libDir)
       contents = (zip: ZipOutputStream) => {
-        Steps.addClassesToZip(result.getClasses.values, zip)
+        Steps.addClassesToZip(result.getClasses, zip)
         Steps.addResourcesFromDirToZip(Bootstrap.getResourcesDirectory(projectPath), zip)
         Steps.addJarsFromDirToZip(libDir, zip)
       }
@@ -990,10 +990,10 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     /**
       * Adds all `classes` to `zip`, writing the bytecode directly from memory.
       */
-    def addClassesToZip(classes: Iterable[JvmClass], zip: ZipOutputStream): Unit = {
+    def addClassesToZip(classes: Map[JvmName, JvmClass], zip: ZipOutputStream): Unit = {
       // Add all classes.
       // Here we sort entries by their entry name to apply https://reproducible-builds.org/
-      val entries = classes.map(clazz => (clazz.name.toClassFileName, clazz)).toList.sortBy(_._1)
+      val entries = classes.values.map(clazz => (clazz.name.toClassFileName, clazz)).toList.sortBy(_._1)
       for ((entryName, clazz) <- entries) {
         FileOps.addToZip(zip, entryName, clazz.bytecode)
       }

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -993,7 +993,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     def addClassesToZip(classes: Iterable[JvmClass], zip: ZipOutputStream): Unit = {
       // Add all classes.
       // Here we sort entries by their entry name to apply https://reproducible-builds.org/
-      val entries = classes.map(clazz => (clazz.name.toInternalName + s".$EXT_CLASS", clazz)).toList.sortBy(_._1)
+      val entries = classes.map(clazz => (clazz.name.toClassFileName, clazz)).toList.sortBy(_._1)
       for ((entryName, clazz) <- entries) {
         FileOps.addToZip(zip, entryName, clazz.bytecode)
       }

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -22,6 +22,7 @@ import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.ast.{Scheme, SourceLocation, Symbol, TypedAst}
 import ca.uwaterloo.flix.language.phase.HtmlDocumentor
+import ca.uwaterloo.flix.language.phase.jvm.JvmClass
 import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.runtime.shell.FileWatcher
 import ca.uwaterloo.flix.tools.Tester
@@ -462,10 +463,10 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     Steps.updateStaleSources(flix)
     for {
       _ <- Steps.configureJarOutput(flix)
-      _ <- Steps.compile(flix)
+      result <- Steps.compile(flix)
       _ <- Steps.validateJarFile(jarFile)
       contents = (zip: ZipOutputStream) => {
-        Steps.addClassFilesFromDirToZip(Bootstrap.getClassDirectory(projectPath), zip)
+        Steps.addClassesToZip(result.getClasses.values, zip)
         Steps.addResourcesFromDirToZip(Bootstrap.getResourcesDirectory(projectPath), zip)
       }
       _ <- Steps.createJar(jarFile, contents)
@@ -483,12 +484,12 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     Steps.updateStaleSources(flix)
     for {
       _ <- Steps.configureJarOutput(flix)
-      _ <- Steps.compile(flix)
+      result <- Steps.compile(flix)
       _ <- Steps.validateJarFile(jarFile)
       _ <- Steps.validateDirectory(libDir)
       _ <- Steps.validateJarFilesIn(libDir)
       contents = (zip: ZipOutputStream) => {
-        Steps.addClassFilesFromDirToZip(Bootstrap.getClassDirectory(projectPath), zip)
+        Steps.addClassesToZip(result.getClasses.values, zip)
         Steps.addResourcesFromDirToZip(Bootstrap.getResourcesDirectory(projectPath), zip)
         Steps.addJarsFromDirToZip(libDir, zip)
       }
@@ -987,14 +988,14 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
   private object Steps {
 
     /**
-      * Adds all class files from `dir` to `zip`.
+      * Adds all `classes` to `zip`, writing the bytecode directly from memory.
       */
-    def addClassFilesFromDirToZip(dir: Path, zip: ZipOutputStream): Unit = {
-      // Add all class files.
-      // Here we sort entries by relative file name to apply https://reproducible-builds.org/
-      val classFiles = FileOps.getFilesWithExtIn(dir, EXT_CLASS, Int.MaxValue)
-      for ((buildFile, fileNameWithSlashes) <- FileOps.sortPlatformIndependently(dir, classFiles)) {
-        FileOps.addToZip(zip, fileNameWithSlashes, buildFile)
+    def addClassesToZip(classes: Iterable[JvmClass], zip: ZipOutputStream): Unit = {
+      // Add all classes.
+      // Here we sort entries by their entry name to apply https://reproducible-builds.org/
+      val entries = classes.map(clazz => (clazz.name.toInternalName + s".$EXT_CLASS", clazz)).toList.sortBy(_._1)
+      for ((entryName, clazz) <- entries) {
+        FileOps.addToZip(zip, entryName, clazz.bytecode)
       }
     }
 
@@ -1190,21 +1191,18 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     }
 
     /**
-      * Configures `flix` to emit class files to the build directory (on the file system)
-      * in production mode.
+      * Configures `flix` to compile in production mode for jar output.
       *
-      * @see [[Bootstrap.getBuildDirectory]]
+      * The generated classes are kept in memory only: they are neither written to the
+      * build directory nor loaded into the JVM. Instead they are packed directly into
+      * the jar file by [[addClassesToZip]].
+      *
       * @see [[Build.Production]]
       */
     def configureJarOutput(flix: Flix): Result[Unit, BootstrapError] = {
-      val buildDir = Bootstrap.getBuildDirectory(projectPath)
-      for {
-        _ <- validateDirectory(buildDir)
-      } yield {
-        val newOptions = flix.options.copy(build = Build.Production, outputJvm = true, outputPath = buildDir)
-        flix.setOptions(newOptions)
-        ()
-      }
+      val newOptions = flix.options.copy(build = Build.Production, outputJvm = false, loadClassFiles = false)
+      flix.setOptions(newOptions)
+      Ok(())
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -700,7 +700,7 @@ class Flix {
 
     // Construct the compilation result.
     val totalSize = bytecodeAst.classes.values.map(_.bytecode.length).sum
-    val result = new CompilationResult(loaderResult.main, loaderResult.tests, loaderResult.sources, bytecodeAst.classes, totalTime, totalSize)
+    val result = new CompilationResult(bytecodeAst.classes, loaderResult.main, loaderResult.tests, loaderResult.sources, totalTime, totalSize)
 
     // Shutdown fork-join thread pool.
     shutdownForkJoinPool()

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -700,7 +700,7 @@ class Flix {
 
     // Construct the compilation result.
     val totalSize = bytecodeAst.classes.values.map(_.bytecode.length).sum
-    val result = new CompilationResult(loaderResult.main, loaderResult.tests, loaderResult.sources, totalTime, totalSize)
+    val result = new CompilationResult(loaderResult.main, loaderResult.tests, loaderResult.sources, bytecodeAst.classes, totalTime, totalSize)
 
     // Shutdown fork-join thread pool.
     shutdownForkJoinPool()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -283,6 +283,13 @@ case class JvmName(pkg: List[String], name: String) {
   lazy val toPath: Path = Paths.get(pkg.mkString("/"), name + ".class")
 
   /**
+    * Returns the class file name of `this` Java name.
+    *
+    * The class file name is of the form `java/lang/String.class`.
+    */
+  lazy val toClassFileName: String = toInternalName + ".class"
+
+  /**
     * Wraps this name in `BackendType.Reference(BackendObjType.Native(...))`.
     */
   def toTpe: BackendType.Reference = BackendObjType.Native(this).toTpe

--- a/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
@@ -23,20 +23,24 @@ import ca.uwaterloo.flix.language.phase.jvm.{JvmClass, JvmName}
 /**
   * A class representing the result of a compilation.
   *
+  * @param classes   the generated JVM classes.
   * @param main      the reflected main function, if present.
   * @param tests     the tests in the program.
   * @param sources   the sources of the program.
-  * @param classes   the generated JVM classes.
   * @param totalTime the total compilation time, excluding class writing/loading.
   * @param codeSize   the number of bytes the compiler generated.
   */
-class CompilationResult(main: Option[Array[String] => Unit],
+class CompilationResult(classes: Map[JvmName, JvmClass],
+                        main: Option[Array[String] => Unit],
                         tests: Map[Symbol.DefnSym, TestFn],
                         sources: Map[Source, SourceLocation],
-                        classes: Map[JvmName, JvmClass],
                         val totalTime: Long,
                         val codeSize: Int
                        ) {
+
+  /** Returns the generated JVM classes. */
+  def getClasses: Map[JvmName, JvmClass] =
+    classes
 
   /** Optionally returns the main function. */
   def getMain: Option[Array[String] => Unit] =
@@ -45,10 +49,6 @@ class CompilationResult(main: Option[Array[String] => Unit],
   /** Returns all the test functions in the program. */
   def getTests: Map[Symbol.DefnSym, TestFn] =
     tests
-
-  /** Returns the generated JVM classes. */
-  def getClasses: Map[JvmName, JvmClass] =
-    classes
 
   /** Returns the total number of lines of compiled code. */
   def getTotalLines: Int = sources.foldLeft(0) {

--- a/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.runtime
 
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.shared.Source
+import ca.uwaterloo.flix.language.phase.jvm.{JvmClass, JvmName}
 
 /**
   * A class representing the result of a compilation.
@@ -25,12 +26,14 @@ import ca.uwaterloo.flix.language.ast.shared.Source
   * @param main      the reflected main function, if present.
   * @param tests     the tests in the program.
   * @param sources   the sources of the program.
+  * @param classes   the generated JVM classes.
   * @param totalTime the total compilation time, excluding class writing/loading.
   * @param codeSize   the number of bytes the compiler generated.
   */
 class CompilationResult(main: Option[Array[String] => Unit],
                         tests: Map[Symbol.DefnSym, TestFn],
                         sources: Map[Source, SourceLocation],
+                        classes: Map[JvmName, JvmClass],
                         val totalTime: Long,
                         val codeSize: Int
                        ) {
@@ -42,6 +45,10 @@ class CompilationResult(main: Option[Array[String] => Unit],
   /** Returns all the test functions in the program. */
   def getTests: Map[Symbol.DefnSym, TestFn] =
     tests
+
+  /** Returns the generated JVM classes. */
+  def getClasses: Map[JvmName, JvmClass] =
+    classes
 
   /** Returns the total number of lines of compiled code. */
   def getTotalLines: Int = sources.foldLeft(0) {

--- a/main/test/ca/uwaterloo/flix/tools/pkg/TestBootstrap.scala
+++ b/main/test/ca/uwaterloo/flix/tools/pkg/TestBootstrap.scala
@@ -74,9 +74,6 @@ class TestBootstrap extends AnyFunSuite {
     val packageName = p.getFileName.toString
     val jarPath = p.resolve("artifact").resolve(packageName + ".jar")
 
-    // Use new bootstrap and flix instances for each build to reset symbol generation.
-    // A bootstrap tracks the timestamps of the source files it has already added to a flix instance,
-    // so reusing a bootstrap for a fresh flix instance would not add the source files again.
     val b1 = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
     val flix1 = PkgTestUtils.mkFlix
     // Use 1 thread for deterministic symbols

--- a/main/test/ca/uwaterloo/flix/tools/pkg/TestBootstrap.scala
+++ b/main/test/ca/uwaterloo/flix/tools/pkg/TestBootstrap.scala
@@ -6,12 +6,11 @@ import org.scalatest.DoNotDiscover
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path}
-import java.security.{DigestInputStream, MessageDigest}
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.zip.ZipFile
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
-import scala.util.Using
 
 @DoNotDiscover
 class TestBootstrap extends AnyFunSuite {
@@ -75,19 +74,21 @@ class TestBootstrap extends AnyFunSuite {
     val packageName = p.getFileName.toString
     val jarPath = p.resolve("artifact").resolve(packageName + ".jar")
 
+    // Use new bootstrap and flix instances for each build to reset symbol generation.
+    // A bootstrap tracks the timestamps of the source files it has already added to a flix instance,
+    // so reusing a bootstrap for a fresh flix instance would not add the source files again.
+    val b1 = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
     val flix1 = PkgTestUtils.mkFlix
     // Use 1 thread for deterministic symbols
     flix1.setOptions(flix1.options.copy(threads = 1))
-
-    val b = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
-    b.buildJar(flix1)
+    b1.buildJar(flix1)
     val hash1 = calcHash(jarPath)
 
-    // Use new flix instance to reset symbol generation
+    val b2 = Bootstrap.bootstrap(p, None)(Formatter.getDefault, System.out).unsafeGet
     val flix2 = PkgTestUtils.mkFlix
     // Use 1 thread for deterministic symbols
     flix2.setOptions(flix2.options.copy(threads = 1))
-    b.buildJar(flix2)
+    b2.buildJar(flix2)
     val hash2 = calcHash(jarPath)
 
     assert(
@@ -400,10 +401,7 @@ class TestBootstrap extends AnyFunSuite {
 
   private def calcHash(p: Path): String = {
     val sha = MessageDigest.getInstance("SHA-256")
-    Using(new DigestInputStream(Files.newInputStream(p), sha)) { input =>
-      input.readNBytes(8192)
-      sha.digest.map("%02x".format(_)).mkString
-    }.get
+    sha.digest(Files.readAllBytes(p)).map("%02x".format(_)).mkString
   }
 
 }


### PR DESCRIPTION
## Summary

`build-jar` and `build-fatjar` used to write every generated class to `build/class/` (`JvmWriter`) and then walk that directory, reading each file back to pack it into the jar. For real programs that is thousands of tiny file writes and reads for nothing: the bytecode is already fully materialized in memory as `BytecodeAst.Root.classes` when code generation finishes.

This PR hands those classes to `Bootstrap` and streams them straight into the jar:

- `CompilationResult` gains `classes: Map[JvmName, JvmClass]` (+ `getClasses`), populated from `bytecodeAst.classes` in `Flix.codeGen`. These are the same instances the class loader already retains, so there is no extra memory.
- `Steps.configureJarOutput` now sets `build = Production, outputJvm = false, loadClassFiles = false`: jar builds neither write class files to disk nor load them into the JVM (previously `:build-fatjar` from the REPL and the tests loaded every class for nothing).
- `Steps.addClassesToZip` replaces `addClassFilesFromDirToZip`. Entries are named `<internalName>.class` and sorted by that name — exactly the string the old code sorted on — so jars remain reproducible.

Side effect: the jar becomes hermetic. Stale class files in `build/class/` from an earlier `build` can no longer leak into it.

Out of scope (unchanged): `build`, `run` and `test` still go through `Bootstrap.build` and emit class files to `build/class/`; `JvmWriter` / `Options.outputJvm` remain for that.

## Test fix

The "byte-for-byte" reproducibility test in `TestBootstrap` only passed by accident:

1. It reused one `Bootstrap` for a second fresh `Flix`. A `Bootstrap` tracks source timestamps for a single `Flix`, so the second instance received no sources and silently compiled the empty program. On master this was masked because run 1's stale class files were still in `build/class/` and got zipped in — exactly what this PR removes.
2. `calcHash` only hashed the first 8 KB of the jar (`readNBytes(8192)`).

The test now creates a fresh `Bootstrap` per build and hashes the whole file. Two independent builds produce byte-for-byte identical jars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
