### PR TITLE
perf: do not write class files to disk for the run and test commands

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -440,11 +440,20 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
   }
 
   /**
-    * Builds (compiles) the source files for the project.
+    * Builds (compiles) the source files for the project and writes the generated class files to the build directory.
     */
-  def build(flix: Flix, build: Build = Build.Development): Result[CompilationResult, BootstrapError] = {
+  def build(flix: Flix, build: Build = Build.Development): Result[CompilationResult, BootstrapError] =
+    compileProject(flix, build, outputJvm = true)
+
+  /**
+    * Compiles the source files for the project.
+    *
+    * If `outputJvm` is `true` the generated class files are written to the build directory.
+    * Otherwise the generated classes are kept in memory only.
+    */
+  private def compileProject(flix: Flix, build: Build, outputJvm: Boolean): Result[CompilationResult, BootstrapError] = {
     // We disable incremental compilation to ensure a clean compile.
-    val newOptions = flix.options.copy(build = build, incremental = false, outputJvm = true, outputPath = Bootstrap.getBuildDirectory(projectPath))
+    val newOptions = flix.options.copy(build = build, incremental = false, outputJvm = outputJvm, outputPath = Bootstrap.getBuildDirectory(projectPath))
     flix.setOptions(newOptions)
 
     // We also clear any cached ASTs.
@@ -844,7 +853,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     */
   def run(flix: Flix, args: Array[String]): Result[Unit, BootstrapError] = {
     for {
-      compilationResult <- build(flix)
+      compilationResult <- compileProject(flix, Build.Development, outputJvm = false)
     } yield {
       compilationResult.getMain match {
         case None => ()
@@ -858,7 +867,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     */
   def test(flix: Flix): Result[Unit, BootstrapError] = {
     for {
-      compilationResult <- build(flix)
+      compilationResult <- compileProject(flix, Build.Development, outputJvm = false)
       res <- Tester.run(Nil, compilationResult)(flix).mapErr(_ => BootstrapError.GeneralError("Tester Error"))
     } yield {
       res


### PR DESCRIPTION
## Summary

`Bootstrap.run` and `Bootstrap.test` compile the project via `build`, which always sets `outputJvm = true` and therefore writes **every** generated class file to `build/class/`. So each `flix run`, `flix test`, `:run` and `:test` on a project rewrites thousands of small class files — for nothing: both commands only use the in-memory `CompilationResult` (the reflected `main` method and the test functions loaded by `JvmLoader`).

This PR splits the compile step out of `build`:

- `build` delegates to a new private `compileProject(flix, build, outputJvm)` and keeps its contract: `flix build` still writes `build/class/` and remains the sole producer of that directory.
- `run` and `test` call `compileProject(..., outputJvm = false)`: same clean compile (`incremental = false`, caches cleared, stale sources updated), just no disk output.

Verified in a temp project: `run` prints `Hello World!` and `test` runs the tests, both without creating `build/class/`; `build` still creates it.

Independent of #13019 (which does the same for `build-jar`/`build-fatjar`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
