### PR TITLE
fix: reset options before each bootstrap command in the REPL

### DIFF
--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -339,9 +339,13 @@ class Shell(bootstrap: Bootstrap, options: Options) {
   /**
     * Executes the given bootstrap function and prints any errors.
     */
-  private def execBootstrap[T](f: => Validation[T, BootstrapError])(implicit formatter: Formatter, out: PrintStream): Unit = f match {
-    case Validation.Success(_) => ()
-    case Validation.Failure(errors) => errors.map(_.message(formatter)).foreach(out.println)
+  private def execBootstrap[T](f: => Validation[T, BootstrapError])(implicit formatter: Formatter, out: PrintStream): Unit = {
+    // Reset the options: a previous command may have changed e.g. the build mode on the shared Flix instance.
+    flix.setOptions(options)
+    f match {
+      case Validation.Success(_) => ()
+      case Validation.Failure(errors) => errors.map(_.message(formatter)).foreach(out.println)
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

The REPL uses a single `Flix` instance for all commands. Some `Bootstrap` commands change options on that instance and never restore them: `build-jar`/`build-fatjar` set `build = Production` (via `configureJarOutput`), and `build`/`build-classes`/`run`/`test` set `incremental = false` (via `compileProject`). Commands that only call `Steps.check` — `:check`, `:doc`, `:format`, `eff-check`, `eff-lock` — inherit whatever was left behind, so e.g. `:check` after `:build-jar` runs in production mode (a def leaking the `Debug` effect passes `:check` before `:build-jar` and fails after it) until something else happens to reset the mode.

`Shell.compile` already resets the options from the shell's base options before every `:eval`. This PR does the same for bootstrap commands: `execBootstrap` (whose argument is by-name) calls `flix.setOptions(options)` before executing the command. Commands that need specific options (`compileProject`, `configureJarOutput`) still set them explicitly afterwards.

The CLI is unaffected (it creates a fresh `Flix` per command); `Bootstrap`'s API is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
