### PR TITLE
refactor: move JvmLoader out of the compiler pipeline

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -23,6 +23,7 @@ import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
 import ca.uwaterloo.flix.language.phase.HtmlDocumentor
 import ca.uwaterloo.flix.language.phase.unification.zhegalkin.ZhegalkinPerf
+import ca.uwaterloo.flix.runtime.JvmLoader
 import ca.uwaterloo.flix.runtime.shell.Shell
 import ca.uwaterloo.flix.tools.*
 import ca.uwaterloo.flix.tools.pkg.PackageModules
@@ -70,7 +71,6 @@ object Main {
       installDeps = cmdOpts.installDeps,
       threads = cmdOpts.threads.getOrElse(Options.Default.threads),
       compilerTop = cmdOpts.top,
-      loadClassFiles = Options.Default.loadClassFiles,
       assumeYes = cmdOpts.assumeYes,
       xprintphases = cmdOpts.xprintphases,
       xnodeprecated = cmdOpts.xnodeprecated,
@@ -176,7 +176,7 @@ object Main {
           // evaluate main.
           flix.check() match {
             case (Some(root), Nil) =>
-              flix.codeGen(root).getMain match {
+              JvmLoader.load(flix.codeGen(root)).main match {
                 case None => // nop
                 case Some(m) =>
                   // Invoke main with the supplied arguments.
@@ -219,7 +219,7 @@ object Main {
           exitOnResult {
             Bootstrap.bootstrap(cwd, options.githubToken).flatMap { bootstrap =>
               val flix = new Flix().setFormatter(formatter)
-              flix.setOptions(options.copy(loadClassFiles = false))
+              flix.setOptions(options)
               bootstrap.build(flix)
             }
           }
@@ -232,7 +232,7 @@ object Main {
           exitOnResult {
             Bootstrap.bootstrap(cwd, options.githubToken).flatMap { bootstrap =>
               val flix = new Flix().setFormatter(formatter)
-              flix.setOptions(options.copy(loadClassFiles = false))
+              flix.setOptions(options)
               bootstrap.buildClasses(flix)
             }
           }
@@ -245,7 +245,7 @@ object Main {
           exitOnResult {
             Bootstrap.bootstrap(cwd, options.githubToken).flatMap { bootstrap =>
               val flix = new Flix().setFormatter(formatter)
-              flix.setOptions(options.copy(loadClassFiles = false))
+              flix.setOptions(options)
               bootstrap.buildJar(flix)
             }
           }
@@ -258,7 +258,7 @@ object Main {
           exitOnResult {
             Bootstrap.bootstrap(cwd, options.githubToken).flatMap { bootstrap =>
               val flix = new Flix().setFormatter(formatter)
-              flix.setOptions(options.copy(loadClassFiles = false))
+              flix.setOptions(options)
               bootstrap.buildFatJar(flix)
             }
           }
@@ -349,7 +349,7 @@ object Main {
             val flix = mkFlixWithFiles(cmdOpts.files, options.copy(progress = false))
             flix.compile() match {
               case Validation.Success(compilationResult) =>
-                Tester.run(Nil, compilationResult)(flix) match {
+                Tester.run(Nil, JvmLoader.load(compilationResult))(flix) match {
                   case Result.Ok(_) => System.exit(0)
                   case Result.Err(_) => System.exit(1)
                 }

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.ast.{Scheme, SourceLocation, Symbol, TypedAst}
 import ca.uwaterloo.flix.language.phase.HtmlDocumentor
 import ca.uwaterloo.flix.language.phase.jvm.{JvmClass, JvmName}
-import ca.uwaterloo.flix.runtime.CompilationResult
+import ca.uwaterloo.flix.runtime.{CompilationResult, JvmLoader}
 import ca.uwaterloo.flix.runtime.shell.FileWatcher
 import ca.uwaterloo.flix.tools.Tester
 import ca.uwaterloo.flix.tools.pkg.github.GitHub
@@ -446,7 +446,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     * No class files (or other files) are written to the file system.
     */
   def build(flix: Flix): Result[CompilationResult, BootstrapError] =
-    compileProject(flix, Build.Development, loadClassFiles = false)
+    compileProject(flix, Build.Development)
 
   /**
     * Builds (compiles) the source files for the project in production mode and
@@ -454,7 +454,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     */
   def buildClasses(flix: Flix): Result[Unit, BootstrapError] = {
     for {
-      result <- compileProject(flix, Build.Production, loadClassFiles = false)
+      result <- compileProject(flix, Build.Production)
       _ <- Steps.writeClasses(result.getClasses)
     } yield {
       ()
@@ -464,11 +464,11 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
   /**
     * Compiles the source files for the project.
     *
-    * If `loadClassFiles` is `true` the generated classes are loaded into the JVM.
+    * The generated classes are not loaded into the JVM (see [[JvmLoader.load]]).
     */
-  private def compileProject(flix: Flix, build: Build, loadClassFiles: Boolean): Result[CompilationResult, BootstrapError] = {
+  private def compileProject(flix: Flix, build: Build): Result[CompilationResult, BootstrapError] = {
     // We disable incremental compilation to ensure a clean compile.
-    val newOptions = flix.options.copy(build = build, incremental = false, loadClassFiles = loadClassFiles)
+    val newOptions = flix.options.copy(build = build, incremental = false)
     flix.setOptions(newOptions)
 
     // We also clear any cached ASTs.
@@ -868,9 +868,9 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     */
   def run(flix: Flix, args: Array[String]): Result[Unit, BootstrapError] = {
     for {
-      compilationResult <- compileProject(flix, Build.Development, loadClassFiles = true)
+      compilationResult <- compileProject(flix, Build.Development)
     } yield {
-      compilationResult.getMain match {
+      JvmLoader.load(compilationResult).main match {
         case None => ()
         case Some(main) => main(args)
       }
@@ -882,8 +882,8 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     */
   def test(flix: Flix): Result[Unit, BootstrapError] = {
     for {
-      compilationResult <- compileProject(flix, Build.Development, loadClassFiles = true)
-      res <- Tester.run(Nil, compilationResult)(flix).mapErr(_ => BootstrapError.GeneralError("Tester Error"))
+      compilationResult <- compileProject(flix, Build.Development)
+      res <- Tester.run(Nil, JvmLoader.load(compilationResult))(flix).mapErr(_ => BootstrapError.GeneralError("Tester Error"))
     } yield {
       res
     }
@@ -1202,7 +1202,6 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     /**
       * Runs the compile function on the `flix` object.
       * It is up to the caller to set the appropriate options on `flix`.
-      * It is often the case that `loadClassFiles` must be toggled on or off.
       */
     def compile(flix: Flix): Result[CompilationResult, BootstrapError] = {
       val (optRoot, errors) = flix.check()
@@ -1222,7 +1221,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       * @see [[Build.Production]]
       */
     def configureJarOutput(flix: Flix): Result[Unit, BootstrapError] = {
-      val newOptions = flix.options.copy(build = Build.Production, loadClassFiles = false)
+      val newOptions = flix.options.copy(build = Build.Production)
       flix.setOptions(newOptions)
       Ok(())
     }

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -697,7 +697,7 @@ class Flix {
     // Construct the compilation result. The generated classes are not loaded into the JVM;
     // that is the caller's responsibility (see [[ca.uwaterloo.flix.runtime.JvmLoader]]).
     val totalSize = bytecodeAst.classes.values.map(_.bytecode.length).sum
-    val result = new CompilationResult(bytecodeAst, this, totalTime, totalSize)
+    val result = new CompilationResult(bytecodeAst, totalTime, totalSize, this)
 
     // Shutdown fork-join thread pool.
     shutdownForkJoinPool()

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.shared.{AvailableClasses, Input, SecurityC
 import ca.uwaterloo.flix.language.dbg.AstPrinter
 import ca.uwaterloo.flix.language.fmt.FormatOptions
 import ca.uwaterloo.flix.language.phase.*
-import ca.uwaterloo.flix.language.phase.jvm.{CodeGen, JvmLoader}
+import ca.uwaterloo.flix.language.phase.jvm.CodeGen
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization
 import ca.uwaterloo.flix.language.phase.monomorph2.ConstraintMonomorphization
 import ca.uwaterloo.flix.language.phase.optimizer.{LambdaDrop, Optimizer}
@@ -694,12 +694,10 @@ class Flix {
 
     val totalTime = flix.getTotalTime
 
-    // (Optionally) load generated JVM classes.
-    val loaderResult = JvmLoader.run(bytecodeAst)
-
-    // Construct the compilation result.
+    // Construct the compilation result. The generated classes are not loaded into the JVM;
+    // that is the caller's responsibility (see [[ca.uwaterloo.flix.runtime.JvmLoader]]).
     val totalSize = bytecodeAst.classes.values.map(_.bytecode.length).sum
-    val result = new CompilationResult(bytecodeAst.classes, loaderResult.main, loaderResult.tests, loaderResult.sources, totalTime, totalSize)
+    val result = new CompilationResult(bytecodeAst, this, totalTime, totalSize)
 
     // Shutdown fork-join thread pool.
     shutdownForkJoinPool()

--- a/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
@@ -27,14 +27,14 @@ import ca.uwaterloo.flix.language.phase.jvm.{JvmClass, JvmName}
   * The generated classes are *not* loaded into the JVM. Use [[JvmLoader.load]] to obtain a [[LoadedProgram]].
   *
   * @param root      the generated JVM classes together with the main and test entry points.
-  * @param flix      the Flix instance that produced this result (provides the external JAR class loader and crash reporting).
   * @param totalTime the total compilation time.
   * @param codeSize  the number of bytes the compiler generated.
+  * @param flix      the Flix instance that produced this result (provides the external JAR class loader and crash reporting).
   */
 class CompilationResult(val root: BytecodeAst.Root,
-                        val flix: Flix,
                         val totalTime: Long,
-                        val codeSize: Int
+                        val codeSize: Int,
+                        val flix: Flix
                        ) {
 
   /** Returns the generated JVM classes. */

--- a/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
@@ -16,6 +16,7 @@
 
 package ca.uwaterloo.flix.runtime
 
+import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.shared.Source
 import ca.uwaterloo.flix.language.phase.jvm.{JvmClass, JvmName}
@@ -23,35 +24,37 @@ import ca.uwaterloo.flix.language.phase.jvm.{JvmClass, JvmName}
 /**
   * A class representing the result of a compilation.
   *
-  * @param classes   the generated JVM classes.
-  * @param main      the reflected main function, if present.
-  * @param tests     the tests in the program.
-  * @param sources   the sources of the program.
-  * @param totalTime the total compilation time, excluding class loading.
-  * @param codeSize   the number of bytes the compiler generated.
+  * The generated classes are *not* loaded into the JVM. Use [[JvmLoader.load]] to obtain a [[LoadedProgram]].
+  *
+  * @param root      the generated JVM classes together with the main and test entry points.
+  * @param flix      the Flix instance that produced this result (provides the external JAR class loader and crash reporting).
+  * @param totalTime the total compilation time.
+  * @param codeSize  the number of bytes the compiler generated.
   */
-class CompilationResult(classes: Map[JvmName, JvmClass],
-                        main: Option[Array[String] => Unit],
-                        tests: Map[Symbol.DefnSym, TestFn],
-                        sources: Map[Source, SourceLocation],
+class CompilationResult(val root: BytecodeAst.Root,
+                        val flix: Flix,
                         val totalTime: Long,
                         val codeSize: Int
                        ) {
 
   /** Returns the generated JVM classes. */
   def getClasses: Map[JvmName, JvmClass] =
-    classes
+    root.classes
 
-  /** Optionally returns the main function. */
-  def getMain: Option[Array[String] => Unit] =
-    main
+  /** Optionally returns the main entry point. */
+  def getMain: Option[BytecodeAst.Def] =
+    root.main
 
-  /** Returns all the test functions in the program. */
-  def getTests: Map[Symbol.DefnSym, TestFn] =
-    tests
+  /** Returns all the test entry points in the program. */
+  def getTests: Map[Symbol.DefnSym, BytecodeAst.Test] =
+    root.tests
+
+  /** Returns the sources of the program. */
+  def getSources: Map[Source, SourceLocation] =
+    root.sources
 
   /** Returns the total number of lines of compiled code. */
-  def getTotalLines: Int = sources.foldLeft(0) {
+  def getTotalLines: Int = root.sources.foldLeft(0) {
     case (acc, (_, sl)) => acc + sl.endLine
   }
 

--- a/main/src/ca/uwaterloo/flix/runtime/FlixClassLoader.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/FlixClassLoader.scala
@@ -14,21 +14,22 @@
  * limitations under the License.
  */
 
-package ca.uwaterloo.flix.language.phase.jvm
+package ca.uwaterloo.flix.runtime
 
-import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.JvmClass
 
 import scala.collection.mutable
 
 /**
   * A custom class loader to load generated class files.
   *
-  * @param classes A map from internal names (strings) to JvmClasses.
+  * @param classes   A map from internal names (strings) to JvmClasses.
+  * @param jarLoader The class loader used to resolve classes from external JARs.
   *
   * We pass the platform class loader as the parent to avoid it delegating to the system classloader
   * (otherwise compiled Flix code has access to all classes within the compiler)
   */
-class FlixClassLoader(classes: Map[String, JvmClass])(implicit flix: Flix) extends ClassLoader(ClassLoader.getPlatformClassLoader) {
+class FlixClassLoader(classes: Map[String, JvmClass], jarLoader: ClassLoader) extends ClassLoader(ClassLoader.getPlatformClassLoader) {
 
   /**
     * An internal cache of already loaded classes.
@@ -47,7 +48,7 @@ class FlixClassLoader(classes: Map[String, JvmClass])(implicit flix: Flix) exten
           case None =>
             // Case 1.1: The internal name does not exist. Try the external JAR loader.
             try {
-              val clazz = flix.jarLoader.loadClass(name)
+              val clazz = jarLoader.loadClass(name)
               cache.put(name, clazz)
               clazz
             } catch {

--- a/main/src/ca/uwaterloo/flix/runtime/JvmLoader.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/JvmLoader.scala
@@ -15,41 +15,54 @@
  * limitations under the License.
  */
 
-package ca.uwaterloo.flix.language.phase.jvm
+package ca.uwaterloo.flix.runtime
 
-import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.BytecodeAst.*
-import ca.uwaterloo.flix.language.ast.shared.Source
+import ca.uwaterloo.flix.api.{CrashHandler, Flix}
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
-import ca.uwaterloo.flix.runtime.TestFn
+import ca.uwaterloo.flix.language.phase.jvm.{JvmClass, JvmName}
 import ca.uwaterloo.flix.util.collection.MapOps
 import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils}
 
 import java.lang.reflect.{InvocationTargetException, Method}
 
+/**
+  * Loads the classes of a [[CompilationResult]] into the JVM.
+  *
+  * This is not part of the compiler pipeline: `Flix.codeGen` stops at bytecode.
+  * Callers that want to *run* the compiled program (or its tests) invoke [[load]] explicitly.
+  */
 object JvmLoader {
 
-  case class LoaderResult(
-                           main: Option[Array[String] => Unit],
-                           tests: Map[Symbol.DefnSym, TestFn],
-                           sources: Map[Source, SourceLocation]
-                         )
-
   /**
-    * Loads `classes` if enabled by [[Flix.options.loadClassFiles]] and returns handles to the methods.
+    * Loads the classes of `result` into a fresh class loader and returns reflected handles to `main` and the tests.
     *
-    * Additionally computes the total byte size of `classes`
+    * The class loader falls back to `result.flix.jarLoader` for classes from external JARs.
+    *
+    * A failure to load (or to find an entry point) is a compiler bug and is reported via [[CrashHandler]].
+    * Exceptions thrown by the *program* itself, when `main` or a test is invoked, are not caught here.
     */
-  def run(root: Root)(implicit flix: Flix): LoaderResult = {
-    if (flix.options.loadClassFiles) {
-      val (main, tests) = load(root)
-      LoaderResult(main, tests, root.sources)
-    } else {
-      LoaderResult(None, Map.empty, root.sources)
+  def load(result: CompilationResult): LoadedProgram = try {
+    implicit val flix: Flix = result.flix
+    val root = result.root
+
+    // Load each class into the JVM in a fresh class loader.
+    implicit val loadedClasses: Map[JvmName, Class[?]] = loadAll(root.classes.values, flix.jarLoader)
+
+    val tests = MapOps.mapValuesWithKey(root.tests) {
+      case (sym, defn) => TestFn(sym, defn.isSkip, wrapTest(loadMethod(defn.className, defn.methodName)))
     }
+    val main = root.main.map {
+      case defn => wrapMain(loadMethod(defn.className, defn.methodName))
+    }
+
+    LoadedProgram(main, tests)
+  } catch {
+    case ex: Throwable =>
+      CrashHandler.handleCrash(ex)(result.flix)
+      throw ex
   }
 
-  /** Returns the tests of `root`. */
+  /** Wraps the reflected test `method` (of type `Unit -> t`) into a thunk. */
   private def wrapTest(method: Method): () => AnyRef = {
     val parameterCount = method.getParameterCount
     val argsArray = Array(null: AnyRef)
@@ -71,22 +84,7 @@ object JvmLoader {
     }
   }
 
-  /** Loads the classes of `root` into the JVM. Returns `(main, tests)` reflected methods, based on `root`. */
-  private def load(root: Root)(implicit flix: Flix): (Option[Array[String] => Unit], Map[Symbol.DefnSym, TestFn]) = {
-    // Load each class into the JVM in a fresh class loader.
-    implicit val loadedClasses: Map[JvmName, Class[?]] = loadAll(root.classes.values)
-
-    val tests = MapOps.mapValuesWithKey(root.tests) {
-      case (sym, defn) => TestFn(sym, defn.isSkip, wrapTest(loadMethod(defn.className, defn.methodName)))
-    }
-    val main = root.main.map {
-      case defn => wrapMain(loadMethod(defn.className, defn.methodName))
-    }
-
-    (main, tests)
-  }
-
-  /** Returns the [[Method]] object of the main function of `root` if it is defined. */
+  /** Wraps the reflected main `method` (of type `Array[String] -> Unit`) into a function. */
   private def wrapMain(method: Method): Array[String] => Unit = {
     val parameterCount = method.getParameterCount
     val argumentCount = 1 // A single Array[String] argument.
@@ -119,15 +117,15 @@ object JvmLoader {
     }
   }
 
-  /** Loads the given JVM `classes` using a custom class loader. */
-  private def loadAll(classes: Iterable[JvmClass])(implicit flix: Flix): Map[JvmName, Class[?]] = {
+  /** Loads the given JVM `classes` using a custom class loader that falls back to `jarLoader`. */
+  private def loadAll(classes: Iterable[JvmClass], jarLoader: ClassLoader): Map[JvmName, Class[?]] = {
     // Compute a map from binary names (strings) to JvmClasses.
     val m = classes.foldLeft(Map.empty[String, JvmClass]) {
       case (macc, jvmClass) => macc + (jvmClass.name.toBinaryName -> jvmClass)
     }
 
     // Instantiate the Flix class loader with this map.
-    val loader = new FlixClassLoader(m)
+    val loader = new FlixClassLoader(m, jarLoader)
 
     // Attempt to load each class using its internal name.
     classes.foldLeft(Map.empty[JvmName, Class[?]]) {

--- a/main/src/ca/uwaterloo/flix/runtime/LoadedProgram.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/LoadedProgram.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.runtime
+
+import ca.uwaterloo.flix.language.ast.Symbol
+
+/**
+  * A compiled Flix program whose classes have been defined in the JVM.
+  *
+  * Obtained from [[JvmLoader.load]].
+  *
+  * @param main  the reflected main function, if present. Takes the program arguments.
+  * @param tests the reflected test functions in the program.
+  */
+case class LoadedProgram(main: Option[Array[String] => Unit], tests: Map[Symbol.DefnSym, TestFn])

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.api.{Bootstrap, BootstrapError, CompilerConstants, Flix
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
+import ca.uwaterloo.flix.runtime.JvmLoader
 import ca.uwaterloo.flix.util.Formatter.AnsiTerminalFormatter
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.Chain
@@ -340,7 +341,7 @@ class Shell(bootstrap: Bootstrap, options: Options) {
     // Recompile the program.
     check(entryPoint = Some(main), progress = false).toResult match {
       case Result.Ok(root) =>
-        flix.codeGen(root).getMain match {
+        JvmLoader.load(flix.codeGen(root)).main match {
           case Some(m) =>
             // Evaluate the main function
             try {

--- a/main/src/ca/uwaterloo/flix/tools/BenchmarkCompilerOld.scala
+++ b/main/src/ca/uwaterloo/flix/tools/BenchmarkCompilerOld.scala
@@ -242,7 +242,7 @@ object BenchmarkCompilerOld {
 
     val flix = new Flix()
 
-    flix.setOptions(opts = o.copy(incremental = false, loadClassFiles = false))
+    flix.setOptions(opts = o.copy(incremental = false))
 
     addInputs(flix)
 

--- a/main/src/ca/uwaterloo/flix/tools/CompilerPerf.scala
+++ b/main/src/ca/uwaterloo/flix/tools/CompilerPerf.scala
@@ -215,7 +215,7 @@ object CompilerPerf {
     */
   def run(opts: Options): Unit = {
     // Options
-    val o = opts.copy(progress = false, loadClassFiles = false)
+    val o = opts.copy(progress = false)
 
     // The number of iterations.
     val N = o.XPerfN.getOrElse(DefaultN)

--- a/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
@@ -16,6 +16,7 @@
 package ca.uwaterloo.flix.tools
 
 import ca.uwaterloo.flix.api.{CompilerConstants, Flix, Version}
+import ca.uwaterloo.flix.runtime.JvmLoader
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
@@ -198,8 +199,8 @@ class SocketServer(port: Int) extends WebSocketServer(new InetSocketAddress(port
         case Result.Ok(compilationResult) =>
           // Compilation was successful.
 
-          // Determine if the main function is present.
-          compilationResult.getMain match {
+          // Load the program and determine if the main function is present.
+          JvmLoader.load(compilationResult).main match {
             case None =>
               // The main function was not present. Just report successful compilation.
               Ok(("Compilation was successful. No main function to run.", compilationResult.totalTime, 0L))

--- a/main/src/ca/uwaterloo/flix/tools/Tester.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Tester.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.tools
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Symbol
-import ca.uwaterloo.flix.runtime.{CompilationResult, TestFn}
+import ca.uwaterloo.flix.runtime.{LoadedProgram, TestFn}
 import ca.uwaterloo.flix.util.{Duration, Result}
 import org.jline.terminal.{Terminal, TerminalBuilder}
 
@@ -34,11 +34,11 @@ object Tester {
   /**
     * Runs all tests.
     */
-  def run(filters: List[Regex], compilationResult: CompilationResult)(implicit flix: Flix): Result[Unit, Int] = {
+  def run(filters: List[Regex], program: LoadedProgram)(implicit flix: Flix): Result[Unit, Int] = {
     //
     // Find all test cases (both active and ignored).
     //
-    val tests = getTestCases(filters, compilationResult)
+    val tests = getTestCases(filters, program)
 
     // Start the TestRunner and TestReporter.
     val queue = new ConcurrentLinkedQueue[TestEvent]()
@@ -315,9 +315,9 @@ object Tester {
   }
 
   /**
-    * Returns all test cases from the given compilation `result` which satisfy at least one filter.
+    * Returns all test cases from the given loaded `program` which satisfy at least one filter.
     */
-  private def getTestCases(filters: List[Regex], compilationResult: CompilationResult): Vector[TestCase] = {
+  private def getTestCases(filters: List[Regex], program: LoadedProgram): Vector[TestCase] = {
     /**
       * Returns `true` if at least one filter matches the given symbol _OR_ if there are no filters.
       */
@@ -326,7 +326,7 @@ object Tester {
       filters.isEmpty || filters.exists(regex => regex.matches(name))
     }
 
-    val allTests = compilationResult.getTests.map {
+    val allTests = program.tests.map {
       case (sym, TestFn(_, skip, run)) => TestCase(sym, skip, run)
     }
 

--- a/main/src/ca/uwaterloo/flix/util/Options.scala
+++ b/main/src/ca/uwaterloo/flix/util/Options.scala
@@ -33,7 +33,6 @@ object Options {
     json = false,
     progress = false,
     threads = Runtime.getRuntime.availableProcessors(),
-    loadClassFiles = true,
     assumeYes = false,
     xprintphases = false,
     xnodeprecated = false,
@@ -80,7 +79,6 @@ object Options {
   * @param json           enable json output.
   * @param progress       print progress during compilation.
   * @param threads        selects the number of threads to use.
-  * @param loadClassFiles loads the generated class files into the JVM.
   * @param assumeYes      run non-interactively and assume answer to all prompts is yes.
   */
 case class Options(lib: LibLevel,
@@ -93,7 +91,6 @@ case class Options(lib: LibLevel,
                    json: Boolean,
                    progress: Boolean,
                    threads: Int,
-                   loadClassFiles: Boolean,
                    assumeYes: Boolean,
                    xprintphases: Boolean,
                    xnodeprecated: Boolean,

--- a/main/test/ca/uwaterloo/flix/StandardLibrarySuite.scala
+++ b/main/test/ca/uwaterloo/flix/StandardLibrarySuite.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
-import ca.uwaterloo.flix.runtime.{CompilationResult, TestFn}
+import ca.uwaterloo.flix.runtime.{JvmLoader, LoadedProgram, TestFn}
 import ca.uwaterloo.flix.util.{FileOps, Options, Result}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -49,7 +49,7 @@ class StandardLibrarySuite extends AnyFunSuite {
     // Compile the program with all test suites.
     flix.compile().toResult match {
       case Result.Ok(compilationResult) =>
-        runTests(compilationResult)
+        runTests(JvmLoader.load(compilationResult))
       case Result.Err(errors) =>
         fail(CompilationMessage.formatAll(errors.toList)(flix.getFormatter, None))
     }
@@ -62,9 +62,9 @@ class StandardLibrarySuite extends AnyFunSuite {
       }
   }
 
-  private def runTests(r: CompilationResult): Unit = {
+  private def runTests(program: LoadedProgram): Unit = {
     // Group the tests by namespace.
-    val testsByNamespace = r.getTests.groupBy {
+    val testsByNamespace = program.tests.groupBy {
       case (sym, _) => sym.namespace
     }
 

--- a/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language
 import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.phase.jvm.BackendObjType
-import ca.uwaterloo.flix.runtime.CompilationResult
+import ca.uwaterloo.flix.runtime.{CompilationResult, JvmLoader}
 import ca.uwaterloo.flix.util.{Options, Result, Validation}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -47,7 +47,7 @@ class TestFlixErrors extends AnyFunSuite {
 
   def expectRuntimeError(v: Validation[CompilationResult, CompilationMessage], name: String): Unit = {
     v.toResult match {
-      case Result.Ok(t) => t.getMain match {
+      case Result.Ok(t) => JvmLoader.load(t).main match {
         case Some(main) => try {
           main.apply(Array.empty)
           fail("No runtime error thrown")

--- a/main/test/ca/uwaterloo/flix/language/TestProgramArgs.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestProgramArgs.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language
 
 import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
+import ca.uwaterloo.flix.runtime.JvmLoader
 import ca.uwaterloo.flix.util.{Options, Result}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -42,7 +43,7 @@ class TestProgramArgs extends AnyFunSuite {
       .addVirtualPath(CompilerConstants.VirtualTestFile, input)
       .compile()
     result.toResult match {
-      case Result.Ok(r) => r.getMain match {
+      case Result.Ok(r) => JvmLoader.load(r).main match {
         case Some(main) => try {
           main.apply(Array(arg))
         } catch {

--- a/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
+++ b/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.api.{Flix, FlixEvent}
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
-import ca.uwaterloo.flix.runtime.{CompilationResult, TestFn}
+import ca.uwaterloo.flix.runtime.{JvmLoader, LoadedProgram, TestFn}
 import ca.uwaterloo.flix.verifier.{EffectVerifier, TypeVerifier}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -117,10 +117,10 @@ class FlixSuite(incremental: Boolean) extends AnyFunSuite {
     }
 
     try {
-      // Compile and Evaluate the program to obtain the compilationResult.
+      // Compile the program, load it into the JVM, and run its tests.
       Flix.compile().toResult match {
         case Result.Ok(compilationResult) =>
-          runTests(compilationResult)
+          runTests(JvmLoader.load(compilationResult))
         case Result.Err(errors) =>
           fail(CompilationMessage.formatAll(errors.toList)(Flix.getFormatter, None))
       }
@@ -132,9 +132,9 @@ class FlixSuite(incremental: Boolean) extends AnyFunSuite {
     }
   }
 
-  private def runTests(compilationResult: CompilationResult): Unit = {
+  private def runTests(program: LoadedProgram): Unit = {
     // Group the tests by namespace.
-    val testsByNamespace = compilationResult.getTests.groupBy(_._1.namespace)
+    val testsByNamespace = program.tests.groupBy(_._1.namespace)
 
     // Iterate through each namespace.
     for ((_, tests) <- testsByNamespace) {


### PR DESCRIPTION
## Summary

`JvmLoader` was the one step in `Flix.codeGen` that *executed* rather than *produced*: it defined the generated classes in a `FlixClassLoader` and reflectively wrapped `main`/`@Test` methods into closures. It was already not a phase (#10790) and excluded from `totalTime`, but it lived in `language.phase.jvm`, ran unconditionally inside `codeGen`, and was the sole reason `Options.loadClassFiles` existed.

This PR makes `Flix.codeGen` a pure "source → bytecode" function and moves class loading into `ca.uwaterloo.flix.runtime` as a caller-invoked service.

- **`CompilationResult`** now holds the `BytecodeAst.Root` (`getClasses` / `getMain: Option[BytecodeAst.Def]` / `getTests: Map[DefnSym, BytecodeAst.Test]` / `getSources` / `getTotalLines`), the producing `Flix` instance, `totalTime` and `codeSize`. No classes are loaded.
- **`runtime.LoadedProgram`** (new): `main: Option[Array[String] => Unit]` + `tests: Map[DefnSym, TestFn]`.
- **`runtime.JvmLoader.load(result): LoadedProgram`** (moved from `phase.jvm`): defines the classes in a fresh `FlixClassLoader` (falling back to `flix.jarLoader` for external JARs) and reflects the entry points. Load-time failures are reported through `CrashHandler`, as they were when this ran inside `codeGen`; exceptions thrown by the program itself are not caught.
- **`FlixClassLoader`** (moved) takes an explicit `ClassLoader` instead of an implicit `Flix`.
- **`Options.loadClassFiles` deleted**, along with all `.copy(loadClassFiles = …)` toggles and `Bootstrap.compileProject`'s `loadClassFiles` parameter.
- Callers that run code now load explicitly: `Main` (`flix <files>`, `flix test <files>`), `Bootstrap.run`/`test`, `Shell.run`, `SocketServer`, and the test harnesses (`FlixSuite`, `StandardLibrarySuite`, `TestFlixErrors`, `TestProgramArgs`). `Tester.run` takes a `LoadedProgram`. Callers that only need timing/size, or that discard the result (`build*`, `CompilerPerf`, `BenchmarkCompilerOld`, `ShowAstProvider`, …), no longer load classes as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
