### PR TITLE
feat: add phase progress bar and elapsed time to progress bar

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/CompilerConstants.scala
+++ b/main/src/ca/uwaterloo/flix/api/CompilerConstants.scala
@@ -28,9 +28,23 @@ object CompilerConstants {
   val AstDirectory: Path = Path.of("./build/asts/")
 
   /**
+    * The number of backend phases, i.e. the number of `phase` / `phaseNew` calls made by [[Flix.codeGen]].
+    *
+    * Must be updated when a phase is added to or removed from `codeGen`.
+    */
+  val BackendPhaseCount: Int = 13
+
+  /**
     * The directory where the recorded type constraint graphs are written.
     */
   val ConstraintGraphDirectory: Path = Path.of("./build/constraint-graphs/")
+
+  /**
+    * The number of frontend phases, i.e. the number of `phase` / `phaseNew` calls made by [[Flix.check]].
+    *
+    * Must be updated when a phase is added to or removed from `check`.
+    */
+  val FrontendPhaseCount: Int = 19
 
   /**
     * The JVM bytecode version used when generating class files.
@@ -57,6 +71,11 @@ object CompilerConstants {
     * The directory where the compiler performance data and graphs are written (see `Xperf`).
     */
   val PerfDirectory: Path = Path.of("./build/perf/")
+
+  /**
+    * The total number of phases run by a full compilation, i.e. by [[Flix.compile]].
+    */
+  val TotalPhases: Int = FrontendPhaseCount + BackendPhaseCount
 
   /**
     * The virtual file name used by the playground.

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -756,7 +756,7 @@ class Flix {
     currentPhase = Some(PhaseTime(phase, 0))
 
     if (options.progress) {
-      progressBar.observe(phase, "")
+      progressBar.observe(phase)
     }
 
     // Measure the execution time.
@@ -785,7 +785,7 @@ class Flix {
     currentPhase = Some(PhaseTime(phase, 0))
 
     if (options.progress) {
-      progressBar.observe(phase, "")
+      progressBar.observe(phase)
     }
 
     // Measure the execution time.

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -15,6 +15,7 @@
  */
 package ca.uwaterloo.flix.tools.compilertop
 
+import ca.uwaterloo.flix.api.CompilerConstants
 import ca.uwaterloo.flix.tools.compilertop.Aggregation.*
 import ca.uwaterloo.flix.tools.compilertop.Ansi.*
 import ca.uwaterloo.flix.tools.compilertop.Formatting.*
@@ -40,7 +41,7 @@ import scala.collection.mutable
   * @param currentPhase    already-resolved phase label (e.g. `"Typer"`,
   *                        `"done"`, or `"starting"`).
   * @param phaseTimersSize raw `flix.phaseTimers.size`; the renderer caps to
-  *                        [[Renderer.TotalPhases]] for the progress bar.
+  *                        [[CompilerConstants.TotalPhases]] for the progress bar.
   * @param coverage        accounted/unaccounted phase-wall split behind the
   *                        stats-line `observed` figure (see [[Model.Coverage]]).
   * @param activeFilter    user-toggled phase filter (drives the legend).
@@ -75,9 +76,6 @@ final case class FrameState(parallelism: Int,
                             coverage: Coverage)
 
 object Renderer {
-
-  /** Total number of phases the compiler runs. Bump when `Flix.check` / `Flix.codeGen` adds or removes a `phase` / `phaseNew` call. */
-  private val TotalPhases: Int = 32
 
   /** Longest phase-name length, used to pad the phase column. Currently set by `"Dependencies"` / `"EffectBinder"`. */
   private val MaxPhaseLen: Int = 12
@@ -412,8 +410,8 @@ final class Renderer {
     // Once compilation has finished, force the bar to 100% rather than relying
     // on `phaseTimers.size + 1` (which is +1 ahead of reality during execution
     // and would still under-fill if any phase is uninstrumented).
-    val done = if (state.isDone) TotalPhases else (state.phaseTimersSize + 1).min(TotalPhases)
-    val filled = (BarWidth.toLong * done / TotalPhases).toInt
+    val done = if (state.isDone) CompilerConstants.TotalPhases else (state.phaseTimersSize + 1).min(CompilerConstants.TotalPhases)
+    val filled = (BarWidth.toLong * done / CompilerConstants.TotalPhases).toInt
 
     sb.append("  ")
     sb.append(bold(rpad(state.currentPhase, MaxPhaseLen)))
@@ -425,7 +423,7 @@ final class Renderer {
     sb.append(if (state.isDone) green(filledBar) else blue(filledBar))
     sb.append(dim("░" * (BarWidth - filled)))
     sb.append(dim("] "))
-    sb.append(f"$done%2d/$TotalPhases%2d")
+    sb.append(f"$done%2d/${CompilerConstants.TotalPhases}%2d")
     sb.append(dim("   threads "))
     // With parallelism=1 ForkJoin runs work inline on the submitter, leaving
     // `getActiveThreadCount` at 0 most of the time — sparkline goes flat,

--- a/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
+++ b/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.util
 
-import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -28,7 +28,14 @@ class ProgressBar(flix: Flix) {
   /**
     * The characters in the spinner.
     */
-  private val SpinnerChars = Array("|", "/", "-", "\\")
+  private val SpinnerChars = Array("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+
+  /**
+    * The width of the phase name column in visible characters.
+    *
+    * Set by the longest phase names: "Dependencies" and "EffectBinder".
+    */
+  private val PhaseWidth = 12
 
   /**
     * An internal counter used to print the spinner.
@@ -38,10 +45,15 @@ class ProgressBar(flix: Flix) {
   private val spinnerTick = new AtomicInteger(0)
 
   /**
-    * Updates the progress with the given message `msg` in the given `phase`.
+    * The time (in nanoseconds) at which the first phase of the current compilation was observed.
     */
-  def observe(phase: String, msg: String): Unit = {
-    print(phase, msg)
+  private var startNanos: Long = System.nanoTime()
+
+  /**
+    * Updates the progress to the given `phase`.
+    */
+  def observe(phase: String): Unit = {
+    print(phase)
   }
 
   /**
@@ -55,11 +67,13 @@ class ProgressBar(flix: Flix) {
   }
 
   /**
-    * Prints the given string `msg` from the given `phase` to the terminal.
+    * Prints the progress line for the given `phase` to the terminal.
     *
     * This function flushes the output and should not be called too often.
     */
-  private def print(phase: String, msg: String): Unit = {
+  private def print(phase: String): Unit = {
+    val fmt = flix.getFormatter
+
     // Compute the next character in the spinner.
     val index = spinnerTick.getAndIncrement() % SpinnerChars.length
     val spinner = SpinnerChars(index)
@@ -73,26 +87,43 @@ class ProgressBar(flix: Flix) {
     val memoryPadded = f"$usedMemoryInMegaBytes%4dM"
     val memPart = usedMemoryInPercent match {
       case x if x < 70 => memoryPadded
-      case x if x < 90 => flix.getFormatter.yellow(memoryPadded)
-      case _ => flix.getFormatter.red(memoryPadded)
+      case x if x < 90 => fmt.yellow(memoryPadded)
+      case _ => fmt.red(memoryPadded)
     }
 
-    // We abbreviate phase and msg if they are too long to fit within `Width`.
-    // The fixed parts (spinner, memory, brackets, and spaces) take up 17 chars.
-    val p = abbreviate(phase, 20)
-    val m = abbreviate(msg, Width - (20 + 17))
-    val s = s" [${flix.getFormatter.green(spinner)}] [$memPart] [${flix.getFormatter.blue(p)}] $m "
+    // The phase name is abbreviated and padded to `PhaseWidth` so the columns to its right do not jitter.
+    val phasePadded = abbreviate(phase, PhaseWidth).padTo(PhaseWidth, ' ')
 
-    // Clear the current line.
-    // NB: We clear the line with spaces (rather than padding the string) because
-    // the string may contain ANSI escape codes which do not take up any width.
-    System.out.print(" " * Width + "\r")
+    // The phase progress bar has one cell per phase: the frontend cells (blue), a divider, and the backend cells (magenta).
+    // The finished phases are recorded in `phaseTimers`, so the current phase is number `phaseTimers.size + 1`.
+    // We cap at `TotalPhases` in case some phase is not instrumented.
+    val current = (flix.phaseTimers.size + 1).min(CompilerConstants.TotalPhases)
+    val frontendDone = current.min(CompilerConstants.FrontendPhaseCount)
+    val backendDone = current - frontendDone
+    val frontendBar = fmt.blue("█" * frontendDone) + "░" * (CompilerConstants.FrontendPhaseCount - frontendDone)
+    val backendBar = fmt.magenta("█" * backendDone) + "░" * (CompilerConstants.BackendPhaseCount - backendDone)
+    val bar = s"$frontendBar│$backendBar"
+    val count = f"$current%2d/${CompilerConstants.TotalPhases}%2d"
 
-    // Print the string followed by carriage return.
-    // NB: We do *NOT* print a newline because then
-    // we would not be able to overwrite the current
-    // line in the iteration.
-    System.out.print(s + "\r")
+    // Compute the time elapsed since the first phase of the current compilation, in tenths of a second.
+    // `phaseTimers` is reset when a compilation starts, so an empty list marks its first phase.
+    // NB: We format the tenths ourselves (rather than with `%.1f`) so the decimal separator is locale-independent.
+    if (flix.phaseTimers.isEmpty) startNanos = System.nanoTime()
+    val elapsedTenths = (System.nanoTime() - startNanos) / 100_000_000L
+    val elapsed = f"${elapsedTenths / 10}%3d.${elapsedTenths % 10}%ds"
+
+    val s = s" [${fmt.green(spinner)}] [$memPart] [${fmt.blue(phasePadded)}] [$bar] $count $elapsed"
+
+    // The visible width of the line, i.e. excluding ANSI escape codes: the spinner, memory, phase, bar, count,
+    // and elapsed fields together with their brackets and spaces. Typically 76 chars, which fits within `Width`.
+    val visibleWidth = 5 + (memoryPadded.length + 3) + (PhaseWidth + 3) + (CompilerConstants.TotalPhases + 4) + (count.length + 1) + elapsed.length
+
+    // Print the line, padded with spaces to `Width`, followed by a carriage return.
+    // NB: We pad the line (rather than first clearing it) so that each frame overwrites the previous
+    // one in a single write. Clearing first would briefly leave the line blank, which flickers, since
+    // `System.out` is auto-flushed and hence every `print` is a separate write to the terminal.
+    // NB: We do *NOT* print a newline because then we would not be able to overwrite the current line.
+    System.out.print(s + " " * (Width - visibleWidth) + "\r")
 
     // Flush to ensure that the string is printed.
     System.out.flush()


### PR DESCRIPTION
Extends the terminal progress bar with a phase progress bar and an elapsed-time field:

```
 [⠋] [  36M] [Reader      ] [█░░░░░░░░░░░░░░░░░░│░░░░░░░░░░░░░]  1/32   0.0s
 [⠏] [  36M] [Typer       ] [██████████░░░░░░░░░│░░░░░░░░░░░░░] 10/32   0.3s
 [⠇] [  36M] [Dependencies] [███████████████████│░░░░░░░░░░░░░] 19/32   1.9s
 [⠏] [  36M] [TreeShaker1 ] [███████████████████│█░░░░░░░░░░░░] 20/32   2.0s
 [⠙] [  36M] [CodeGen     ] [███████████████████│█████████████] 32/32   2.5s
```

- One cell per phase: the 19 frontend cells (blue), a divider, and the 13 backend cells (magenta), followed by the phase count. The current phase is `phaseTimers.size + 1`, matching the compiler top dashboard.
- Elapsed time since the first phase of the compilation, right-aligned in a fixed-width field. Formatted with integer arithmetic so the decimal separator is locale-independent.
- Braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`).
- The phase name is padded to a fixed width so the fields to its right do not jitter.
- Each frame is now a single write padded to the full width, rather than a clear followed by a print. `System.out` is auto-flushed, so every `print` is a separate write to the terminal and the pre-clear painted a blank frame in between (visible as flicker).
- The unused `msg` parameter of `ProgressBar.observe` is removed (dead since `flix.subtask` was removed in #11127).
- The phase counts live in `CompilerConstants` (`FrontendPhaseCount`, `BackendPhaseCount`, `TotalPhases`) and are shared by the progress bar and the compiler top renderer, replacing the latter's private `TotalPhases = 32`.

The line is 76 visible columns and always fits within the 80-column width.

Known limitation (kept for now): for frontend-only invocations such as `flix check`, the bar stops at `19/32` with the backend track empty, since `check()` cannot know whether a `codeGen()` will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
