### PR TITLE
chore: print bug-report message when PickException is thrown

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3412,6 +3412,7 @@ object Weeder2 {
       case Some(t) => t
       case None =>
         val error = NeedAtleastOne(NamedTokenSet.FromTreeKinds(Set(kind)), synctx, loc = tree.loc)
+        System.err.println(s"Unexpected PickException near ${tree.loc.format}. If you see this error, please report it to https://github.com/flix/flix/issues")
         throw PickException(error)
     }
   }
@@ -3426,6 +3427,7 @@ object Weeder2 {
       case Some(t) => t
       case _ =>
         val error = NeedAtleastOne(NamedTokenSet.FromKinds(Set(kind)), synctx, loc = tree.loc)
+        System.err.println(s"Unexpected PickException near ${tree.loc.format}. If you see this error, please report it to https://github.com/flix/flix/issues")
         throw PickException(error)
     }
   }


### PR DESCRIPTION
Both `PickException` throw sites in `Weeder2` (`pick` and `pickToken`) now print a message to stderr before throwing:

```
Unexpected PickException near <file>:<line>:<col>. If you see this error, please report it to https://github.com/flix/flix/issues
```

This makes it easier for users to notice and report cases where the weeder hits a missing sub-tree or token, which should not happen for well-formed syntax trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)