### PR TITLE
refactor: merge Flix.phase and Flix.phaseNew

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/CompilerConstants.scala
+++ b/main/src/ca/uwaterloo/flix/api/CompilerConstants.scala
@@ -28,7 +28,7 @@ object CompilerConstants {
   val AstDirectory: Path = Path.of("./build/asts/")
 
   /**
-    * The number of backend phases, i.e. the number of `phase` / `phaseNew` calls made by [[Flix.codeGen]].
+    * The number of backend phases, i.e. the number of `phase` calls made by [[Flix.codeGen]].
     *
     * Must be updated when a phase is added to or removed from `codeGen`.
     */
@@ -40,7 +40,7 @@ object CompilerConstants {
   val ConstraintGraphDirectory: Path = Path.of("./build/constraint-graphs/")
 
   /**
-    * The number of frontend phases, i.e. the number of `phase` / `phaseNew` calls made by [[Flix.check]].
+    * The number of frontend phases, i.e. the number of `phase` calls made by [[Flix.check]].
     *
     * Must be updated when a phase is added to or removed from `check`.
     */

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -147,7 +147,7 @@ class Flix {
   /**
     * The current phase we are in. Initially `None`. Volatile so the compiler
     * profiler renderer thread sees each store made by the compile thread in
-    * [[phase]] / [[phaseNew]].
+    * [[phase]].
     */
   @volatile private var currentPhase: Option[PhaseTime] = None
 
@@ -750,35 +750,10 @@ class Flix {
 
   /**
     * Enters the phase with the given name.
-    */
-  def phaseNew[A, B](phase: String)(f: => (A, B))(implicit d: Debug[A]): (A, B) = {
-    // Initialize the phase time object.
-    currentPhase = Some(PhaseTime(phase, 0))
-
-    if (options.progress) {
-      progressBar.observe(phase)
-    }
-
-    // Measure the execution time.
-    val t = System.nanoTime()
-    val (root, errs) = f
-    val e = System.nanoTime() - t
-
-    // Update the phase time and add it to the list of executed phases.
-    val finished = PhaseTime(phase, e)
-    currentPhase = Some(finished)
-    phaseTimers += finished
-
-    if (this.options.xprintphases) {
-      d.output(phase, root)(this)
-    }
-
-    // Return the result computed by the phase.
-    (root, errs)
-  }
-
-  /**
-    * Enters the phase with the given name.
+    *
+    * Runs `f`, records its execution time, and, if `--Xprint-phases` is enabled,
+    * hands the result to `d`. Phases returning a `(root, errors)` pair get their
+    * [[Debug]] instance from [[Debug.debugPair]], which debugs only the root.
     */
   def phase[A](phase: String)(f: => A)(implicit d: Debug[A]): A = {
     // Initialize the phase time object.

--- a/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.shared.Source
 import ca.uwaterloo.flix.language.dbg.printer.*
 import ca.uwaterloo.flix.util.tc.Debug
-import ca.uwaterloo.flix.util.{FileOps, Validation}
+import ca.uwaterloo.flix.util.FileOps
 
 import java.nio.file.Path
 
@@ -99,17 +99,6 @@ object AstPrinter {
   implicit object DebugJvmAst extends Debug[JvmAst.Root] {
     override def emit(phase: String, root: JvmAst.Root)(implicit flix: Flix): Unit =
       printDocProgram(phase, JvmAstPrinter.print(root))
-  }
-
-  case class DebugValidation[T, E]()(implicit d: Debug[T]) extends Debug[Validation[T, E]] {
-    override val hasAst: Boolean = d.hasAst
-
-    override def output(name: String, v: Validation[T, E])(implicit flix: Flix): Unit =
-      Validation.mapN(v) {
-        case x => d.output(name, x)
-      }
-
-    override def emit(name: String, a: Validation[T, E])(implicit flix: Flix): Unit = ()
   }
 
   private def printDocProgram(phase: String, dast: DocAst.Program)(implicit flix: Flix): Unit = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
     *   - SymUse
     *   - Instance
     */
-  def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, Unit) = flix.phaseNew("Dependencies") {
+  def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, Unit) = flix.phase("Dependencies") {
     implicit val sctx: SharedContext = SharedContext(new ConcurrentHashMap[(Input, Input), Unit]())
     val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(defn => flix.profile(defn.sym, defn.loc)(visitDef(defn))))
     val effects = changeSet.updateStaleValues(root.effects, oldRoot.effects)(ParOps.parMapValues(_)(visitEff))

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -48,7 +48,7 @@ object Deriver {
 
   private val DerivableSyms: List[Symbol.TraitSym] = List(EqSym, OrderSym, ToStringSym, HashSym, CoerceSym)
 
-  def run(root: KindedAst.Root)(implicit flix: Flix): (KindedAst.Root, List[DerivationError]) = flix.phaseNew("Deriver") {
+  def run(root: KindedAst.Root)(implicit flix: Flix): (KindedAst.Root, List[DerivationError]) = flix.phase("Deriver") {
     implicit val sctx: SharedContext = SharedContext.mk()
     val derivedInstances = ParOps.parMap(root.enums.values)(getDerivedInstances(_, root)).flatten
     val newInstances = derivedInstances.foldLeft(root.instances) {

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -56,7 +56,7 @@ object EntryPoints {
   // We don't use regions, so we are safe to use the global scope everywhere in this phase.
   private implicit val S: RegionScope = RegionScope.Top
 
-  def run(root: TypedAst.Root)(implicit flix: Flix): (TypedAst.Root, List[EntryPointError]) = flix.phaseNew("EntryPoints") {
+  def run(root: TypedAst.Root)(implicit flix: Flix): (TypedAst.Root, List[EntryPointError]) = flix.phase("EntryPoints") {
     val (root1, errs1) = resolveMain(root)
     val (root2, errs2) = checkEntryPoints(root1)
     val root3 = findEntryPoints(root2)

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -53,7 +53,7 @@ object Instances {
     */
   def run(root: TypedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (TypedAst.Root, List[InstanceError]) = {
     implicit val sctx: SharedContext = SharedContext.mk()
-    flix.phaseNew("Instances") {
+    flix.phase("Instances") {
       val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList2(_)(checkInstancesOfTrait(_, root)))
       (root.copy(instances = instances), sctx.errors.asScala.toList)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -59,7 +59,7 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
   */
 object Kinder {
 
-  def run(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (KindedAst.Root, List[KindError]) = flix.phaseNew("Kinder") {
+  def run(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (KindedAst.Root, List[KindError]) = flix.phase("Kinder") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     // Precompute the kind of every declaration once, so it is not recomputed at each occurrence of the type.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -222,7 +222,7 @@ object Lexer {
 
   /** Run the lexer on multiple `Source`s in parallel. */
   def run(root: ReadAst.Root, oldTokens: Map[Source, Array[Token]], changeSet: ChangeSet)(implicit flix: Flix): (Map[Source, Array[Token]], List[LexerError]) =
-    flix.phaseNew("Lexer") {
+    flix.phase("Lexer") {
       // Compute the stale and fresh sources.
       val (stale, fresh) = changeSet.partition(root.sources, oldTokens)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -39,7 +39,7 @@ object Namer {
     * Introduces unique names for each syntactic entity in the given `program`.
     * */
   def run(program: DesugaredAst.Root)(implicit flix: Flix): (NamedAst.Root, List[NameError]) =
-    flix.phaseNew("Namer") {
+    flix.phase("Namer") {
 
       // Construct a new shared context.
       implicit val sctx: SharedContext = SharedContext.mk()

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -122,7 +122,7 @@ object Parser2 {
     case class Closed(index: Int) extends Mark
   }
 
-  def run(tokens0: Map[Source, Array[Token]], oldRoot: SyntaxTree.Root, changeSet: ChangeSet)(implicit flix: Flix): (SyntaxTree.Root, List[CompilationMessage]) = flix.phaseNew("Parser2") {
+  def run(tokens0: Map[Source, Array[Token]], oldRoot: SyntaxTree.Root, changeSet: ChangeSet)(implicit flix: Flix): (SyntaxTree.Root, List[CompilationMessage]) = flix.phase("Parser2") {
     // Compute the stale and fresh sources.
     val (stale, fresh) = changeSet.partition(tokens0, oldRoot.units)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
@@ -610,7 +610,7 @@ object PatMatch2 {
     * Returns the (unmodified) root together with any errors found.
     */
   def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, List[CompilationMessage]) =
-    flix.phaseNew("PatMatch") {
+    flix.phase("PatMatch") {
       implicit val r: Root = root
       implicit val sctx: SharedContext = SharedContext.mk()
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -38,7 +38,7 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
   */
 object PredDeps {
 
-  def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, List[CompilationMessage]) = flix.phaseNew("PredDeps") {
+  def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, List[CompilationMessage]) = flix.phase("PredDeps") {
     // Compute an over-approximation of the dependency graph for all constraints in the program.
     implicit val sctx: SharedContext = SharedContext.mk()
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Reader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reader.scala
@@ -37,7 +37,7 @@ object Reader {
     * Reads the given source inputs into memory.
     */
   def run(inputs: List[Input], availableClasses: AvailableClasses)(implicit flix: Flix): (ReadAst.Root, List[CompilationMessage]) =
-    flix.phaseNew("Reader") {
+    flix.phase("Reader") {
 
       val result = mutable.Map.empty[Source, Unit]
       for (input <- inputs) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -54,7 +54,7 @@ object Redundancy {
   /**
     * Checks the given AST `root` for redundancies.
     */
-  def run(root: Root)(implicit flix: Flix): (Root, List[RedundancyError]) = flix.phaseNew("Redundancy") {
+  def run(root: Root)(implicit flix: Flix): (Root, List[RedundancyError]) = flix.phase("Redundancy") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     val errorsFromDefs = ParOps.parAgg(root.defs, Used.empty)({

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -77,7 +77,7 @@ object Resolver {
   /**
     * Performs name resolution on the given program `root`.
     */
-  def run(root: NamedAst.Root, @unused oldRoot: ResolvedAst.Root, @unused changeSet: ChangeSet)(implicit flix: Flix): (Validation[ResolvedAst.Root, ResolutionError], List[ResolutionError]) = flix.phaseNew("Resolver") {
+  def run(root: NamedAst.Root, @unused oldRoot: ResolvedAst.Root, @unused changeSet: ChangeSet)(implicit flix: Flix): (Validation[ResolvedAst.Root, ResolutionError], List[ResolutionError]) = flix.phase("Resolver") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     // Get the default uses.
@@ -126,7 +126,7 @@ object Resolver {
     }
 
     (resolvedRoot, sctx.errors.asScala.toList)
-  }(DebugValidation())
+  }
 
   /**
     * Builds a symbol table from the compilation unit.

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 object Safety {
 
   /** Checks the safety and well-formedness of `root`. */
-  def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, List[SafetyError]) = flix.phaseNew("Safety") {
+  def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, List[SafetyError]) = flix.phase("Safety") {
     implicit val sctx: SharedContext = SharedContext.mk()
     implicit val _r: Root = root
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -49,7 +49,7 @@ object Stratifier {
   /**
     * Returns a stratified version of the given AST `root`.
     */
-  def run(root: Root)(implicit flix: Flix): (Root, List[StratificationError]) = flix.phaseNew("Stratifier") {
+  def run(root: Root)(implicit flix: Flix): (Root, List[StratificationError]) = flix.phase("Stratifier") {
     // Construct a new shared context.
     implicit val sctx: SharedContext = SharedContext.mk()
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
@@ -83,7 +83,7 @@ object Terminator {
     * Checks termination properties of `root`.
     */
   def run(root: Root, oldRoot: Root, changeSet: ChangeSet)(implicit flix: Flix): (Root, List[TerminationError]) =
-    flix.phaseNew("Terminator") {
+    flix.phase("Terminator") {
       implicit val sctx: SharedContext = SharedContext.mk()
       implicit val _r: Root = root
       val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -35,7 +35,7 @@ object Typer {
   /**
     * Type checks the given AST root.
     */
-  def run(root: KindedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (TypedAst.Root, List[TypeError]) = flix.phaseNew("Typer") {
+  def run(root: KindedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (TypedAst.Root, List[TypeError]) = flix.phase("Typer") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     val traitEnv = mkTraitEnv(root.traits, root.instances)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -50,7 +50,7 @@ object Weeder2 {
   import WeededAst.*
 
   def run(readRoot: ReadAst.Root, entryPoint: Option[Symbol.DefnSym], root: SyntaxTree.Root, oldRoot: WeededAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (Validation[WeededAst.Root, CompilationMessage], List[CompilationMessage]) = {
-    flix.phaseNew("Weeder2") {
+    flix.phase("Weeder2") {
       implicit val sctx: SharedContext = SharedContext.mk()
       val (stale, fresh) = changeSet.partition(root.units, oldRoot.units)
 
@@ -64,7 +64,7 @@ object Weeder2 {
 
       val compilationUnits = mapN(sequence(refreshed))(_.toMap ++ fresh)
       (mapN(compilationUnits)(WeededAst.Root(_, entryPoint, readRoot.availableClasses, root.tokens)), sctx.errors.asScala.toList)
-    }(DebugValidation())
+    }
   }
 
   private def weed(tree: Tree)(implicit sctx: SharedContext, flix: Flix): Validation[CompilationUnit, CompilationMessage] = {

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Model.scala
@@ -89,7 +89,7 @@ object Model {
   /**
     * Phase-name strings that count as "frontend" — i.e. phases that run
     * inside `Flix.check`. Strings must match the literals each phase passes
-    * to `flix.phase("…")` / `flix.phaseNew("…")`. Verified against the
+    * to `flix.phase("…")`. Verified against the
     * `run` methods under `main/src/ca/uwaterloo/flix/language/phase`.
     *
     * Phases not in this set (and not the unknown-phase fallback `"?"`) are

--- a/main/src/ca/uwaterloo/flix/util/tc/Debug.scala
+++ b/main/src/ca/uwaterloo/flix/util/tc/Debug.scala
@@ -17,6 +17,7 @@ package ca.uwaterloo.flix.util.tc
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.dbg.AstPrinter
+import ca.uwaterloo.flix.util.Validation
 
 /** Trait for values logged to disk. */
 trait Debug[-A] {
@@ -30,4 +31,32 @@ trait Debug[-A] {
 
   /** Emit the debug information of `a` to disk. */
   protected def emit(name: String, a: A)(implicit flix: Flix): Unit
+}
+
+object Debug {
+
+  /**
+    * A [[Debug]] instance for a pair `(A, B)` (typically an AST root and its errors)
+    * that emits only the first component.
+    */
+  implicit def debugPair[A, B](implicit d: Debug[A]): Debug[(A, B)] = new Debug[(A, B)] {
+    override def hasAst: Boolean = d.hasAst
+
+    override def output(name: String, p: (A, B))(implicit flix: Flix): Unit = d.output(name, p._1)
+
+    override protected def emit(name: String, p: (A, B))(implicit flix: Flix): Unit = ()
+  }
+
+  /**
+    * A [[Debug]] instance for a [[Validation]] that emits the value on success and nothing on failure.
+    */
+  implicit def debugValidation[T, E](implicit d: Debug[T]): Debug[Validation[T, E]] = new Debug[Validation[T, E]] {
+    override def hasAst: Boolean = d.hasAst
+
+    override def output(name: String, v: Validation[T, E])(implicit flix: Flix): Unit =
+      Validation.mapN(v)(x => d.output(name, x))
+
+    override protected def emit(name: String, v: Validation[T, E])(implicit flix: Flix): Unit = ()
+  }
+
 }


### PR DESCRIPTION
## Summary

`Flix.scala` had two near-identical phase wrappers, `phase[A]` and `phaseNew[A, B]`, differing only in that `phaseNew` returned a `(root, errors)` pair and debug-printed just the `root`. This PR merges them into a single `Flix.phase`.

- **`util/tc/Debug.scala`**: add a companion `object Debug` with two derived instances:
  - `implicit def debugPair[A, B](implicit d: Debug[A]): Debug[(A, B)]` — emits only the first component (what `phaseNew` hardcoded).
  - `implicit def debugValidation[T, E](implicit d: Debug[T]): Debug[Validation[T, E]]` — replaces the non-implicit `AstPrinter.DebugValidation` case class (emits on success only, as before).
- **`api/Flix.scala`**: delete `phaseNew`; `phase` is unchanged apart from its doc comment.
- **`dbg/AstPrinter.scala`**: remove `DebugValidation`.
- **18 frontend phases**: `flix.phaseNew(` → `flix.phase(`. `Weeder2` and `Resolver` drop their explicit `(DebugValidation())` argument; resolution now chains `debugPair → debugValidation → DebugWeededAst/DebugResolvedAst`. `Reader` keeps its explicit `(DebugNoOp())`.
- Doc-comment updates in `CompilerConstants.scala` and `compilertop/Model.scala`.

Both derived instances live in the `Debug` companion, so they are in implicit scope everywhere and no call site needs import changes.

Behaviour is preserved: same phase names, same `phaseTimers`/progress-bar/`CompilerTop` bookkeeping, and `--Xprint-phases` produces the same set of files and an identical `build/asts/0phases.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)