### PR TITLE
refactor: make undefined trait in instances and super traits a soft failure

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -327,15 +327,18 @@ object Resolver {
           val scp = appendAllUseScp(defaultUses, usesAndImports, root)
           val declsVal = traverse(decls0)(visitDecl(_, scp, Name.RootNS.copy(loc = loc), defaultUses))
           mapN(declsVal) {
-            case decls => ResolvedAst.CompilationUnit(usesAndImports, decls, loc)
+            case decls => ResolvedAst.CompilationUnit(usesAndImports, decls.flatten, loc)
           }
       }
   }
 
   /**
     * Performs name resolution on the declaration.
+    *
+    * Returns `None` if the declaration is dropped as part of error recovery
+    * (currently only an instance of an undefined trait, see [[resolveInstance]]).
     */
-  private def visitDecl(decl: NamedAst.Declaration, scp0: LocalScope, ns0: Name.NName, defaultUses: LocalScope)(implicit taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): Validation[ResolvedAst.Declaration, ResolutionError] = decl match {
+  private def visitDecl(decl: NamedAst.Declaration, scp0: LocalScope, ns0: Name.NName, defaultUses: LocalScope)(implicit taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): Validation[Option[ResolvedAst.Declaration], ResolutionError] = decl match {
     case NamedAst.Declaration.Mod(doc, ann, mod, sym, _, usesAndImports0, decls0, loc) =>
       // TODO NS-REFACTOR move to helper for consistency
       // use the new namespace
@@ -347,25 +350,25 @@ object Resolver {
           val scp = appendAllUseScp(defaultUses, usesAndImports, root)
           val declsVal = traverse(decls0)(visitDecl(_, scp, ns, defaultUses))
           mapN(declsVal) {
-            case decls => ResolvedAst.Declaration.Mod(doc, ann, mod, sym, usesAndImports, decls, loc)
+            case decls => Some(ResolvedAst.Declaration.Mod(doc, ann, mod, sym, usesAndImports, decls.flatten, loc))
           }
       }
     case trt@NamedAst.Declaration.Trait(_, _, _, _, _, _, _, _, _) =>
-      resolveTrait(trt, scp0, ns0)
+      Validation.Success(Some(resolveTrait(trt, scp0, ns0)))
     case inst@NamedAst.Declaration.Instance(_, _, _, _, _, _, _, _, _, _, _, _) =>
-      resolveInstance(inst, scp0, ns0)
+      Validation.Success(resolveInstance(inst, scp0, ns0))
     case defn@NamedAst.Declaration.Def(_, _, _, _) =>
-      Validation.Success(resolveDef(defn, None, scp0)(ns0, taenv, sctx, root, flix))
+      Validation.Success(Some(resolveDef(defn, None, scp0)(ns0, taenv, sctx, root, flix)))
     case enum0@NamedAst.Declaration.Enum(_, _, _, _, _, _, _, _) =>
-      Validation.Success(resolveEnum(enum0, scp0, taenv, ns0, root))
+      Validation.Success(Some(resolveEnum(enum0, scp0, taenv, ns0, root)))
     case struct@NamedAst.Declaration.Struct(_, _, _, _, _, _, _) =>
-      Validation.Success(resolveStruct(struct, scp0, taenv, ns0, root))
+      Validation.Success(Some(resolveStruct(struct, scp0, taenv, ns0, root)))
     case enum0@NamedAst.Declaration.RestrictableEnum(_, _, _, _, _, _, _, _, _) =>
-      Validation.Success(resolveRestrictableEnum(enum0, scp0, taenv, ns0, root))
+      Validation.Success(Some(resolveRestrictableEnum(enum0, scp0, taenv, ns0, root)))
     case NamedAst.Declaration.TypeAlias(_, _, _, sym, _, _, _) =>
-      Validation.Success(taenv(sym))
+      Validation.Success(Some(taenv(sym)))
     case eff@NamedAst.Declaration.Effect(_, _, _, _, _, _, _) =>
-      Validation.Success(resolveEffect(eff, scp0, taenv, ns0, root))
+      Validation.Success(Some(resolveEffect(eff, scp0, taenv, ns0, root)))
     case NamedAst.Declaration.Op(sym, _, _) => throw InternalCompilerException("unexpected op", sym.loc)
     case NamedAst.Declaration.Sig(sym, _, _, _) => throw InternalCompilerException("unexpected sig", sym.loc)
     case NamedAst.Declaration.Case(sym, _, _) => throw InternalCompilerException("unexpected case", sym.loc)
@@ -404,34 +407,37 @@ object Resolver {
   /**
     * Resolves all the traits in the given root.
     */
-  private def resolveTrait(c0: NamedAst.Declaration.Trait, scp0: LocalScope, ns0: Name.NName)(implicit taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): Validation[ResolvedAst.Declaration.Trait, ResolutionError] = c0 match {
+  private def resolveTrait(c0: NamedAst.Declaration.Trait, scp0: LocalScope, ns0: Name.NName)(implicit taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): ResolvedAst.Declaration.Trait = c0 match {
     case NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, signatures, loc) =>
       val tparam = resolveTypeParam(tparam0, scp0, ns0, root)
       val scp = scp0 ++ mkTypeParamScp(List(tparam))
       // ignore the parameter of the super traits; we don't use it
-      val superTraitsVal = traverse(superTraits0)(tconstr => resolveSuperTrait(tconstr, scp, taenv, ns0, root))
+      val superTraits = superTraits0.flatMap(tconstr => resolveSuperTrait(tconstr, scp, taenv, ns0, root))
       val assocs = assocs0.map(resolveAssocTypeSig(_, scp, taenv, ns0, root))
       val sigsList = signatures.map(resolveSig(_, sym, tparam.sym, scp)(ns0, taenv, sctx, root, flix))
-      mapN(superTraitsVal) {
-        case superTraits =>
-          val sigs = sigsList.map(sig => (sig.sym, sig)).toMap
-          ResolvedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, loc)
-      }
+      val sigs = sigsList.map(sig => (sig.sym, sig)).toMap
+      ResolvedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, loc)
   }
 
   /**
     * Performs name resolution on the given instance `i0` in the given namespace `ns0`.
+    *
+    * Returns `None` (after [[UndefinedTrait]] has been reported) if the trait of the instance
+    * does not resolve. The instance is dropped: without a trait symbol there is nothing to
+    * attach it to, and since instances are only reachable through the trait no other
+    * declaration can refer to it. The instance type, trait constraints and equality
+    * constraints are still resolved so that errors in them are reported.
     */
-  private def resolveInstance(i0: NamedAst.Declaration.Instance, scp0: LocalScope, ns0: Name.NName)(implicit taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): Validation[ResolvedAst.Declaration.Instance, ResolutionError] = i0 match {
+  private def resolveInstance(i0: NamedAst.Declaration.Instance, scp0: LocalScope, ns0: Name.NName)(implicit taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], sctx: SharedContext, root: NamedAst.Root, flix: Flix): Option[ResolvedAst.Declaration.Instance] = i0 match {
     case NamedAst.Declaration.Instance(doc, ann, mod, trt0, tparams0, tpe0, tconstrs0, econstrs0, assocs0, defs0, ns, loc) =>
       val tparams = resolveTypeParams(tparams0, scp0, ns0, root)
       val scp = scp0 ++ mkTypeParamScp(tparams)
-      val traitVal = lookupTraitForImplementation(trt0, TraitUsageKind.Implementation, scp, ns0, root).toValidation
+      val optTrait = lookupTraitForImplementation(trt0, TraitUsageKind.Implementation, scp, ns0, root)
       val tpe = resolveType(tpe0, None, Wildness.ForbidWild, scp, taenv, ns0, root)(RegionScope.Top, sctx, flix)
       val optTconstrs = tconstrs0.map(resolveTraitConstraint(_, scp, taenv, ns0, root))
       val econstrs = econstrs0.map(resolveEqualityConstraint(_, scp, taenv, ns0, root))
-      mapN(traitVal) {
-        case trt =>
+      optTrait.map {
+        trt =>
           val assocs = resolveAssocTypeDefs(assocs0, trt, tpe, scp, taenv, ns0, root, trt0.loc)
           val tconstr = ResolvedAst.TraitConstraint(TraitSymUse(trt.sym, trt0.loc), tpe, trt0.loc)
           val defs = checkDuplicateInstanceDefs(defs0.map(resolveDef(_, Some(tconstr), scp)(ns0, taenv, sctx, root, flix)), trt.sym)
@@ -2076,13 +2082,16 @@ object Resolver {
 
   /**
     * Performs name resolution on the given supertrait constraint `tconstr0`.
+    *
+    * Returns `None` (after [[UndefinedTrait]] has been reported) if the super trait does not
+    * resolve, in which case the super trait is dropped.
     */
-  private def resolveSuperTrait(tconstr0: NamedAst.TraitConstraint, scp0: LocalScope, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit sctx: SharedContext, flix: Flix): Validation[ResolvedAst.TraitConstraint, ResolutionError] = tconstr0 match {
+  private def resolveSuperTrait(tconstr0: NamedAst.TraitConstraint, scp0: LocalScope, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit sctx: SharedContext, flix: Flix): Option[ResolvedAst.TraitConstraint] = tconstr0 match {
     case NamedAst.TraitConstraint(trt0, tpe0, loc) =>
-      val traitVal = lookupTraitForImplementation(trt0, TraitUsageKind.Constraint, scp0, ns0, root).toValidation
+      val optTrait = lookupTraitForImplementation(trt0, TraitUsageKind.Constraint, scp0, ns0, root)
       val tpe = resolveType(tpe0, None, Wildness.ForbidWild, scp0, taenv, ns0, root)(RegionScope.Top, sctx, flix)
 
-      mapN(traitVal) {
+      optTrait.map {
         trt =>
           val symUse = TraitSymUse(trt.sym, trt0.loc)
           ResolvedAst.TraitConstraint(symUse, tpe, loc)
@@ -2130,8 +2139,12 @@ object Resolver {
 
   /**
     * Finds the trait with the qualified name `qname` in the namespace `ns0`, for the purposes of implementation.
+    *
+    * Unlike [[lookupTrait]], this reports [[SealedTrait]] if the trait is sealed and declared in another namespace.
+    *
+    * Returns `None` (after [[UndefinedTrait]] has been reported) if no such trait exists.
     */
-  private def lookupTraitForImplementation(qname: Name.QName, traitUseKind: TraitUsageKind, scp0: LocalScope, ns0: Name.NName, root: NamedAst.Root)(implicit sctx: SharedContext): Result[NamedAst.Declaration.Trait, ResolutionError] = {
+  private def lookupTraitForImplementation(qname: Name.QName, traitUseKind: TraitUsageKind, scp0: LocalScope, ns0: Name.NName, root: NamedAst.Root)(implicit sctx: SharedContext): Option[NamedAst.Declaration.Trait] = {
     val traitOpt = tryLookupName(qname, scp0, ns0, root)
     traitOpt.collectFirst {
       case Resolution.Declaration(trt: NamedAst.Declaration.Trait) => trt
@@ -2139,18 +2152,20 @@ object Resolver {
       case Some(trt) =>
         getTraitAccessibility(trt, ns0) match {
           case TraitAccessibility.Accessible =>
-            Result.Ok(trt)
+            Some(trt)
           case TraitAccessibility.Sealed =>
             val error = ResolutionError.SealedTrait(trt.sym, ns0, qname.loc)
             sctx.errors.add(error)
-            Result.Ok(trt)
+            Some(trt)
           case TraitAccessibility.Inaccessible =>
             val error = ResolutionError.InaccessibleTrait(trt.sym, ns0, qname.loc)
             sctx.errors.add(error)
-            Result.Ok(trt)
+            Some(trt)
         }
       case None =>
-        Result.Err(ResolutionError.UndefinedTrait(qname, traitUseKind, AnchorPosition.mkImportOrUseAnchor(ns0), scp0, ns0, qname.loc))
+        val error = ResolutionError.UndefinedTrait(qname, traitUseKind, AnchorPosition.mkImportOrUseAnchor(ns0), scp0, ns0, qname.loc)
+        sctx.errors.add(error)
+        None
     }
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -625,6 +625,26 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.UndefinedTrait](result)
   }
 
+  test("UndefinedTrait.05") {
+    val input =
+      """
+        |trait K[a] with U[a]
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UndefinedTrait](result)
+  }
+
+  test("UndefinedTrait.06") {
+    // The instance of the undefined trait `C` is dropped, but its type is still resolved: both errors are reported.
+    val input =
+      """
+        |instance C[Nope]
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UndefinedTrait](result)
+    expectError[ResolutionError.UndefinedType](result)
+  }
+
   test("UndefinedJvmConstructor.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -2196,6 +2196,80 @@ class TestTyper extends AnyFunSuite with TestUtils {
     rejectError[TypeError](result)
   }
 
+  test("ErrorType.09") {
+    // There should be no type error because the trait `C` is undefined.
+    // The Resolver reports UndefinedTrait and recovers by dropping the instance.
+    val input =
+      """
+        |instance C[Int32] {
+        |    pub def f(x: Int32): Int32 = x
+        |}
+        |
+        |def g(): Int32 = 42
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    rejectError[TypeError](result)
+  }
+
+  test("ErrorType.10") {
+    // There should be no type error because the trait `C` is undefined.
+    // The Resolver reports UndefinedTrait and recovers by dropping the instance,
+    // including its trait constraint and associated type definition.
+    val input =
+      """
+        |enum MyBox[a](a)
+        |
+        |trait D[a] {
+        |    pub def h(x: a): a
+        |}
+        |
+        |instance C[MyBox[a]] with D[a] {
+        |    type T = a
+        |    pub def f(x: MyBox[a]): a = let MyBox.MyBox(y) = x; D.h(y)
+        |}
+        |
+        |def g(): Int32 = 42
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    rejectError[TypeError](result)
+  }
+
+  test("ErrorType.11") {
+    // There should be no type error because the super trait `B` is undefined.
+    // The Resolver reports UndefinedTrait and recovers by dropping the super trait,
+    // so the instance `A[Int32]` does not require an instance of `B`.
+    val input =
+      """
+        |trait A[a] with B[a] {
+        |    pub def f(x: a): a
+        |}
+        |
+        |instance A[Int32] {
+        |    pub def f(x: Int32): Int32 = x
+        |}
+        |
+        |def g(): Int32 = A.f(42)
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    rejectError[TypeError](result)
+  }
+
+  test("ErrorType.12") {
+    // There should be no type error because the super trait `B` is undefined.
+    // The Resolver reports UndefinedTrait and recovers by dropping the super trait;
+    // the constraint `A[a]` on `g` still resolves and `A.f(x)` type checks against it.
+    val input =
+      """
+        |trait A[a] with B[a] {
+        |    pub def f(x: a): a
+        |}
+        |
+        |def g(x: a): a with A[a] = A.f(x)
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    rejectError[TypeError](result)
+  }
+
   test("UndefinedLabel.01") {
     val input =
       """


### PR DESCRIPTION
Continues the removal of `Validation` from the Resolver.

`lookupTraitForImplementation` was the last place (besides the two cycle checks) that produced a hard failure through `Validation`: an undefined trait in an instance head or in a super trait position failed the whole Resolver, so no later phase ran.

This PR makes it a soft failure, mirroring how `lookupTrait` / `resolveTraitConstraint` already handle undefined traits in constraints:

- `lookupTraitForImplementation` now returns `Option[Trait]` and reports `UndefinedTrait` to the shared context.
- `resolveSuperTrait` returns `Option[TraitConstraint]`; an undefined super trait is dropped. `resolveTrait` is now `Validation`-free.
- `resolveInstance` returns `Option[Instance]`; an instance of an undefined trait is dropped. Its type, trait constraints and equality constraints are still resolved first so their errors are reported. Dropping is safe because instances are not in the Namer symbol table, so nothing else can refer to them.
- `visitDecl` returns `Validation[Option[Declaration], _]` for now (the remaining `Validation` is only due to `visitUseOrImport`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)