### PR TITLE
refactor: make cyclic type aliases a soft failure in the Resolver

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -537,61 +537,69 @@ class Flix {
         val (afterNamer, nameErrors) = Namer.run(afterDesugar)
         errors ++= nameErrors
 
-        val (afterResolver, resolutionErrors) = Resolver.run(afterNamer, cachedResolverAst, changeSet)
+        val (resolverValidation, resolutionErrors) = Resolver.run(afterNamer, cachedResolverAst, changeSet)
         errors ++= resolutionErrors
 
-        val (afterKinder, kindErrors) = Kinder.run(afterResolver, cachedKinderAst, changeSet)
-        errors ++= kindErrors
+        resolverValidation match {
+          case Validation.Failure(failures) =>
+            errors ++= failures.toList
+            None
 
-        val (afterDeriver, derivationErrors) = Deriver.run(afterKinder)
-        errors ++= derivationErrors
+          case Validation.Success(afterResolver) =>
 
-        val (afterTyper, typeErrors) = Typer.run(afterDeriver, cachedTyperAst, changeSet)
-        errors ++= typeErrors
+            val (afterKinder, kindErrors) = Kinder.run(afterResolver, cachedKinderAst, changeSet)
+            errors ++= kindErrors
 
-        val (afterEntryPoint, entryPointErrors) = EntryPoints.run(afterTyper)
-        errors ++= entryPointErrors
+            val (afterDeriver, derivationErrors) = Deriver.run(afterKinder)
+            errors ++= derivationErrors
 
-        val (afterInstances, instanceErrors) = Instances.run(afterEntryPoint, cachedTyperAst, changeSet)
-        errors ++= instanceErrors
+            val (afterTyper, typeErrors) = Typer.run(afterDeriver, cachedTyperAst, changeSet)
+            errors ++= typeErrors
 
-        val (afterPredDeps, predDepErrors) = PredDeps.run(afterInstances, cachedTyperAst, changeSet)
-        errors ++= predDepErrors
+            val (afterEntryPoint, entryPointErrors) = EntryPoints.run(afterTyper)
+            errors ++= entryPointErrors
 
-        val (afterStratifier, stratificationErrors) = Stratifier.run(afterPredDeps)
-        errors ++= stratificationErrors
+            val (afterInstances, instanceErrors) = Instances.run(afterEntryPoint, cachedTyperAst, changeSet)
+            errors ++= instanceErrors
 
-        val (afterPatMatch, patMatchErrors) = PatMatch2.run(afterStratifier, cachedTyperAst, changeSet)
-        errors ++= patMatchErrors
+            val (afterPredDeps, predDepErrors) = PredDeps.run(afterInstances, cachedTyperAst, changeSet)
+            errors ++= predDepErrors
 
-        val (afterRedundancy, redundancyErrors) = Redundancy.run(afterPatMatch)
-        errors ++= redundancyErrors
+            val (afterStratifier, stratificationErrors) = Stratifier.run(afterPredDeps)
+            errors ++= stratificationErrors
 
-        val (_, safetyErrors) = Safety.run(afterRedundancy, cachedTyperAst, changeSet)
-        errors ++= safetyErrors
+            val (afterPatMatch, patMatchErrors) = PatMatch2.run(afterStratifier, cachedTyperAst, changeSet)
+            errors ++= patMatchErrors
 
-        val (afterTerminator, terminationErrors) = Terminator.run(afterRedundancy, cachedTyperAst, changeSet)
-        errors ++= terminationErrors
+            val (afterRedundancy, redundancyErrors) = Redundancy.run(afterPatMatch)
+            errors ++= redundancyErrors
 
-        val (afterDependencies, _) = Dependencies.run(afterTerminator, cachedTyperAst, changeSet)
+            val (_, safetyErrors) = Safety.run(afterRedundancy, cachedTyperAst, changeSet)
+            errors ++= safetyErrors
 
-        if (options.incremental) {
-          this.cachedLexerTokens = afterLexer
-          this.cachedParserCst = afterParser
-          this.cachedWeederAst = afterWeeder
-          this.cachedDesugarAst = afterDesugar
-          this.cachedKinderAst = afterKinder
-          this.cachedResolverAst = afterResolver
-          this.cachedTyperAst = afterDependencies
+            val (afterTerminator, terminationErrors) = Terminator.run(afterRedundancy, cachedTyperAst, changeSet)
+            errors ++= terminationErrors
 
-          // We record that no files are dirty in the change set.
-          this.changeSet = ChangeSet.Dirty(Set.empty)
+            val (afterDependencies, _) = Dependencies.run(afterTerminator, cachedTyperAst, changeSet)
 
-          // We save all the current errors.
-          this.cachedErrors = errors.toList
+            if (options.incremental) {
+              this.cachedLexerTokens = afterLexer
+              this.cachedParserCst = afterParser
+              this.cachedWeederAst = afterWeeder
+              this.cachedDesugarAst = afterDesugar
+              this.cachedKinderAst = afterKinder
+              this.cachedResolverAst = afterResolver
+              this.cachedTyperAst = afterDependencies
+
+              // We record that no files are dirty in the change set.
+              this.changeSet = ChangeSet.Dirty(Set.empty)
+
+              // We save all the current errors.
+              this.cachedErrors = errors.toList
+            }
+
+            Some(afterDependencies)
         }
-
-        Some(afterDependencies)
     }
     // Shutdown fork-join thread pool.
     shutdownForkJoinPool()

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -537,69 +537,61 @@ class Flix {
         val (afterNamer, nameErrors) = Namer.run(afterDesugar)
         errors ++= nameErrors
 
-        val (resolverValidation, resolutionErrors) = Resolver.run(afterNamer, cachedResolverAst, changeSet)
+        val (afterResolver, resolutionErrors) = Resolver.run(afterNamer, cachedResolverAst, changeSet)
         errors ++= resolutionErrors
 
-        resolverValidation match {
-          case Validation.Failure(failures) =>
-            errors ++= failures.toList
-            None
+        val (afterKinder, kindErrors) = Kinder.run(afterResolver, cachedKinderAst, changeSet)
+        errors ++= kindErrors
 
-          case Validation.Success(afterResolver) =>
+        val (afterDeriver, derivationErrors) = Deriver.run(afterKinder)
+        errors ++= derivationErrors
 
-            val (afterKinder, kindErrors) = Kinder.run(afterResolver, cachedKinderAst, changeSet)
-            errors ++= kindErrors
+        val (afterTyper, typeErrors) = Typer.run(afterDeriver, cachedTyperAst, changeSet)
+        errors ++= typeErrors
 
-            val (afterDeriver, derivationErrors) = Deriver.run(afterKinder)
-            errors ++= derivationErrors
+        val (afterEntryPoint, entryPointErrors) = EntryPoints.run(afterTyper)
+        errors ++= entryPointErrors
 
-            val (afterTyper, typeErrors) = Typer.run(afterDeriver, cachedTyperAst, changeSet)
-            errors ++= typeErrors
+        val (afterInstances, instanceErrors) = Instances.run(afterEntryPoint, cachedTyperAst, changeSet)
+        errors ++= instanceErrors
 
-            val (afterEntryPoint, entryPointErrors) = EntryPoints.run(afterTyper)
-            errors ++= entryPointErrors
+        val (afterPredDeps, predDepErrors) = PredDeps.run(afterInstances, cachedTyperAst, changeSet)
+        errors ++= predDepErrors
 
-            val (afterInstances, instanceErrors) = Instances.run(afterEntryPoint, cachedTyperAst, changeSet)
-            errors ++= instanceErrors
+        val (afterStratifier, stratificationErrors) = Stratifier.run(afterPredDeps)
+        errors ++= stratificationErrors
 
-            val (afterPredDeps, predDepErrors) = PredDeps.run(afterInstances, cachedTyperAst, changeSet)
-            errors ++= predDepErrors
+        val (afterPatMatch, patMatchErrors) = PatMatch2.run(afterStratifier, cachedTyperAst, changeSet)
+        errors ++= patMatchErrors
 
-            val (afterStratifier, stratificationErrors) = Stratifier.run(afterPredDeps)
-            errors ++= stratificationErrors
+        val (afterRedundancy, redundancyErrors) = Redundancy.run(afterPatMatch)
+        errors ++= redundancyErrors
 
-            val (afterPatMatch, patMatchErrors) = PatMatch2.run(afterStratifier, cachedTyperAst, changeSet)
-            errors ++= patMatchErrors
+        val (_, safetyErrors) = Safety.run(afterRedundancy, cachedTyperAst, changeSet)
+        errors ++= safetyErrors
 
-            val (afterRedundancy, redundancyErrors) = Redundancy.run(afterPatMatch)
-            errors ++= redundancyErrors
+        val (afterTerminator, terminationErrors) = Terminator.run(afterRedundancy, cachedTyperAst, changeSet)
+        errors ++= terminationErrors
 
-            val (_, safetyErrors) = Safety.run(afterRedundancy, cachedTyperAst, changeSet)
-            errors ++= safetyErrors
+        val (afterDependencies, _) = Dependencies.run(afterTerminator, cachedTyperAst, changeSet)
 
-            val (afterTerminator, terminationErrors) = Terminator.run(afterRedundancy, cachedTyperAst, changeSet)
-            errors ++= terminationErrors
+        if (options.incremental) {
+          this.cachedLexerTokens = afterLexer
+          this.cachedParserCst = afterParser
+          this.cachedWeederAst = afterWeeder
+          this.cachedDesugarAst = afterDesugar
+          this.cachedKinderAst = afterKinder
+          this.cachedResolverAst = afterResolver
+          this.cachedTyperAst = afterDependencies
 
-            val (afterDependencies, _) = Dependencies.run(afterTerminator, cachedTyperAst, changeSet)
+          // We record that no files are dirty in the change set.
+          this.changeSet = ChangeSet.Dirty(Set.empty)
 
-            if (options.incremental) {
-              this.cachedLexerTokens = afterLexer
-              this.cachedParserCst = afterParser
-              this.cachedWeederAst = afterWeeder
-              this.cachedDesugarAst = afterDesugar
-              this.cachedKinderAst = afterKinder
-              this.cachedResolverAst = afterResolver
-              this.cachedTyperAst = afterDependencies
-
-              // We record that no files are dirty in the change set.
-              this.changeSet = ChangeSet.Dirty(Set.empty)
-
-              // We save all the current errors.
-              this.cachedErrors = errors.toList
-            }
-
-            Some(afterDependencies)
+          // We save all the current errors.
+          this.cachedErrors = errors.toList
         }
+
+        Some(afterDependencies)
     }
     // Shutdown fork-join thread pool.
     shutdownForkJoinPool()

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -29,7 +29,7 @@ import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
 import ca.uwaterloo.flix.util.*
-import ca.uwaterloo.flix.util.collection.{Chain, ListMap, ListOps, MapOps, Nel}
+import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.unused
@@ -76,7 +76,7 @@ object Resolver {
   /**
     * Performs name resolution on the given program `root`.
     */
-  def run(root: NamedAst.Root, @unused oldRoot: ResolvedAst.Root, @unused changeSet: ChangeSet)(implicit flix: Flix): (Validation[ResolvedAst.Root, ResolutionError], List[ResolutionError]) = flix.phase("Resolver") {
+  def run(root: NamedAst.Root, @unused oldRoot: ResolvedAst.Root, @unused changeSet: ChangeSet)(implicit flix: Flix): (ResolvedAst.Root, List[ResolutionError]) = flix.phase("Resolver") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     // Get the default uses.
@@ -93,35 +93,28 @@ object Resolver {
         new Symbol.ModuleSym(ns.parts, ModuleKind.Standalone) -> uses0.flatMap(visitUseOrImport(_, ns, root).toOption)
     }
 
-    val resolvedRoot: Validation[ResolvedAst.Root, ResolutionError] = try {
-      // Type aliases must be processed first in order to provide a `taenv` for looking up type alias symbols.
-      val (taenv, taOrder) = resolveTypeAliases(defaultUses, root)
-      val units = ParOps.parMap(root.units.values)(visitUnit(_, defaultUses)(taenv, sctx, root, flix))
-      val table = SymbolTable.traverse(units)(tableUnit)
-      val traits = findReportAndBreakSuperTraitCycles(table.traits)
-      Validation.Success(ResolvedAst.Root(
-        table.modules,
-        traits,
-        table.instances,
-        table.defs,
-        table.enums,
-        table.structs,
-        table.restrictableEnums,
-        table.effects,
-        table.typeAliases,
-        ListMap(uses),
-        taOrder,
-        root.mainEntryPoint,
-        root.sources,
-        root.availableClasses,
-        root.tokens
-      ))
-    } catch {
-      case CyclicTypeAliasesException(cycle) =>
-        // Report one CyclicTypeAliases error per alias in the cycle.
-        val errors = cycle.map(sym => ResolutionError.CyclicTypeAliases(cycle, sym.loc))
-        Validation.Failure(Chain.from(errors))
-    }
+    // Type aliases must be processed first in order to provide a `taenv` for looking up type alias symbols.
+    val (taenv, taOrder) = resolveTypeAliases(defaultUses, root)
+    val units = ParOps.parMap(root.units.values)(visitUnit(_, defaultUses)(taenv, sctx, root, flix))
+    val table = SymbolTable.traverse(units)(tableUnit)
+    val traits = findReportAndBreakSuperTraitCycles(table.traits)
+    val resolvedRoot = ResolvedAst.Root(
+      table.modules,
+      traits,
+      table.instances,
+      table.defs,
+      table.enums,
+      table.structs,
+      table.restrictableEnums,
+      table.effects,
+      table.typeAliases,
+      ListMap(uses),
+      taOrder,
+      root.mainEntryPoint,
+      root.sources,
+      root.availableClasses,
+      root.tokens
+    )
 
     (resolvedRoot, sctx.errors.asScala.toList)
   }
@@ -228,7 +221,7 @@ object Resolver {
     *     such that any alias only depends on those earlier in the list
     */
   private def resolveTypeAliases(defaultUses: LocalScope, root: NamedAst.Root)(implicit sctx: SharedContext, flix: Flix): (Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], List[Symbol.TypeAliasSym]) = {
-    val semiResolved = semiResolveTypeAliases(defaultUses, root)
+    val semiResolved = findReportAndBreakTypeAliasCycles(semiResolveTypeAliases(defaultUses, root))
     val orderedSyms = findResolutionOrder(semiResolved.values)
     val orderedSemiResolved = orderedSyms.map(semiResolved)
     val aliases = finishResolveTypeAliases(orderedSemiResolved)
@@ -261,11 +254,81 @@ object Resolver {
   }
 
   /**
+    * Ensures that the type aliases do not (transitively) refer to themselves.
+    *
+    * A cycle is a strongly connected component of the type alias dependency graph with more than one
+    * alias, or a single alias that refers to itself. For every such component we report a
+    * [[CyclicTypeAliases]] error for each alias in it and recover by replacing the references to aliases
+    * in the same component by error types. References to aliases outside the component are kept, as
+    * are references from outside into the component.
+    *
+    * [[findResolutionOrder]] and [[finishResolveTypeAliases]] expand aliases inline and would not
+    * terminate on a cyclic alias, so the returned aliases are guaranteed to be acyclic.
+    */
+  private def findReportAndBreakTypeAliasCycles(aliases: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias])(implicit sctx: SharedContext): Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias] = {
+    /** Returns the symbols of the type aliases directly used by the type alias `sym`. */
+    def getUses(sym: Symbol.TypeAliasSym): List[Symbol.TypeAliasSym] = getAliasUses(aliases(sym).tpe)
+
+    /** Returns `true` if the strongly connected component `syms` contains a cycle. */
+    def isCyclic(syms: Iterable[Symbol.TypeAliasSym]): Boolean = syms.sizeIs > 1 || syms.exists(sym => getUses(sym).contains(sym))
+
+    // Group the type aliases by strongly connected component.
+    val components = Graph.stronglyConnectedComponents(aliases.keys, getUses).groupMap(_._2)(_._1)
+
+    components.values.foldLeft(aliases) {
+      case (acc, syms) =>
+        if (!isCyclic(syms)) {
+          acc
+        } else {
+          // The aliases in the cycle, in source order (used for the error message).
+          val cycle = syms.toList.sortBy(_.loc)
+          // The aliases in the cycle as a set (used to erase the cyclic references).
+          val cycleSet = cycle.toSet
+          cycle.foldLeft(acc) {
+            case (innerAcc, sym) =>
+              sctx.errors.add(ResolutionError.CyclicTypeAliases(cycle, sym.loc))
+              val alias = innerAcc(sym)
+              innerAcc + (sym -> alias.copy(tpe = eraseAliasUses(alias.tpe, cycleSet)))
+          }
+        }
+    }
+  }
+
+  /**
+    * Replaces every use of a type alias in `syms` within the partially resolved type `tpe0` by an error type.
+    *
+    * The arguments of an applied alias are kept, so that e.g. `type alias L[a] = Option[L[a]]` becomes
+    * `Option[Error[a]]` and the type parameter `a` remains used.
+    */
+  private def eraseAliasUses(tpe0: UnkindedType, syms: Set[Symbol.TypeAliasSym]): UnkindedType = tpe0 match {
+    case UnkindedType.UnappliedAlias(sym, loc) if syms.contains(sym) => UnkindedType.Error(loc)
+    case UnkindedType.Apply(tpe1, tpe2, loc) => UnkindedType.Apply(eraseAliasUses(tpe1, syms), eraseAliasUses(tpe2, syms), loc)
+    case UnkindedType.Ascribe(tpe, kind, loc) => UnkindedType.Ascribe(eraseAliasUses(tpe, syms), kind, loc)
+    case UnkindedType.Arrow(eff, arity, loc) => UnkindedType.Arrow(eff.map(eraseAliasUses(_, syms)), arity, loc)
+    case UnkindedType.CaseComplement(tpe, loc) => UnkindedType.CaseComplement(eraseAliasUses(tpe, syms), loc)
+    case UnkindedType.CaseUnion(tpe1, tpe2, loc) => UnkindedType.CaseUnion(eraseAliasUses(tpe1, syms), eraseAliasUses(tpe2, syms), loc)
+    case UnkindedType.CaseIntersection(tpe1, tpe2, loc) => UnkindedType.CaseIntersection(eraseAliasUses(tpe1, syms), eraseAliasUses(tpe2, syms), loc)
+    case _: UnkindedType.UnappliedAlias => tpe0
+    case _: UnkindedType.Var => tpe0
+    case _: UnkindedType.Cst => tpe0
+    case _: UnkindedType.Enum => tpe0
+    case _: UnkindedType.Effect => tpe0
+    case _: UnkindedType.Struct => tpe0
+    case _: UnkindedType.RestrictableEnum => tpe0
+    case _: UnkindedType.CaseSet => tpe0
+    case _: UnkindedType.UnappliedAssocType => tpe0
+    case _: UnkindedType.UnappliedNative => tpe0
+    case _: UnkindedType.Error => tpe0
+    case alias: UnkindedType.Alias => throw InternalCompilerException("unexpected applied alias", alias.loc)
+    case assoc: UnkindedType.AssocType => throw InternalCompilerException("unexpected applied associated type", assoc.loc)
+  }
+
+  /**
     * Gets the resolution order for the aliases.
     *
     * Any alias only depends on those earlier in the list.
     *
-    * Throws [[CyclicTypeAliasesException]] if the aliases form a cycle.
+    * The aliases must be acyclic (see [[findReportAndBreakTypeAliasCycles]]).
     */
   private def findResolutionOrder(aliases: Iterable[ResolvedAst.Declaration.TypeAlias]): List[Symbol.TypeAliasSym] = {
     val aliasSyms = aliases.map(_.sym)
@@ -274,7 +337,7 @@ object Resolver {
 
     Graph.topologicalSort(aliasSyms, getUses) match {
       case Graph.TopologicalSort.Sorted(sorted) => sorted
-      case Graph.TopologicalSort.Cycle(path) => throw CyclicTypeAliasesException(path)
+      case Graph.TopologicalSort.Cycle(path) => throw InternalCompilerException(s"Unexpected cyclic type aliases: ${path.mkString(", ")}", path.head.loc)
     }
   }
 
@@ -3724,17 +3787,6 @@ object Resolver {
     * @param errors the [[ResolutionError]]s in the AST, if any.
     */
   private case class SharedContext(errors: ConcurrentLinkedQueue[ResolutionError])
-
-  /**
-    * An exception thrown by [[findResolutionOrder]] when the type aliases form a cycle.
-    *
-    * This bypasses the [[Validation]] machinery: the exception is thrown from type alias resolution and
-    * caught in [[run]], where it is converted into a [[Validation.Failure]]. It exists so that the
-    * remaining hard failures no longer rely on [[Validation]], which is slated for removal.
-    *
-    * @param cycle the type alias symbols that form the cycle.
-    */
-  private case class CyclicTypeAliasesException(cycle: List[Symbol.TypeAliasSym]) extends RuntimeException
 
   /**
     * A type represented by a lowercase name.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -76,7 +76,7 @@ object Resolver {
   /**
     * Performs name resolution on the given program `root`.
     */
-  def run(root: NamedAst.Root, @unused oldRoot: ResolvedAst.Root, @unused changeSet: ChangeSet)(implicit flix: Flix): (ResolvedAst.Root, List[ResolutionError]) = flix.phase("Resolver") {
+  def run(root: NamedAst.Root, @unused oldRoot: ResolvedAst.Root, @unused changeSet: ChangeSet)(implicit flix: Flix): (Validation[ResolvedAst.Root, ResolutionError], List[ResolutionError]) = flix.phase("Resolver") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     // Get the default uses.
@@ -116,7 +116,7 @@ object Resolver {
       root.tokens
     )
 
-    (resolvedRoot, sctx.errors.asScala.toList)
+    (Validation.Success(resolvedRoot), sctx.errors.asScala.toList)
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -505,6 +505,46 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.CyclicTypeAliases](result)
   }
 
+  test("CyclicTypeAliases.09") {
+    // One error is reported per alias in the cycle. `Baz` is not in the cycle and must not be reported.
+    val input =
+      s"""
+         |type alias Foo = Bar
+         |type alias Bar = Foo
+         |type alias Baz = Foo
+         |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.CyclicTypeAliases](result)
+    assert(result._2.count(_.isInstanceOf[ResolutionError.CyclicTypeAliases]) == 2)
+  }
+
+  test("CyclicTypeAliases.10") {
+    // Two independent cycles are both reported (three errors: two for Foo/Bar and one for the self loop of Baz).
+    val input =
+      s"""
+         |type alias Foo = Bar
+         |type alias Bar = Foo
+         |type alias Baz = Baz
+         |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.CyclicTypeAliases](result)
+    assert(result._2.count(_.isInstanceOf[ResolutionError.CyclicTypeAliases]) == 3)
+  }
+
+  test("CyclicTypeAliases.11") {
+    // The cycle is broken and resolution continues, so the unrelated error in `f` is also reported.
+    val input =
+      s"""
+         |type alias Foo = Bar
+         |type alias Bar = Foo
+         |
+         |def f(): Int32 = undefinedName()
+         |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.CyclicTypeAliases](result)
+    expectError[ResolutionError.UndefinedName](result)
+  }
+
   test("UndefinedName.01") {
     val input = "def f(): Int32 = x"
     val result = check(input, Options.TestWithLibNix)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -2392,6 +2392,59 @@ class TestTyper extends AnyFunSuite with TestUtils {
     rejectError[TypeError](result)
   }
 
+  test("ErrorType.19") {
+    // There should be no type error because the type aliases `A` and `B` are cyclic.
+    // The Resolver reports CyclicTypeAliases and recovers by replacing the cyclic references
+    // with error types, so `A` is `(Int32, Error)` and `f` type checks against it.
+    val input =
+      """
+        |type alias A = (Int32, B)
+        |type alias B = A
+        |type alias C = A
+        |
+        |def f(x: A): Int32 = fst(x)
+        |
+        |def g(x: C): Int32 = fst(x)
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    rejectError[TypeError](result)
+  }
+
+  test("ErrorType.20") {
+    // There should be no type error because the type alias `L` refers to itself.
+    // The Resolver reports CyclicTypeAliases and recovers by replacing the cyclic reference
+    // with an error type, keeping the argument: `L[a]` is `Option[Error[a]]`.
+    val input =
+      """
+        |type alias L[a] = Option[L[a]]
+        |
+        |def f(x: L[Int32]): Int32 = match x {
+        |    case Some(y) => y
+        |    case None => 0
+        |}
+        |
+        |def g(): L[Bool] = Some(Some(None))
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    rejectError[TypeError](result)
+  }
+
+  test("ErrorType.21") {
+    // There should be no type error because the type aliases `P`, `Q` and `R` are cyclic through
+    // a function type and a record type. The Resolver reports CyclicTypeAliases and recovers by
+    // replacing the cyclic references with error types.
+    val input =
+      """
+        |type alias P = Q -> Int32
+        |type alias Q = {x = R}
+        |type alias R = P
+        |
+        |def f(x: P): Int32 = x({x = 1})
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    rejectError[TypeError](result)
+  }
+
   test("UndefinedLabel.01") {
     val input =
       """

--- a/main/test/flix/Test.Dec.TypeAlias.flix
+++ b/main/test/flix/Test.Dec.TypeAlias.flix
@@ -238,4 +238,18 @@ mod Test.Dec.TypeAlias {
     @Test
     def testTypeAlias34(): Unit \ Assert =
         assertEq(expected = 42, testTypeAlias34Helper(testTypeAlias34Fn))
+
+    ///
+    /// A diamond: the shared alias `Diamond0` is reachable from `Diamond3` through both `Diamond1` and `Diamond2`.
+    ///
+    type alias Diamond0 = Int32
+    type alias Diamond1 = (Diamond0, Diamond0)
+    type alias Diamond2 = (Diamond0, Bool)
+    type alias Diamond3 = (Diamond1, Diamond2)
+
+    def testTypeAlias35Helper(x: Diamond3): Int32 = fst(fst(x)) + snd(fst(x)) + fst(snd(x))
+
+    @Test
+    def testTypeAlias35(): Unit \ Assert =
+        assertEq(expected = 6, testTypeAlias35Helper(((1, 2), (3, true))))
 }


### PR DESCRIPTION
Continues the removal of `Validation` from the Resolver. Cyclic type aliases were the last hard failure (via `CyclicTypeAliasesException`).

`findResolutionOrder` and `finishResolveTypeAliases` expand aliases inline and would not terminate on a cycle, so the aliases handed to them must be acyclic. The new `findReportAndBreakTypeAliasCycles` runs on the semi-resolved aliases before ordering and:

- computes the strongly connected components of the alias dependency graph (`Graph.stronglyConnectedComponents`); a component is cyclic if it has more than one alias or an alias refers to itself,
- reports one `CyclicTypeAliases` per alias in each cyclic component (as before),
- recovers by replacing the references to aliases *in the same component* by error types (`eraseAliasUses`). References to aliases outside the component, and references from outside into it, are kept: `type alias A = (Int32, B)`, `type alias B = A`, `type alias C = A` becomes `A = (Int32, Error)`, `B = Error`, `C = A`. The arguments of an applied alias are kept (`type alias L[a] = Option[L[a]]` becomes `Option[Error[a]]`), so no spurious "unused type parameter" follows.

Since `visitDecl` fetches type alias declarations from `taenv`, repairing the semi-resolved map is consistent everywhere.

`CyclicTypeAliasesException` is removed. With no hard failures left, `run` now always returns `Validation.Success`; its return type (and the corresponding `match` in `Flix.scala`) is left unchanged for a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)