### PR TITLE
refactor: make Flix.compile return a Result instead of a Validation

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -348,12 +348,12 @@ object Main {
           } else {
             val flix = mkFlixWithFiles(cmdOpts.files, options.copy(progress = false))
             flix.compile() match {
-              case Validation.Success(compilationResult) =>
+              case Result.Ok(compilationResult) =>
                 Tester.run(Nil, JvmLoader.load(compilationResult))(flix) match {
                   case Result.Ok(_) => System.exit(0)
                   case Result.Err(_) => System.exit(1)
                 }
-              case Validation.Failure(errors) => exitWithErrors(flix, errors.toList, None)
+              case Result.Err(errors) => exitWithErrors(flix, errors, None)
             }
           }
 

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -31,7 +31,7 @@ import ca.uwaterloo.flix.tools.Summary
 import ca.uwaterloo.flix.tools.compilertop.{CompilerTop, Profiler}
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.Formatter.NoFormatter
-import ca.uwaterloo.flix.util.collection.{Chain, MultiMap}
+import ca.uwaterloo.flix.util.collection.MultiMap
 import ca.uwaterloo.flix.util.tc.Debug
 
 import java.net.URI
@@ -716,12 +716,12 @@ class Flix {
   /**
     * Compiles the given typed ast to an executable ast.
     */
-  def compile(): Validation[CompilationResult, CompilationMessage] = {
+  def compile(): Result[CompilationResult, List[CompilationMessage]] = {
     val (result, errors) = check()
     if (errors.isEmpty) {
-      Validation.Success(codeGen(result.get))
+      Result.Ok(codeGen(result.get))
     } else {
-      Validation.Failure(Chain.from(errors))
+      Result.Err(errors)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
@@ -195,7 +195,7 @@ class SocketServer(port: Int) extends WebSocketServer(new InetSocketAddress(port
       // Compile the program.
       flix.addVirtualPath(CompilerConstants.VirtualPlaygroundFile, input)(SecurityContext.Plain)
 
-      flix.compile().toResult match {
+      flix.compile() match {
         case Result.Ok(compilationResult) =>
           // Compilation was successful.
 
@@ -214,7 +214,7 @@ class SocketServer(port: Int) extends WebSocketServer(new InetSocketAddress(port
 
         case Result.Err(errors) =>
           // Compilation failed. Format and return all the errors.
-          Err(CompilationMessage.formatAll(errors.toList)(flix.getFormatter, None))
+          Err(CompilationMessage.formatAll(errors)(flix.getFormatter, None))
       }
     } catch {
       // Catch `Throwable` (not just `RuntimeException`): a successfully compiled

--- a/main/test/ca/uwaterloo/flix/RunVerifiers.scala
+++ b/main/test/ca/uwaterloo/flix/RunVerifiers.scala
@@ -4,7 +4,7 @@ import ca.uwaterloo.flix.api.{Flix, FlixEvent}
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.util.Formatter.NoFormatter
-import ca.uwaterloo.flix.util.{Options, Validation}
+import ca.uwaterloo.flix.util.{Options, Result}
 import ca.uwaterloo.flix.verifier.{EffectVerifier, TokenVerifier, TypeVerifier}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -50,8 +50,8 @@ class RunVerifiers extends AnyFunSuite with TestUtils {
     flix.addFile(Paths.get(path))(SecurityContext.Unrestricted)
 
     flix.compile() match {
-      case Validation.Success(_) => ()
-      case Validation.Failure(errors) => fail(CompilationMessage.formatAll(errors.toList)(NoFormatter, None))
+      case Result.Ok(_) => ()
+      case Result.Err(errors) => fail(CompilationMessage.formatAll(errors)(NoFormatter, None))
     }
   }
 

--- a/main/test/ca/uwaterloo/flix/StandardLibrarySuite.scala
+++ b/main/test/ca/uwaterloo/flix/StandardLibrarySuite.scala
@@ -47,11 +47,11 @@ class StandardLibrarySuite extends AnyFunSuite {
     }
 
     // Compile the program with all test suites.
-    flix.compile().toResult match {
+    flix.compile() match {
       case Result.Ok(compilationResult) =>
         runTests(JvmLoader.load(compilationResult))
       case Result.Err(errors) =>
-        fail(CompilationMessage.formatAll(errors.toList)(flix.getFormatter, None))
+        fail(CompilationMessage.formatAll(errors)(flix.getFormatter, None))
     }
   } catch {
     case ex: Throwable =>

--- a/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.phase.jvm.BackendObjType
 import ca.uwaterloo.flix.runtime.{CompilationResult, JvmLoader}
-import ca.uwaterloo.flix.util.{Options, Result, Validation}
+import ca.uwaterloo.flix.util.{Options, Result}
 import org.scalatest.funsuite.AnyFunSuite
 
 class TestFlixErrors extends AnyFunSuite {
@@ -45,8 +45,8 @@ class TestFlixErrors extends AnyFunSuite {
     expectRuntimeError(result, BackendObjType.HoleError.jvmName.name)
   }
 
-  def expectRuntimeError(v: Validation[CompilationResult, CompilationMessage], name: String): Unit = {
-    v.toResult match {
+  def expectRuntimeError(v: Result[CompilationResult, List[CompilationMessage]], name: String): Unit = {
+    v match {
       case Result.Ok(t) => JvmLoader.load(t).main match {
         case Some(main) => try {
           main.apply(Array.empty)

--- a/main/test/ca/uwaterloo/flix/language/TestProgramArgs.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestProgramArgs.scala
@@ -42,7 +42,7 @@ class TestProgramArgs extends AnyFunSuite {
       .setOptions(Options.TestWithLibAll)
       .addVirtualPath(CompilerConstants.VirtualTestFile, input)
       .compile()
-    result.toResult match {
+    result match {
       case Result.Ok(r) => JvmLoader.load(r).main match {
         case Some(main) => try {
           main.apply(Array(arg))

--- a/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
+++ b/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
@@ -118,11 +118,11 @@ class FlixSuite(incremental: Boolean) extends AnyFunSuite {
 
     try {
       // Compile the program, load it into the JVM, and run its tests.
-      Flix.compile().toResult match {
+      Flix.compile() match {
         case Result.Ok(compilationResult) =>
           runTests(JvmLoader.load(compilationResult))
         case Result.Err(errors) =>
-          fail(CompilationMessage.formatAll(errors.toList)(Flix.getFormatter, None))
+          fail(CompilationMessage.formatAll(errors)(Flix.getFormatter, None))
       }
     } finally {
       // Remove the source path.


### PR DESCRIPTION
Changes `Flix.compile()` to return `Result[CompilationResult, List[CompilationMessage]]` instead of `Validation[CompilationResult, CompilationMessage]`.

`compile()` is a thin wrapper over `check()` + `codeGen()`, and the outcome is binary: either every phase succeeded and we have a `CompilationResult`, or we have a non-empty list of errors. `Result` expresses that directly, and matches the `(root, errors)` pair that `check()` already returns.

Most callers were already calling `.toResult` on the `Validation` immediately, so this mostly removes an adapter:

- `Flix.scala`: new signature; drops the now-unused `Chain` import.
- `Main.scala`, `RunVerifiers.scala`: `Validation.Success/Failure` matches become `Result.Ok/Err`.
- `SocketServer.scala`, `StandardLibrarySuite.scala`, `FlixSuite.scala`, `TestProgramArgs.scala`: drop `.toResult` (and the redundant `errors.toList`).
- `TestFlixErrors.scala`: helper retyped to `Result[...]`.

Callers using `.unsafeGet` or ignoring the return value are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
