### PR TITLE
refactor: rewrite Type.eval with a local exception and remove Result.mapN

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -34,8 +34,6 @@
 
 - No shadowed variables.
 - No unused local variables.
-- When using monads like `Result` use `mapN` over `for ... yield` whenever possible
-- Write single-variable `mapN` cases open to additional variables with `mapN ... { case ... => ... }`
 - Never use toString for anything other than debugging.
 - Leave the code in better state than you found it in.
 - Avoid inheritance. Prefer algebraic data types and functions on them.

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -654,35 +654,34 @@ object Type {
     *   or error types and hence reduces to a single Cofinite set.
     * - Returns `Err[()]` otherwise.
     */
-  def eval(eff: Type): Result[CofiniteSet[Symbol.EffSym], Unit] = eff match {
-    case Type.Cst(tc, _) => tc match {
-      case TypeConstructor.Pure => Result.Ok(CofiniteSet.empty)
-      case TypeConstructor.Univ => Result.Ok(CofiniteSet.universe)
-      case TypeConstructor.Effect(sym, _) => Result.Ok(CofiniteSet.mkSet(sym))
-      case _ => Result.Err(())
+  def eval(eff: Type): Result[CofiniteSet[Symbol.EffSym], Unit] = {
+    /** Thrown by `visit` when the effect does not reduce to a set of effect symbols. Never escapes `eval`. */
+    case object NonGroundEffect extends RuntimeException
+
+    def visit(t: Type): CofiniteSet[Symbol.EffSym] = t match {
+      case Type.Cst(tc, _) => tc match {
+        case TypeConstructor.Pure => CofiniteSet.empty
+        case TypeConstructor.Univ => CofiniteSet.universe
+        case TypeConstructor.Effect(sym, _) => CofiniteSet.mkSet(sym)
+        case _ => throw NonGroundEffect
+      }
+      case Type.Apply(Type.Cst(TypeConstructor.Complement, _), x, _) =>
+        CofiniteSet.complement(visit(x))
+      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Union, _), x, _), y, _) =>
+        CofiniteSet.union(visit(x), visit(y))
+      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Intersection, _), x, _), y, _) =>
+        CofiniteSet.intersection(visit(x), visit(y))
+      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Difference, _), x, _), y, _) =>
+        CofiniteSet.difference(visit(x), visit(y))
+      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y, _) =>
+        CofiniteSet.xor(visit(x), visit(y))
+      case Type.Alias(_, _, tpe, _) => visit(tpe)
+      case _ => throw NonGroundEffect
     }
-    case Type.Apply(Type.Cst(TypeConstructor.Complement, _), x0, _) =>
-      Result.mapN(eval(x0)) {
-        case x => CofiniteSet.complement(x)
-      }
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Union, _), x0, _), y0, _) =>
-      Result.mapN(eval(x0), eval(y0)) {
-        case (x, y) => CofiniteSet.union(x, y)
-      }
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Intersection, _), x0, _), y0, _) =>
-      Result.mapN(eval(x0), eval(y0)) {
-        case (x, y) => CofiniteSet.intersection(x, y)
-      }
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Difference, _), x0, _), y0, _) =>
-      Result.mapN(eval(x0), eval(y0)) {
-        case (x, y) => CofiniteSet.difference(x, y)
-      }
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x0, _), y0, _) =>
-      Result.mapN(eval(x0), eval(y0)) {
-        case (x, y) => CofiniteSet.xor(x, y)
-      }
-    case Type.Alias(_, _, tpe, _) => eval(tpe)
-    case _ => Result.Err(())
+
+    try Result.Ok(visit(eff)) catch {
+      case NonGroundEffect => Result.Err(())
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/Result.scala
+++ b/main/src/ca/uwaterloo/flix/util/Result.scala
@@ -90,18 +90,6 @@ object Result {
   case class Err[T, E](e: E) extends Result[T, E]
 
   /**
-    * Applies the given function `f` to value of `res` wrapping it in [[Result.Ok]].
-    */
-  def mapN[T, U, E](res: Result[T, E])(f: T => U): Result[U, E] =
-    res.map(f)
-
-  /**
-    * Applies the given function `f` to values of the results wrapping it in [[Result.Ok]].
-    */
-  def mapN[T1, T2, U, E](res1: Result[T1, E], res2: Result[T2, E])(f: (T1, T2) => U): Result[U, E] =
-    res1.flatMap(r1 => res2.map(r2 => f(r1, r2)))
-
-  /**
     * Evaluates the given results from left to right collecting the values into a list.
     *
     * Returns the first error value encountered, if any.


### PR DESCRIPTION
Follow-up to #13047.

## Changes

- **`Type.eval`** now uses a local `visit` function that returns a `CofiniteSet` directly and throws a method-local `NonGroundEffect` exception when the effect does not reduce to a set; a single `try`/`catch` around `visit(eff)` converts that into `Result.Err(())`. The recursion no longer wraps/unwraps a `Result` at every node. Same pattern as `EffAtom.InvalidType` and `CaseSetUnification.SetUnificationException`.
- **`Result.mapN`** (both arities) removed — `Type.eval` was its only caller. `mapN` was applicative vocabulary inherited from `Validation`; on `Result` it was just `flatMap` + `map`.
- **`docs/STYLE.md`** — drop the two `mapN` bullets, which no longer describe anything in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)