### PR TITLE
feat: give compiler worker threads a larger stack

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/CompilerConstants.scala
+++ b/main/src/ca/uwaterloo/flix/api/CompilerConstants.scala
@@ -73,6 +73,26 @@ object CompilerConstants {
   val PerfDirectory: Path = Path.of("./build/perf/")
 
   /**
+    * How long (in seconds) an idle worker thread in the compiler's thread pool stays alive
+    * before it exits.
+    *
+    * Ensures that a pool which is never shut down (e.g. because a compilation crashed)
+    * does not pin its threads and their stacks forever.
+    */
+  val ThreadKeepAliveSeconds: Long = 60L
+
+  /**
+    * The minimum stack size (in bytes) of each worker thread in the compiler's thread pool.
+    * Workers get the larger of this value and the JVM's default thread stack size (`-Xss`).
+    *
+    * The JVM default (typically 1-2 MB) is easily exhausted by the deeply recursive visitors
+    * in the compiler when given large or deeply nested inputs. Only address space is reserved
+    * up front; physical memory is committed lazily as the stack grows, so a generous size is
+    * essentially free unless it is actually used.
+    */
+  val ThreadStackSize: Long = 64L * 1024L * 1024L
+
+  /**
     * The total number of phases run by a full compilation, i.e. by [[Flix.compile]].
     */
   val TotalPhases: Int = FrontendPhaseCount + BackendPhaseCount

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -37,7 +37,6 @@ import ca.uwaterloo.flix.util.tc.Debug
 import java.net.URI
 import java.nio.charset.Charset
 import java.nio.file.{Files, Path}
-import java.util.concurrent.ForkJoinPool
 import java.util.zip.ZipFile
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -179,9 +178,9 @@ class Flix {
   var options: Options = Options.Default
 
   /**
-    * The thread pool executor service for `this` Flix instance.
+    * The thread pool for `this` Flix instance.
     */
-  var threadPool: java.util.concurrent.ForkJoinPool = _
+  var threadPool: ThreadPool = _
 
   /**
     * The symbol generator associated with this Flix instance.
@@ -488,8 +487,8 @@ class Flix {
     // Mark this object as implicit.
     implicit val flix: Flix = this
 
-    // Initialize fork-join thread pool.
-    initForkJoinPool()
+    // Initialize the thread pool.
+    initThreadPool()
 
     // Reset the phase information.
     phaseTimers = ArrayBuffer.empty
@@ -592,8 +591,8 @@ class Flix {
         Some(afterDependencies)
     }
 
-    // Shutdown fork-join thread pool.
-    shutdownForkJoinPool()
+    // Shutdown the thread pool.
+    shutdownThreadPool()
 
     // Reset the progress bar.
     if (options.progress) {
@@ -636,8 +635,8 @@ class Flix {
     // Mark this object as implicit.
     implicit val flix: Flix = this
 
-    // Initialize fork-join thread pool.
-    initForkJoinPool()
+    // Initialize the thread pool.
+    initThreadPool()
 
     var treeShaker1Ast = TreeShaker1.run(typedAst)
     // Note: Do not null typedAst. It is used later.
@@ -690,8 +689,8 @@ class Flix {
     val totalSize = bytecodeAst.classes.values.map(_.bytecode.length).sum
     val result = new CompilationResult(bytecodeAst, totalTime, totalSize, this)
 
-    // Shutdown fork-join thread pool.
-    shutdownForkJoinPool()
+    // Shutdown the thread pool.
+    shutdownThreadPool()
 
     // Reset the progress bar.
     if (options.progress) {
@@ -825,16 +824,16 @@ class Flix {
   }
 
   /**
-    * Initializes the fork-join thread pool.
+    * Initializes the thread pool.
     */
-  private def initForkJoinPool(): Unit = {
-    threadPool = new ForkJoinPool(options.threads)
+  private def initThreadPool(): Unit = {
+    threadPool = new ThreadPool(options.threads)
   }
 
   /**
-    * Shuts down the fork-join thread pools.
+    * Shuts down the thread pool.
     */
-  private def shutdownForkJoinPool(): Unit = {
+  private def shutdownThreadPool(): Unit = {
     threadPool.shutdown()
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/CompilerTop.scala
@@ -303,7 +303,7 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     // `completed` first and uses the snapshot when it sees true; the volatile
     // writes here happen-before the AtomicBoolean store via JMM.
     frozenElapsedNanos = System.nanoTime() - startNanos
-    frozenActiveThreads = if (flix.threadPool == null) 0 else flix.threadPool.getActiveThreadCount
+    frozenActiveThreads = if (flix.threadPool == null) 0 else flix.threadPool.getActiveCount
     frozenHeap = heapUsage()
 
     if (!completed.compareAndSet(false, true)) return
@@ -353,12 +353,12 @@ final class CompilerTop(flix: Flix, profiler: Profiler) {
     val isDone = completed.get()
     val now = System.nanoTime()
     val pool = flix.threadPool
-    val parallelism = if (pool == null) flix.options.threads.max(1) else pool.getParallelism.max(1)
+    val parallelism = if (pool == null) flix.options.threads.max(1) else pool.getCorePoolSize.max(1)
     // Once compilation is done, freeze elapsed + active threads + heap at
     // their snapshot values so the dashboard reflects the state at
     // completion rather than ticking forward during the wait-for-quit phase.
     val elapsed = if (isDone) frozenElapsedNanos else now - startNanos
-    val activeThreads = if (isDone) frozenActiveThreads else (if (pool == null) 0 else pool.getActiveThreadCount)
+    val activeThreads = if (isDone) frozenActiveThreads else (if (pool == null) 0 else pool.getActiveCount)
     val heap = if (isDone) frozenHeap else heapUsage()
     val currentPhase = if (isDone) "done" else flix.getCurrentPhaseName.getOrElse("starting")
     val phaseTimersSize = flix.phaseTimers.size

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Renderer.scala
@@ -425,8 +425,8 @@ final class Renderer {
     sb.append(dim("] "))
     sb.append(f"$done%2d/${CompilerConstants.TotalPhases}%2d")
     sb.append(dim("   threads "))
-    // With parallelism=1 ForkJoin runs work inline on the submitter, leaving
-    // `getActiveThreadCount` at 0 most of the time — sparkline goes flat,
+    // With parallelism=1 ParOps runs all work inline on the submitter, leaving
+    // `getActiveCount` at 0 most of the time — sparkline goes flat,
     // field reads `0/1` continuously. Show a label instead.
     if (state.parallelism > 1) {
       sb.append(dim(cyan(renderSparkline(state.parallelism.toDouble))))

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -132,6 +132,20 @@ object ParOps {
     *
     * Every task folds the elements it claims with `seq` (starting from `z`), and the resulting
     * partial results are then combined with `comb` on the calling thread.
+    *
+    * == Contract ==
+    *
+    * The elements are partitioned across the tasks nondeterministically (see [[parFold]]), so the
+    * result is only well-defined if:
+    *
+    *   - `comb` is associative '''and commutative''', and `z` is its neutral element, and
+    *   - `seq(comb(s1, s2), x) == comb(s1, seq(s2, x))`, i.e. folding an element into an
+    *     accumulator with `seq` agrees with combining it in with `comb`.
+    *
+    * In particular, the order in which the elements reach `seq` is unspecified. This is a stronger
+    * requirement than that of e.g. `Iterable.aggregate`, which preserves the order of the elements
+    * and hence only needs `comb` to be associative. It is met by e.g. set union and by merging maps
+    * with pairwise disjoint keys, but not by e.g. list concatenation.
     */
   def parAgg[A: ClassTag, S](xs: Iterable[A], z: => S)(seq: (S, A) => S, comb: (S, S) => S)(implicit flix: Flix): S = {
     // Just fold if we're single-threaded.
@@ -191,6 +205,12 @@ object ParOps {
     * Claiming indices from a shared counter balances the work dynamically across the tasks, and
     * bounds the number of tasks handed to the pool by the number of threads rather than by `size`.
     * The latter keeps the scheduling overhead low even for many tiny work items.
+    *
+    * The price of dynamic balancing is that '''which''' indices end up in '''which''' accumulator
+    * is nondeterministic: it depends on the timing of the tasks. Callers must therefore either
+    * treat each index independently (as [[parMap]] does, writing to a distinct slot per index) or
+    * fold with an operation whose result does not depend on how the indices are grouped and
+    * ordered (as [[parAgg]] and [[parReach]] do; see the contract of [[parAgg]]).
     */
   private def parFold[S](size: Int, z: => S)(step: (S, Int) => S)(implicit flix: Flix): List[S] = {
     // The number of tasks: at most one per thread, and never more than there are indices.

--- a/main/src/ca/uwaterloo/flix/util/ThreadPool.scala
+++ b/main/src/ca/uwaterloo/flix/util/ThreadPool.scala
@@ -23,28 +23,6 @@ import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{LinkedBlockingQueue, ThreadFactory, ThreadPoolExecutor, TimeUnit}
 
-/**
-  * The thread pool used by the compiler: a fixed-size pool of `threads` worker threads, each
-  * created with a stack of at least [[CompilerConstants.ThreadStackSize]] bytes.
-  *
-  * We use a plain [[ThreadPoolExecutor]] rather than a `ForkJoinPool` because the latter offers
-  * no way to control the stack size of its worker threads: `ForkJoinWorkerThread` always requests
-  * the JVM default. Here we supply our own [[ThreadFactory]] which requests a larger stack for
-  * every worker.
-  *
-  * Idle workers exit after [[CompilerConstants.ThreadKeepAliveSeconds]] so that a pool which is
-  * never shut down (e.g. because a compilation crashed) does not pin its threads and their stacks
-  * forever.
-  */
-class ThreadPool(threads: Int) extends ThreadPoolExecutor(
-  threads, threads,
-  CompilerConstants.ThreadKeepAliveSeconds, TimeUnit.SECONDS,
-  new LinkedBlockingQueue[Runnable](),
-  new ThreadPool.WorkerFactory
-) {
-  allowCoreThreadTimeOut(true)
-}
-
 object ThreadPool {
 
   /**
@@ -87,4 +65,26 @@ object ThreadPool {
     }
   }
 
+}
+
+/**
+  * The thread pool used by the compiler: a fixed-size pool of `threads` worker threads, each
+  * created with a stack of at least [[CompilerConstants.ThreadStackSize]] bytes.
+  *
+  * We use a plain [[ThreadPoolExecutor]] rather than a `ForkJoinPool` because the latter offers
+  * no way to control the stack size of its worker threads: `ForkJoinWorkerThread` always requests
+  * the JVM default. Here we supply our own [[ThreadFactory]] which requests a larger stack for
+  * every worker.
+  *
+  * Idle workers exit after [[CompilerConstants.ThreadKeepAliveSeconds]] so that a pool which is
+  * never shut down (e.g. because a compilation crashed) does not pin its threads and their stacks
+  * forever.
+  */
+class ThreadPool(threads: Int) extends ThreadPoolExecutor(
+  threads, threads,
+  CompilerConstants.ThreadKeepAliveSeconds, TimeUnit.SECONDS,
+  new LinkedBlockingQueue[Runnable](),
+  new ThreadPool.WorkerFactory
+) {
+  allowCoreThreadTimeOut(true)
 }

--- a/main/src/ca/uwaterloo/flix/util/ThreadPool.scala
+++ b/main/src/ca/uwaterloo/flix/util/ThreadPool.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.util
+
+import ca.uwaterloo.flix.api.CompilerConstants
+import com.sun.management.HotSpotDiagnosticMXBean
+
+import java.lang.management.ManagementFactory
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{LinkedBlockingQueue, ThreadFactory, ThreadPoolExecutor, TimeUnit}
+
+/**
+  * The thread pool used by the compiler: a fixed-size pool of `threads` worker threads, each
+  * created with a stack of at least [[CompilerConstants.ThreadStackSize]] bytes.
+  *
+  * We use a plain [[ThreadPoolExecutor]] rather than a `ForkJoinPool` because the latter offers
+  * no way to control the stack size of its worker threads: `ForkJoinWorkerThread` always requests
+  * the JVM default. Here we supply our own [[ThreadFactory]] which requests a larger stack for
+  * every worker.
+  *
+  * Idle workers exit after [[CompilerConstants.ThreadKeepAliveSeconds]] so that a pool which is
+  * never shut down (e.g. because a compilation crashed) does not pin its threads and their stacks
+  * forever.
+  */
+class ThreadPool(threads: Int) extends ThreadPoolExecutor(
+  threads, threads,
+  CompilerConstants.ThreadKeepAliveSeconds, TimeUnit.SECONDS,
+  new LinkedBlockingQueue[Runnable](),
+  new ThreadPool.WorkerFactory
+) {
+  allowCoreThreadTimeOut(true)
+}
+
+object ThreadPool {
+
+  /**
+    * The stack size (in bytes) requested for each worker thread: the larger of
+    * [[CompilerConstants.ThreadStackSize]] and the JVM's default thread stack size.
+    *
+    * An explicit per-thread stack size overrides the JVM default rather than adding to it, so
+    * without this maximum the workers would end up with *smaller* stacks than every other thread
+    * whenever the JVM is run with a larger `-Xss`. Taking the maximum guarantees that the workers
+    * are never worse off than the default.
+    */
+  private val WorkerStackSize: Long = math.max(CompilerConstants.ThreadStackSize, jvmDefaultStackSize())
+
+  /**
+    * Returns the JVM's default thread stack size in bytes, as set by `-Xss` or
+    * `-XX:ThreadStackSize`, or `0` if it cannot be determined (e.g. on a non-HotSpot JVM or a
+    * runtime image without the `jdk.management` module).
+    */
+  private def jvmDefaultStackSize(): Long = try {
+    val bean = ManagementFactory.getPlatformMXBean(classOf[HotSpotDiagnosticMXBean])
+    // HotSpot tracks `ThreadStackSize` in kilobytes.
+    val kb = bean.getVMOption("ThreadStackSize").getValue.toLong
+    kb * 1024L
+  } catch {
+    case _: Exception => 0L
+    case _: LinkageError => 0L
+  }
+
+  /**
+    * A [[ThreadFactory]] that creates daemon threads named `flix-worker-N` with a stack of
+    * [[WorkerStackSize]] bytes.
+    */
+  private class WorkerFactory extends ThreadFactory {
+    private val counter = new AtomicInteger(1)
+
+    override def newThread(r: Runnable): Thread = {
+      val t = new Thread(null, r, s"flix-worker-${counter.getAndIncrement()}", WorkerStackSize)
+      t.setDaemon(true)
+      t
+    }
+  }
+
+}


### PR DESCRIPTION
> Builds on #13051 (merged), which made `ParOps` executor-agnostic. This PR is the pool change plus a doc-only follow-up on `ParOps`.

## Summary

Deeply nested inputs (long list literals, long `a + b + c + …` chains, generated code) blow the JVM's default 1–2 MB thread stack inside the compiler's parallel phases. This PR gives the compiler's worker threads a larger stack.

- **`util/ThreadPool.scala`** (new): a fixed-size `ThreadPoolExecutor` whose `ThreadFactory` creates daemon `flix-worker-N` threads with an explicit stack size. `ForkJoinPool` cannot do this — `ForkJoinWorkerThread` hard-codes the JVM default (`super(group, null, name, 0L, …)`), even with a custom `ForkJoinWorkerThreadFactory` — hence the switch. Idle workers time out after 60 s so a pool that is never shut down (crash path) does not pin its threads.
- **`CompilerConstants.ThreadStackSize`** = 64 MB, and **`ThreadKeepAliveSeconds`** = 60 s.
- The stack size is a **floor**: workers get `max(64 MB, JVM default)`, where the JVM default is read via `HotSpotDiagnosticMXBean` (falls back to the constant on non-HotSpot JVMs / images without `jdk.management`). An explicit per-thread size *overrides* `-Xss` rather than adding to it, so without this a user raising `-Xss` would end up with workers that have the *smallest* stacks in the process.
- `Flix.scala`: `threadPool: ThreadPool`, `initThreadPool`/`shutdownThreadPool`. `CompilerTop`: `getParallelism`/`getActiveThreadCount` → `getCorePoolSize`/`getActiveCount`.
- **`ParOps` (doc only)**: `parAgg`'s scaladoc now states the laws it requires — since #13051 the elements are partitioned across tasks nondeterministically, so `comb` must be commutative as well as associative (the old fork/join version preserved element order and only needed associativity). Both current callers satisfy this (set union in Redundancy, disjoint-key `Map ++` in `GenFunAndClosureClasses`); `parFold`'s doc explains why.

## Performance

`Xperf --par --n 50` (10 threads, 89,922 lines), interleaved with master in the same session, this pool on top of #13051's `ParOps`: median **62.6K · 62.1K** lines/s vs pre-#13051 master 61.5K · 61.4K · 60.9K. Relative to #13051 alone the pool swap is neutral. (A one-task-per-element `ParOps` on a `ThreadPoolExecutor` was ~8.5% slower than ForkJoin, which is why #13051 went first.)

## Memory

Only address space is reserved up front; physical pages are committed on first touch. Measured on macOS: 16 idle threads with 256 MB stacks cost +2 MB RSS — identical to 16 default-stack threads. With 64 MB × 16 workers that is 1 GB of address space. Physical cost is exactly the stack a compile actually uses, i.e. what a smaller stack would have needed too before throwing `StackOverflowError`.

## Effect

Probe: `def f(): Int32 = 1 + 1 + … + 1` with *n* terms.

| | n=2000 | n=5000 | n=10000 |
|---|---|---|---|
| master (2 MB workers) | SOE (Weeder) | | |
| this PR (64 MB) | ✓ | ✓ | SOE (Typer) |
| this PR + `-Xss128m` (→ 128 MB) | | | ✓ |
| this PR + `-Xss1m` (floor holds) | | ✓ | |

Note: only pool workers get the larger stack; the calling thread (`main`, LSP) still has the JVM default, so purely sequential phases and `--threads 1` (where `ParOps` runs inline) do not benefit. That could be a follow-up (run the compile in a large-stack thread in `Main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
