### PR TITLE
fix: broken link to STYLE.md in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,4 +51,4 @@ We are interested in correct, well-documented, and well-tested code.
 
 We expect all pull requests to be maintainable and follow established style.
 
-Please have a look at [docs/STYLE.md](docs/STYLE.md) for more information on how to structure your code.
+Please have a look at [docs/STYLE.md](STYLE.md) for more information on how to structure your code.


### PR DESCRIPTION
Summary

Fixes a broken relative link in docs/CONTRIBUTING.md.

The link to the style guide read [docs/STYLE.md](docs/STYLE.md). Since CONTRIBUTING.md itself lives in docs/, that relative path resolved to the nonexistent docs/docs/STYLE.md instead of the actual docs/STYLE.md.