### PR TITLE
fix: make predicate arity picking recoverable

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3299,10 +3299,7 @@ object Weeder2 {
     val ident = pickNameIdent(tree)
     val arity = tryPickToken(TokenKind.LiteralInt, tree) match {
       case Some(token) => tryParsePredicateArity(token)
-      case None =>
-        // Soft failure: the parser has already reported the missing integer literal.
-        sctx.errors.add(WeederError.IllegalPredicateArity(tree.loc))
-        0
+      case None => 0 // The parser has already reported the missing integer literal.
     }
     PredicateAndArity(Name.mkPred(ident), arity)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3296,9 +3296,14 @@ object Weeder2 {
   }
 
   private def visitPredicateAndArity(tree: Tree)(implicit sctx: SharedContext): PredicateAndArity = {
-    val arityToken = pickToken(TokenKind.LiteralInt, tree)
     val ident = pickNameIdent(tree)
-    val arity = tryParsePredicateArity(arityToken)
+    val arity = tryPickToken(TokenKind.LiteralInt, tree) match {
+      case Some(token) => tryParsePredicateArity(token)
+      case None =>
+        // Soft failure: the parser has already reported the missing integer literal.
+        sctx.errors.add(WeederError.IllegalPredicateArity(tree.loc))
+        0
+    }
     PredicateAndArity(Name.mkPred(ident), arity)
   }
 
@@ -3435,13 +3440,20 @@ object Weeder2 {
     * Picks out the first token of a specific [[TokenKind]].
     */
   private def pickToken(kind: TokenKind, tree: Tree, synctx: SyntacticContext = SyntacticContext.Unknown): Token = {
-    tree.children.collectFirst {
-      case token: Token if token.kind == kind => token
-    } match {
+    tryPickToken(kind, tree) match {
       case Some(t) => t
       case _ =>
         val error = NeedAtleastOne(NamedTokenSet.FromKinds(Set(kind)), synctx, loc = tree.loc)
         throw PickException(error)
+    }
+  }
+
+  /**
+    * Tries to pick out the first token of a specific [[TokenKind]].
+    */
+  private def tryPickToken(kind: TokenKind, tree: Tree): Option[Token] = {
+    tree.children.collectFirst {
+      case token: Token if token.kind == kind => token
     }
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1998,7 +1998,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalUnaryPlus](result)
   }
 
-  test("IllegalPredicateArity.01") {
+  test("MissingPredicateArity.01") {
     val input =
       """
         |def f(x: Vector[Int32]): Unit = {
@@ -2007,7 +2007,8 @@ class TestWeeder extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = check(input, Options.TestWithLibAll)
-    expectError[WeederError.IllegalPredicateArity](result)
+    expectError[ParseError.UnexpectedToken](result)
+    rejectError[WeederError.IllegalPredicateArity](result)
   }
 
   test("IllegalConstantPattern.LetMatch.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1998,6 +1998,18 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalUnaryPlus](result)
   }
 
+  test("IllegalPredicateArity.01") {
+    val input =
+      """
+        |def f(x: Vector[Int32]): Unit = {
+        |  let _ = inject x into A/x;
+        |  ()
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibAll)
+    expectError[WeederError.IllegalPredicateArity](result)
+  }
+
   test("IllegalConstantPattern.LetMatch.01") {
     val input =
       """enum E {


### PR DESCRIPTION
Handle malformed predicate arities without throwing `PickException`.

When the parser cannot produce a `LiteralInt` token, Weeder2 now reports `IllegalPredicateArity` and uses arity zero as a fallback. This lets weeding continue after the parser error.

Adds a regression test for `inject x into A/x`.

Addresses the `visitPredicateAndArity` case in #13033.