### PR TITLE
fix: pick schema predicate alias name

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -2969,7 +2969,7 @@ object Weeder2 {
       }
       pickAllTrees(parentTree).foldRight(rest) {
         case (tree, acc) if tree.kind == TreeKind.Type.PredicateWithAlias =>
-          val qname = pickQName(parentTree)
+          val qname = pickQName(tree)
           val targs = Types.pickArguments(tree)
           Type.SchemaRowExtendByAlias(qname, targs, acc, tree.loc)
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -574,6 +574,12 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.UndefinedName](result)
   }
 
+  test("UndefinedName.04") {
+    val input = "def f(): #{ A[Int32] } = ???"
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UndefinedNameUnrecoverable](result)
+  }
+
   test("UndefinedUse.01") {
     val input =
       s"""

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.language.errors.{ParseError, WeederError}
+import ca.uwaterloo.flix.language.errors.{ParseError, ResolutionError, WeederError}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -2009,6 +2009,12 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     val result = check(input, Options.TestWithLibAll)
     expectError[ParseError.UnexpectedToken](result)
     rejectError[WeederError.IllegalPredicateArity](result)
+  }
+
+  test("PredicateWithAlias.01") {
+    val input = "def f(): #{ A[Int32] } = ???"
+    val result = check(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UndefinedNameUnrecoverable](result)
   }
 
   test("IllegalConstantPattern.LetMatch.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.language.errors.{ParseError, ResolutionError, WeederError}
+import ca.uwaterloo.flix.language.errors.{ParseError, WeederError}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -2009,12 +2009,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     val result = check(input, Options.TestWithLibAll)
     expectError[ParseError.UnexpectedToken](result)
     rejectError[WeederError.IllegalPredicateArity](result)
-  }
-
-  test("PredicateWithAlias.01") {
-    val input = "def f(): #{ A[Int32] } = ???"
-    val result = check(input, Options.TestWithLibNix)
-    expectError[ResolutionError.UndefinedNameUnrecoverable](result)
   }
 
   test("IllegalConstantPattern.LetMatch.01") {


### PR DESCRIPTION
Read the qualified name from the `PredicateWithAlias` subtree instead of the enclosing schema tree.

This prevents `PickException` for schema aliases such as `#{ A[Int32] }` and adds a regression demonstrating that the program proceeds to name resolution.

Addresses the `visitSchemaRowType` case in #13033.