### PR TITLE
feat: animate compiler progress bar

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -487,14 +487,15 @@ class Flix {
     // Mark this object as implicit.
     implicit val flix: Flix = this
 
+    // Begin drawing the progress bar (if enabled).
+    progressBar.start()
+
     // Initialize the thread pool.
     initThreadPool()
 
     // Reset the phase information.
     phaseTimers = ArrayBuffer.empty
     currentPhase = None
-
-    progressBar.start()
 
     // Reset the phase list file if relevant
     if (this.options.xprintphases) {
@@ -639,10 +640,11 @@ class Flix {
     // Mark this object as implicit.
     implicit val flix: Flix = this
 
+    // Begin drawing the progress bar (if enabled).
+    progressBar.start()
+
     // Initialize the thread pool.
     initThreadPool()
-
-    progressBar.start()
 
     var treeShaker1Ast = TreeShaker1.run(typedAst)
     // Note: Do not null typedAst. It is used later.

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -494,9 +494,7 @@ class Flix {
     phaseTimers = ArrayBuffer.empty
     currentPhase = None
 
-    if (options.progress) {
-      progressBar.start()
-    }
+    progressBar.start()
 
     // Reset the phase list file if relevant
     if (this.options.xprintphases) {
@@ -599,9 +597,7 @@ class Flix {
     shutdownThreadPool()
 
     // Reset the progress bar.
-    if (options.progress) {
-      progressBar.complete()
-    }
+    progressBar.complete()
 
     // Stop the live compiler profiler TUI only if there are errors and no
     // `codeGen` will follow. On the success path, leave it running so
@@ -622,11 +618,11 @@ class Flix {
     (result, errors.toList)
   } catch {
     case ex: InternalCompilerException =>
-      if (options.progress) progressBar.complete()
+      progressBar.complete()
       CrashHandler.handleCrash(ex)(this)
       throw ex
     case ex: Throwable =>
-      if (options.progress) progressBar.complete()
+      progressBar.complete()
       throw ex
   }
 
@@ -646,9 +642,7 @@ class Flix {
     // Initialize the thread pool.
     initThreadPool()
 
-    if (options.progress) {
-      progressBar.start()
-    }
+    progressBar.start()
 
     var treeShaker1Ast = TreeShaker1.run(typedAst)
     // Note: Do not null typedAst. It is used later.
@@ -705,9 +699,7 @@ class Flix {
     shutdownThreadPool()
 
     // Reset the progress bar.
-    if (options.progress) {
-      progressBar.complete()
-    }
+    progressBar.complete()
 
     // Stop the live compiler profiler TUI, if it is running.
     compilerTop.foreach(_.stop())
@@ -716,11 +708,11 @@ class Flix {
     result
   } catch {
     case ex: InternalCompilerException =>
-      if (options.progress) progressBar.complete()
+      progressBar.complete()
       CrashHandler.handleCrash(ex)(this)
       throw ex
     case ex: Throwable =>
-      if (options.progress) progressBar.complete()
+      progressBar.complete()
       CrashHandler.handleCrash(ex)(this)
       throw ex
   }
@@ -763,9 +755,7 @@ class Flix {
     // Initialize the phase time object.
     currentPhase = Some(PhaseTime(phase, 0))
 
-    if (options.progress) {
-      progressBar.observe(phase)
-    }
+    progressBar.observe(phase)
 
     // Measure the execution time.
     val t = System.nanoTime()

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -494,6 +494,10 @@ class Flix {
     phaseTimers = ArrayBuffer.empty
     currentPhase = None
 
+    if (options.progress) {
+      progressBar.start()
+    }
+
     // Reset the phase list file if relevant
     if (this.options.xprintphases) {
       AstPrinter.resetPhaseFile()
@@ -618,7 +622,11 @@ class Flix {
     (result, errors.toList)
   } catch {
     case ex: InternalCompilerException =>
+      if (options.progress) progressBar.complete()
       CrashHandler.handleCrash(ex)(this)
+      throw ex
+    case ex: Throwable =>
+      if (options.progress) progressBar.complete()
       throw ex
   }
 
@@ -637,6 +645,10 @@ class Flix {
 
     // Initialize the thread pool.
     initThreadPool()
+
+    if (options.progress) {
+      progressBar.start()
+    }
 
     var treeShaker1Ast = TreeShaker1.run(typedAst)
     // Note: Do not null typedAst. It is used later.
@@ -704,9 +716,11 @@ class Flix {
     result
   } catch {
     case ex: InternalCompilerException =>
+      if (options.progress) progressBar.complete()
       CrashHandler.handleCrash(ex)(this)
       throw ex
     case ex: Throwable =>
+      if (options.progress) progressBar.complete()
       CrashHandler.handleCrash(ex)(this)
       throw ex
   }

--- a/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
+++ b/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
@@ -23,24 +23,9 @@ import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 
 class ProgressBar(flix: Flix) {
   /**
-    * An immutable snapshot passed from the compiler thread to the animation thread.
-    *
-    * @param phase                  the name of the current compiler phase.
-    * @param current                the one-based index of the current compiler phase.
-    * @param phaseStartMillis       the monotonic time at which the current phase started.
-    * @param compilationStartMillis the monotonic time at which the compilation started.
-    */
-  private case class State(phase: String, current: Int, phaseStartMillis: Long, compilationStartMillis: Long)
-
-  /**
     * The width of the progress bar in visible characters.
     */
   private val Width = 80
-
-  /**
-    * The characters in the spinner.
-    */
-  private val SpinnerChars = Array("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 
   /**
     * The width of the phase name column in visible characters.
@@ -48,6 +33,11 @@ class ProgressBar(flix: Flix) {
     * Set by the longest phase names: "Dependencies" and "EffectBinder".
     */
   private val PhaseWidth = 12
+
+  /**
+    * The characters in the spinner.
+    */
+  private val SpinnerChars = Array("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 
   /**
     * The delay between frames. At 80 ms the animation runs at 12.5 frames per second.
@@ -66,17 +56,14 @@ class ProgressBar(flix: Flix) {
   private val MemorySampleIntervalMillis = 750L
 
   /**
-    * An internal counter used to print the spinner.
+    * An immutable snapshot passed from the compiler thread to the animation thread.
     *
-    * Monotonically increasing.
+    * @param phase                  the name of the current compiler phase.
+    * @param current                the one-based index of the current compiler phase.
+    * @param phaseStartMillis       the monotonic time at which the current phase started.
+    * @param compilationStartMillis the monotonic time at which the compilation started.
     */
-  private val spinnerTick = new AtomicInteger(0)
-
-  /**
-    * Guards writes to the terminal and the render-thread-owned memory sample cache
-    * (`cachedMemory` and `memorySampleMillis`).
-    */
-  private val renderLock = new ReentrantLock()
+  private case class State(phase: String, current: Int, phaseStartMillis: Long, compilationStartMillis: Long)
 
   /**
     * Guards animator lifecycle transitions, ensuring that creation, publication, removal,
@@ -85,14 +72,32 @@ class ProgressBar(flix: Flix) {
   private val lifecycleLock = new ReentrantLock()
 
   /**
+    * The executor responsible for refreshing the current progress line.
+    */
+  private val animator = new AtomicReference[ScheduledExecutorService](null)
+
+  /**
     * The latest phase snapshot published by the compiler thread.
     */
   private val state = new AtomicReference[State](null)
 
   /**
-    * The executor responsible for refreshing the current progress line.
+    * The time (in milliseconds) at which the first phase of the current compilation was observed.
     */
-  private val animator = new AtomicReference[ScheduledExecutorService](null)
+  private var startMillis: Long = nowMillis()
+
+  /**
+    * Guards writes to the terminal and the render-thread-owned memory sample cache
+    * (`cachedMemory` and `memorySampleMillis`).
+    */
+  private val renderLock = new ReentrantLock()
+
+  /**
+    * An internal counter used to print the spinner.
+    *
+    * Monotonically increasing.
+    */
+  private val spinnerTick = new AtomicInteger(0)
 
   /**
     * The most recently sampled heap-memory display and its percentage of the maximum heap.
@@ -103,11 +108,6 @@ class ProgressBar(flix: Flix) {
     * The time at which `cachedMemory` was last updated, or zero if no sample is cached.
     */
   private var memorySampleMillis: Long = 0L
-
-  /**
-    * The time (in milliseconds) at which the first phase of the current compilation was observed.
-    */
-  private var startMillis: Long = nowMillis()
 
   /**
     * Starts the animation thread if it is not already running.
@@ -265,6 +265,26 @@ class ProgressBar(flix: Flix) {
   }
 
   /**
+    * Colors each character of `phase` independently, producing a soft highlight that travels
+    * from left to right. The highlight begins and ends outside the text so consecutive pulses
+    * join without a visible jump.
+    */
+  private def pulsePhase(phase: String, progress: Double, fmt: Formatter): String = {
+    val margin = 3.0
+    val center = progress * (phase.length + 2.0 * margin) - margin
+    phase.zipWithIndex.map { case (char, index) =>
+      val distance = index - center
+      val intensity = Math.exp(-(distance * distance) / 4.0)
+      fmt.fgColor(
+        interpolate(68, 120, intensity),
+        interpolate(147, 210, intensity),
+        interpolate(200, 255, intensity),
+        char.toString
+      )
+    }.mkString
+  }
+
+  /**
     * Returns `s` if it less than or equal to `l` chars.
     *
     * Otherwise returns a prefix of `s` with ...
@@ -285,25 +305,5 @@ class ProgressBar(flix: Flix) {
     * Returns monotonic time in milliseconds.
     */
   private def nowMillis(): Long = TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
-
-  /**
-    * Colors each character of `phase` independently, producing a soft highlight that travels
-    * from left to right. The highlight begins and ends outside the text so consecutive pulses
-    * join without a visible jump.
-    */
-  private def pulsePhase(phase: String, progress: Double, fmt: Formatter): String = {
-    val margin = 3.0
-    val center = progress * (phase.length + 2.0 * margin) - margin
-    phase.zipWithIndex.map { case (char, index) =>
-      val distance = index - center
-      val intensity = Math.exp(-(distance * distance) / 4.0)
-      fmt.fgColor(
-        interpolate(68, 120, intensity),
-        interpolate(147, 210, intensity),
-        interpolate(200, 255, intensity),
-        char.toString
-      )
-    }.mkString
-  }
 
 }

--- a/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
+++ b/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
@@ -107,7 +107,7 @@ class ProgressBar(flix: Flix) {
     * Locking: Acquires `lifecycleLock`. Does not acquire `renderLock`.
     */
   def start(): Unit = lifecycleLock.synchronized {
-    if (animator.get() == null) {
+    if (flix.options.progress && animator.get() == null) {
       val executor = Executors.newSingleThreadScheduledExecutor((r: Runnable) => {
         val thread = new Thread(r, "flix-progress-bar")
         thread.setDaemon(true)
@@ -124,10 +124,12 @@ class ProgressBar(flix: Flix) {
     * Locking: Acquires no locks. Publishes the new state atomically.
     */
   def observe(phase: String): Unit = {
-    val now = nowMillis()
-    if (flix.phaseTimers.isEmpty) startMillis = now
-    val current = (flix.phaseTimers.size + 1).min(CompilerConstants.TotalPhases)
-    state.set(State(phase, current, now, startMillis))
+    if (animator.get() != null) {
+      val now = nowMillis()
+      if (flix.phaseTimers.isEmpty) startMillis = now
+      val current = (flix.phaseTimers.size + 1).min(CompilerConstants.TotalPhases)
+      state.set(State(phase, current, now, startMillis))
+    }
   }
 
   /**
@@ -139,17 +141,20 @@ class ProgressBar(flix: Flix) {
     * The locks are never held simultaneously.
     */
   def complete(): Unit = {
-    lifecycleLock.synchronized {
+    val wasRunning = lifecycleLock.synchronized {
       state.set(null)
       val executor = animator.getAndSet(null)
       if (executor != null) executor.shutdownNow()
+      executor != null
     }
 
-    // Wait only for an in-flight terminal write, never for phase-state computation.
-    renderLock.synchronized {
-      memorySampleMillis = 0L
-      System.out.print(" " * Width + "\r")
-      System.out.flush()
+    if (wasRunning) {
+      // Wait only for an in-flight terminal write, never for phase-state computation.
+      renderLock.synchronized {
+        memorySampleMillis = 0L
+        System.out.print(" " * Width + "\r")
+        System.out.flush()
+      }
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
+++ b/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.util
 import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
 
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.locks.ReentrantLock
 import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 
 class ProgressBar(flix: Flix) {
@@ -72,14 +73,16 @@ class ProgressBar(flix: Flix) {
   private val spinnerTick = new AtomicInteger(0)
 
   /**
-    * Ensures that terminal frames and line clearing never interleave.
+    * Guards writes to the terminal and the render-thread-owned memory sample cache
+    * (`cachedMemory` and `memorySampleMillis`).
     */
-  private val renderLock = new Object
+  private val renderLock = new ReentrantLock()
 
   /**
-    * Guards the infrequent start and completion transitions of the animator.
+    * Guards animator lifecycle transitions, ensuring that creation, publication, removal,
+    * and shutdown of the scheduled executor occur atomically with respect to one another.
     */
-  private val lifecycleLock = new Object
+  private val lifecycleLock = new ReentrantLock()
 
   /**
     * The latest phase snapshot published by the compiler thread.
@@ -111,15 +114,20 @@ class ProgressBar(flix: Flix) {
     *
     * Locking: Acquires `lifecycleLock`. Does not acquire `renderLock`.
     */
-  def start(): Unit = lifecycleLock.synchronized {
-    if (flix.options.progress && animator.get() == null) {
-      val executor = Executors.newSingleThreadScheduledExecutor((r: Runnable) => {
-        val thread = new Thread(r, "flix-progress-bar")
-        thread.setDaemon(true)
-        thread
-      })
-      executor.scheduleAtFixedRate(() => renderFrame(executor), FrameDelayMillis, FrameDelayMillis, TimeUnit.MILLISECONDS)
-      animator.set(executor)
+  def start(): Unit = {
+    lifecycleLock.lock()
+    try {
+      if (flix.options.progress && animator.get() == null) {
+        val executor = Executors.newSingleThreadScheduledExecutor((r: Runnable) => {
+          val thread = new Thread(r, "flix-progress-bar")
+          thread.setDaemon(true)
+          thread
+        })
+        executor.scheduleAtFixedRate(() => renderFrame(executor), FrameDelayMillis, FrameDelayMillis, TimeUnit.MILLISECONDS)
+        animator.set(executor)
+      }
+    } finally {
+      lifecycleLock.unlock()
     }
   }
 
@@ -146,19 +154,25 @@ class ProgressBar(flix: Flix) {
     * The locks are never held simultaneously.
     */
   def complete(): Unit = {
-    val wasRunning = lifecycleLock.synchronized {
+    lifecycleLock.lock()
+    val wasRunning = try {
       state.set(null)
       val executor = animator.getAndSet(null)
       if (executor != null) executor.shutdownNow()
       executor != null
+    } finally {
+      lifecycleLock.unlock()
     }
 
     if (wasRunning) {
       // Wait only for an in-flight terminal write, never for phase-state computation.
-      renderLock.synchronized {
+      renderLock.lock()
+      try {
         memorySampleMillis = 0L
         System.out.print(" " * Width + "\r")
         System.out.flush()
+      } finally {
+        renderLock.unlock()
       }
     }
   }
@@ -168,10 +182,15 @@ class ProgressBar(flix: Flix) {
     *
     * Locking: Acquires `renderLock`. Does not acquire `lifecycleLock`.
     */
-  private def renderFrame(executor: ScheduledExecutorService): Unit = renderLock.synchronized {
-    if (animator.get() eq executor) {
-      val snapshot = state.get()
-      if (snapshot != null) print(snapshot)
+  private def renderFrame(executor: ScheduledExecutorService): Unit = {
+    renderLock.lock()
+    try {
+      if (animator.get() eq executor) {
+        val snapshot = state.get()
+        if (snapshot != null) print(snapshot)
+      }
+    } finally {
+      renderLock.unlock()
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
+++ b/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
@@ -17,9 +17,15 @@ package ca.uwaterloo.flix.util
 
 import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
 
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 
 class ProgressBar(flix: Flix) {
+  /**
+    * An immutable snapshot passed from the compiler thread to the animation thread.
+    */
+  private case class State(phase: String, current: Int, phaseStartMillis: Long, compilationStartMillis: Long)
+
   /**
     * The width of the progress bar in visible characters.
     */
@@ -38,6 +44,22 @@ class ProgressBar(flix: Flix) {
   private val PhaseWidth = 12
 
   /**
+    * The delay between frames. At 80 ms the animation runs at 12.5 frames per second.
+    */
+  private val FrameDelayMillis = 80L
+
+  /**
+    * The duration of one complete phase-name pulse.
+    */
+  private val PulsePeriodMillis = 1500L
+
+  /**
+    * The interval between heap-memory samples. Memory changes less frequently than animation
+    * frames so the displayed value remains readable.
+    */
+  private val MemorySampleIntervalMillis = 750L
+
+  /**
     * An internal counter used to print the spinner.
     *
     * Monotonically increasing.
@@ -45,46 +67,130 @@ class ProgressBar(flix: Flix) {
   private val spinnerTick = new AtomicInteger(0)
 
   /**
-    * The time (in nanoseconds) at which the first phase of the current compilation was observed.
+    * Ensures that terminal frames and line clearing never interleave.
     */
-  private var startNanos: Long = System.nanoTime()
+  private val renderLock = new Object
+
+  /**
+    * Guards the infrequent start and completion transitions of the animator.
+    */
+  private val lifecycleLock = new Object
+
+  /**
+    * The latest phase snapshot published by the compiler thread.
+    */
+  private val state = new AtomicReference[State](null)
+
+  /**
+    * The executor responsible for refreshing the current progress line.
+    */
+  private val animator = new AtomicReference[ScheduledExecutorService](null)
+
+  /**
+    * The most recently sampled heap-memory display and its percentage of the maximum heap.
+    */
+  private var cachedMemory: (String, Int) = ("   0M", 0)
+
+  /**
+    * The time at which `cachedMemory` was last updated, or zero if no sample is cached.
+    */
+  private var memorySampleMillis: Long = 0L
+
+  /**
+    * The time (in milliseconds) at which the first phase of the current compilation was observed.
+    */
+  private var startMillis: Long = nowMillis()
+
+  /**
+    * Starts the animation thread if it is not already running.
+    *
+    * Locking: Acquires `lifecycleLock`. Does not acquire `renderLock`.
+    */
+  def start(): Unit = lifecycleLock.synchronized {
+    if (animator.get() == null) {
+      val executor = Executors.newSingleThreadScheduledExecutor((r: Runnable) => {
+        val thread = new Thread(r, "flix-progress-bar")
+        thread.setDaemon(true)
+        thread
+      })
+      executor.scheduleAtFixedRate(() => renderFrame(executor), FrameDelayMillis, FrameDelayMillis, TimeUnit.MILLISECONDS)
+      animator.set(executor)
+    }
+  }
 
   /**
     * Updates the progress to the given `phase`.
+    *
+    * Locking: Acquires no locks. Publishes the new state atomically.
     */
   def observe(phase: String): Unit = {
-    print(phase)
+    val now = nowMillis()
+    if (flix.phaseTimers.isEmpty) startMillis = now
+    val current = (flix.phaseTimers.size + 1).min(CompilerConstants.TotalPhases)
+    state.set(State(phase, current, now, startMillis))
   }
 
   /**
     * Indicates that no further events will be observed.
     *
     * Used to properly reset the current line.
+    *
+    * Locking: Acquires and releases `lifecycleLock`, then acquires `renderLock`.
+    * The locks are never held simultaneously.
     */
   def complete(): Unit = {
-    System.out.print(" " * Width + "\r")
-    System.out.flush()
+    lifecycleLock.synchronized {
+      state.set(null)
+      val executor = animator.getAndSet(null)
+      if (executor != null) executor.shutdownNow()
+    }
+
+    // Wait only for an in-flight terminal write, never for phase-state computation.
+    renderLock.synchronized {
+      memorySampleMillis = 0L
+      System.out.print(" " * Width + "\r")
+      System.out.flush()
+    }
   }
 
   /**
-    * Prints the progress line for the given `phase` to the terminal.
+    * Renders the latest state, if this executor is still the active animator.
+    *
+    * Locking: Acquires `renderLock`. Does not acquire `lifecycleLock`.
+    */
+  private def renderFrame(executor: ScheduledExecutorService): Unit = renderLock.synchronized {
+    if (animator.get() eq executor) {
+      val snapshot = state.get()
+      if (snapshot != null) print(snapshot)
+    }
+  }
+
+  /**
+    * Prints the progress line represented by `snapshot` to the terminal.
     *
     * This function flushes the output and should not be called too often.
+    *
+    * Locking: Must only be called while holding `renderLock`.
     */
-  private def print(phase: String): Unit = {
+  private def print(snapshot: State): Unit = {
     val fmt = flix.getFormatter
 
     // Compute the next character in the spinner.
     val index = spinnerTick.getAndIncrement() % SpinnerChars.length
     val spinner = SpinnerChars(index)
 
-    // Compute the amount of heap memory in use and color it by its percentage of the maximum heap size.
-    val runtime = Runtime.getRuntime
-    val usedMemoryInBytes = runtime.totalMemory() - runtime.freeMemory()
-    val maxMemoryInBytes = runtime.maxMemory()
-    val usedMemoryInMegaBytes = (usedMemoryInBytes / (1024L * 1024L)).toInt
-    val usedMemoryInPercent = ((100L * usedMemoryInBytes) / maxMemoryInBytes).toInt
-    val memoryPadded = f"$usedMemoryInMegaBytes%4dM"
+    // Sample heap memory less frequently than animation frames so the value remains readable.
+    val now = nowMillis()
+    if (memorySampleMillis == 0L || now - memorySampleMillis >= MemorySampleIntervalMillis) {
+      val runtime = Runtime.getRuntime
+      val usedMemoryInBytes = runtime.totalMemory() - runtime.freeMemory()
+      val maxMemoryInBytes = runtime.maxMemory()
+      val usedMemoryInMegaBytes = (usedMemoryInBytes / (1024L * 1024L)).toInt
+      val usedMemoryInPercent = ((100L * usedMemoryInBytes) / maxMemoryInBytes).toInt
+      cachedMemory = (f"$usedMemoryInMegaBytes%4dM", usedMemoryInPercent)
+      memorySampleMillis = now
+    }
+    val (memoryPadded, usedMemoryInPercent) = cachedMemory
     val memPart = usedMemoryInPercent match {
       case x if x < 70 => memoryPadded
       case x if x < 90 => fmt.yellow(memoryPadded)
@@ -92,27 +198,27 @@ class ProgressBar(flix: Flix) {
     }
 
     // The phase name is abbreviated and padded to `PhaseWidth` so the columns to its right do not jitter.
-    val phasePadded = abbreviate(phase, PhaseWidth).padTo(PhaseWidth, ' ')
+    val phasePadded = abbreviate(snapshot.phase, PhaseWidth).padTo(PhaseWidth, ' ')
+    val pulseProgress = ((nowMillis() - snapshot.phaseStartMillis) % PulsePeriodMillis).toDouble / PulsePeriodMillis
+    val phasePart = pulsePhase(phasePadded, pulseProgress, fmt)
 
     // The phase progress bar has one cell per phase: the frontend cells (blue), a divider, and the backend cells (magenta).
     // The finished phases are recorded in `phaseTimers`, so the current phase is number `phaseTimers.size + 1`.
     // We cap at `TotalPhases` in case some phase is not instrumented.
-    val current = (flix.phaseTimers.size + 1).min(CompilerConstants.TotalPhases)
-    val frontendDone = current.min(CompilerConstants.FrontendPhaseCount)
-    val backendDone = current - frontendDone
+    val frontendDone = snapshot.current.min(CompilerConstants.FrontendPhaseCount)
+    val backendDone = snapshot.current - frontendDone
     val frontendBar = fmt.blue("█" * frontendDone) + "░" * (CompilerConstants.FrontendPhaseCount - frontendDone)
     val backendBar = fmt.magenta("█" * backendDone) + "░" * (CompilerConstants.BackendPhaseCount - backendDone)
     val bar = s"$frontendBar│$backendBar"
-    val count = f"$current%2d/${CompilerConstants.TotalPhases}%2d"
+    val count = f"${snapshot.current}%2d/${CompilerConstants.TotalPhases}%2d"
 
     // Compute the time elapsed since the first phase of the current compilation, in tenths of a second.
     // `phaseTimers` is reset when a compilation starts, so an empty list marks its first phase.
     // NB: We format the tenths ourselves (rather than with `%.1f`) so the decimal separator is locale-independent.
-    if (flix.phaseTimers.isEmpty) startNanos = System.nanoTime()
-    val elapsedTenths = (System.nanoTime() - startNanos) / 100_000_000L
+    val elapsedTenths = (nowMillis() - snapshot.compilationStartMillis) / 100L
     val elapsed = f"${elapsedTenths / 10}%3d.${elapsedTenths % 10}%ds"
 
-    val s = s" [${fmt.green(spinner)}] [$memPart] [${fmt.blue(phasePadded)}] [$bar] $count $elapsed"
+    val s = s" [${fmt.green(spinner)}] [$memPart] [$phasePart] [$bar] $count $elapsed"
 
     // The visible width of the line, i.e. excluding ANSI escape codes: the spinner, memory, phase, bar, count,
     // and elapsed fields together with their brackets and spaces. Typically 76 chars, which fits within `Width`.
@@ -139,5 +245,36 @@ class ProgressBar(flix: Flix) {
       s
     else
       s.substring(0, l - 3) + "..."
+
+  /**
+    * Linearly interpolates between `from` and `to` by `amount`.
+    */
+  private def interpolate(from: Int, to: Int, amount: Double): Int =
+    (from + (to - from) * amount).round.toInt
+
+  /**
+    * Returns monotonic time in milliseconds.
+    */
+  private def nowMillis(): Long = TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
+
+  /**
+    * Colors each character of `phase` independently, producing a soft highlight that travels
+    * from left to right. The highlight begins and ends outside the text so consecutive pulses
+    * join without a visible jump.
+    */
+  private def pulsePhase(phase: String, progress: Double, fmt: Formatter): String = {
+    val margin = 3.0
+    val center = progress * (phase.length + 2.0 * margin) - margin
+    phase.zipWithIndex.map { case (char, index) =>
+      val distance = index - center
+      val intensity = Math.exp(-(distance * distance) / 4.0)
+      fmt.fgColor(
+        interpolate(68, 120, intensity),
+        interpolate(147, 210, intensity),
+        interpolate(200, 255, intensity),
+        char.toString
+      )
+    }.mkString
+  }
 
 }

--- a/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
+++ b/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
@@ -102,7 +102,7 @@ class ProgressBar(flix: Flix) {
   private var memorySampleMillis: Long = 0L
 
   /**
-    * Starts the animation thread if it is not already running.
+    * Starts the animation thread if progress is enabled and the animator is not already running.
     */
   def start(): Unit = {
     if (flix.options.progress && animator == null) {
@@ -139,7 +139,7 @@ class ProgressBar(flix: Flix) {
     if (executor != null) executor.shutdownNow()
 
     if (executor != null) {
-      // Wait only for an in-flight terminal write, never for phase-state computation.
+      // Wait for an in-flight terminal write.
       renderLock.lock()
       try {
         memorySampleMillis = 0L

--- a/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
+++ b/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
@@ -17,7 +17,6 @@ package ca.uwaterloo.flix.util
 
 import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
 
-import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 
@@ -66,20 +65,15 @@ class ProgressBar(flix: Flix) {
   private case class State(phase: String, current: Int, phaseStartMillis: Long, compilationStartMillis: Long)
 
   /**
-    * Guards animator lifecycle transitions, ensuring that creation, publication, removal,
-    * and shutdown of the scheduled executor occur atomically with respect to one another.
-    */
-  private val lifecycleLock = new ReentrantLock()
-
-  /**
     * The executor responsible for refreshing the current progress line.
+    * Only accessed by the compiler thread.
     */
-  private val animator = new AtomicReference[ScheduledExecutorService](null)
+  private var animator: ScheduledExecutorService = null
 
   /**
-    * The latest phase snapshot published by the compiler thread.
+    * The latest phase snapshot published by the compiler thread and read by the animation thread.
     */
-  private val state = new AtomicReference[State](null)
+  @volatile private var state: State = null
 
   /**
     * The time (in milliseconds) at which the first phase of the current compilation was observed.
@@ -87,17 +81,15 @@ class ProgressBar(flix: Flix) {
   private var startMillis: Long = nowMillis()
 
   /**
-    * Guards writes to the terminal and the render-thread-owned memory sample cache
-    * (`cachedMemory` and `memorySampleMillis`).
+    * Guards terminal writes against line clearing and protects the render-thread-owned fields
+    * `spinnerTick`, `cachedMemory`, and `memorySampleMillis`.
     */
   private val renderLock = new ReentrantLock()
 
   /**
-    * An internal counter used to print the spinner.
-    *
-    * Monotonically increasing.
+    * The index of the spinner character to print in the next frame.
     */
-  private val spinnerTick = new AtomicInteger(0)
+  private var spinnerTick: Int = 0
 
   /**
     * The most recently sampled heap-memory display and its percentage of the maximum heap.
@@ -111,37 +103,27 @@ class ProgressBar(flix: Flix) {
 
   /**
     * Starts the animation thread if it is not already running.
-    *
-    * Locking: Acquires `lifecycleLock`. Does not acquire `renderLock`.
     */
   def start(): Unit = {
-    lifecycleLock.lock()
-    try {
-      if (flix.options.progress && animator.get() == null) {
-        val executor = Executors.newSingleThreadScheduledExecutor((r: Runnable) => {
-          val thread = new Thread(r, "flix-progress-bar")
-          thread.setDaemon(true)
-          thread
-        })
-        executor.scheduleAtFixedRate(() => renderFrame(executor), FrameDelayMillis, FrameDelayMillis, TimeUnit.MILLISECONDS)
-        animator.set(executor)
-      }
-    } finally {
-      lifecycleLock.unlock()
+    if (flix.options.progress && animator == null) {
+      animator = Executors.newSingleThreadScheduledExecutor((r: Runnable) => {
+        val thread = new Thread(r, "flix-progress-bar")
+        thread.setDaemon(true)
+        thread
+      })
+      animator.scheduleAtFixedRate(() => renderFrame(), FrameDelayMillis, FrameDelayMillis, TimeUnit.MILLISECONDS)
     }
   }
 
   /**
     * Updates the progress to the given `phase`.
-    *
-    * Locking: Acquires no locks. Publishes the new state atomically.
     */
   def observe(phase: String): Unit = {
-    if (animator.get() != null) {
+    if (animator != null) {
       val now = nowMillis()
       if (flix.phaseTimers.isEmpty) startMillis = now
       val current = (flix.phaseTimers.size + 1).min(CompilerConstants.TotalPhases)
-      state.set(State(phase, current, now, startMillis))
+      state = State(phase, current, now, startMillis)
     }
   }
 
@@ -149,22 +131,14 @@ class ProgressBar(flix: Flix) {
     * Indicates that no further events will be observed.
     *
     * Used to properly reset the current line.
-    *
-    * Locking: Acquires and releases `lifecycleLock`, then acquires `renderLock`.
-    * The locks are never held simultaneously.
     */
   def complete(): Unit = {
-    lifecycleLock.lock()
-    val wasRunning = try {
-      state.set(null)
-      val executor = animator.getAndSet(null)
-      if (executor != null) executor.shutdownNow()
-      executor != null
-    } finally {
-      lifecycleLock.unlock()
-    }
+    state = null
+    val executor = animator
+    animator = null
+    if (executor != null) executor.shutdownNow()
 
-    if (wasRunning) {
+    if (executor != null) {
       // Wait only for an in-flight terminal write, never for phase-state computation.
       renderLock.lock()
       try {
@@ -178,17 +152,13 @@ class ProgressBar(flix: Flix) {
   }
 
   /**
-    * Renders the latest state, if this executor is still the active animator.
-    *
-    * Locking: Acquires `renderLock`. Does not acquire `lifecycleLock`.
+    * Renders the latest state.
     */
-  private def renderFrame(executor: ScheduledExecutorService): Unit = {
+  private def renderFrame(): Unit = {
     renderLock.lock()
     try {
-      if (animator.get() eq executor) {
-        val snapshot = state.get()
-        if (snapshot != null) print(snapshot)
-      }
+      val snapshot = state
+      if (snapshot != null) print(snapshot)
     } finally {
       renderLock.unlock()
     }
@@ -205,8 +175,8 @@ class ProgressBar(flix: Flix) {
     val fmt = flix.getFormatter
 
     // Compute the next character in the spinner.
-    val index = spinnerTick.getAndIncrement() % SpinnerChars.length
-    val spinner = SpinnerChars(index)
+    val spinner = SpinnerChars(spinnerTick)
+    spinnerTick = (spinnerTick + 1) % SpinnerChars.length
 
     // Sample heap memory less frequently than animation frames so the value remains readable.
     val now = nowMillis()

--- a/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
+++ b/main/src/ca/uwaterloo/flix/util/ProgressBar.scala
@@ -23,6 +23,11 @@ import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 class ProgressBar(flix: Flix) {
   /**
     * An immutable snapshot passed from the compiler thread to the animation thread.
+    *
+    * @param phase                  the name of the current compiler phase.
+    * @param current                the one-based index of the current compiler phase.
+    * @param phaseStartMillis       the monotonic time at which the current phase started.
+    * @param compilationStartMillis the monotonic time at which the compilation started.
     */
   private case class State(phase: String, current: Int, phaseStartMillis: Long, compilationStartMillis: Long)
 


### PR DESCRIPTION
## Summary
- animate the compiler spinner and add a traveling blue shimmer across phase names
- move rendering to a dedicated daemon thread while publishing phase state atomically
- cache heap-memory readings for readability and explicitly manage renderer startup and shutdown

## Testing
- ./mill --no-server flix.compile
- ./mill --no-server flix.test.compile