### PR TITLE
fix: add a streaming download primitive to GitHub with refusal classification

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -60,6 +60,49 @@ object PackageError {
          |""".stripMargin
   }
 
+  /**
+    * A download refused (403/429), which for an anonymous request usually means a rate limit.
+    */
+  case class DownloadRefused(url: URL, status: Int, retryAfter: Option[String])
+    extends PackageError {
+    override def message(f: Formatter): String = {
+      // Retry-After is delta-seconds per RFC 9110, but may also be an HTTP-date.
+      val when = retryAfter match {
+        case Some(s) if s.forall(_.isDigit) => s"Retry after $s seconds."
+        case Some(s) => s"Retry after $s."
+        case None => "This is usually a rate limit."
+      }
+      s"""Refused (HTTP ${f.red(status.toString)}) by ${f.cyan(url.toString)}.
+         |$when
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * A download answered with a status that is neither success nor a refusal.
+    */
+  case class DownloadFailed(url: URL, status: Int) extends PackageError {
+    override def message(f: Formatter): String = {
+      val detail =
+        if (status >= 300 && status < 400)
+          "The address redirected somewhere that could not be followed."
+        else "Unexpected response."
+      s"""Could not download ${f.cyan(url.toString)}: HTTP ${f.red(status.toString)}.
+         |$detail
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * A download never reached a server at all.
+    */
+  case class DownloadUnreachable(url: URL, message: String) extends PackageError {
+    override def message(f: Formatter): String =
+      s"""Could not reach ${f.cyan(url.toString)}.
+         |$message
+         |""".stripMargin
+  }
+
   case class DownloadError(asset: Asset, message: Option[String]) extends PackageError {
     override def message(f: Formatter): String =
       s"""A download error occurred while downloading ${f.bold(asset.name)}

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -365,8 +365,8 @@ object GitHub {
       * Reusing the instance yields better performance since it can
       * keep connections open.
       *
-      * This field should only be accessed in a thread-safe manner, e.g.,
-      * such as using `this.synchronized` blocks or some other locking mechanism.
+      * The client is immutable once built and manages its own connection pool,
+      * so it can be shared across threads without external locking.
       */
     private val HTTP_CLIENT: HttpClient =
       // Follows redirects: a release download address redirects to the storage the asset lives on.
@@ -379,16 +379,14 @@ object GitHub {
       *
       * May throw [[IOException]].
       */
-    def sendRequest(request: HttpRequest): HttpResponse[String] = this.synchronized {
+    def sendRequest(request: HttpRequest): HttpResponse[String] =
       HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString())
-    }
 
     /**
       * As [[sendRequest]], but with a streamed body. May throw [[IOException]].
       */
-    def sendStreamingRequest(request: HttpRequest): HttpResponse[InputStream] = this.synchronized {
+    def sendStreamingRequest(request: HttpRequest): HttpResponse[InputStream] =
       HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream())
-    }
 
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -235,6 +235,45 @@ object GitHub {
   }
 
   /**
+    * Opens a stream over `url`, following redirects. The caller closes the stream.
+    *
+    * Kept apart: a refusal (403/429, usually a rate limit), any other unexpected status, and never
+    * reaching a server at all.
+    */
+  def download(url: URL): Result[InputStream, PackageError] = {
+    val request = HttpRequest.newBuilder(url.toURI).GET().build()
+
+    val response = try {
+      Client.sendStreamingRequest(request)
+    } catch {
+      case ex: IOException => return Err(PackageError.DownloadUnreachable(url, ex.getMessage))
+      case ex: InterruptedException =>
+        Thread.currentThread().interrupt()
+        return Err(PackageError.DownloadUnreachable(url, ex.getMessage))
+    }
+
+    response.statusCode() match {
+      case status if status >= 200 && status < 300 =>
+        Ok(response.body())
+      case status =>
+        // A close failure must not shadow the status being reported.
+        try response.body().close() catch { case _: IOException => () }
+        status match {
+          case 403 | 429 => Err(PackageError.DownloadRefused(url, status, retryAfter(response)))
+          case _ => Err(PackageError.DownloadFailed(url, status))
+        }
+    }
+  }
+
+  /**
+    * Returns `response`'s `Retry-After` header, if it has one.
+    */
+  private def retryAfter(response: HttpResponse[InputStream]): Option[String] = {
+    val header = response.headers().firstValue("Retry-After")
+    if (header.isPresent) Some(header.get()) else None
+  }
+
+  /**
     * Gets the project release with the relevant semantic version.
     */
   def getSpecificRelease(project: Project, version: SemVer, apiKey: Option[String]): Result[Release, PackageError] = {
@@ -328,7 +367,9 @@ object GitHub {
       * This field should only be accessed in a thread-safe manner, e.g.,
       * such as using `this.synchronized` blocks or some other locking mechanism.
       */
-    private val HTTP_CLIENT: HttpClient = HttpClient.newHttpClient()
+    private val HTTP_CLIENT: HttpClient =
+      // Follows redirects: a release download address redirects to the storage the asset lives on.
+      HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()
 
     /**
       * Sends the HTTP request, `request`, and returns the response.
@@ -339,6 +380,13 @@ object GitHub {
       */
     def sendRequest(request: HttpRequest): HttpResponse[String] = this.synchronized {
       HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString())
+    }
+
+    /**
+      * As [[sendRequest]], but with a streamed body. May throw [[IOException]].
+      */
+    def sendStreamingRequest(request: HttpRequest): HttpResponse[InputStream] = this.synchronized {
+      HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream())
     }
 
   }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -259,7 +259,8 @@ object GitHub {
         // A close failure must not shadow the status being reported.
         try response.body().close() catch { case _: IOException => () }
         status match {
-          case 403 | 429 => Err(PackageError.DownloadRefused(url, status, retryAfter(response)))
+          case 403 => Err(PackageError.DownloadRefused(url, status, retryAfter(response)))
+          case 429 => Err(PackageError.DownloadRefused(url, status, retryAfter(response)))
           case _ => Err(PackageError.DownloadFailed(url, status))
         }
     }


### PR DESCRIPTION
## Summary

Adds `GitHub.download(url)`: a streaming download over an arbitrary URL,
following redirects (a release address redirects to the storage the asset
actually lives on) and classifying a non-2xx response into three distinct
failure modes instead of one generic error:

- `DownloadRefused` -- a 403/429, which for an anonymous request usually
  means a rate limit. Carries `Retry-After` when GitHub sends one, printed
  as seconds only when the header is numeric (it can also be an HTTP-date).
- `DownloadFailed` -- any other unexpected status, including a redirect
  that couldn't be followed.
- `DownloadUnreachable` -- the request never reached a server at all.

Purely additive: nothing calls `download` yet. It's the primitive the rest
of this stack builds on -- #13062 uses it to look up a release asset by
address, #13063 wires that into `FlixPackageManager`.

First of a stack: this one (a streaming download primitive), then #13062
(asset lookup by address), #13063 (wiring `FlixPackageManager` to guess
addresses), and #13064 (removing the now-dead old lookup) -- each builds
on the previous ones' changes.