### PR TITLE
fix: write downloads atomically and make the candidate search testable

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -31,6 +31,47 @@ import scala.util.Using
 object FlixPackageManager {
 
   /**
+    * The manifest asset's fixed name -- `Bootstrap.release` uploads `flix.toml` unchanged.
+    */
+  private val ManifestAssetName = "flix.toml"
+
+  /**
+    * Opens a stream over the first of `candidates` the release actually publishes, falling back to
+    * a rate-limited listing when none of them do. See [[installAll]] for the guessed candidates.
+    */
+  private def openAsset(
+    project: GitHub.Project,
+    version: SemVer,
+    extension: String,
+    candidates: List[String],
+    apiKey: Option[String]
+  ): Result[java.io.InputStream, PackageError] =
+    tryCandidates(project, version, candidates) match {
+      case Some(result) => result
+      case None =>
+        GitHub.findReleaseAsset(project, version, extension, apiKey)
+          .flatMap(asset => GitHub.download(asset.url))
+    }
+
+  /**
+    * Opens the first candidate the release publishes, or `None` if it publishes none of them.
+    */
+  private def tryCandidates(
+    project: GitHub.Project,
+    version: SemVer,
+    candidates: List[String]
+  ): Option[Result[java.io.InputStream, PackageError]] =
+    candidates match {
+      case Nil => None
+      case assetName :: rest =>
+        GitHub.downloadReleaseAsset(project, version, assetName) match {
+          case Ok(stream) => Some(Ok(stream))
+          case Err(_: PackageError.ReleaseAssetNotFound) => tryCandidates(project, version, rest)
+          case Err(e) => Some(Err(e))
+        }
+    }
+
+  /**
     * Represents the dependency resolution of [[origin]].
     * All fields should be considered private except [[origin]] and [[manifests]].
     *
@@ -125,11 +166,23 @@ object FlixPackageManager {
   def installAll(resolution: SecureResolution, projectRoot: Path, apiKey: Option[String])(implicit formatter: Formatter, out: PrintStream): Result[List[(Path, SecurityContext)], PackageError] = {
     out.println("Downloading Flix dependencies...")
 
-    val allFlixDeps = ListMap.from(resolution.manifestToFlixDeps.map { case (manifest, flixDep) => resolution.security(manifest) -> flixDep })
+    // The manifest's declared name travels along too: it's the second guess at the asset's name.
+    val allFlixDeps = ListMap.from(resolution.manifestToFlixDeps.map {
+      case (manifest, flixDep) => (resolution.security(manifest), manifest.name) -> flixDep
+    })
 
-    val flixPaths = allFlixDeps.map { case (sctx, dep) =>
+    val flixPaths = allFlixDeps.map { case ((sctx, packageName), dep) =>
       val depName: String = s"${dep.username}/${dep.projectName}"
-      install(depName, dep.version, "fpkg", projectRoot, apiKey) match {
+      // Three strategies, tried in this order, each falling through to the next only on a 404:
+      //   1. Guess the repository name -- `release` publishes under it, so this is exact for
+      //      anything published from now on, and it is an unmetered request either way.
+      //   2. Guess the manifest's declared name -- covers releases published before (1) was true,
+      //      when the asset was named after the directory `release` ran in. Also unmetered.
+      //   3. Fall back to the listing (inside `install`, via `openAsset`/`findReleaseAsset`) --
+      //      reads whatever name the release actually used. The only one of the three that spends
+      //      REST quota, which is why it is last.
+      val candidates = List(s"${dep.projectName}.fpkg", s"$packageName.fpkg")
+      install(depName, dep.version, "fpkg", candidates, projectRoot, apiKey) match {
         case Ok(p) => (p, sctx)
         case Err(e) =>
           out.println(s"ERROR: Installation of `$depName' failed.")
@@ -147,51 +200,55 @@ object FlixPackageManager {
     *
     * The package is installed at `lib/<owner>/<repo>`
     *
-    * There should be only one file with the given extension.
+    * `candidates` are tried against the asset's computed address first, each an unmetered request;
+    * a rate-limited listing is read only if none of them are what the release actually published.
     *
     * Returns the path to the downloaded file.
     */
-  private def install(project: String, version: SemVer, extension: String, p: Path, apiKey: Option[String])(implicit formatter: Formatter, out: PrintStream): Result[Path, PackageError] = {
+  private def install(
+    project: String,
+    version: SemVer,
+    extension: String,
+    candidates: List[String],
+    p: Path,
+    apiKey: Option[String]
+  )(implicit formatter: Formatter, out: PrintStream): Result[Path, PackageError] = {
     GitHub.parseProject(project).flatMap { proj =>
       val lib = Bootstrap.getLibraryDirectory(p)
-      val assetName = s"${proj.repo}-$version.$extension"
+      val localName = s"${proj.repo}-$version.$extension"
       val dirPath = lib.resolve("github").resolve(proj.owner).resolve(proj.repo).resolve(version.toString)
       // create the directory if it does not exist
       Files.createDirectories(dirPath)
-      val assetPath = dirPath.resolve(assetName)
+      val assetPath = dirPath.resolve(localName)
 
       if (Files.exists(assetPath)) {
         out.println(s"  Cached `${formatter.blue(s"${proj.owner}/${proj.repo}.$extension")}` (${formatter.cyan(s"v$version")}).")
         Ok(assetPath)
       } else {
-        GitHub.getSpecificRelease(proj, version, apiKey).flatMap { release =>
-          val assets = release.assets.filter(_.name.endsWith(s".$extension"))
-          if (assets.isEmpty) {
-            Err(PackageError.NoSuchFile(project, extension))
-          } else if (assets.length != 1) {
-            Err(PackageError.TooManyFiles(project, extension))
-          } else {
-            // download asset to the directory
-            val asset = assets.head
-            out.print(s"  Downloading `${formatter.blue(s"${proj.owner}/${proj.repo}.$extension")}` (${formatter.cyan(s"v$version")})... ")
-            out.flush()
+        val name = formatter.blue(s"${proj.owner}/${proj.repo}.$extension")
+        val label = s"$name` (${formatter.cyan(s"v$version")})"
+        out.print(s"  Downloading `$label... ")
+        out.flush()
+        openAsset(proj, version, extension, candidates.distinct, apiKey) match {
+          case Err(e) =>
+            out.println("ERROR.")
+            Err(e)
+          case Ok(stream) =>
             try {
-              Using(GitHub.downloadAsset(asset)) {
-                stream => Files.copy(stream, assetPath, StandardCopyOption.REPLACE_EXISTING)
-              }
+              Using(stream) { s => Files.copy(s, assetPath, StandardCopyOption.REPLACE_EXISTING) }
             } catch {
               case e: IOException =>
                 out.println(s"ERROR: ${e.getMessage}.")
-                return Err(PackageError.DownloadError(asset, Some(e.getMessage)))
+                val msg = Some(e.getMessage)
+                return Err(PackageError.DownloadIncomplete(proj, version, localName, msg))
             }
             if (Files.exists(assetPath)) {
               out.println(s"OK.")
               Ok(assetPath)
             } else {
               out.println(s"ERROR: File was not created.")
-              Err(PackageError.DownloadError(asset, None))
+              Err(PackageError.DownloadIncomplete(proj, version, localName, None))
             }
-          }
         }
       }
     }
@@ -211,7 +268,9 @@ object FlixPackageManager {
       // download toml files
       tomlPaths <- traverse(flixDeps) { dep =>
         val depName = s"${dep.username}/${dep.projectName}"
-        install(depName, dep.version, "toml", path, apiKey).map(p => (p, dep))
+        // The manifest's asset name is fixed, not guessed, so a miss goes straight to the listing.
+        val candidates = List(ManifestAssetName)
+        install(depName, dep.version, "toml", candidates, path, apiKey).map(p => (p, dep))
       }
 
       // parse manifests

--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -23,10 +23,10 @@ import ca.uwaterloo.flix.util.{Formatter, Result}
 import ca.uwaterloo.flix.util.Result.{Err, Ok, traverse}
 import ca.uwaterloo.flix.util.collection.ListMap
 
-import java.io.{IOException, PrintStream}
-import java.nio.file.{Files, Path, StandardCopyOption}
+import java.io.{IOException, InputStream, PrintStream}
+import java.nio.file.{AtomicMoveNotSupportedException, Files, Path, StandardCopyOption}
 import scala.collection.mutable
-import scala.util.Using
+import scala.util.{Failure, Success, Try, Using}
 
 object FlixPackageManager {
 
@@ -36,16 +36,24 @@ object FlixPackageManager {
   private val ManifestAssetName = "flix.toml"
 
   /**
-    * Opens a stream over the first of `candidates` the release actually publishes, falling back to
-    * a rate-limited listing when none of them do. See [[installAll]] for the guessed candidates.
+    * Opens a stream over the first of `candidates` that the release actually publishes, falling
+    * back to a rate-limited listing when none of them do. `candidates` is the caller's ordered list
+    * of guesses -- see [[installAll]] for the concrete strategies used to install a package.
+    *
+    * Each candidate is a request against the asset's computed address, which does not consume the
+    * REST API quota; the listing costs a rate-limited request, which is the whole reason for
+    * guessing at all.
+    *
+    * `transport` does not change across this search, so it is implicit; [[GitHub.Transport.live]]
+    * answers it in production, and a test brings a scripted one into scope instead.
     */
-  private def openAsset(
+  private[pkg] def openAsset(
     project: GitHub.Project,
     version: SemVer,
     extension: String,
     candidates: List[String],
     apiKey: Option[String]
-  ): Result[java.io.InputStream, PackageError] =
+  )(implicit transport: GitHub.Transport): Result[InputStream, PackageError] =
     tryCandidates(project, version, candidates) match {
       case Some(result) => result
       case None =>
@@ -60,7 +68,7 @@ object FlixPackageManager {
     project: GitHub.Project,
     version: SemVer,
     candidates: List[String]
-  ): Option[Result[java.io.InputStream, PackageError]] =
+  )(implicit transport: GitHub.Transport): Option[Result[InputStream, PackageError]] =
     candidates match {
       case Nil => None
       case assetName :: rest =>
@@ -200,19 +208,28 @@ object FlixPackageManager {
     *
     * The package is installed at `lib/<owner>/<repo>`
     *
-    * `candidates` are tried against the asset's computed address first, each an unmetered request;
-    * a rate-limited listing is read only if none of them are what the release actually published.
+    * `candidates` names are tried against the asset's computed address, none of which consume the
+    * REST API quota; a rate-limited listing is read only if none of them are what the release
+    * actually published.
+    *
+    * The download is written to a uniquely named temporary file beside `assetPath` and moved into
+    * place only once it is known to be whole, so a copy that fails partway -- a dropped connection,
+    * a full disk -- cannot leave a truncated file where a cache hit is later trusted blindly.
     *
     * Returns the path to the downloaded file.
     */
-  private def install(
+  private[pkg] def install(
     project: String,
     version: SemVer,
     extension: String,
     candidates: List[String],
     p: Path,
     apiKey: Option[String]
-  )(implicit formatter: Formatter, out: PrintStream): Result[Path, PackageError] = {
+  )(
+    implicit formatter: Formatter,
+    out: PrintStream,
+    transport: GitHub.Transport
+  ): Result[Path, PackageError] = {
     GitHub.parseProject(project).flatMap { proj =>
       val lib = Bootstrap.getLibraryDirectory(p)
       val localName = s"${proj.repo}-$version.$extension"
@@ -234,24 +251,85 @@ object FlixPackageManager {
             out.println("ERROR.")
             Err(e)
           case Ok(stream) =>
-            try {
-              Using(stream) { s => Files.copy(s, assetPath, StandardCopyOption.REPLACE_EXISTING) }
-            } catch {
-              case e: IOException =>
+            writeAtomically(stream, dirPath, localName, assetPath) match {
+              case Failure(e) =>
                 out.println(s"ERROR: ${e.getMessage}.")
                 val msg = Some(e.getMessage)
-                return Err(PackageError.DownloadIncomplete(proj, version, localName, msg))
-            }
-            if (Files.exists(assetPath)) {
-              out.println(s"OK.")
-              Ok(assetPath)
-            } else {
-              out.println(s"ERROR: File was not created.")
-              Err(PackageError.DownloadIncomplete(proj, version, localName, None))
+                Err(PackageError.DownloadIncomplete(proj, version, localName, msg))
+              case Success(()) =>
+                out.println("OK.")
+                Ok(assetPath)
             }
         }
       }
     }
+  }
+
+  /**
+    * Copies `stream` to a temporary file beside `assetPath` and moves it into place atomically,
+    * only once the copy is known to have succeeded.
+    *
+    * The temporary file's name is unique per call ([[Files.createTempFile]] guarantees this), so
+    * two builds racing to install the same dependency at once do not corrupt each other's
+    * download; the loser's temporary file is simply moved second, over the winner's
+    * already-correct result.
+    *
+    * `stream` is always closed and the temporary file is always removed on failure -- attaching
+    * either as a suppressed exception on the failure being reported, never replacing it. This
+    * guarantees only that a copy which throws cannot produce a cache hit; it does not verify a
+    * copy that completes cleanly, since a release asset carries no checksum this code can check
+    * it against.
+    */
+  private def writeAtomically(
+    stream: InputStream,
+    dirPath: Path,
+    localName: String,
+    assetPath: Path
+  ): Try[Unit] =
+    Try(Files.createTempFile(dirPath, localName, ".part")) match {
+      case Failure(e) =>
+        closeSuppressing(stream, e)
+        Failure(e)
+      case Success(tmpPath) =>
+        val copied = Using(stream)(s => Files.copy(s, tmpPath, StandardCopyOption.REPLACE_EXISTING))
+        copied.flatMap(_ => moveIntoPlace(tmpPath, assetPath)) match {
+          case failure@Failure(e) =>
+            deleteSuppressing(tmpPath, e)
+            failure
+          case success => success
+        }
+    }
+
+  /**
+    * Closes `stream`, attaching a failure to close as suppressed on `primary` rather than letting
+    * it replace the failure already being reported.
+    */
+  private def closeSuppressing(stream: InputStream, primary: Throwable): Unit =
+    try stream.close() catch { case e: IOException => primary.addSuppressed(e) }
+
+  /**
+    * Deletes `path` if it exists, attaching a failure to delete as suppressed on `primary` rather
+    * than letting it replace the failure already being reported.
+    */
+  private def deleteSuppressing(path: Path, primary: Throwable): Unit =
+    try Files.deleteIfExists(path) catch { case e: IOException => primary.addSuppressed(e) }
+
+  /**
+    * Moves `tmpPath` to `assetPath`, atomically if the filesystem supports it.
+    */
+  private def moveIntoPlace(tmpPath: Path, assetPath: Path): Try[Unit] = Try {
+    try {
+      Files.move(
+        tmpPath,
+        assetPath,
+        StandardCopyOption.REPLACE_EXISTING,
+        StandardCopyOption.ATOMIC_MOVE
+      )
+    } catch {
+      case _: AtomicMoveNotSupportedException =>
+        Files.move(tmpPath, assetPath, StandardCopyOption.REPLACE_EXISTING)
+    }
+    ()
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -76,18 +76,34 @@ object PackageError {
 
   /**
     * A download refused (403/429), which for an anonymous request usually means a rate limit.
+    *
+    * `retryAfter` is GitHub's secondary rate limit signal; `rateLimitReset` and
+    * `rateLimitRemaining` come from `X-RateLimit-Reset`/`X-RateLimit-Remaining` and describe the
+    * primary REST quota. Both are preserved rather than collapsed into one message, since they
+    * answer different questions -- "when can I retry this exact request" versus "how much of the
+    * hourly budget is left".
     */
-  case class DownloadRefused(url: URL, status: Int, retryAfter: Option[String])
-    extends PackageError {
+  case class DownloadRefused(
+    url: URL,
+    status: Int,
+    retryAfter: Option[String],
+    rateLimitReset: Option[String],
+    rateLimitRemaining: Option[String]
+  ) extends PackageError {
     override def message(f: Formatter): String = {
-      // Retry-After is delta-seconds per RFC 9110, but may also be an HTTP-date.
-      val when = retryAfter match {
-        case Some(s) if s.forall(_.isDigit) => s"Retry after $s seconds."
-        case Some(s) => s"Retry after $s."
-        case None => "This is usually a rate limit."
+      // Retry-After is delta-seconds per RFC 9110, but may also be an HTTP-date; only the former
+      // has a "seconds" unit to name.
+      val when = (retryAfter, rateLimitReset) match {
+        case (Some(s), _) if s.forall(_.isDigit) => s"Retry after $s seconds."
+        case (Some(s), _) => s"Retry after $s."
+        case (None, Some(reset)) => s"The rate limit resets at epoch second $reset."
+        case (None, None) => "This is usually a rate limit."
       }
+      val remaining = rateLimitRemaining
+        .map(r => s" $r requests remain in the current window.")
+        .getOrElse("")
       s"""Refused (HTTP ${f.red(status.toString)}) by ${f.cyan(url.toString)}.
-         |$when
+         |$when$remaining
          |""".stripMargin
     }
   }
@@ -114,6 +130,30 @@ object PackageError {
     override def message(f: Formatter): String =
       s"""Could not reach ${f.cyan(url.toString)}.
          |$message
+         |""".stripMargin
+  }
+
+  /**
+    * An error raised when a response's body could not be fully read, e.g. because the connection
+    * dropped partway through.
+    */
+  case class ResponseBodyUnreadable(url: URL, message: String) extends PackageError {
+    override def message(f: Formatter): String =
+      s"""Could not read the response from ${f.cyan(url.toString)}.
+         |$message
+         |""".stripMargin
+  }
+
+  /**
+    * An error raised when a request is refused for a reason other than a confirmed rate limit --
+    * an invalid token, a private repository, or anything else GitHub answers with 403 or 429
+    * without the headers that would identify it as quota exhaustion. `message` is GitHub's own
+    * explanation, when the body parses as JSON and has one.
+    */
+  case class RequestRefused(url: URL, status: Int, message: Option[String]) extends PackageError {
+    override def message(f: Formatter): String =
+      s"""Refused (HTTP ${f.red(status.toString)}) by ${f.cyan(url.toString)}.
+         |${message.getOrElse("No further detail was given.")}
          |""".stripMargin
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -60,6 +60,49 @@ object PackageError {
          |""".stripMargin
   }
 
+  /**
+    * A download refused (403/429), which for an anonymous request usually means a rate limit.
+    */
+  case class DownloadRefused(url: URL, status: Int, retryAfter: Option[String])
+    extends PackageError {
+    override def message(f: Formatter): String = {
+      // Retry-After is delta-seconds per RFC 9110, but may also be an HTTP-date.
+      val when = retryAfter match {
+        case Some(s) if s.forall(_.isDigit) => s"Retry after $s seconds."
+        case Some(s) => s"Retry after $s."
+        case None => "This is usually a rate limit."
+      }
+      s"""Refused (HTTP ${f.red(status.toString)}) by ${f.cyan(url.toString)}.
+         |$when
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * A download answered with a status that is neither success nor a refusal.
+    */
+  case class DownloadFailed(url: URL, status: Int) extends PackageError {
+    override def message(f: Formatter): String = {
+      val detail =
+        if (status >= 300 && status < 400)
+          "The address redirected somewhere that could not be followed."
+        else "Unexpected response."
+      s"""Could not download ${f.cyan(url.toString)}: HTTP ${f.red(status.toString)}.
+         |$detail
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * A download never reached a server at all.
+    */
+  case class DownloadUnreachable(url: URL, message: String) extends PackageError {
+    override def message(f: Formatter): String =
+      s"""Could not reach ${f.cyan(url.toString)}.
+         |$message
+         |""".stripMargin
+  }
+
   case class DownloadError(asset: Asset, message: Option[String]) extends PackageError {
     override def message(f: Formatter): String =
       s"""A download error occurred while downloading ${f.bold(asset.name)}

--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.tools.pkg
 
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.tools.pkg.Dependency.FlixDependency
-import ca.uwaterloo.flix.tools.pkg.github.GitHub.{Asset, Project}
+import ca.uwaterloo.flix.tools.pkg.github.GitHub.Project
 import ca.uwaterloo.flix.util.Formatter
 
 import java.io.IOException
@@ -117,15 +117,19 @@ object PackageError {
          |""".stripMargin
   }
 
-  case class DownloadError(asset: Asset, message: Option[String]) extends PackageError {
+  /**
+    * A download was served but could not be written to disk.
+    */
+  case class DownloadIncomplete(
+    project: Project,
+    version: SemVer,
+    assetName: String,
+    message: Option[String]
+  ) extends PackageError {
     override def message(f: Formatter): String =
-      s"""A download error occurred while downloading ${f.bold(asset.name)}
-         |${
-        message match {
-          case Some(e) => e
-          case None => ""
-        }
-      }
+      s"""Could not save ${f.bold(assetName)} from release ${f.bold(s"v$version")}
+         |of ${f.bold(project.toString)}.
+         |${message.getOrElse("The file was not created.")}
          |""".stripMargin
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -61,6 +61,20 @@ object PackageError {
   }
 
   /**
+    * A release asset isn't where its address says: either the release doesn't exist, or it exists
+    * without that asset -- a 404 can't say which, so the message names both possibilities.
+    */
+  case class ReleaseAssetNotFound(project: Project, version: SemVer, assetName: String, url: URL)
+    extends PackageError {
+    override def message(f: Formatter): String =
+      s"""Could not find ${f.bold(assetName)} in release ${f.bold(s"v$version")}
+         |of ${f.bold(project.toString)}.
+         |Either the release does not exist, or it does not publish that file.
+         |Looked at ${f.cyan(url.toString)}.
+         |""".stripMargin
+  }
+
+  /**
     * A download refused (403/429), which for an anonymous request usually means a rate limit.
     */
   case class DownloadRefused(url: URL, status: Int, retryAfter: Option[String])

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -27,7 +27,9 @@ import java.io.{IOException, InputStream}
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.net.{URI, URL}
+import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import java.time.Duration
 
 /**
   * An interface for the GitHub API.
@@ -54,27 +56,102 @@ object GitHub {
   case class Asset(name: String, url: URL)
 
   /**
-    * Lists the project's releases.
+    * A source of GitHub HTTP responses. Implicit, since it never changes across a call chain,
+    * including recursion through transitive dependencies: [[Transport.live]] answers it by default,
+    * via this type's companion, and a test brings a scripted one into scope instead.
     */
-  def getReleases(project: Project, apiKey: Option[String]): Result[List[Release], PackageError] = {
-    val url = releasesUrl(project)
-    val reqBuilder = HttpRequest.newBuilder(url.toURI)
+  final case class Transport(send: HttpRequest => HttpResponse[InputStream])
+
+  object Transport {
+    implicit val live: Transport = {
+      val client: HttpClient = HttpClient.newBuilder()
+        // A release download address redirects to the storage the asset actually lives on, and the
+        // default policy is to follow nothing at all, which would turn every download into a 302.
+        .followRedirects(HttpClient.Redirect.NORMAL)
+        // Bounds connecting; a peer that accepts the connection and then never responds is bounded
+        // separately, by RequestTimeout on each request.
+        .connectTimeout(Duration.ofSeconds(10))
+        .build()
+      Transport(request => client.send(request, HttpResponse.BodyHandlers.ofInputStream()))
+    }
+  }
+
+  /**
+    * Bounds an entire request/response, not just connecting -- a peer that accepts the connection
+    * and then never answers would otherwise hang indefinitely even with `Transport.live`'s
+    * `connectTimeout`.
+    */
+  private val RequestTimeout = Duration.ofSeconds(30)
+
+  /**
+    * Lists every one of the project's releases, following GitHub's `Link: rel="next"` pagination.
+    * Used by `outdated`, which genuinely needs every version to compare against --
+    * [[getReleaseByTag]] is what everything else uses, since it asks for one release directly and
+    * cannot page.
+    */
+  def getReleases(
+    project: Project,
+    apiKey: Option[String]
+  )(implicit transport: Transport): Result[List[Release], PackageError] =
+    getReleasesPage(project, releasesUrl(project), apiKey, MaxReleasePages)
+
+  /**
+    * The number of pages [[getReleasesPage]] follows before stopping, so a `Link` header cannot
+    * page forever. GitHub's default page size is 30; this comfortably covers any real project's
+    * release history while keeping the request budget fixed.
+    */
+  private val MaxReleasePages = 20
+
+  private def getReleasesPage(
+    project: Project,
+    url: URL,
+    apiKey: Option[String],
+    pagesRemaining: Int
+  )(implicit transport: Transport): Result[List[Release], PackageError] = {
+    val reqBuilder = HttpRequest.newBuilder(url.toURI).timeout(RequestTimeout)
     // add the API key as bearer if needed
     apiKey.foreach(key => reqBuilder.header("Authorization", "Bearer " + key))
     val req = reqBuilder.GET().build()
-    val json = try {
-      Client.sendRequest(req).body()
+    val response = try {
+      transport.send(req)
     } catch {
       case ex: IOException => return Err(PackageError.ProjectNotFound(url, project, ex))
+      case ex: InterruptedException =>
+        Thread.currentThread().interrupt()
+        return Err(PackageError.ProjectNotFound(url, project, new IOException(ex)))
     }
-    val releaseJsons = try {
-      parse(json).asInstanceOf[JArray]
-    } catch {
-
-      case _: ClassCastException => return Err(PackageError.JsonError(json, project))
+    response.statusCode() match {
+      case status if status >= 200 && status < 300 =>
+        val next = if (pagesRemaining > 1) nextPageUrl(response) else None
+        readBody(url, response).flatMap { json =>
+          val page = try {
+            Ok(parse(json).asInstanceOf[JArray].arr.map(parseRelease))
+          } catch {
+            case _: ClassCastException => Err(PackageError.JsonError(json, project))
+          }
+          (page, next) match {
+            case (Ok(releases), Some(nextUrl)) =>
+              getReleasesPage(project, nextUrl, apiKey, pagesRemaining - 1).map(releases ::: _)
+            case _ => page
+          }
+        }
+      case status @ (403 | 429) => Err(classifyRefusal(url, status, response))
+      case status =>
+        closeQuietly(response)
+        Err(PackageError.DownloadFailed(url, status))
     }
-    Ok(releaseJsons.arr.map(parseRelease))
   }
+
+  /**
+    * Returns the address `response`'s `Link` header names with `rel="next"`, if it has one.
+    */
+  private def nextPageUrl(response: HttpResponse[InputStream]): Option[URL] =
+    header(response, "Link").flatMap { link =>
+      link.split(",").iterator.map(_.trim).collectFirst {
+        case entry if entry.matches("""<[^>]+>;\s*rel="next"""") =>
+          new URI(entry.drop(1).takeWhile(_ != '>')).toURL
+      }
+    }
 
   /**
     * Publish a new release the given project.
@@ -240,11 +317,11 @@ object GitHub {
     * Kept apart: a refusal (403/429, usually a rate limit), any other unexpected status, and never
     * reaching a server at all.
     */
-  def download(url: URL): Result[InputStream, PackageError] = {
-    val request = HttpRequest.newBuilder(url.toURI).GET().build()
+  def download(url: URL)(implicit transport: Transport): Result[InputStream, PackageError] = {
+    val request = HttpRequest.newBuilder(url.toURI).timeout(RequestTimeout).GET().build()
 
     val response = try {
-      Client.sendStreamingRequest(request)
+      transport.send(request)
     } catch {
       case ex: IOException => return Err(PackageError.DownloadUnreachable(url, ex.getMessage))
       case ex: InterruptedException =>
@@ -255,22 +332,122 @@ object GitHub {
     response.statusCode() match {
       case status if status >= 200 && status < 300 =>
         Ok(response.body())
+      case status @ (403 | 429) =>
+        Err(classifyRefusal(url, status, response))
       case status =>
-        // A close failure must not shadow the status being reported.
-        try response.body().close() catch { case _: IOException => () }
-        status match {
-          case 403 | 429 => Err(PackageError.DownloadRefused(url, status, retryAfter(response)))
-          case _ => Err(PackageError.DownloadFailed(url, status))
-        }
+        closeQuietly(response)
+        Err(PackageError.DownloadFailed(url, status))
     }
   }
 
   /**
-    * Returns `response`'s `Retry-After` header, if it has one.
+    * Reads `response`'s body as UTF-8 text, closing it either way. A failure while reading -- the
+    * connection dropped partway -- is reported rather than left to propagate as an uncaught
+    * [[IOException]], which would otherwise crash dependency resolution instead of returning a
+    * [[PackageError]].
     */
-  private def retryAfter(response: HttpResponse[InputStream]): Option[String] = {
-    val header = response.headers().firstValue("Retry-After")
-    if (header.isPresent) Some(header.get()) else None
+  private def readBody(url: URL, response: HttpResponse[InputStream])
+    : Result[String, PackageError] =
+    try {
+      Ok(new String(response.body().readAllBytes(), StandardCharsets.UTF_8))
+    } catch {
+      case ex: IOException => Err(PackageError.ResponseBodyUnreadable(url, ex.getMessage))
+    } finally {
+      closeQuietly(response)
+    }
+
+  /**
+    * Closes `response`'s body, swallowing a failure to close: this runs only when the body is being
+    * discarded in favor of reporting some other status, so a close error must not shadow it.
+    */
+  private def closeQuietly(response: HttpResponse[InputStream]): Unit =
+    try response.body().close() catch { case _: IOException => () }
+
+  /**
+    * Classifies a 403/429 `response` as a rate limit only when the evidence confirms it -- `429`
+    * always means one, and `403` does when `X-RateLimit-Remaining` reads `0`. A `403` is just as
+    * often an invalid token or a private repository, and treating every refusal as "wait for the
+    * reset" sends whoever reads the message chasing the wrong cause; those keep GitHub's own
+    * message.
+    */
+  private def classifyRefusal(
+    url: URL,
+    status: Int,
+    response: HttpResponse[InputStream]
+  ): PackageError = {
+    val remaining = header(response, "X-RateLimit-Remaining")
+    if (status == 429 || remaining.contains("0")) {
+      val retryAfter = header(response, "Retry-After")
+      val reset = header(response, "X-RateLimit-Reset")
+      val error = PackageError.DownloadRefused(url, status, retryAfter, reset, remaining)
+      closeQuietly(response)
+      error
+    } else {
+      val message = readBody(url, response).toOption.flatMap(extractMessage)
+      PackageError.RequestRefused(url, status, message)
+    }
+  }
+
+  /**
+    * Extracts GitHub's `message` field from an error body, if it parses as JSON and has one.
+    */
+  private def extractMessage(json: String): Option[String] =
+    try {
+      parse(json) \ "message" match {
+        case JString(s) => Some(s)
+        case _ => None
+      }
+    } catch {
+      case _: Exception => None
+    }
+
+  /**
+    * Returns the first value of header `name` on `response`, if it has one.
+    */
+  private def header(response: HttpResponse[InputStream], name: String): Option[String] = {
+    val h = response.headers().firstValue(name)
+    if (h.isPresent) Some(h.get()) else None
+  }
+
+  /**
+    * Gets the project release with the relevant semantic version, directly by tag. Unlike
+    * [[getReleases]] this does not page: a tag names exactly one release.
+    */
+  def getReleaseByTag(
+    project: Project,
+    version: SemVer,
+    apiKey: Option[String]
+  )(implicit transport: Transport): Result[Release, PackageError] = {
+    val url = releaseVersionUrl(project, version)
+    val reqBuilder = HttpRequest.newBuilder(url.toURI).timeout(RequestTimeout)
+    apiKey.foreach(key => reqBuilder.header("Authorization", "Bearer " + key))
+    val req = reqBuilder.GET().build()
+    val response = try {
+      transport.send(req)
+    } catch {
+      case ex: IOException => return Err(PackageError.ProjectNotFound(url, project, ex))
+      case ex: InterruptedException =>
+        Thread.currentThread().interrupt()
+        return Err(PackageError.ProjectNotFound(url, project, new IOException(ex)))
+    }
+    response.statusCode() match {
+      case 200 =>
+        readBody(url, response).flatMap { json =>
+          try {
+            Ok(parseRelease(parse(json)))
+          } catch {
+            case _: ClassCastException => Err(PackageError.JsonError(json, project))
+          }
+        }
+      case 404 =>
+        closeQuietly(response)
+        Err(PackageError.VersionDoesNotExist(version, project))
+      case status @ (403 | 429) =>
+        Err(classifyRefusal(url, status, response))
+      case status =>
+        closeQuietly(response)
+        Err(PackageError.DownloadFailed(url, status))
+    }
   }
 
   /**
@@ -282,7 +459,7 @@ object GitHub {
     project: Project,
     version: SemVer,
     assetName: String
-  ): Result[InputStream, PackageError] = {
+  )(implicit transport: Transport): Result[InputStream, PackageError] = {
     val url = releaseAssetUrl(project, version, assetName)
     download(url) match {
       case Err(PackageError.DownloadFailed(_, 404)) =>
@@ -300,16 +477,12 @@ object GitHub {
     version: SemVer,
     extension: String,
     apiKey: Option[String]
-  ): Result[Asset, PackageError] = {
-    getReleases(project, apiKey).flatMap { releases =>
-      releases.find(r => r.version == version) match {
-        case None => Err(PackageError.VersionDoesNotExist(version, project))
-        case Some(release) =>
-          release.assets.filter(_.name.endsWith(s".$extension")) match {
-            case Nil => Err(PackageError.NoSuchFile(project.toString, extension))
-            case asset :: Nil => Ok(asset)
-            case _ => Err(PackageError.TooManyFiles(project.toString, extension))
-          }
+  )(implicit transport: Transport): Result[Asset, PackageError] = {
+    getReleaseByTag(project, version, apiKey).flatMap { release =>
+      release.assets.filter(_.name.endsWith(s".$extension")) match {
+        case Nil => Err(PackageError.NoSuchFile(project.toString, extension))
+        case asset :: Nil => Ok(asset)
+        case _ => Err(PackageError.TooManyFiles(project.toString, extension))
       }
     }
   }
@@ -397,9 +570,7 @@ object GitHub {
       * This field should only be accessed in a thread-safe manner, e.g.,
       * such as using `this.synchronized` blocks or some other locking mechanism.
       */
-    private val HTTP_CLIENT: HttpClient =
-      // Follows redirects: a release download address redirects to the storage the asset lives on.
-      HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()
+    private val HTTP_CLIENT: HttpClient = HttpClient.newHttpClient()
 
     /**
       * Sends the HTTP request, `request`, and returns the response.
@@ -410,13 +581,6 @@ object GitHub {
       */
     def sendRequest(request: HttpRequest): HttpResponse[String] = this.synchronized {
       HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString())
-    }
-
-    /**
-      * As [[sendRequest]], but with a streamed body. May throw [[IOException]].
-      */
-    def sendStreamingRequest(request: HttpRequest): HttpResponse[InputStream] = this.synchronized {
-      HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream())
     }
 
   }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -235,6 +235,45 @@ object GitHub {
   }
 
   /**
+    * Opens a stream over `url`, following redirects. The caller closes the stream.
+    *
+    * Kept apart: a refusal (403/429, usually a rate limit), any other unexpected status, and never
+    * reaching a server at all.
+    */
+  def download(url: URL): Result[InputStream, PackageError] = {
+    val request = HttpRequest.newBuilder(url.toURI).GET().build()
+
+    val response = try {
+      Client.sendStreamingRequest(request)
+    } catch {
+      case ex: IOException => return Err(PackageError.DownloadUnreachable(url, ex.getMessage))
+      case ex: InterruptedException =>
+        Thread.currentThread().interrupt()
+        return Err(PackageError.DownloadUnreachable(url, ex.getMessage))
+    }
+
+    response.statusCode() match {
+      case status if status >= 200 && status < 300 =>
+        Ok(response.body())
+      case status =>
+        // A close failure must not shadow the status being reported.
+        try response.body().close() catch { case _: IOException => () }
+        status match {
+          case 403 | 429 => Err(PackageError.DownloadRefused(url, status, retryAfter(response)))
+          case _ => Err(PackageError.DownloadFailed(url, status))
+        }
+    }
+  }
+
+  /**
+    * Returns `response`'s `Retry-After` header, if it has one.
+    */
+  private def retryAfter(response: HttpResponse[InputStream]): Option[String] = {
+    val header = response.headers().firstValue("Retry-After")
+    if (header.isPresent) Some(header.get()) else None
+  }
+
+  /**
     * Gets the project release with the relevant semantic version.
     */
   def getSpecificRelease(project: Project, version: SemVer, apiKey: Option[String]): Result[Release, PackageError] = {
@@ -328,7 +367,9 @@ object GitHub {
       * This field should only be accessed in a thread-safe manner, e.g.,
       * such as using `this.synchronized` blocks or some other locking mechanism.
       */
-    private val HTTP_CLIENT: HttpClient = HttpClient.newHttpClient()
+    private val HTTP_CLIENT: HttpClient =
+      // Follows redirects: a release download address redirects to the storage the asset lives on.
+      HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()
 
     /**
       * Sends the HTTP request, `request`, and returns the response.
@@ -339,6 +380,13 @@ object GitHub {
       */
     def sendRequest(request: HttpRequest): HttpResponse[String] = this.synchronized {
       HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString())
+    }
+
+    /**
+      * As [[sendRequest]], but with a streamed body. May throw [[IOException]].
+      */
+    def sendStreamingRequest(request: HttpRequest): HttpResponse[InputStream] = this.synchronized {
+      HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream())
     }
 
   }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -323,25 +323,6 @@ object GitHub {
   }
 
   /**
-    * Gets the project release with the relevant semantic version.
-    */
-  def getSpecificRelease(project: Project, version: SemVer, apiKey: Option[String]): Result[Release, PackageError] = {
-    getReleases(project, apiKey).flatMap {
-      releases =>
-        releases.find(r => r.version == version) match {
-          case None => Err(PackageError.VersionDoesNotExist(version, project))
-          case Some(release) => Ok(release)
-        }
-    }
-  }
-
-  /**
-    * Downloads the given asset.
-    */
-  def downloadAsset(asset: Asset): InputStream =
-    asset.url.openStream()
-
-  /**
     * Returns the URL that returns data related to the project's releases.
     */
   private def releasesUrl(project: Project): URL = {

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -274,6 +274,55 @@ object GitHub {
   }
 
   /**
+    * Opens a stream over the `assetName` asset of `project`'s `version` release, without consulting
+    * the REST API -- a release asset's address is fully predictable from owner/repo/tag/name.
+    * The caller closes the stream. See [[findReleaseAsset]] for the fallback when this 404s.
+    */
+  def downloadReleaseAsset(
+    project: Project,
+    version: SemVer,
+    assetName: String
+  ): Result[InputStream, PackageError] = {
+    val url = releaseAssetUrl(project, version, assetName)
+    download(url) match {
+      case Err(PackageError.DownloadFailed(_, 404)) =>
+        Err(PackageError.ReleaseAssetNotFound(project, version, assetName, url))
+      case other => other
+    }
+  }
+
+  /**
+    * Finds the single `extension` asset in `project`'s `version` release by reading the REST API --
+    * the fallback for when [[downloadReleaseAsset]]'s guessed name 404s.
+    */
+  def findReleaseAsset(
+    project: Project,
+    version: SemVer,
+    extension: String,
+    apiKey: Option[String]
+  ): Result[Asset, PackageError] = {
+    getReleases(project, apiKey).flatMap { releases =>
+      releases.find(r => r.version == version) match {
+        case None => Err(PackageError.VersionDoesNotExist(version, project))
+        case Some(release) =>
+          release.assets.filter(_.name.endsWith(s".$extension")) match {
+            case Nil => Err(PackageError.NoSuchFile(project.toString, extension))
+            case asset :: Nil => Ok(asset)
+            case _ => Err(PackageError.TooManyFiles(project.toString, extension))
+          }
+      }
+    }
+  }
+
+  /**
+    * The permanent, non-REST address of a release asset.
+    */
+  private def releaseAssetUrl(project: Project, version: SemVer, assetName: String): URL = {
+    val base = s"https://github.com/${project.owner}/${project.repo}/releases/download"
+    new URI(s"$base/v$version/$assetName").toURL
+  }
+
+  /**
     * Gets the project release with the relevant semantic version.
     */
   def getSpecificRelease(project: Project, version: SemVer, apiKey: Option[String]): Result[Release, PackageError] = {

--- a/main/test/ca/uwaterloo/flix/tools/pkg/TestFlixPackageManagerInstall.scala
+++ b/main/test/ca/uwaterloo/flix/tools/pkg/TestFlixPackageManagerInstall.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Werner Stein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.tools.pkg
+
+import ca.uwaterloo.flix.api.Bootstrap
+import ca.uwaterloo.flix.tools.pkg.github.{CannedResponse, FakeTransport, GitHub}
+import ca.uwaterloo.flix.util.Formatter
+import ca.uwaterloo.flix.util.Result.{Err, Ok}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.{OutputStream, PrintStream}
+import java.nio.file.Files
+import scala.util.Using
+import scala.jdk.CollectionConverters.*
+
+/**
+  * Exercises [[FlixPackageManager.install]] and [[FlixPackageManager.openAsset]] against a
+  * [[FakeTransport]]: the candidate-then-fallback search, and the atomic-write guarantee that a
+  * failed download cannot be cached as if it had succeeded. Deterministic and quota-free, so it
+  * belongs in the default `flix.test` pass rather than behind the network-gated
+  * `flix.testPackageManager`.
+  */
+class TestFlixPackageManagerInstall extends AnyFunSuite {
+
+  private implicit val formatter: Formatter = Formatter.NoFormatter
+  private implicit val out: PrintStream = new PrintStream(OutputStream.nullOutputStream())
+
+  private val version = SemVer(1, 0, 0)
+  private val tagUrl = "https://api.github.com/repos/flix/museum/releases/tags/v1.0.0"
+
+  private def assetUrl(name: String): String =
+    s"https://github.com/flix/museum/releases/download/v1.0.0/$name"
+
+  test("install succeeds from the first candidate that hits, without reading the listing") {
+    // The first case never queries "museum-clerk.fpkg"; the second 404s on "museum.fpkg" first and
+    // falls through to it. Neither queries the listing -- FakeTransport would throw if they did.
+    val candidates = List("museum.fpkg", "museum-clerk.fpkg")
+    val scripts = List(
+      Map(assetUrl("museum.fpkg") -> List(CannedResponse(200, body = "package-bytes"))),
+      Map(
+        assetUrl("museum.fpkg") -> List(CannedResponse(404)),
+        assetUrl("museum-clerk.fpkg") -> List(CannedResponse(200, body = "package-bytes"))
+      )
+    )
+    for (script <- scripts) {
+      implicit val transport: GitHub.Transport = FakeTransport(script)
+      val root = Files.createTempDirectory("install-test")
+      val result = FlixPackageManager
+        .install("flix/museum", version, "fpkg", candidates, root, apiKey = None)
+      result match {
+        case Ok(path) => assertResult("package-bytes")(Files.readString(path))
+        case Err(e) => fail(e.message(formatter))
+      }
+    }
+  }
+
+  test("install falls back to the listing when every candidate 404s") {
+    val assetName = "published-under-a-different-name.fpkg"
+    val listingBody =
+      s"""{"tag_name":"v1.0.0","assets":[{"name":"$assetName",""" +
+        """"browser_download_url":"https://example.invalid/asset.fpkg"}]}"""
+    implicit val transport: GitHub.Transport = FakeTransport(Map(
+      assetUrl("museum.fpkg") -> List(CannedResponse(404)),
+      assetUrl("museum-clerk.fpkg") -> List(CannedResponse(404)),
+      tagUrl -> List(CannedResponse(200, body = listingBody)),
+      "https://example.invalid/asset.fpkg" -> List(CannedResponse(200, body = "package-bytes"))
+    ))
+    val root = Files.createTempDirectory("install-test")
+    val candidates = List("museum.fpkg", "museum-clerk.fpkg")
+
+    val result = FlixPackageManager
+      .install("flix/museum", version, "fpkg", candidates, root, apiKey = None)
+    result match {
+      case Ok(path) => assertResult("package-bytes")(Files.readString(path))
+      case Err(e) => fail(e.message(formatter))
+    }
+  }
+
+  test("a download that fails partway through is not cached as a successful install") {
+    val response = CannedResponse(200, body = "a-lot-of-package-bytes", failAfterBytes = Some(4))
+    val script = Map(assetUrl("museum.fpkg") -> List(response))
+    implicit val transport: GitHub.Transport = FakeTransport(script)
+    val root = Files.createTempDirectory("install-test")
+
+    val candidates = List("museum.fpkg")
+    val result = FlixPackageManager
+      .install("flix/museum", version, "fpkg", candidates, root, apiKey = None)
+    val msg = s"expected the failed download to be reported as an error, got $result"
+    assert(result.toOption.isEmpty, msg)
+
+    val dirPath = Bootstrap.getLibraryDirectory(root)
+      .resolve("github").resolve("flix").resolve("museum").resolve(version.toString)
+    val filesLeftBehind = Using(Files.list(dirPath))(_.iterator().asScala.toList).get
+    assertResult(List.empty)(filesLeftBehind)
+  }
+}

--- a/main/test/ca/uwaterloo/flix/tools/pkg/github/FakeTransport.scala
+++ b/main/test/ca/uwaterloo/flix/tools/pkg/github/FakeTransport.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Werner Stein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.tools.pkg.github
+
+import java.io.{ByteArrayInputStream, IOException, InputStream}
+import java.net.URI
+import java.net.http.{HttpClient, HttpHeaders, HttpRequest, HttpResponse}
+import java.nio.charset.StandardCharsets
+import java.util.Optional
+import javax.net.ssl.SSLSession
+import scala.jdk.CollectionConverters.*
+
+/**
+  * A single scripted answer for [[FakeTransport]]. `failAfterBytes`, when set, makes the body throw
+  * [[IOException]] after that many bytes, standing in for a connection dropped mid-download.
+  */
+case class CannedResponse(
+  status: Int,
+  headers: Map[String, String] = Map.empty,
+  body: String = "",
+  failAfterBytes: Option[Int] = None
+)
+
+/**
+  * Builds a [[GitHub.Transport]] that answers from a fixed script instead of the network.
+  *
+  * `script` maps a request URI to the responses it should give, in order. A URI that runs out of
+  * queued responses -- or was never given any -- fails the test loudly rather than falling through
+  * to a real network call.
+  */
+object FakeTransport {
+
+  def apply(script: Map[String, List[CannedResponse]]): GitHub.Transport = {
+    var remaining = script
+    GitHub.Transport { request =>
+      val uri = request.uri().toString
+      remaining.get(uri) match {
+        case Some(next :: rest) =>
+          remaining = remaining.updated(uri, rest)
+          toHttpResponse(request, next)
+        case Some(Nil) =>
+          throw new AssertionError(s"FakeTransport's script for $uri is exhausted")
+        case None =>
+          throw new AssertionError(s"FakeTransport has no response scripted for $uri")
+      }
+    }
+  }
+
+  private def toHttpResponse(req: HttpRequest, canned: CannedResponse): HttpResponse[InputStream] =
+    new HttpResponse[InputStream] {
+      override def statusCode(): Int = canned.status
+      override def request(): HttpRequest = req
+      override def previousResponse(): Optional[HttpResponse[InputStream]] = Optional.empty()
+      override def headers(): HttpHeaders = {
+        val raw = canned.headers.view.mapValues(v => java.util.List.of(v)).toMap.asJava
+        HttpHeaders.of(raw, (_, _) => true)
+      }
+      override def body(): InputStream = {
+        val bytes = new ByteArrayInputStream(canned.body.getBytes(StandardCharsets.UTF_8))
+        canned.failAfterBytes.fold[InputStream](bytes)(new FailingAfterStream(bytes, _))
+      }
+      override def sslSession(): Optional[SSLSession] = Optional.empty()
+      override def uri(): URI = req.uri()
+      override def version(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+    }
+
+  /**
+    * Wraps `delegate`, throwing [[IOException]] once `budget` bytes have been read from it.
+    */
+  private class FailingAfterStream(delegate: InputStream, budget: Int) extends InputStream {
+    private var remaining = budget
+
+    override def read(): Int = {
+      if (remaining <= 0) throw new IOException("FakeTransport: simulated connection drop")
+      remaining -= 1
+      delegate.read()
+    }
+  }
+}

--- a/main/test/ca/uwaterloo/flix/tools/pkg/github/TestGitHubHttp.scala
+++ b/main/test/ca/uwaterloo/flix/tools/pkg/github/TestGitHubHttp.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Werner Stein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.tools.pkg.github
+
+import ca.uwaterloo.flix.tools.pkg.github.GitHub.Project
+import ca.uwaterloo.flix.tools.pkg.{PackageError, SemVer}
+import ca.uwaterloo.flix.util.Result.{Err, Ok}
+import com.sun.net.httpserver.HttpServer
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.IOException
+import java.net.{InetSocketAddress, URI, URL}
+import java.nio.charset.StandardCharsets
+
+/**
+  * Exercises [[GitHub]]'s HTTP handling deterministically: status codes, redirects and rate-limit
+  * headers via a real local server, and the by-tag/listing split via a [[FakeTransport]]. Belongs
+  * in the default `flix.test` pass rather than behind the network-gated `flix.testPackageManager`.
+  */
+class TestGitHubHttp extends AnyFunSuite with BeforeAndAfterAll {
+
+  private var server: HttpServer = _
+  private var port: Int = _
+
+  override def beforeAll(): Unit = {
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+    port = server.getAddress.getPort
+
+    def respond(
+      path: String,
+      status: Int,
+      headers: Map[String, String] = Map.empty,
+      body: String = ""
+    ): Unit =
+      server.createContext(path, exchange => {
+        headers.foreach { case (k, v) => exchange.getResponseHeaders.add(k, v) }
+        val bytes = body.getBytes(StandardCharsets.UTF_8)
+        exchange.sendResponseHeaders(status, if (body.isEmpty) -1 else bytes.length.toLong)
+        if (body.nonEmpty) exchange.getResponseBody.write(bytes)
+        exchange.close()
+      })
+
+    respond("/ok", 200, body = "hello")
+    respond("/redirect", 302, headers = Map("Location" -> s"http://localhost:$port/ok"))
+    respond("/missing", 404)
+    respond("/refused", 403, headers = Map(
+      "Retry-After" -> "42",
+      "X-RateLimit-Remaining" -> "0",
+      "X-RateLimit-Reset" -> "1234567890"
+    ))
+    respond("/secondary-limit", 429)
+
+    server.start()
+  }
+
+  override def afterAll(): Unit = server.stop(0)
+
+  private def urlFor(path: String): URL = new URI(s"http://localhost:$port$path").toURL
+
+  test("download succeeds, follows a redirect, and reports 404/403/429 distinctly") {
+    implicit val transport: GitHub.Transport = GitHub.Transport.live
+    for (path <- List("/ok", "/redirect")) {
+      GitHub.download(urlFor(path)) match {
+        case Ok(stream) =>
+          try assertResult("hello")(new String(stream.readAllBytes(), StandardCharsets.UTF_8))
+          finally stream.close()
+        case Err(e) => fail(s"$path: ${e.getClass.getSimpleName}")
+      }
+    }
+    GitHub.download(urlFor("/missing")) match {
+      case Err(PackageError.DownloadFailed(_, 404)) => succeed
+      case other => fail(other.toString)
+    }
+    GitHub.download(urlFor("/refused")) match {
+      case Err(PackageError.DownloadRefused(_, 403, Some("42"), Some("1234567890"), Some("0"))) =>
+        succeed
+      case other => fail(other.toString)
+    }
+    GitHub.download(urlFor("/secondary-limit")) match {
+      case Err(PackageError.DownloadRefused(_, 429, _, _, _)) => succeed
+      case other => fail(other.toString)
+    }
+  }
+
+  test("download reports an unreachable server distinctly from a refusal") {
+    // A transport that never returns normally stands in for a dropped connection -- deterministic,
+    // unlike the real socket timing a genuinely closed or firewalled port would need.
+    implicit val unreachable: GitHub.Transport =
+      GitHub.Transport(_ => throw new IOException("simulated: no route to host"))
+
+    GitHub.download(new URI("http://example.invalid/x").toURL) match {
+      case Err(PackageError.DownloadUnreachable(_, _)) => succeed
+      case other => fail(other.toString)
+    }
+  }
+
+  private val project = Project("flix", "museum")
+  private val version = SemVer(1, 1, 0)
+  private val listingUrl = "https://api.github.com/repos/flix/museum/releases"
+  private val tagUrl = "https://api.github.com/repos/flix/museum/releases/tags/v1.1.0"
+  private val museumFpkgJson =
+    """{"tag_name":"v1.1.0","assets":[{"name":"museum.fpkg",""" +
+      """"browser_download_url":"https://example.invalid/museum.fpkg"}]}"""
+
+  test("getReleases reports 403/429 as refusals rather than JSON parse errors") {
+    // Before this fix, a rate-limit error body -- itself valid but non-array JSON -- was fed
+    // straight to the JSON parser and reported as a malformed release listing.
+    for (status <- List(403, 429)) {
+      val response = CannedResponse(
+        status,
+        headers = Map("X-RateLimit-Remaining" -> "0"),
+        body = """{"message":"rate limited"}"""
+      )
+      implicit val transport: GitHub.Transport = FakeTransport(Map(listingUrl -> List(response)))
+      GitHub.getReleases(project, apiKey = None) match {
+        case Err(PackageError.DownloadRefused(_, `status`, _, _, Some("0"))) => succeed
+        case other => fail(s"status $status: $other")
+      }
+    }
+  }
+
+  test("getReleaseByTag succeeds without reading the paginated listing," +
+    " and reports 404/403 distinctly") {
+    // Only the tag URL is ever scripted; a fallback to the listing makes FakeTransport throw.
+    val ok200 = CannedResponse(200, body = museumFpkgJson)
+    implicit val ok: GitHub.Transport = FakeTransport(Map(tagUrl -> List(ok200)))
+    GitHub.getReleaseByTag(project, version, apiKey = None)(ok) match {
+      case Ok(release) => assertResult(version)(release.version)
+      case other => fail(other.toString)
+    }
+
+    val notFound404 = List(CannedResponse(404))
+    implicit val notFound: GitHub.Transport = FakeTransport(Map(tagUrl -> notFound404))
+    GitHub.getReleaseByTag(project, version, apiKey = None)(notFound) match {
+      case Err(PackageError.VersionDoesNotExist(v, p)) =>
+        assertResult(version)(v)
+        assertResult(project)(p)
+      case other => fail(other.toString)
+    }
+
+    // No X-RateLimit-Remaining: not confirmed as a rate limit, so GitHub's own message is kept
+    // instead of being folded into a generic "this is usually a rate limit".
+    val badCreds = CannedResponse(403, body = """{"message":"Bad credentials"}""")
+    implicit val refused: GitHub.Transport = FakeTransport(Map(tagUrl -> List(badCreds)))
+    GitHub.getReleaseByTag(project, version, apiKey = None)(refused) match {
+      case Err(PackageError.RequestRefused(_, 403, Some("Bad credentials"))) => succeed
+      case other => fail(other.toString)
+    }
+  }
+
+  test("getReleaseByTag reports a truncated response body distinctly") {
+    implicit val transport: GitHub.Transport = FakeTransport(Map(
+      tagUrl -> List(CannedResponse(200, body = museumFpkgJson, failAfterBytes = Some(4)))
+    ))
+    GitHub.getReleaseByTag(project, version, apiKey = None) match {
+      case Err(PackageError.ResponseBodyUnreadable(_, _)) => succeed
+      case other => fail(other.toString)
+    }
+  }
+
+  test("findReleaseAsset finds the single matching asset via the tag endpoint," +
+    " not the listing") {
+    val ok200 = CannedResponse(200, body = museumFpkgJson)
+    implicit val transport: GitHub.Transport = FakeTransport(Map(tagUrl -> List(ok200)))
+    GitHub.findReleaseAsset(project, version, "fpkg", apiKey = None) match {
+      case Ok(asset) => assertResult("museum.fpkg")(asset.name)
+      case other => fail(other.toString)
+    }
+  }
+
+  test("getReleases follows Link: rel=\"next\" pagination across pages") {
+    val page2 = "https://api.github.com/repos/flix/museum/releases?page=2"
+    def releaseListJson(tag: String, assetName: String): String = {
+      val url = s"https://example.invalid/$assetName"
+      s"""[{"tag_name":"$tag","assets":[{"name":"$assetName","browser_download_url":"$url"}]}]"""
+    }
+
+    implicit val transport: GitHub.Transport = FakeTransport(Map(
+      listingUrl -> List(CannedResponse(200,
+        headers = Map("Link" -> s"""<$page2>; rel="next", <$page2>; rel="last""""),
+        body = releaseListJson("v1.0.0", "museum-a.fpkg"))),
+      page2 -> List(CannedResponse(200, body = releaseListJson("v1.1.0", "museum-b.fpkg")))
+    ))
+
+    GitHub.getReleases(project, apiKey = None) match {
+      case Ok(releases) =>
+        assertResult(List(SemVer(1, 0, 0), SemVer(1, 1, 0)))(releases.map(_.version))
+      case other => fail(other.toString)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Stacked on #13059, #13062, #13063, #13064 and #13060 -- this PR's diff
includes all five until they merge (GitHub shows the full range between
this branch and `master`).

`install()` copied a stream straight onto the destination path and discarded
the `Try` that `Using(...)` returned. A copy that failed partway -- a dropped
connection, a full disk -- left a truncated file sitting exactly where a
complete one belongs, and the very next `Files.exists` check trusted it as a
cache hit; nothing ever noticed or retried.

The download now goes to a uniquely named temporary file beside the
destination (`Files.createTempFile` guarantees the name, so two builds
racing to install the same dependency can't corrupt each other's copy) and is
moved into place only once the copy is verified to have succeeded. Any
failure, from the copy or from the move, removes the temporary file and is
reported rather than silently cached. Cleanup itself is protected too: a
close or delete failure that happens while already handling a copy failure
is attached as suppressed rather than replacing the original failure.

`install` and the asset search take their transport implicitly, so the
candidate-then-fallback search and the atomic-write guarantee can be
exercised against a scripted transport instead of the network.