### PR TITLE
fix: guess release asset addresses in FlixPackageManager before falling back to the listing

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -61,6 +61,20 @@ object PackageError {
   }
 
   /**
+    * A release asset isn't where its address says: either the release doesn't exist, or it exists
+    * without that asset -- a 404 can't say which, so the message names both possibilities.
+    */
+  case class ReleaseAssetNotFound(project: Project, version: SemVer, assetName: String, url: URL)
+    extends PackageError {
+    override def message(f: Formatter): String =
+      s"""Could not find ${f.bold(assetName)} in release ${f.bold(s"v$version")}
+         |of ${f.bold(project.toString)}.
+         |Either the release does not exist, or it does not publish that file.
+         |Looked at ${f.cyan(url.toString)}.
+         |""".stripMargin
+  }
+
+  /**
     * A download refused (403/429), which for an anonymous request usually means a rate limit.
     */
   case class DownloadRefused(url: URL, status: Int, retryAfter: Option[String])

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -275,6 +275,48 @@ object GitHub {
   }
 
   /**
+    * Opens a stream over the `assetName` asset of `project`'s `version` release, without consulting
+    * the REST API -- a release asset's address is fully predictable from owner/repo/tag/name.
+    * The caller closes the stream. See [[findReleaseAsset]] for the fallback when this 404s.
+    */
+  def downloadReleaseAsset(project: Project, version: SemVer, assetName: String): Result[InputStream, PackageError] = {
+    val url = releaseAssetUrl(project, version, assetName)
+    download(url) match {
+      case Err(PackageError.DownloadFailed(_, 404)) =>
+        Err(PackageError.ReleaseAssetNotFound(project, version, assetName, url))
+      case other => other
+    }
+  }
+
+  /**
+    * Finds the single `extension` asset in `project`'s `version` release by reading the REST API --
+    * the fallback for when [[downloadReleaseAsset]]'s guessed name 404s.
+    */
+  def findReleaseAsset(project: Project, version: SemVer, extension: String, apiKey: Option[String]): Result[Asset, PackageError] = {
+    getReleases(project, apiKey).flatMap { releases =>
+      releases.find(r => r.version == version) match {
+        case None => Err(PackageError.VersionDoesNotExist(version, project))
+        case Some(release) =>
+          release.assets.filter(_.name.endsWith(s".$extension")) match {
+            case Nil => Err(PackageError.NoSuchFile(project.toString, extension))
+            case asset :: Nil => Ok(asset)
+            case _ => Err(PackageError.TooManyFiles(project.toString, extension))
+          }
+      }
+    }
+  }
+
+  /**
+    * The permanent, non-REST address of a release asset.
+    */
+  private def releaseAssetUrl(project: Project, version: SemVer, assetName: String): URL = {
+    // The 4-arg constructor percent-encodes the path, so a name with a space or "#" (legal in a
+    // manifest's declared name, which this can be built from) can't produce a malformed URL.
+    val path = s"/${project.owner}/${project.repo}/releases/download/v$version/$assetName"
+    new URI("https", "github.com", path, null).toURL
+  }
+
+  /**
     * Gets the project release with the relevant semantic version.
     */
   def getSpecificRelease(project: Project, version: SemVer, apiKey: Option[String]): Result[Release, PackageError] = {


### PR DESCRIPTION
## Summary

Stacked on #13059 and #13062 -- this PR's diff includes both until they
merge.

Wires `FlixPackageManager.install` to try two unmetered guesses -- the
repository name, then the manifest's declared name -- against the asset's
computed address before falling back to the rate-limited listing:

1. Guess the repository name -- `release` publishes under it, so this is
   exact for anything published from now on, and it is an unmetered
   request either way.
2. Guess the manifest's declared name -- covers releases published before
   (1) was true, when the asset was named after the directory `release`
   ran in. Also unmetered.
3. Fall back to the listing (via `openAsset`/`findReleaseAsset` from
   #13062) -- reads whatever name the release actually used. The only one
   of the three that spends REST quota, which is why it is last.

`getSpecificRelease`/`downloadAsset` become unused here; their removal is
a separate follow-up PR (#13064) to keep this one focused on the new
behavior.