### PR TITLE
chore: remove getSpecificRelease/downloadAsset, unused since the address-guessing switch

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -31,6 +31,37 @@ import scala.util.Using
 object FlixPackageManager {
 
   /**
+    * The manifest asset's fixed name -- `Bootstrap.release` uploads `flix.toml` unchanged.
+    */
+  private val ManifestAssetName = "flix.toml"
+
+  /**
+    * Opens a stream over the first of `candidates` the release actually publishes, falling back to
+    * a rate-limited listing when none of them do. See [[installAll]] for the guessed candidates.
+    */
+  private def openAsset(project: GitHub.Project, version: SemVer, extension: String, candidates: List[String], apiKey: Option[String]): Result[java.io.InputStream, PackageError] =
+    tryCandidates(project, version, candidates) match {
+      case Some(result) => result
+      case None =>
+        GitHub.findReleaseAsset(project, version, extension, apiKey)
+          .flatMap(asset => GitHub.download(asset.url))
+    }
+
+  /**
+    * Opens the first candidate the release publishes, or `None` if it publishes none of them.
+    */
+  private def tryCandidates(project: GitHub.Project, version: SemVer, candidates: List[String]): Option[Result[java.io.InputStream, PackageError]] =
+    candidates match {
+      case Nil => None
+      case assetName :: rest =>
+        GitHub.downloadReleaseAsset(project, version, assetName) match {
+          case Ok(stream) => Some(Ok(stream))
+          case Err(_: PackageError.ReleaseAssetNotFound) => tryCandidates(project, version, rest)
+          case Err(e) => Some(Err(e))
+        }
+    }
+
+  /**
     * Represents the dependency resolution of [[origin]].
     * All fields should be considered private except [[origin]] and [[manifests]].
     *
@@ -125,11 +156,23 @@ object FlixPackageManager {
   def installAll(resolution: SecureResolution, projectRoot: Path, apiKey: Option[String])(implicit formatter: Formatter, out: PrintStream): Result[List[(Path, SecurityContext)], PackageError] = {
     out.println("Downloading Flix dependencies...")
 
-    val allFlixDeps = ListMap.from(resolution.manifestToFlixDeps.map { case (manifest, flixDep) => resolution.security(manifest) -> flixDep })
+    // The manifest's declared name travels along too: it's the second guess at the asset's name.
+    val allFlixDeps = ListMap.from(resolution.manifestToFlixDeps.map {
+      case (manifest, flixDep) => (resolution.security(manifest), manifest.name) -> flixDep
+    })
 
-    val flixPaths = allFlixDeps.map { case (sctx, dep) =>
+    val flixPaths = allFlixDeps.map { case ((sctx, packageName), dep) =>
       val depName: String = s"${dep.username}/${dep.projectName}"
-      install(depName, dep.version, "fpkg", projectRoot, apiKey) match {
+      // Three strategies, tried in this order, each falling through to the next only on a 404:
+      //   1. Guess the repository name -- `release` publishes under it, so this is exact for
+      //      anything published from now on, and it is an unmetered request either way.
+      //   2. Guess the manifest's declared name -- covers releases published before (1) was true,
+      //      when the asset was named after the directory `release` ran in. Also unmetered.
+      //   3. Fall back to the listing (inside `install`, via `openAsset`/`findReleaseAsset`) --
+      //      reads whatever name the release actually used. The only one of the three that spends
+      //      REST quota, which is why it is last.
+      val candidates = List(s"${dep.projectName}.fpkg", s"$packageName.fpkg")
+      install(depName, dep.version, "fpkg", candidates, projectRoot, apiKey) match {
         case Ok(p) => (p, sctx)
         case Err(e) =>
           out.println(s"ERROR: Installation of `$depName' failed.")
@@ -147,51 +190,50 @@ object FlixPackageManager {
     *
     * The package is installed at `lib/<owner>/<repo>`
     *
-    * There should be only one file with the given extension.
+    * `candidates` are tried against the asset's computed address first, each an unmetered request;
+    * a rate-limited listing is read only if none of them are what the release actually published.
     *
     * Returns the path to the downloaded file.
     */
-  private def install(project: String, version: SemVer, extension: String, p: Path, apiKey: Option[String])(implicit formatter: Formatter, out: PrintStream): Result[Path, PackageError] = {
+  private def install(project: String, version: SemVer, extension: String, candidates: List[String], p: Path, apiKey: Option[String])(implicit formatter: Formatter, out: PrintStream): Result[Path, PackageError] = {
     GitHub.parseProject(project).flatMap { proj =>
       val lib = Bootstrap.getLibraryDirectory(p)
-      val assetName = s"${proj.repo}-$version.$extension"
+      val localName = s"${proj.repo}-$version.$extension"
       val dirPath = lib.resolve("github").resolve(proj.owner).resolve(proj.repo).resolve(version.toString)
       // create the directory if it does not exist
       Files.createDirectories(dirPath)
-      val assetPath = dirPath.resolve(assetName)
+      val assetPath = dirPath.resolve(localName)
 
       if (Files.exists(assetPath)) {
         out.println(s"  Cached `${formatter.blue(s"${proj.owner}/${proj.repo}.$extension")}` (${formatter.cyan(s"v$version")}).")
         Ok(assetPath)
       } else {
-        GitHub.getSpecificRelease(proj, version, apiKey).flatMap { release =>
-          val assets = release.assets.filter(_.name.endsWith(s".$extension"))
-          if (assets.isEmpty) {
-            Err(PackageError.NoSuchFile(project, extension))
-          } else if (assets.length != 1) {
-            Err(PackageError.TooManyFiles(project, extension))
-          } else {
-            // download asset to the directory
-            val asset = assets.head
-            out.print(s"  Downloading `${formatter.blue(s"${proj.owner}/${proj.repo}.$extension")}` (${formatter.cyan(s"v$version")})... ")
-            out.flush()
+        val name = formatter.blue(s"${proj.owner}/${proj.repo}.$extension")
+        val label = s"`$name` (${formatter.cyan(s"v$version")})"
+        out.print(s"  Downloading $label... ")
+        out.flush()
+        openAsset(proj, version, extension, candidates.distinct, apiKey) match {
+          case Err(e) =>
+            out.println("ERROR.")
+            Err(e)
+          case Ok(stream) =>
             try {
-              Using(GitHub.downloadAsset(asset)) {
-                stream => Files.copy(stream, assetPath, StandardCopyOption.REPLACE_EXISTING)
+              Using(stream) {
+                s => Files.copy(s, assetPath, StandardCopyOption.REPLACE_EXISTING)
               }
             } catch {
               case e: IOException =>
                 out.println(s"ERROR: ${e.getMessage}.")
-                return Err(PackageError.DownloadError(asset, Some(e.getMessage)))
+                val msg = Some(e.getMessage)
+                return Err(PackageError.DownloadIncomplete(proj, version, localName, msg))
             }
             if (Files.exists(assetPath)) {
               out.println(s"OK.")
               Ok(assetPath)
             } else {
               out.println(s"ERROR: File was not created.")
-              Err(PackageError.DownloadError(asset, None))
+              Err(PackageError.DownloadIncomplete(proj, version, localName, None))
             }
-          }
         }
       }
     }
@@ -211,7 +253,9 @@ object FlixPackageManager {
       // download toml files
       tomlPaths <- traverse(flixDeps) { dep =>
         val depName = s"${dep.username}/${dep.projectName}"
-        install(depName, dep.version, "toml", path, apiKey).map(p => (p, dep))
+        // The manifest's asset name is fixed, not guessed, so a miss goes straight to the listing.
+        val candidates = List(ManifestAssetName)
+        install(depName, dep.version, "toml", candidates, path, apiKey).map(p => (p, dep))
       }
 
       // parse manifests

--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.tools.pkg
 
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.tools.pkg.Dependency.FlixDependency
-import ca.uwaterloo.flix.tools.pkg.github.GitHub.{Asset, Project}
+import ca.uwaterloo.flix.tools.pkg.github.GitHub.Project
 import ca.uwaterloo.flix.util.Formatter
 
 import java.io.IOException
@@ -117,15 +117,19 @@ object PackageError {
          |""".stripMargin
   }
 
-  case class DownloadError(asset: Asset, message: Option[String]) extends PackageError {
+  /**
+    * A download was served but could not be written to disk.
+    */
+  case class DownloadIncomplete(
+    project: Project,
+    version: SemVer,
+    assetName: String,
+    message: Option[String]
+  ) extends PackageError {
     override def message(f: Formatter): String =
-      s"""A download error occurred while downloading ${f.bold(asset.name)}
-         |${
-        message match {
-          case Some(e) => e
-          case None => ""
-        }
-      }
+      s"""Could not save ${f.bold(assetName)} from release ${f.bold(s"v$version")}
+         |of ${f.bold(project.toString)}.
+         |${message.getOrElse("The file was not created.")}
          |""".stripMargin
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -61,6 +61,20 @@ object PackageError {
   }
 
   /**
+    * A release asset isn't where its address says: either the release doesn't exist, or it exists
+    * without that asset -- a 404 can't say which, so the message names both possibilities.
+    */
+  case class ReleaseAssetNotFound(project: Project, version: SemVer, assetName: String, url: URL)
+    extends PackageError {
+    override def message(f: Formatter): String =
+      s"""Could not find ${f.bold(assetName)} in release ${f.bold(s"v$version")}
+         |of ${f.bold(project.toString)}.
+         |Either the release does not exist, or it does not publish that file.
+         |Looked at ${f.cyan(url.toString)}.
+         |""".stripMargin
+  }
+
+  /**
     * A download refused (403/429), which for an anonymous request usually means a rate limit.
     */
   case class DownloadRefused(url: URL, status: Int, retryAfter: Option[String])

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -275,6 +275,48 @@ object GitHub {
   }
 
   /**
+    * Opens a stream over the `assetName` asset of `project`'s `version` release, without consulting
+    * the REST API -- a release asset's address is fully predictable from owner/repo/tag/name.
+    * The caller closes the stream. See [[findReleaseAsset]] for the fallback when this 404s.
+    */
+  def downloadReleaseAsset(project: Project, version: SemVer, assetName: String): Result[InputStream, PackageError] = {
+    val url = releaseAssetUrl(project, version, assetName)
+    download(url) match {
+      case Err(PackageError.DownloadFailed(_, 404)) =>
+        Err(PackageError.ReleaseAssetNotFound(project, version, assetName, url))
+      case other => other
+    }
+  }
+
+  /**
+    * Finds the single `extension` asset in `project`'s `version` release by reading the REST API --
+    * the fallback for when [[downloadReleaseAsset]]'s guessed name 404s.
+    */
+  def findReleaseAsset(project: Project, version: SemVer, extension: String, apiKey: Option[String]): Result[Asset, PackageError] = {
+    getReleases(project, apiKey).flatMap { releases =>
+      releases.find(r => r.version == version) match {
+        case None => Err(PackageError.VersionDoesNotExist(version, project))
+        case Some(release) =>
+          release.assets.filter(_.name.endsWith(s".$extension")) match {
+            case Nil => Err(PackageError.NoSuchFile(project.toString, extension))
+            case asset :: Nil => Ok(asset)
+            case _ => Err(PackageError.TooManyFiles(project.toString, extension))
+          }
+      }
+    }
+  }
+
+  /**
+    * The permanent, non-REST address of a release asset.
+    */
+  private def releaseAssetUrl(project: Project, version: SemVer, assetName: String): URL = {
+    // The 4-arg constructor percent-encodes the path, so a name with a space or "#" (legal in a
+    // manifest's declared name, which this can be built from) can't produce a malformed URL.
+    val path = s"/${project.owner}/${project.repo}/releases/download/v$version/$assetName"
+    new URI("https", "github.com", path, null).toURL
+  }
+
+  /**
     * Gets the project release with the relevant semantic version.
     */
   def getSpecificRelease(project: Project, version: SemVer, apiKey: Option[String]): Result[Release, PackageError] = {

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -317,25 +317,6 @@ object GitHub {
   }
 
   /**
-    * Gets the project release with the relevant semantic version.
-    */
-  def getSpecificRelease(project: Project, version: SemVer, apiKey: Option[String]): Result[Release, PackageError] = {
-    getReleases(project, apiKey).flatMap {
-      releases =>
-        releases.find(r => r.version == version) match {
-          case None => Err(PackageError.VersionDoesNotExist(version, project))
-          case Some(release) => Ok(release)
-        }
-    }
-  }
-
-  /**
-    * Downloads the given asset.
-    */
-  def downloadAsset(asset: Asset): InputStream =
-    asset.url.openStream()
-
-  /**
     * Returns the URL that returns data related to the project's releases.
     */
   private def releasesUrl(project: Project): URL = {


### PR DESCRIPTION
## Summary

Stacked on #13059, #13062 and #13063 -- this PR's diff includes all three
until they merge.

`getSpecificRelease` and `downloadAsset` have no remaining callers once
#13063 switches `FlixPackageManager` over to the guess-then-fallback
search. Pure removal, kept separate from #13063 so that PR stays focused
on the new behavior rather than mixing it with cleanup.