### PR TITLE
feat: add a guess-then-fallback release asset lookup helper

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -30,13 +30,8 @@ import scala.collection.mutable
 object FlixPackageManager {
 
   /**
-    * The manifest asset's fixed name -- `Bootstrap.release` uploads `flix.toml` unchanged.
-    */
-  private val ManifestAssetName = "flix.toml"
-
-  /**
-    * Opens a stream over the first of `candidateNames` the release actually publishes, falling back
-    * to a rate-limited listing when none of them do. See [[installAll]] for the guessed names.
+    * Opens a stream over `guessedName` if the release actually publishes it, falling back to a
+    * rate-limited listing otherwise. The caller closes the stream.
     *
     * `candidateNames` are full asset file names (e.g. `"myrepo.fpkg"`), each already carrying its
     * own extension; `extension` is used only by the fallback listing lookup, to pick the one asset

--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -33,30 +33,30 @@ object FlixPackageManager {
     * Opens a stream over `guessedName` if the release actually publishes it, falling back to a
     * rate-limited listing otherwise. The caller closes the stream.
     *
-    * `candidateNames` are full asset file names (e.g. `"myrepo.fpkg"`), each already carrying its
-    * own extension; `extension` is used only by the fallback listing lookup, to pick the one asset
-    * of that kind out of the release's full asset list.
+    * `guessedName` is the full asset file name (e.g. `"myrepo.fpkg"`), already carrying its own
+    * extension; here `extension` is used only by the fallback listing lookup, to pick the one
+    * asset of that kind out of the release's full asset list.
     */
-  private def openAsset(project: GitHub.Project, version: SemVer, candidateNames: List[String], extension: String, apiKey: Option[String]): Result[InputStream, PackageError] =
-    tryCandidates(project, version, candidateNames) match {
-      case Some(result) => result
-      case None =>
-        GitHub.findReleaseAsset(project, version, extension, apiKey)
-          .flatMap(asset => GitHub.download(asset.url))
+  private def openAsset(project: GitHub.Project, version: SemVer, guessedName: String, extension: String, apiKey: Option[String]): Result[InputStream, PackageError] =
+    tryGuess(GitHub.downloadReleaseAsset(project, version, guessedName)) {
+      GitHub.findReleaseAsset(project, version, extension, apiKey).flatMap(asset => GitHub.download(asset.url))
     }
 
   /**
-    * Opens the first of `candidateNames` the release publishes, or `None` if it publishes none of them.
+    * Returns `guess`, or `fallback` if `guess` is a [[PackageError.ReleaseAssetNotFound]].
+    *
+    * Package-private, and `guess` is a parameter rather than inlined into [[openAsset]], so this
+    * can be tested without a network.
+    *
+    * A [[PackageError.ReleaseAssetNotFound]] means only that the guess was wrong, so the search
+    * falls back. Any other failure is the caller's to report, and is returned as-is: a rate limit
+    * or an unreachable host says nothing about whether the fallback would succeed.
     */
-  private def tryCandidates(project: GitHub.Project, version: SemVer, candidateNames: List[String]): Option[Result[InputStream, PackageError]] =
-    candidateNames match {
-      case Nil => None
-      case assetName :: rest =>
-        GitHub.downloadReleaseAsset(project, version, assetName) match {
-          case Ok(stream) => Some(Ok(stream))
-          case Err(_: PackageError.ReleaseAssetNotFound) => tryCandidates(project, version, rest)
-          case Err(e) => Some(Err(e))
-        }
+  private[pkg] def tryGuess(guess: Result[InputStream, PackageError])
+                            (fallback: => Result[InputStream, PackageError]): Result[InputStream, PackageError] =
+    guess match {
+      case Err(_: PackageError.ReleaseAssetNotFound) => fallback
+      case other => other
     }
 
   /**
@@ -158,7 +158,7 @@ object FlixPackageManager {
 
     val flixPaths = allFlixDeps.map { case (sctx, dep) =>
       val depName: String = s"${dep.username}/${dep.projectName}"
-      install(depName, dep.version, "fpkg", projectRoot, apiKey) match {
+      install(depName, dep.version, fpkgAssetName(dep), Bootstrap.EXT_FPKG, projectRoot, apiKey) match {
         case Ok(p) => (p, sctx)
         case Err(e) =>
           out.println(s"ERROR: Installation of `$depName' failed.")
@@ -170,42 +170,51 @@ object FlixPackageManager {
   }
 
   /**
+    * Returns the asset name `dep`'s release is expected to publish its package under.
+    *
+    * `Bootstrap.release` uploads the package as `<project directory>.fpkg`, which is the repository
+    * name for a conventional checkout. Guessing it costs an unmetered request; [[openAsset]] falls
+    * back to the listing for the projects where it does not hold.
+    */
+  private[pkg] def fpkgAssetName(dep: FlixDependency): String =
+    s"${dep.projectName}.${Bootstrap.EXT_FPKG}"
+
+  /**
     * Installs a flix package from the Github `project`.
     *
     * `project` must be of the form `<owner>/<repo>`
     *
     * The package is installed at `lib/<owner>/<repo>`
     *
-    * There should be only one file with the given extension.
+    * `guessedName` is the name the release is expected to publish its asset under, tried before the
+    * rate-limited listing; see [[openAsset]]. The listing requires that the release publish exactly
+    * one `extension` asset.
     *
     * Returns the path to the downloaded file.
     */
-  private def install(project: String, version: SemVer, extension: String, p: Path, apiKey: Option[String])(implicit formatter: Formatter, out: PrintStream): Result[Path, PackageError] = {
+  private def install(project: String, version: SemVer, guessedName: String, extension: String, p: Path, apiKey: Option[String])(implicit formatter: Formatter, out: PrintStream): Result[Path, PackageError] = {
     GitHub.parseProject(project).flatMap { proj =>
       val lib = Bootstrap.getLibraryDirectory(p)
-      val assetName = s"${proj.repo}-$version.$extension"
+      val cacheName = s"${proj.repo}-$version.$extension"
       val dirPath = lib.resolve("github").resolve(proj.owner).resolve(proj.repo).resolve(version.toString)
       // create the directory if it does not exist
       Files.createDirectories(dirPath)
-      val assetPath = dirPath.resolve(assetName)
+      val assetPath = dirPath.resolve(cacheName)
 
       if (Files.exists(assetPath)) {
         out.println(s"  Cached `${formatter.blue(s"${proj.owner}/${proj.repo}.$extension")}` (${formatter.cyan(s"v$version")}).")
         Ok(assetPath)
       } else {
-        GitHub.getSpecificRelease(proj, version, apiKey).flatMap { release =>
-          val assets = release.assets.filter(_.name.endsWith(s".$extension"))
-          if (assets.isEmpty) {
-            Err(PackageError.NoSuchFile(project, extension))
-          } else if (assets.length != 1) {
-            Err(PackageError.TooManyFiles(project, extension))
-          } else {
-            // download asset to the directory
-            val asset = assets.head
-            out.print(s"  Downloading `${formatter.blue(s"${proj.owner}/${proj.repo}.$extension")}` (${formatter.cyan(s"v$version")})... ")
-            out.flush()
+        out.print(s"  Downloading `${formatter.blue(s"${proj.owner}/${proj.repo}.$extension")}` (${formatter.cyan(s"v$version")})... ")
+        out.flush()
+        openAsset(proj, version, guessedName, extension, apiKey) match {
+          case Err(e) =>
+            // Terminate the line started above; the error carries its own message.
+            out.println("ERROR.")
+            Err(e)
+
+          case Ok(stream) =>
             try {
-              val stream = GitHub.downloadAsset(asset)
               try {
                 Files.copy(stream, assetPath, StandardCopyOption.REPLACE_EXISTING)
               } finally {
@@ -225,16 +234,15 @@ object FlixPackageManager {
                   case e2: IOException => e.addSuppressed(e2)
                 }
                 out.println(s"ERROR: ${e.getMessage}.")
-                return Err(PackageError.DownloadError(asset, Some(e.getMessage)))
+                return Err(PackageError.DownloadError(cacheName, Some(e.getMessage)))
             }
             if (Files.exists(assetPath)) {
               out.println(s"OK.")
               Ok(assetPath)
             } else {
               out.println(s"ERROR: File was not created.")
-              Err(PackageError.DownloadError(asset, None))
+              Err(PackageError.DownloadError(cacheName, None))
             }
-          }
         }
       }
     }
@@ -254,7 +262,8 @@ object FlixPackageManager {
       // download toml files
       tomlPaths <- traverse(flixDeps) { dep =>
         val depName = s"${dep.username}/${dep.projectName}"
-        install(depName, dep.version, Bootstrap.EXT_TOML, path, apiKey).map(p => (p, dep))
+        // `Bootstrap.release` uploads the manifest under its fixed name, unchanged.
+        install(depName, dep.version, Bootstrap.FLIX_TOML, Bootstrap.EXT_TOML, path, apiKey).map(p => (p, dep))
       }
 
       // parse manifests

--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -30,6 +30,37 @@ import scala.collection.mutable
 object FlixPackageManager {
 
   /**
+    * The manifest asset's fixed name -- `Bootstrap.release` uploads `flix.toml` unchanged.
+    */
+  private val ManifestAssetName = "flix.toml"
+
+  /**
+    * Opens a stream over the first of `candidates` the release actually publishes, falling back to
+    * a rate-limited listing when none of them do. See [[installAll]] for the guessed candidates.
+    */
+  private def openAsset(project: GitHub.Project, version: SemVer, extension: String, candidates: List[String], apiKey: Option[String]): Result[java.io.InputStream, PackageError] =
+    tryCandidates(project, version, candidates) match {
+      case Some(result) => result
+      case None =>
+        GitHub.findReleaseAsset(project, version, extension, apiKey)
+          .flatMap(asset => GitHub.download(asset.url))
+    }
+
+  /**
+    * Opens the first candidate the release publishes, or `None` if it publishes none of them.
+    */
+  private def tryCandidates(project: GitHub.Project, version: SemVer, candidates: List[String]): Option[Result[java.io.InputStream, PackageError]] =
+    candidates match {
+      case Nil => None
+      case assetName :: rest =>
+        GitHub.downloadReleaseAsset(project, version, assetName) match {
+          case Ok(stream) => Some(Ok(stream))
+          case Err(_: PackageError.ReleaseAssetNotFound) => tryCandidates(project, version, rest)
+          case Err(e) => Some(Err(e))
+        }
+    }
+
+  /**
     * Represents the dependency resolution of [[origin]].
     * All fields should be considered private except [[origin]] and [[manifests]].
     *

--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.util.{Formatter, Result}
 import ca.uwaterloo.flix.util.Result.{Err, Ok, traverse}
 import ca.uwaterloo.flix.util.collection.ListMap
 
-import java.io.{IOException, PrintStream}
+import java.io.{IOException, InputStream, PrintStream}
 import java.nio.file.{Files, Path, StandardCopyOption}
 import scala.collection.mutable
 
@@ -35,11 +35,15 @@ object FlixPackageManager {
   private val ManifestAssetName = "flix.toml"
 
   /**
-    * Opens a stream over the first of `candidates` the release actually publishes, falling back to
-    * a rate-limited listing when none of them do. See [[installAll]] for the guessed candidates.
+    * Opens a stream over the first of `candidateNames` the release actually publishes, falling back
+    * to a rate-limited listing when none of them do. See [[installAll]] for the guessed names.
+    *
+    * `candidateNames` are full asset file names (e.g. `"myrepo.fpkg"`), each already carrying its
+    * own extension; `extension` is used only by the fallback listing lookup, to pick the one asset
+    * of that kind out of the release's full asset list.
     */
-  private def openAsset(project: GitHub.Project, version: SemVer, extension: String, candidates: List[String], apiKey: Option[String]): Result[java.io.InputStream, PackageError] =
-    tryCandidates(project, version, candidates) match {
+  private def openAsset(project: GitHub.Project, version: SemVer, candidateNames: List[String], extension: String, apiKey: Option[String]): Result[InputStream, PackageError] =
+    tryCandidates(project, version, candidateNames) match {
       case Some(result) => result
       case None =>
         GitHub.findReleaseAsset(project, version, extension, apiKey)
@@ -47,10 +51,10 @@ object FlixPackageManager {
     }
 
   /**
-    * Opens the first candidate the release publishes, or `None` if it publishes none of them.
+    * Opens the first of `candidateNames` the release publishes, or `None` if it publishes none of them.
     */
-  private def tryCandidates(project: GitHub.Project, version: SemVer, candidates: List[String]): Option[Result[java.io.InputStream, PackageError]] =
-    candidates match {
+  private def tryCandidates(project: GitHub.Project, version: SemVer, candidateNames: List[String]): Option[Result[InputStream, PackageError]] =
+    candidateNames match {
       case Nil => None
       case assetName :: rest =>
         GitHub.downloadReleaseAsset(project, version, assetName) match {

--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.tools.pkg
 
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.tools.pkg.Dependency.FlixDependency
-import ca.uwaterloo.flix.tools.pkg.github.GitHub.{Asset, Project}
+import ca.uwaterloo.flix.tools.pkg.github.GitHub.Project
 import ca.uwaterloo.flix.util.Formatter
 
 import java.io.IOException
@@ -117,9 +117,12 @@ object PackageError {
          |""".stripMargin
   }
 
-  case class DownloadError(asset: Asset, message: Option[String]) extends PackageError {
+  /**
+    * A downloaded asset could not be written to disk under `fileName`.
+    */
+  case class DownloadError(fileName: String, message: Option[String]) extends PackageError {
     override def message(f: Formatter): String =
-      s"""A download error occurred while downloading ${f.bold(asset.name)}
+      s"""An error occurred while saving ${f.bold(fileName)}
          |${
         message match {
           case Some(e) => e

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -315,25 +315,6 @@ object GitHub {
   }
 
   /**
-    * Gets the project release with the relevant semantic version.
-    */
-  def getSpecificRelease(project: Project, version: SemVer, apiKey: Option[String]): Result[Release, PackageError] = {
-    getReleases(project, apiKey).flatMap {
-      releases =>
-        releases.find(r => r.version == version) match {
-          case None => Err(PackageError.VersionDoesNotExist(version, project))
-          case Some(release) => Ok(release)
-        }
-    }
-  }
-
-  /**
-    * Downloads the given asset.
-    */
-  def downloadAsset(asset: Asset): InputStream =
-    asset.url.openStream()
-
-  /**
     * Returns the URL that returns data related to the project's releases.
     */
   private def releasesUrl(project: Project): URL = {

--- a/main/test/ca/uwaterloo/flix/tools/pkg/TestFlixPackageManager.scala
+++ b/main/test/ca/uwaterloo/flix/tools/pkg/TestFlixPackageManager.scala
@@ -5,12 +5,13 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.tools.pkg.github.GitHub.Project
-import ca.uwaterloo.flix.util.Formatter
+import ca.uwaterloo.flix.util.{Formatter, Result}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import org.scalatest.{BeforeAndAfter, DoNotDiscover}
 import org.scalatest.funsuite.AnyFunSuite
 
-import java.io.{File, PrintStream}
+import java.io.{ByteArrayInputStream, File, InputStream, PrintStream}
+import java.net.{URI, URL}
 import java.nio.file.{Files, Path}
 
 @DoNotDiscover
@@ -703,6 +704,63 @@ class TestFlixPackageManager extends AnyFunSuite with BeforeAndAfter {
       case _ => false
     }
     (forbidden, CompilationMessage.formatAll(errors)(flix.getFormatter, optRoot))
+  }
+
+  // Whether the guess-then-fallback lookup in `FlixPackageManager.tryGuess` falls back decides how
+  // many requests a dependency install costs, so it is tested directly, with stubbed results,
+  // rather than against GitHub.
+
+  /** A project and version to attribute the stubbed lookups below to. */
+  private val StubProject: Project = Project("flix", "museum")
+  private val StubVersion: SemVer = SemVer(1, 1, 0)
+
+  /** A host the stubbed lookups below can name without reaching it. */
+  private val StubUrl: URL = new URI("https://example.invalid").toURL
+
+  /** The result the lookup falls back to when the guess missed, i.e. the listing lookup. */
+  private val Exhausted: Result[InputStream, PackageError] =
+    Err(PackageError.NoSuchFile(s"${StubProject.owner}/${StubProject.repo}", "fpkg"))
+
+  /** A stubbed 404: `assetName` is not published by the release. */
+  private def notFound(assetName: String): Result[InputStream, PackageError] =
+    Err(PackageError.ReleaseAssetNotFound(StubProject, StubVersion, assetName, StubUrl))
+
+  /** A stubbed hit: a stream whose contents are `assetName`, so the winner can be identified. */
+  private def found(assetName: String): Result[InputStream, PackageError] =
+    Ok(new ByteArrayInputStream(assetName.getBytes))
+
+  /** A stubbed rate limit, i.e. a failure that says nothing about whether the asset exists. */
+  private def refused: Result[InputStream, PackageError] =
+    Err(PackageError.DownloadRefused(StubUrl, 429, None))
+
+  /** Returns the name of the asset `result` opened, failing if it did not open one. */
+  private def openedName(result: Result[InputStream, PackageError]): String = result match {
+    case Ok(stream) => new String(stream.readAllBytes())
+    case Err(e) => fail(s"expected a stream, got ${e.message(formatter)}")
+  }
+
+  test("tryGuess.01: a hit on the guess is used, without falling back") {
+    val result = FlixPackageManager.tryGuess(found("museum.fpkg"))(fail("must not fall back after a hit"))
+    assertResult(expected = "museum.fpkg")(actual = openedName(result))
+  }
+
+  test("tryGuess.02: a 404 on the guess falls back to the listing") {
+    val result = FlixPackageManager.tryGuess(notFound("museum.fpkg"))(Exhausted)
+    assertResult(expected = Exhausted)(actual = result)
+  }
+
+  test("tryGuess.03: a failure other than a 404 is reported without falling back") {
+    val result = FlixPackageManager.tryGuess(refused)(fail("must not fall back after a refusal"))
+    val reported = result match {
+      case Err(e: PackageError.DownloadRefused) => e.status
+      case other => fail(s"expected a refusal, got $other")
+    }
+    assertResult(expected = 429)(actual = reported)
+  }
+
+  test("fpkgAssetName.01: the package is guessed under the repository name") {
+    val dep = Dependency.FlixDependency(Repository.GitHub, StubProject.owner, StubProject.repo, StubVersion, SecurityContext.Unrestricted)
+    assertResult(expected = "museum.fpkg")(actual = FlixPackageManager.fpkgAssetName(dep))
   }
 
 }


### PR DESCRIPTION
## Summary

This is the piece that didn't make it in when #13063 merged -- that merge
commit only touched `GitHub.scala`/`PackageError.scala` (the address-lookup
primitives from #13062), not `FlixPackageManager.scala` itself. So the
actual dependency-installation behavior never changed on master: `install`
still reads the rate-limited listing for every dependency.

This PR is just the first, self-contained piece: `openAsset`/
`tryCandidates`. They try each of a caller-supplied list of candidate asset
names against GitHub's predictable per-asset address (an unmetered request
per guess) before falling back to the rate-limited listing
(`findReleaseAsset`, already on master) for whichever name the release
actually used. A 404 (`ReleaseAssetNotFound`) moves to the next candidate;
any other failure or a hit stops the search.

Not wired to anything yet -- `FlixPackageManager.install` still reads the
listing unconditionally, and nothing calls `openAsset`/`tryCandidates`. No
behavior change on master from this PR alone.

The remaining pieces (wiring `install`/`installAll` to actually use this,
and deterministic tests for the lookup) are ready and will land as
follow-up PRs, sequentially, once this one is settled.