### PR TITLE
fix: report a download's copy failure instead of silently discarding it

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -16,17 +16,17 @@
 package ca.uwaterloo.flix.tools.pkg
 
 import ca.uwaterloo.flix.api.Bootstrap
+import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.tools.pkg.Dependency.{FlixDependency, JarDependency, MavenDependency}
 import ca.uwaterloo.flix.tools.pkg.github.GitHub
-import ca.uwaterloo.flix.util.{Formatter, Result}
+import ca.uwaterloo.flix.util.{Formatter, InternalCompilerException, Result}
 import ca.uwaterloo.flix.util.Result.{Err, Ok, traverse}
 import ca.uwaterloo.flix.util.collection.ListMap
 
 import java.io.{IOException, PrintStream}
 import java.nio.file.{Files, Path, StandardCopyOption}
 import scala.collection.mutable
-import scala.util.Using
 
 object FlixPackageManager {
 
@@ -176,16 +176,25 @@ object FlixPackageManager {
             out.print(s"  Downloading `${formatter.blue(s"${proj.owner}/${proj.repo}.$extension")}` (${formatter.cyan(s"v$version")})... ")
             out.flush()
             try {
-              // Using(...) traps a copy failure into a Failure instead of throwing it; .get
-              // rethrows it so the catch below sees it and the partial file gets cleaned up.
-              Using(GitHub.downloadAsset(asset)) {
-                stream => Files.copy(stream, assetPath, StandardCopyOption.REPLACE_EXISTING)
-              }.get
+              val stream = GitHub.downloadAsset(asset)
+              try {
+                Files.copy(stream, assetPath, StandardCopyOption.REPLACE_EXISTING)
+              } finally {
+                // Best-effort: the stream is already broken if the copy above failed, so a
+                // close failure here must not mask that error.
+                try stream.close() catch { case _: IOException => () }
+              }
             } catch {
               case e: IOException =>
                 // Remove a truncated file so the cache check above doesn't trust it next run.
-                // Best-effort: a failure here must not mask the error being reported below.
-                try Files.deleteIfExists(assetPath) catch { case _: IOException => () }
+                // Unlike closing an already-broken stream, a failure to delete a file means the
+                // filesystem itself is in an unexpected state, so it is not swallowed.
+                try {
+                  Files.deleteIfExists(assetPath)
+                } catch {
+                  case e2: IOException =>
+                    throw InternalCompilerException(s"Unable to remove truncated download '$assetPath': ${e2.getMessage}", SourceLocation.Unknown)
+                }
                 out.println(s"ERROR: ${e.getMessage}.")
                 return Err(PackageError.DownloadError(asset, Some(e.getMessage)))
             }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -176,11 +176,16 @@ object FlixPackageManager {
             out.print(s"  Downloading `${formatter.blue(s"${proj.owner}/${proj.repo}.$extension")}` (${formatter.cyan(s"v$version")})... ")
             out.flush()
             try {
+              // Using(...) traps a copy failure into a Failure instead of throwing it; .get
+              // rethrows it so the catch below sees it and the partial file gets cleaned up.
               Using(GitHub.downloadAsset(asset)) {
                 stream => Files.copy(stream, assetPath, StandardCopyOption.REPLACE_EXISTING)
-              }
+              }.get
             } catch {
               case e: IOException =>
+                // A copy or close failure can leave a truncated file at assetPath -- exactly what
+                // the cache check above trusts on the next run. Remove it rather than risk that.
+                Files.deleteIfExists(assetPath)
                 out.println(s"ERROR: ${e.getMessage}.")
                 return Err(PackageError.DownloadError(asset, Some(e.getMessage)))
             }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -183,9 +183,9 @@ object FlixPackageManager {
               }.get
             } catch {
               case e: IOException =>
-                // A copy or close failure can leave a truncated file at assetPath -- exactly what
-                // the cache check above trusts on the next run. Remove it rather than risk that.
-                Files.deleteIfExists(assetPath)
+                // Remove a truncated file so the cache check above doesn't trust it next run.
+                // Best-effort: a failure here must not mask the error being reported below.
+                try Files.deleteIfExists(assetPath) catch { case _: IOException => () }
                 out.println(s"ERROR: ${e.getMessage}.")
                 return Err(PackageError.DownloadError(asset, Some(e.getMessage)))
             }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -16,11 +16,10 @@
 package ca.uwaterloo.flix.tools.pkg
 
 import ca.uwaterloo.flix.api.Bootstrap
-import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.tools.pkg.Dependency.{FlixDependency, JarDependency, MavenDependency}
 import ca.uwaterloo.flix.tools.pkg.github.GitHub
-import ca.uwaterloo.flix.util.{Formatter, InternalCompilerException, Result}
+import ca.uwaterloo.flix.util.{Formatter, Result}
 import ca.uwaterloo.flix.util.Result.{Err, Ok, traverse}
 import ca.uwaterloo.flix.util.collection.ListMap
 
@@ -186,14 +185,14 @@ object FlixPackageManager {
               }
             } catch {
               case e: IOException =>
-                // Remove a truncated file so the cache check above doesn't trust it next run.
-                // Unlike closing an already-broken stream, a failure to delete a file means the
-                // filesystem itself is in an unexpected state, so it is not swallowed.
+                // Remove a truncated file so the cache check above doesn't trust it next run. A
+                // failure here is attached rather than swallowed, since it means the filesystem
+                // itself is in an unexpected state -- but it must not prevent the original
+                // download error from being reported below.
                 try {
                   Files.deleteIfExists(assetPath)
                 } catch {
-                  case e2: IOException =>
-                    throw InternalCompilerException(s"Unable to remove truncated download '$assetPath': ${e2.getMessage}", SourceLocation.Unknown)
+                  case e2: IOException => e.addSuppressed(e2)
                 }
                 out.println(s"ERROR: ${e.getMessage}.")
                 return Err(PackageError.DownloadError(asset, Some(e.getMessage)))


### PR DESCRIPTION
## Summary

Independent, minimal fix -- not part of the guess-release-address work in
flight in #13067 and its follow-ups.

`Using(GitHub.downloadAsset(asset)) { ... }` returned a `Try`, and a failure
inside the block -- `Files.copy` throwing partway through a write -- became
a `Failure` value that was never inspected, not an exception the surrounding
`catch` could see. `install` would fall through past the `catch`, and the
partially-written file left at `assetPath` is exactly what the cache check a
few lines above trusts as a complete download on the next run.

The stream is now fetched directly and closed in a `finally` block instead
of going through `Using` -- there was no suppressed-exception bookkeeping
worth keeping once the `.get` rethrow made `Using` redundant with a plain
try/finally. A close failure there is swallowed, since the stream is already
broken by the copy failure and closing it again has no bearing on anything
downstream.

The `catch` now also removes the partial file, so it isn't left for the next
invocation to mistake for a successful install. A failure to delete it is
attached to the original exception via `addSuppressed` rather than silently
dropped -- it means the filesystem itself is in an unexpected state, which
is worth keeping visible -- but it must not itself prevent the original
download error from being reported and returned as `DownloadError`.