### PR TITLE
fix(pkg): percent-encode the release asset upload URL

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -360,7 +360,10 @@ object GitHub {
     * Returns the URL that release assets can be uploaded to.
     */
   private def releaseAssetUploadUrl(project: Project, releaseId: String, assetName: String): URL = {
-    new URI(s"https://uploads.github.com/repos/${project.owner}/${project.repo}/releases/$releaseId/assets?name=$assetName").toURL
+    // The 5-arg constructor percent-encodes the path and query, so an assetName with a space or "#"
+    // (legal in a filename) can't produce a malformed URL, as it could with raw string interpolation.
+    val path = s"/repos/${project.owner}/${project.repo}/releases/$releaseId/assets"
+    new URI("https", "uploads.github.com", path, s"name=$assetName", null).toURL
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -26,7 +26,8 @@ import org.json4s.native.JsonMethods.{compact, parse, render}
 import java.io.{IOException, InputStream}
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
-import java.net.{URI, URL}
+import java.net.{URI, URL, URLEncoder}
+import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 
 /**
@@ -360,10 +361,12 @@ object GitHub {
     * Returns the URL that release assets can be uploaded to.
     */
   private def releaseAssetUploadUrl(project: Project, releaseId: String, assetName: String): URL = {
-    // The 5-arg constructor percent-encodes the path and query, so an assetName with a space or "#"
-    // (legal in a filename) can't produce a malformed URL, as it could with raw string interpolation.
+    // "&" and "=" are legal query characters, so the URI constructor won't escape them -- an
+    // assetName containing one could inject an extra query parameter. URLEncoder escapes them.
     val path = s"/repos/${project.owner}/${project.repo}/releases/$releaseId/assets"
-    new URI("https", "uploads.github.com", path, s"name=$assetName", null).toURL
+    val base = new URI("https", "uploads.github.com", path, null, null)
+    val encodedName = URLEncoder.encode(assetName, StandardCharsets.UTF_8)
+    new URI(s"$base?name=$encodedName").toURL
   }
 
   /**


### PR DESCRIPTION
## Summary

`releaseAssetUrl` was already fixed to build its URL with the 4-arg `URI` constructor, so an asset name containing a space or `#` (legal in a filename) gets percent-encoded instead of producing a malformed URL. `releaseAssetUploadUrl`, used by the maintainer-only `publishRelease`/`uploadAsset` flow, has the same bug: it interpolates `assetName` directly into a string and builds the `URI` from that.

This applies the same fix using the 5-arg `URI(scheme, authority, path, query, fragment)` constructor, since this URL needs a query string as well as a path.

## Test plan

- [x] `./mill flix.compile` succeeds
- [x] Verified via `jshell` that a name like `my file #1.fpkg` now percent-encodes correctly in both path and query position