### PR TITLE
fix(pkg): restore the interrupt flag on GitHub API calls, not just downloads

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -66,6 +66,9 @@ object GitHub {
       Client.sendRequest(req).body()
     } catch {
       case ex: IOException => return Err(PackageError.ProjectNotFound(url, project, ex))
+      case ex: InterruptedException =>
+        Thread.currentThread().interrupt()
+        return Err(PackageError.ProjectNotFound(url, project, new IOException(ex)))
     }
     val releaseJsons = try {
       parse(json).asInstanceOf[JArray]
@@ -110,6 +113,9 @@ object GitHub {
       }
     } catch {
       case _: IOException => Err(ReleaseError.NetworkError)
+      case _: InterruptedException =>
+        Thread.currentThread().interrupt()
+        Err(ReleaseError.NetworkError)
     }
   }
 
@@ -150,6 +156,9 @@ object GitHub {
 
     } catch {
       case _: IOException => return Err(ReleaseError.NetworkError)
+      case _: InterruptedException =>
+        Thread.currentThread().interrupt()
+        return Err(ReleaseError.NetworkError)
     }
 
     // Extract URL from returned JSON
@@ -191,6 +200,9 @@ object GitHub {
 
     } catch {
       case _: IOException => Err(ReleaseError.NetworkError)
+      case _: InterruptedException =>
+        Thread.currentThread().interrupt()
+        Err(ReleaseError.NetworkError)
     }
   }
 
@@ -223,6 +235,9 @@ object GitHub {
       }
     } catch {
       case _: IOException => Err(ReleaseError.NetworkError)
+      case _: InterruptedException =>
+        Thread.currentThread().interrupt()
+        Err(ReleaseError.NetworkError)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -68,7 +68,7 @@ object GitHub {
       case ex: IOException => return Err(PackageError.ProjectNotFound(url, project, ex))
       case ex: InterruptedException =>
         Thread.currentThread().interrupt()
-        return Err(PackageError.ProjectNotFound(url, project, new IOException(ex)))
+        return Err(PackageError.ProjectNotFound(url, project, new IOException("Interrupted while waiting for a response", ex)))
     }
     val releaseJsons = try {
       parse(json).asInstanceOf[JArray]


### PR DESCRIPTION
## Summary

`download()` already caught `InterruptedException` separately from `IOException`, re-setting the thread's interrupt flag before returning an error result. The other five blocking HTTP calls in `GitHub.scala` -- `getReleases`, `verifyRelease`, `createDraftRelease`, `uploadAsset`, and `markReleaseReady` -- only caught `IOException`. If a thread running one of these was interrupted, the exception would propagate uncaught instead of the flag being restored and an error result returned, same as `download()` already handles it.

This applies the same catch clause to all five, following the existing `download()` pattern.

## Test plan

- [x] `./mill flix.compile` succeeds