### PR TITLE
fix: match Console.readln() as Option[String] in tic-tac-toe example

### DIFF
--- a/examples/apps/tic-tac-toe/src/Interface.flix
+++ b/examples/apps/tic-tac-toe/src/Interface.flix
@@ -21,16 +21,16 @@ mod Interface {
     ///
     /// Recursive helper function to read and return only valid moves.
     ///
-    def getMoveFromConsole(): Int32 \ Console = {
+    def getMoveFromConsole(): Int32 \ Console + Sys.Exit = {
         match Console.readln() {
             case None => {
-                Console.println("Invalid move. Move must be a positive integer between 0 and 8");
-                getMoveFromConsole()
+                Console.println("No input available. Exiting.");
+                Sys.Exit.exit(0)
             }
             case Some(line) => match Int32.parse(10, line) {
                 case Result.Ok(move) if (0 <= move and move <= 8) => move
                 case _ => {
-                    Console.println("Invalid move. Move must be a positive integer between 0 and 8");
+                    Console.println("Invalid move. Move must be an integer between 0 and 8 (inclusive)");
                     getMoveFromConsole()
                 }
             }
@@ -43,7 +43,7 @@ mod Interface {
     ///
     /// In other words, re-interprets the Interface effect using the IO and Console effects.
     ///
-    pub def interfaceWithConsole(f: Unit -> a \ ef): a \ ef - Interface + Console =
+    pub def interfaceWithConsole(f: Unit -> a \ ef): a \ ef - Interface + Console + Sys.Exit =
         run {
             f()
         }

--- a/examples/apps/tic-tac-toe/src/Interface.flix
+++ b/examples/apps/tic-tac-toe/src/Interface.flix
@@ -22,12 +22,12 @@ mod Interface {
     /// Recursive helper function to read and return only valid moves.
     ///
     def getMoveFromConsole(): Int32 \ Console = {
-        let line = Console.readln();
-        if (Object.isNull(line)) {
-            Console.println("Invalid move. Move must be a positive integer between 0 and 8");
-            getMoveFromConsole()
-        } else {
-            match Int32.parse(10, line) {
+        match Console.readln() {
+            case None => {
+                Console.println("Invalid move. Move must be a positive integer between 0 and 8");
+                getMoveFromConsole()
+            }
+            case Some(line) => match Int32.parse(10, line) {
                 case Result.Ok(move) if (0 <= move and move <= 8) => move
                 case _ => {
                     Console.println("Invalid move. Move must be a positive integer between 0 and 8");

--- a/examples/apps/tic-tac-toe/src/Main.flix
+++ b/examples/apps/tic-tac-toe/src/Main.flix
@@ -56,4 +56,5 @@ def main(): Unit \ IO = {
         gameLoop(board, Symbol.X)
     } with Interface.interfaceWithConsole
     with Console.runWithIO
+    with Sys.Exit.runWithIO
 }


### PR DESCRIPTION
   ## Summary

   - `Console.readln()` returns `Option[String]`, not a nullable `String`, so `Object.isNull(line)` never triggered and `Int32.parse` received an `Option[String]` instead of a `String`.
   - Updated the tic-tac-toe example's `Interface.flix` to pattern-match on the `Option[String]` result correctly.
