### PR TITLE
refactor: make Bootstrap.FLIX_TOML visible

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -187,7 +187,7 @@ object Bootstrap {
   private val EXT_JAR: String = "jar"
 
   /** The manifest / flix toml file name. */
-  private val FLIX_TOML: String = "flix.toml"
+  val FLIX_TOML: String = "flix.toml"
 
   /** The license file name. */
   private val LICENSE: String = "LICENSE.md"


### PR DESCRIPTION
## Summary
- Widens `Bootstrap.FLIX_TOML` from `private` to public, per review feedback on #13067: "I think making it visible is better than duplication."

This is a standalone prerequisite for reusing the constant instead of duplicating the `"flix.toml"` literal elsewhere.