### PR TITLE
refactor: reuse FLIX_TOML in Bootstrap error messages and CI workflow template

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -131,7 +131,7 @@ object Bootstrap {
     }
 
     FileOps.newFileIfAbsent(buildAndTestWorkflowFile) {
-      """name: Build and Test
+      ("""name: Build and Test
         |
         |on:
         |  pull_request:
@@ -151,10 +151,10 @@ object Bootstrap {
         |          distribution: 'temurin'
         |          java-version: '21'
         |
-        |      - name: Read Flix version from flix.toml
+        |      - name: Read Flix version from """ + FLIX_TOML + """
         |        id: flix
         |        run: |
-        |          version=$(grep -E '^"?flix"?[[:space:]]*=' flix.toml \
+        |          version=$(grep -E '^"?flix"?[[:space:]]*=' """ + FLIX_TOML + """ \
         |            | head -n1 \
         |            | sed -E 's/.*"([^"]+)"[[:space:]]*$/\1/')
         |          echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -169,7 +169,7 @@ object Bootstrap {
         |
         |      - name: Test
         |        run: java -jar flix.jar test
-        |""".stripMargin
+        |""").stripMargin
     }
     Result.Ok(())
   }
@@ -571,7 +571,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     */
   def checkEffects(flix: Flix): Result[Unit, BootstrapError] = {
     if (!isProjectMode) {
-      return Err(BootstrapError.FileError("No 'flix.toml' found. Refusing to run 'eff-check'"))
+      return Err(BootstrapError.FileError(s"No '$FLIX_TOML' found. Refusing to run 'eff-check'"))
     }
 
     FileOps.exists(Bootstrap.getEffectLockFile(projectPath)) match {
@@ -645,7 +645,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     */
   def lockEffects(flix: Flix): Result[Unit, BootstrapError] = {
     if (!isProjectMode) {
-      return Err(BootstrapError.FileError("No 'flix.toml' found. Refusing to run 'eff-lock'"))
+      return Err(BootstrapError.FileError(s"No '$FLIX_TOML' found. Refusing to run 'eff-lock'"))
     }
     Steps.updateStaleSources(flix)
     for {
@@ -677,7 +677,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
   def clean(): Result[Unit, BootstrapError] = {
     // Ensure project mode
     if (optManifest.isEmpty) {
-      return Err(BootstrapError.FileError("No manifest found ('flix.toml'). Refusing to run 'clean' in a non-project directory."))
+      return Err(BootstrapError.FileError(s"No manifest found ('$FLIX_TOML'). Refusing to run 'clean' in a non-project directory."))
     }
 
     // Ensure `cwd` is not dangerous

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -130,8 +130,8 @@ object Bootstrap {
         |""".stripMargin
     }
 
-    FileOps.newFileIfAbsent(buildAndTestWorkflowFile) {
-      ("""name: Build and Test
+    FileOps.newFileIfAbsent(buildAndTestWorkflowFile) {(
+      """name: Build and Test
         |
         |on:
         |  pull_request:


### PR DESCRIPTION
## Summary
- Replaces three hardcoded `"flix.toml"` literals in `Bootstrap`'s error messages, and two in the scaffolded `build-and-test.yaml` template, with the existing `FLIX_TOML` constant.
- The template splice wraps the concatenation in parens, since `.stripMargin` binds tighter than `+` and would otherwise only strip the trailing segment's margins. Verified byte-for-byte identical generated output before/after.

Does not depend on #13084 (making `FLIX_TOML` public) — every usage here is inside the `Bootstrap` object/class itself, so `private` visibility is sufficient.