### PR TITLE
refactor: use nominal ClassDesc in AtomicOp.InstanceOf

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
@@ -17,6 +17,7 @@ package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.ast.shared.{JField, Mutability}
 
+import java.lang.constant.ClassDesc
 import java.lang.reflect.{Constructor, Method}
 
 /**
@@ -76,7 +77,7 @@ object AtomicOp {
 
   case class StructPut(sym: Symbol.StructFieldSym) extends AtomicOp
 
-  case class InstanceOf(clazz: Class[?]) extends AtomicOp
+  case class InstanceOf(clazz: ClassDesc) extends AtomicOp
 
   case object Cast extends AtomicOp
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -252,6 +252,9 @@ object DocAst {
     def InstanceOf(d: Expr, clazz: Class[?]): Expr =
       Binary(d, "instanceof", Native(clazz))
 
+    def InstanceOf(d: Expr, clazz: ClassDesc): Expr =
+      Binary(d, "instanceof", AsIs(javaClassName(clazz)))
+
     def ClosureLifted(sym: Symbol.DefnSym, ds: List[Expr]): Expr = {
       val defName = AsIs(sym.toString)
       if (ds.isEmpty) defName else App(defName, ds)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -803,11 +803,9 @@ object GenExpression {
         GETSTATIC(BackendObjType.Unit.SingletonField)
 
       case AtomicOp.InstanceOf(clazz) =>
-        import BytecodeInstructions.*
         val List(exp) = exps
-        val jvmName = JvmName.ofClass(clazz)
         compileExpr(exp)
-        INSTANCEOF(jvmName)
+        mv.visitTypeInsn(INSTANCEOF, internalNameOf(clazz))
 
       case AtomicOp.Cast =>
         import BytecodeInstructions.*

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -26,7 +26,7 @@ import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, Den
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoAst, Name, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization.Context
 import ca.uwaterloo.flix.language.phase.monomorph.Symbols.{Defs, Enums, Types}
-import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils, Result}
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, JvmUtils, Result}
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListOps, Nel}
 
 /**
@@ -431,7 +431,7 @@ object Lowering {
         MonoAst.Expr.Stm(List(e), MonoAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc), Type.Bool, e.eff, loc)
       } else {
         // If it's a reference type, then do the instanceof check
-        MonoAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(clazz), List(e), Type.Bool, e.eff, loc)
+        MonoAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(ClassDescs.of(clazz)), List(e), Type.Bool, e.eff, loc)
       }
 
     case TypedAst.Expr.CheckedCast(_, exp, tpe, eff, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -25,7 +25,7 @@ import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, JFi
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoAst, Scheme, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.phase.monomorph2.Specialize.{SpecializationTables, StrictSubstitution, lookupCaseSym, lookupRestrictableCaseSym, lookupStructSym, lookupSym, resolveSigSym, specializeFormalParam, specializeFormalParams}
 import ca.uwaterloo.flix.language.phase.monomorph2.Symbols.{Defs, Enums, Types}
-import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils, Result}
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, JvmUtils, Result}
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListOps, Nel}
 
 /**
@@ -438,7 +438,7 @@ object SpecializeAndLower {
         MonoAst.Expr.Stm(List(e), MonoAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc), Type.Bool, e.eff, loc)
       } else {
         // If it's a reference type, then do the instanceof check
-        MonoAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(clazz), List(e), Type.Bool, e.eff, loc)
+        MonoAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(ClassDescs.of(clazz)), List(e), Type.Bool, e.eff, loc)
       }
 
     case TypedAst.Expr.CheckedCast(_, exp, tpe, eff, loc) =>

--- a/main/src/ca/uwaterloo/flix/util/ClassDescs.scala
+++ b/main/src/ca/uwaterloo/flix/util/ClassDescs.scala
@@ -13,24 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ca.uwaterloo.flix.language.ast.shared
+package ca.uwaterloo.flix.util
 
-import ca.uwaterloo.flix.util.ClassDescs
+import ca.uwaterloo.flix.language.ast.SourceLocation
 
 import java.lang.constant.ClassDesc
-import java.lang.reflect.Field
 
-object JField {
+object ClassDescs {
 
-  /** Returns the [[JField]] of the given reflective `field`. */
-  def of(field: Field): JField =
-    JField(ClassDescs.of(field.getDeclaringClass), field.getName)
+  /**
+    * Returns the [[ClassDesc]] of the given loaded class `clazz`.
+    *
+    * Throws an [[InternalCompilerException]] if `clazz` has no nominal descriptor (e.g. a hidden class).
+    */
+  def of(clazz: Class[?]): ClassDesc =
+    clazz.describeConstable().orElseThrow(() =>
+      InternalCompilerException(s"The class '${clazz.getName}' has no nominal descriptor.", SourceLocation.Unknown)
+    )
 
 }
-
-/**
-  * A nominal reference to the Java field `name` declared by the class `owner`.
-  *
-  * Unlike [[java.lang.reflect.Field]], a [[JField]] does not retain a loaded [[Class]].
-  */
-case class JField(owner: ClassDesc, name: String)


### PR DESCRIPTION
Part of #13091. Follow-up to #13092.

Replaces the `Class[?]` payload of `AtomicOp.InstanceOf` with a `java.lang.constant.ClassDesc`, converted at the construction sites in `Lowering` and `SpecializeAndLower`.

- Codegen emits `INSTANCEOF` directly from the descriptor, deleting one `JvmName.ofClass` call site in `GenExpression`.
- Introduces `ClassDescs.of` in `util` as the single Class-to-ClassDesc conversion (fails eagerly on classes without a nominal descriptor); `JField.of` now uses it instead of its private copy.
- `DocAst.InstanceOf` gains a `ClassDesc` overload; the `Class`-based one remains for the frontend printers.
- The `TypeVerifier` `InstanceOf` case was already payload-blind, so no verifier change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)