### PR TITLE
refactor: use nominal ClassDesc in JvmAnnotation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/shared/JvmAnnotation.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/JvmAnnotation.scala
@@ -17,8 +17,13 @@ package ca.uwaterloo.flix.language.ast.shared
 
 import ca.uwaterloo.flix.language.ast.SourceLocation
 
+import java.lang.constant.ClassDesc
+
 /**
   * Represents a resolved JVM annotation (after name resolution).
   * Used from ResolvedAst through JvmAst.
+  *
+  * `isRuntimeVisible` holds whether the annotation has runtime retention. It is computed
+  * during resolution, where the annotation class is loaded, so the backend needs no reflection.
   */
-case class JvmAnnotation(clazz: java.lang.Class[?], loc: SourceLocation)
+case class JvmAnnotation(clazz: ClassDesc, isRuntimeVisible: Boolean, loc: SourceLocation)

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
@@ -94,6 +94,6 @@ object JvmAstPrinter {
   /** Returns the [[DocAst.JvmMethod]] representation of `method`. */
   private def printJvmMethod(method: JvmAst.JvmMethod): DocAst.JvmMethod = method match {
     case JvmAst.JvmMethod(ann, ident, fparams, exp, tpe, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
+      DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -76,7 +76,7 @@ object LiftedAstPrinter {
       }
       val ms = methods.map {
         case LiftedAst.JvmMethod(ann, ident, fparams, clo, retTpe, _, _) =>
-          DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.map(printFormalParam), print(clo), SimpleTypePrinter.print(retTpe))
+          DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.map(printFormalParam), print(clo), SimpleTypePrinter.print(retTpe))
       }
       DocAst.Expr.NewObject(sym, clazz, SimpleTypePrinter.print(tpe), cs, ms)
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -55,7 +55,7 @@ object MonoAstPrinter {
   /** Returns the [[DocAst.JvmMethod]] representation of `method`. */
   private def printJvmMethod(method: MonoAst.JvmMethod): DocAst.JvmMethod = method match {
     case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
+      DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
   }
 
   /** Returns the [[DocAst]] representation of `rule`. */

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -100,6 +100,6 @@ object ReducedAstPrinter {
     */
   private def printJvmMethod(method: ReducedAst.JvmMethod): DocAst.JvmMethod = method match {
     case ReducedAst.JvmMethod(ann, ident, fparams, exp, tpe, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
+      DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -81,7 +81,7 @@ object SimplifiedAstPrinter {
       }
       val ms = methods.map {
         case SimplifiedAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _) =>
-          DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.map(printFormalParam), print(exp), SimpleTypePrinter.print(retTpe))
+          DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.map(printFormalParam), print(exp), SimpleTypePrinter.print(retTpe))
       }
       DocAst.Expr.NewObject(sym, clazz, SimpleTypePrinter.print(tpe), cs, ms)
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -119,7 +119,7 @@ object TypedAstPrinter {
     */
   private def printJvmMethod(method: TypedAst.JvmMethod): DocAst.JvmMethod = method match {
     case TypedAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.getSimpleName), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
+      DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1764,7 +1764,9 @@ object Resolver {
     lookupJvmClass2(ann.name, ns0, scp0) match {
       case Result.Ok(clazz) =>
         if (clazz.isAnnotation) {
-          Some(JvmAnnotation(clazz, ann.loc))
+          val retention = clazz.getAnnotation(classOf[java.lang.annotation.Retention])
+          val isRuntimeVisible = retention != null && retention.value() == java.lang.annotation.RetentionPolicy.RUNTIME
+          Some(JvmAnnotation(ClassDescs.of(clazz), isRuntimeVisible, ann.loc))
         } else {
           sctx.errors.add(ResolutionError.IllegalNonJavaAnnotation(ann.name.name, ann.loc))
           None

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -61,10 +61,7 @@ sealed trait ClassMaker {
     val m = v.toInt + f.toInt + s.toInt + a.toInt
     val mv = visitor.visitMethod(m, methodName, d.toDescriptor, null, null)
     for (a <- ann) {
-      val descriptor = JvmName.ofClass(a.clazz).toDescriptor
-      val retention = a.clazz.getAnnotation(classOf[java.lang.annotation.Retention])
-      val visible = retention != null && retention.value() == java.lang.annotation.RetentionPolicy.RUNTIME
-      val av = mv.visitAnnotation(descriptor, visible)
+      val av = mv.visitAnnotation(a.clazz.descriptorString(), a.isRuntimeVisible)
       av.visitEnd()
     }
     i match {


### PR DESCRIPTION
Part of #13091. Follow-up to #13093.

Replaces the `Class[?]` payload of `JvmAnnotation` (carried from ResolvedAst through JvmAst) with a `ClassDesc` plus a precomputed `isRuntimeVisible` flag.

- The `Resolver` computes the retention policy at the one place the annotation class is loaded and validated (`isAnnotation`), so the visibility decision moves to the frontend.
- `ClassMaker` emits the annotation directly from `descriptorString()`, deleting a `JvmName.ofClass` call site **and** the backend's reflective `getAnnotation(classOf[Retention])` lookup.
- The AST printers switch from `getSimpleName` to `ClassDesc.displayName()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)