### PR TITLE
refactor: use nominal ClassDesc in SimpleType.Native

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SimpleType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimpleType.scala
@@ -80,7 +80,7 @@ object SimpleType {
   // Compound Types.
   //
 
-  val Object: SimpleType = Native(classOf[java.lang.Object])
+  val Object: SimpleType = Native(java.lang.constant.ConstantDescs.CD_Object)
 
   case class Array(tpe: SimpleType) extends SimpleType
 
@@ -102,7 +102,7 @@ object SimpleType {
 
   case class ExtensibleExtend(cons: Name.Pred, tpes: List[SimpleType], rest: SimpleType) extends SimpleType
 
-  case class Native(clazz: Class[?]) extends SimpleType
+  case class Native(clazz: java.lang.constant.ClassDesc) extends SimpleType
 
   /**
     * Smart constructor for [[SimpleType.Array]].

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -359,7 +359,7 @@ object DocAst {
       Assign(Dot(AsIs(javaClassName(f.owner)), AsIs(f.name)), d)
 
     /** Returns the fully-qualified dotted name of the class descriptor `desc`. */
-    private def javaClassName(desc: ClassDesc): String = {
+    private[dbg] def javaClassName(desc: ClassDesc): String = {
       val pkg = desc.packageName()
       if (pkg.isEmpty) desc.displayName() else s"$pkg.${desc.displayName()}"
     }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimpleTypePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimpleTypePrinter.scala
@@ -17,6 +17,7 @@
 package ca.uwaterloo.flix.language.dbg.printer
 
 import ca.uwaterloo.flix.language.ast.SimpleType
+import ca.uwaterloo.flix.language.dbg.DocAst
 import ca.uwaterloo.flix.language.dbg.DocAst.Type
 
 object SimpleTypePrinter {
@@ -50,7 +51,7 @@ object SimpleTypePrinter {
     case SimpleType.RecordExtend(label, value, rest) => Type.RecordExtend(label, print(value), print(rest))
     case SimpleType.ExtensibleEmpty => Type.ExtensibleEmpty
     case SimpleType.ExtensibleExtend(cons, tpes, rest) => Type.ExtensibleExtend(cons.name, tpes.map(print), print(rest))
-    case SimpleType.Native(clazz) => Type.Native(clazz)
+    case SimpleType.Native(clazz) => Type.AsIs(DocAst.Expr.javaClassName(clazz))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Modifiers, Muta
 import ca.uwaterloo.flix.language.ast.{Purity, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.util.collection.{ListOps, MapOps, Nel}
-import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, ParOps}
 
 import scala.annotation.tailrec
 
@@ -343,7 +343,7 @@ object Simplifier {
             val enumSym = new Symbol.EnumSym(None, sym.namespace, sym.name, sym.loc)
             SimpleType.mkEnum(enumSym, targs.map(visitType))
 
-          case TypeConstructor.Native(clazz) => SimpleType.Native(clazz)
+          case TypeConstructor.Native(clazz) => SimpleType.Native(ClassDescs.of(clazz))
 
           case TypeConstructor.Array =>
             // Remove the region from the array.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -159,7 +159,7 @@ object BackendType {
       case SimpleType.RecordExtend(_, _, _) => BackendObjType.Record.toTpe
       case SimpleType.ExtensibleEmpty => BackendObjType.ExtTagged.toTpe
       case SimpleType.ExtensibleExtend(_, _, _) => BackendObjType.ExtTagged.toTpe
-      case SimpleType.Native(clazz) => BackendObjType.Native(JvmName.ofClass(clazz)).toTpe
+      case SimpleType.Native(clazz) => BackendObjType.Native(JvmName.ofClassDesc(clazz)).toTpe
       case SimpleType.Enum(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe0'", SourceLocation.Unknown)
       case SimpleType.Struct(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe0'", SourceLocation.Unknown)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -82,6 +82,17 @@ object JvmName {
     JvmName(parts.init.toList, parts.last)
   }
 
+  /** Returns the JvmName of the given class or interface descriptor `desc`. */
+  def ofClassDesc(desc: java.lang.constant.ClassDesc): JvmName = {
+    if (desc.isPrimitive) throw InternalCompilerException(s"Cannot create a JvmName from the primitive type '${desc.displayName()}'", SourceLocation.Unknown)
+    if (desc.isArray) throw InternalCompilerException(s"Cannot create a JvmName from the array type '${desc.displayName()}'", SourceLocation.Unknown)
+
+    // Strip the leading `L` and trailing `;` of the descriptor to obtain the internal name.
+    val descriptor = desc.descriptorString()
+    val parts = descriptor.substring(1, descriptor.length - 1).split("/")
+    JvmName(parts.init.toList, parts.last)
+  }
+
   val RootPackage: List[String] = Nil
 
   /**

--- a/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.ReducedAst.*
 import ca.uwaterloo.flix.language.ast.shared.{Constant, Mutability}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, SemanticOp, SimpleType, SourceLocation, Symbol}
 import ca.uwaterloo.flix.util.collection.ListOps
-import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, ParOps}
 
 import scala.annotation.tailrec
 
@@ -435,39 +435,38 @@ object TypeVerifier {
           val List(_) = ts
           check(expected = SimpleType.Unit)(actual = tpe, loc)
 
+        // Note: The Java subtype checks are gone (they need loaded classes, and the AST
+        // moves to nominal descriptors). Only shape and Flix-type checks remain.
         case AtomicOp.Throw =>
-          val List(t) = ts
-          checkJavaSubtype(t, classOf[Throwable], loc)
+          val List(_) = ts
           tpe
 
         case AtomicOp.InstanceOf(_) =>
           val List(t) = ts
-          checkJavaSubtype(t, new Object().getClass, loc) // must not be primitive type
+          checkReferenceType(t, loc)
           check(expected = SimpleType.Bool)(actual = tpe, loc)
 
         case AtomicOp.InvokeConstructor(constructor) =>
-          checkJavaParameters(ts, constructor.getParameterTypes.toList, loc)
-          checkJavaSubtype(tpe, constructor.getDeclaringClass, loc)
+          checkArity(ts, constructor.getParameterCount, loc)
+          tpe
 
         case AtomicOp.InvokeSuperConstructor(constructor) =>
-          checkJavaParameters(ts, constructor.getParameterTypes.toList, loc)
-          checkJavaSubtype(tpe, constructor.getDeclaringClass, loc)
+          checkArity(ts, constructor.getParameterCount, loc)
+          tpe
 
         case AtomicOp.InvokeMethod(method) =>
-          val t :: pts = ts
-          checkJavaParameters(pts, method.getParameterTypes.toList, loc)
-          checkJavaSubtype(t, method.getDeclaringClass, loc)
-          checkJavaSubtype(tpe, method.getReturnType, loc)
+          val _ :: pts = ts
+          checkArity(pts, method.getParameterCount, loc)
+          tpe
 
         case AtomicOp.InvokeSuperMethod(_, method) =>
-          val t :: pts = ts
-          checkJavaParameters(pts, method.getParameterTypes.toList, loc)
-          checkJavaSubtype(t, method.getDeclaringClass, loc)
-          checkJavaSubtype(tpe, method.getReturnType, loc)
+          val _ :: pts = ts
+          checkArity(pts, method.getParameterCount, loc)
+          tpe
 
         case AtomicOp.InvokeStaticMethod(method) =>
-          checkJavaParameters(ts, method.getParameterTypes.toList, loc)
-          checkJavaSubtype(tpe, method.getReturnType, loc)
+          checkArity(ts, method.getParameterCount, loc)
+          tpe
 
         // Vector operations are simplified to array operations in the Simplifier.
         case AtomicOp.VectorLit => throw InternalCompilerException(s"Unexpected vector operation: '$op'.", loc)
@@ -560,7 +559,7 @@ object TypeVerifier {
 
     case Expr.TryCatch(exp, rules, tpe, _, loc) =>
       for (CatchRule(sym, clazz, exp) <- rules) {
-        checkEq(tpe, visitExpr(exp)(root, env + (sym -> SimpleType.Native(clazz)), lenv), exp.loc)
+        checkEq(tpe, visitExpr(exp)(root, env + (sym -> SimpleType.Native(ClassDescs.of(clazz))), lenv), exp.loc)
       }
       val t = visitExpr(exp)
       checkEq(tpe, t, loc)
@@ -599,7 +598,7 @@ object TypeVerifier {
         val signature = SimpleType.mkArrow(m.fparams.map(_.tpe), m.tpe)
         checkEq(signature, exptype, m.loc)
       }
-      checkEq(tpe, SimpleType.Native(clazz), loc)
+      checkEq(tpe, SimpleType.Native(ClassDescs.of(clazz)), loc)
 
   }
 
@@ -622,13 +621,21 @@ object TypeVerifier {
   }
 
   /**
-    * Asserts that the list of types `ts` matches the list of java classes `cs`
+    * Asserts that the list of types `ts` has exactly `arity` elements.
     */
-  private def checkJavaParameters(ts: List[SimpleType], cs: List[Class[?]], loc: SourceLocation): Unit = {
-    ListOps.zipOption(ts, cs) match {
-      case None => throw InternalCompilerException("Number of types in constructor call mismatch with parameter list", loc)
-      case Some(zipped) => zipped.foreach { case (tp, klazz) => checkJavaSubtype(tp, klazz, loc) }
-    }
+  private def checkArity(ts: List[SimpleType], arity: Int, loc: SourceLocation): Unit = {
+    if (ts.length != arity)
+      throw InternalCompilerException(s"Number of argument types (${ts.length}) mismatch with parameter count ($arity)", loc)
+  }
+
+  /**
+    * Asserts that `tpe` is represented as a reference (non-primitive) type at runtime.
+    */
+  private def checkReferenceType(tpe: SimpleType, loc: SourceLocation): Unit = tpe match {
+    case SimpleType.Bool | SimpleType.Char | SimpleType.Int8 | SimpleType.Int16 |
+         SimpleType.Int32 | SimpleType.Int64 | SimpleType.Float32 | SimpleType.Float64 =>
+      failMismatchedShape(tpe, "a reference type", loc)
+    case _ => ()
   }
 
   /**
@@ -641,78 +648,6 @@ object TypeVerifier {
           throw InternalCompilerException(s"Expected struct type $sym0, got struct type $sym", loc)
         }
       case _ => failMismatchedShape(tpe, "Struct", loc)
-    }
-  }
-
-  /**
-    * Asserts that `tpe` is a subtype of the java class type `klazz`.
-    */
-  private def checkJavaSubtype(tpe: SimpleType, klazz: Class[?], loc: SourceLocation): SimpleType = {
-    if (isJavaSubtype(tpe, klazz))
-      tpe
-    else
-      failMismatchedTypes(tpe, klazz, loc)
-  }
-
-  /**
-    * Returns `true` if `tpe` is a subtype of the java class type `klazz`.
-    */
-  private def isJavaSubtype(tpe: SimpleType, klazz: Class[?]): Boolean = {
-    tpe match {
-      case SimpleType.Array(elmt) =>
-        (klazz.isArray && isJavaSubtype(elmt, klazz.getComponentType)) || klazz == classOf[Object]
-
-      case SimpleType.Native(k) => klazz.isAssignableFrom(k)
-
-      case SimpleType.Int8 => klazz == classOf[Byte]
-      case SimpleType.Int16 => klazz == classOf[Short]
-      case SimpleType.Int32 => klazz == classOf[Int]
-      case SimpleType.Int64 => klazz == classOf[Long]
-      case SimpleType.Float32 => klazz == classOf[Float]
-      case SimpleType.Float64 => klazz == classOf[Double]
-      case SimpleType.Bool => klazz == classOf[Boolean]
-      case SimpleType.Char => klazz == classOf[Char]
-      // Unit is represented as a reference (the Unit singleton) at runtime, so it is a
-      // subtype of any non-primitive Java type, e.g. the erased `Object` return of a
-      // generic interface method implemented by an anonymous class.
-      case SimpleType.Unit => klazz == classOf[Unit] || !klazz.isPrimitive
-      case SimpleType.Null => !klazz.isPrimitive
-
-      case SimpleType.String => klazz.isAssignableFrom(classOf[java.lang.String])
-      case SimpleType.BigInt => klazz.isAssignableFrom(classOf[java.math.BigInteger])
-      case SimpleType.BigDecimal => klazz.isAssignableFrom(classOf[java.math.BigDecimal])
-      case SimpleType.Regex => klazz.isAssignableFrom(classOf[java.util.regex.Pattern])
-      case SimpleType.Arrow(List(SimpleType.Object), SimpleType.Unit) => klazz.isAssignableFrom(classOf[java.util.function.Consumer[Object]])
-      case SimpleType.Arrow(List(SimpleType.Object), SimpleType.Bool) => klazz.isAssignableFrom(classOf[java.util.function.Predicate[Object]])
-      case SimpleType.Arrow(List(SimpleType.Int32), SimpleType.Unit) => klazz.isAssignableFrom(classOf[java.util.function.IntConsumer])
-      case SimpleType.Arrow(List(SimpleType.Int32), SimpleType.Object) => klazz.isAssignableFrom(classOf[java.util.function.IntFunction[Object]])
-      case SimpleType.Arrow(List(SimpleType.Int32), SimpleType.Bool) => klazz.isAssignableFrom(classOf[java.util.function.IntPredicate])
-      case SimpleType.Arrow(List(SimpleType.Int32), SimpleType.Int32) => klazz.isAssignableFrom(classOf[java.util.function.IntUnaryOperator])
-      case SimpleType.Arrow(List(SimpleType.Int64), SimpleType.Unit) => klazz.isAssignableFrom(classOf[java.util.function.LongConsumer])
-      case SimpleType.Arrow(List(SimpleType.Int64), SimpleType.Object) => klazz.isAssignableFrom(classOf[java.util.function.LongFunction[Object]])
-      case SimpleType.Arrow(List(SimpleType.Int64), SimpleType.Bool) => klazz.isAssignableFrom(classOf[java.util.function.LongPredicate])
-      case SimpleType.Arrow(List(SimpleType.Int64), SimpleType.Int64) => klazz.isAssignableFrom(classOf[java.util.function.LongUnaryOperator])
-      case SimpleType.Arrow(List(SimpleType.Float64), SimpleType.Unit) => klazz.isAssignableFrom(classOf[java.util.function.DoubleConsumer])
-      case SimpleType.Arrow(List(SimpleType.Float64), SimpleType.Object) => klazz.isAssignableFrom(classOf[java.util.function.DoubleFunction[Object]])
-      case SimpleType.Arrow(List(SimpleType.Float64), SimpleType.Bool) => klazz.isAssignableFrom(classOf[java.util.function.DoublePredicate])
-      case SimpleType.Arrow(List(SimpleType.Float64), SimpleType.Float64) => klazz.isAssignableFrom(classOf[java.util.function.DoubleUnaryOperator])
-
-      case SimpleType.AnyType => klazz == classOf[Object]
-
-      // Every Flix reference type (enums, tuples, structs, records, lazies, lambdas, lists,
-      // BigInt, ...) is represented as a reference (an object) at runtime, so it is a subtype of
-      // `java.lang.Object`
-      case SimpleType.Arrow(_, _) => klazz == classOf[Object]
-      case SimpleType.Void => klazz == classOf[Object]
-      case SimpleType.Region => klazz == classOf[Object]
-      case SimpleType.Lazy(_) => klazz == classOf[Object]
-      case SimpleType.Tuple(_) => klazz == classOf[Object]
-      case SimpleType.Enum(_, _) => klazz == classOf[Object]
-      case SimpleType.Struct(_, _) => klazz == classOf[Object]
-      case SimpleType.RecordEmpty => klazz == classOf[Object]
-      case SimpleType.RecordExtend(_, _, _) => klazz == classOf[Object]
-      case SimpleType.ExtensibleEmpty => klazz == classOf[Object]
-      case SimpleType.ExtensibleExtend(_, _, _) => klazz == classOf[Object]
     }
   }
 


### PR DESCRIPTION
Part of #13091. Follow-up to #13094.

Replaces the `Class[?]` payload of `SimpleType.Native` with a `java.lang.constant.ClassDesc`, converted once at the `Simplifier` (the only construction site); `SimpleType.Object` becomes `Native(CD_Object)`. Taken **before** the `CatchRule` slice: the `TypeVerifier` binds catch variables as `SimpleType.Native` built from the `CatchRule` payload, so the type language had to go nominal first.

- `BackendType` builds backend names via a new `JvmName.ofClassDesc` (a direct constructor — the target type is `JvmName`, so no round-trip).
- `SimpleTypePrinter` prints the descriptor's dotted name.
- The `TypeVerifier`'s Java subtype machinery (`checkJavaSubtype`/`isJavaSubtype`, ~90 lines) needed loaded classes throughout and is deleted per the strip-as-we-go decision; the `Throw`/`InstanceOf`/invoke/constructor cases keep arity and shape checks (`checkArity`, `checkReferenceType`), and `TryCatch`/`NewObject` convert their still-reflective payloads with `ClassDescs.of`.

Net: −53 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)