### PR TITLE
refactor: use nominal JMethod in AtomicOp.InvokeStaticMethod

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.ast.shared.{JField, Mutability}
+import ca.uwaterloo.flix.language.ast.shared.{JField, JMethod, Mutability}
 
 import java.lang.constant.ClassDesc
 import java.lang.reflect.{Constructor, Method}
@@ -93,7 +93,7 @@ object AtomicOp {
 
   case class InvokeSuperMethod(sym: Symbol.AnonClassSym, method: Method) extends AtomicOp
 
-  case class InvokeStaticMethod(method: Method) extends AtomicOp
+  case class InvokeStaticMethod(method: JMethod) extends AtomicOp
 
   case class GetField(field: JField) extends AtomicOp
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/JMethod.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/JMethod.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.ast.shared
+
+import ca.uwaterloo.flix.util.ClassDescs
+
+import java.lang.constant.{ClassDesc, MethodTypeDesc}
+import java.lang.reflect.Method
+
+object JMethod {
+
+  /** Returns the [[JMethod]] of the given reflective `method`. */
+  def of(method: Method): JMethod = {
+    val paramDescs = method.getParameterTypes.map(ClassDescs.of)
+    val descriptor = MethodTypeDesc.of(ClassDescs.of(method.getReturnType), paramDescs: _*)
+    JMethod(ClassDescs.of(method.getDeclaringClass), method.getName, descriptor, method.getDeclaringClass.isInterface)
+  }
+
+}
+
+/**
+  * A nominal reference to the Java method `name` declared by the class or interface `owner`
+  * with the given method type `descriptor`.
+  *
+  * `isInterface` holds whether `owner` is an interface; the JVM needs the distinction to
+  * emit method invocations.
+  *
+  * Unlike [[java.lang.reflect.Method]], a [[JMethod]] does not retain a loaded [[Class]].
+  */
+case class JMethod(owner: ClassDesc, name: String, descriptor: MethodTypeDesc, isInterface: Boolean)

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -328,6 +328,10 @@ object DocAst {
       App(Dot(Native(m.getDeclaringClass), AsIs(m.getName)), ds)
     }
 
+    def JavaInvokeStaticMethod(m: JMethod, ds: List[Expr]): Expr = {
+      App(Dot(AsIs(javaClassName(m.owner)), AsIs(m.name)), ds)
+    }
+
     def JavaGetStaticField(f: Field): Expr = {
       Dot(Native(f.getDeclaringClass), AsIs(f.getName))
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -30,6 +30,8 @@ import org.objectweb.asm
 import org.objectweb.asm.*
 import org.objectweb.asm.Opcodes.*
 
+import scala.jdk.CollectionConverters.*
+
 /**
   * Generate expression
   */
@@ -936,20 +938,13 @@ object GenExpression {
       case AtomicOp.InvokeStaticMethod(method) =>
         // Add source line number for debugging (can fail when calling unsafe java methods)
         BytecodeInstructions.addLoc(loc)
-        for ((arg, argType) <- exps.zip(method.getParameterTypes)) {
+        for ((arg, argType) <- exps.zip(method.descriptor.parameterList.asScala)) {
           compileExpr(arg)
-          if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
+          if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, internalNameOf(argType))
         }
-        val declaration = asm.Type.getInternalName(method.getDeclaringClass)
-        val name = method.getName
-        val descriptor = asm.Type.getMethodDescriptor(method)
-        // Check if we are invoking an interface or class.
-        if (method.getDeclaringClass.isInterface) {
-          mv.visitMethodInsn(INVOKESTATIC, declaration, name, descriptor, true)
-        } else {
-          mv.visitMethodInsn(INVOKESTATIC, declaration, name, descriptor, false)
-        }
-        if (asm.Type.getType(method.getReturnType) == asm.Type.VOID_TYPE) {
+        val declaration = internalNameOf(method.owner)
+        mv.visitMethodInsn(INVOKESTATIC, declaration, method.name, method.descriptor.descriptorString(), method.isInterface)
+        if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
           mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
         }
 
@@ -1633,11 +1628,19 @@ object GenExpression {
 
   }
 
-  /** Returns the JVM internal name of the class or interface descriptor `desc`, e.g. `java/lang/String`. */
+  /**
+    * Returns the JVM internal name of the class, interface, or array descriptor `desc`,
+    * e.g. `java/lang/String` or `[Ljava/lang/String;`.
+    */
   private def internalNameOf(desc: java.lang.constant.ClassDesc): String = {
-    // Strip the leading `L` and trailing `;` of the descriptor.
-    val descriptor = desc.descriptorString()
-    descriptor.substring(1, descriptor.length - 1)
+    if (desc.isArray) {
+      // The internal name of an array type is its descriptor.
+      desc.descriptorString()
+    } else {
+      // Strip the leading `L` and trailing `;` of the descriptor.
+      val descriptor = desc.descriptorString()
+      descriptor.substring(1, descriptor.length - 1)
+    }
   }
 
   private def getStructType(struct: Struct)(implicit root: Root): BackendObjType.Struct = {

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.{DefaultHandler, Predicate}
 import ca.uwaterloo.flix.language.ast.MonoAst.{DefContext, Occur}
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.TypedAst.ApplyPosition
-import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, Denotation, Fixity, JField, Mutability, Polarity, PredicateAndArity, RegionScope, SolveMode, SymUse, TypeSource}
+import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, Denotation, Fixity, JField, JMethod, Mutability, Polarity, PredicateAndArity, RegionScope, SolveMode, SymUse, TypeSource}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoAst, Name, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization.Context
 import ca.uwaterloo.flix.language.phase.monomorph.Symbols.{Defs, Enums, Types}
@@ -535,7 +535,7 @@ object Lowering {
       val javaReturnType = method.getReturnType
       val needsUnbox = isPrimType(t) && !javaReturnType.isPrimitive
       val invokeType = if (needsUnbox) boxedWrapperType(t, loc) else t
-      val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeStaticMethod(method), boxedArgs, invokeType, eff, loc)
+      val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeStaticMethod(JMethod.of(method)), boxedArgs, invokeType, eff, loc)
       unboxIfNecessary(invoke, t, javaReturnType)
 
     case TypedAst.Expr.GetField(field, exp, tpe, eff, loc) =>
@@ -1032,16 +1032,21 @@ object Lowering {
     * Returns the `valueOf` boxing method for a Flix primitive type.
     * This is the same mechanism javac uses to implement autoboxing.
     */
-  private def javaBoxMethod(tpe: Type): java.lang.reflect.Method = tpe match {
-    case Type.Bool => classOf[java.lang.Boolean].getMethod("valueOf", java.lang.Boolean.TYPE)
-    case Type.Char => classOf[java.lang.Character].getMethod("valueOf", java.lang.Character.TYPE)
-    case Type.Int8 => classOf[java.lang.Byte].getMethod("valueOf", java.lang.Byte.TYPE)
-    case Type.Int16 => classOf[java.lang.Short].getMethod("valueOf", java.lang.Short.TYPE)
-    case Type.Int32 => classOf[java.lang.Integer].getMethod("valueOf", java.lang.Integer.TYPE)
-    case Type.Int64 => classOf[java.lang.Long].getMethod("valueOf", java.lang.Long.TYPE)
-    case Type.Float32 => classOf[java.lang.Float].getMethod("valueOf", java.lang.Float.TYPE)
-    case Type.Float64 => classOf[java.lang.Double].getMethod("valueOf", java.lang.Double.TYPE)
-    case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+  private def javaBoxMethod(tpe: Type): JMethod = {
+    import java.lang.constant.ConstantDescs.*
+    def valueOf(box: java.lang.constant.ClassDesc, prim: java.lang.constant.ClassDesc): JMethod =
+      JMethod(box, "valueOf", java.lang.constant.MethodTypeDesc.of(box, prim), isInterface = false)
+    tpe match {
+      case Type.Bool => valueOf(CD_Boolean, CD_boolean)
+      case Type.Char => valueOf(CD_Character, CD_char)
+      case Type.Int8 => valueOf(CD_Byte, CD_byte)
+      case Type.Int16 => valueOf(CD_Short, CD_short)
+      case Type.Int32 => valueOf(CD_Integer, CD_int)
+      case Type.Int64 => valueOf(CD_Long, CD_long)
+      case Type.Float32 => valueOf(CD_Float, CD_float)
+      case Type.Float64 => valueOf(CD_Double, CD_double)
+      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.MonoAst.{DefContext, Occur}
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.TypedAst.{ApplyPosition, DefaultHandler}
-import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, JField, Mutability, RegionScope, SymUse, TypeSource}
+import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, JField, JMethod, Mutability, RegionScope, SymUse, TypeSource}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoAst, Scheme, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.phase.monomorph2.Specialize.{SpecializationTables, StrictSubstitution, lookupCaseSym, lookupRestrictableCaseSym, lookupStructSym, lookupSym, resolveSigSym, specializeFormalParam, specializeFormalParams}
 import ca.uwaterloo.flix.language.phase.monomorph2.Symbols.{Defs, Enums, Types}
@@ -526,7 +526,7 @@ object SpecializeAndLower {
     case TypedAst.Expr.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp(_, env0, subst))
       val t = visitType(tpe, subst)
-      mkJavaInvoke(method, Nil, es, t, subst(eff), loc, AtomicOp.InvokeStaticMethod.apply)
+      mkJavaInvoke(method, Nil, es, t, subst(eff), loc, m => AtomicOp.InvokeStaticMethod(JMethod.of(m)))
 
     case TypedAst.Expr.GetField(field, exp, tpe, eff, loc) =>
       val e = visitExp(exp, env0, subst)
@@ -1086,16 +1086,21 @@ object SpecializeAndLower {
     * Returns the `valueOf` boxing method for a Flix primitive type.
     * This is the same mechanism javac uses to implement autoboxing.
     */
-  private def javaBoxMethod(tpe: Type): java.lang.reflect.Method = tpe match {
-    case Type.Bool => classOf[java.lang.Boolean].getMethod("valueOf", java.lang.Boolean.TYPE)
-    case Type.Char => classOf[java.lang.Character].getMethod("valueOf", java.lang.Character.TYPE)
-    case Type.Int8 => classOf[java.lang.Byte].getMethod("valueOf", java.lang.Byte.TYPE)
-    case Type.Int16 => classOf[java.lang.Short].getMethod("valueOf", java.lang.Short.TYPE)
-    case Type.Int32 => classOf[java.lang.Integer].getMethod("valueOf", java.lang.Integer.TYPE)
-    case Type.Int64 => classOf[java.lang.Long].getMethod("valueOf", java.lang.Long.TYPE)
-    case Type.Float32 => classOf[java.lang.Float].getMethod("valueOf", java.lang.Float.TYPE)
-    case Type.Float64 => classOf[java.lang.Double].getMethod("valueOf", java.lang.Double.TYPE)
-    case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+  private def javaBoxMethod(tpe: Type): JMethod = {
+    import java.lang.constant.ConstantDescs.*
+    def valueOf(box: java.lang.constant.ClassDesc, prim: java.lang.constant.ClassDesc): JMethod =
+      JMethod(box, "valueOf", java.lang.constant.MethodTypeDesc.of(box, prim), isInterface = false)
+    tpe match {
+      case Type.Bool => valueOf(CD_Boolean, CD_boolean)
+      case Type.Char => valueOf(CD_Character, CD_char)
+      case Type.Int8 => valueOf(CD_Byte, CD_byte)
+      case Type.Int16 => valueOf(CD_Short, CD_short)
+      case Type.Int32 => valueOf(CD_Integer, CD_int)
+      case Type.Int64 => valueOf(CD_Long, CD_long)
+      case Type.Float32 => valueOf(CD_Float, CD_float)
+      case Type.Float64 => valueOf(CD_Double, CD_double)
+      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+    }
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
@@ -465,7 +465,7 @@ object TypeVerifier {
           tpe
 
         case AtomicOp.InvokeStaticMethod(method) =>
-          checkArity(ts, method.getParameterCount, loc)
+          checkArity(ts, method.descriptor.parameterCount(), loc)
           tpe
 
         // Vector operations are simplified to array operations in the Simplifier.


### PR DESCRIPTION
Part of #13091. Follow-up to #13096.

Introduces `JMethod(owner: ClassDesc, name: String, descriptor: MethodTypeDesc, isInterface: Boolean)` — the last new wrapper type of the ladder — and swaps it into `InvokeStaticMethod`, converted at the construction sites in both monomorphizers.

- The `javaBoxMethod` tables in `Lowering` and `SpecializeAndLower` now build `JMethod` constants from `ConstantDescs` (`CD_Integer`/`CD_int`, ...), deleting their reflective `getMethod` lookups.
- `GenExpression` emits `INVOKESTATIC` directly from the descriptor string, with the itf flag from the precomputed `isInterface` bit; `internalNameOf` now also handles array descriptors for argument `CHECKCAST`s.
- `DocAst` gains a `JMethod` overload for `JavaInvokeStaticMethod`; the verifier's arity check reads `descriptor.parameterCount()`.

Smoke-tested: plain static call, static interface method (`Map.entry`, exercising the itf flag), and the boxing path (`Objects.hashCode(42)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)