### PR TITLE
refactor: use nominal JMethod in AtomicOp.InvokeMethod

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
@@ -89,7 +89,7 @@ object AtomicOp {
 
   case class InvokeSuperConstructor(constructor: Constructor[?]) extends AtomicOp
 
-  case class InvokeMethod(method: Method) extends AtomicOp
+  case class InvokeMethod(method: JMethod) extends AtomicOp
 
   case class InvokeSuperMethod(sym: Symbol.AnonClassSym, method: Method) extends AtomicOp
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -324,6 +324,9 @@ object DocAst {
     def JavaInvokeMethod(m: Method, d: Expr, ds: List[Expr]): Expr =
       App(DoubleDot(d, AsIs(m.getName)), ds)
 
+    def JavaInvokeMethod(m: JMethod, d: Expr, ds: List[Expr]): Expr =
+      App(DoubleDot(d, AsIs(m.name)), ds)
+
     def JavaInvokeStaticMethod(m: Method, ds: List[Expr]): Expr = {
       App(Dot(Native(m.getDeclaringClass), AsIs(m.getName)), ds)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.shared.SymUse.CaseSymUse
-import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Modifiers, Mutability, RegionScope}
+import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, JMethod, Modifiers, Mutability, RegionScope}
 import ca.uwaterloo.flix.language.ast.{Purity, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.util.collection.{ListOps, MapOps, Nel}
@@ -33,6 +33,24 @@ object Simplifier {
 
   // We are safe to use the top scope everywhere because we do not use unification in this or future phases.
   private implicit val S: RegionScope = RegionScope.Top
+
+  /** The `String.concat(String)` method. */
+  private val StringConcatMethod: JMethod = {
+    import java.lang.constant.ConstantDescs.*
+    JMethod(CD_String, "concat", java.lang.constant.MethodTypeDesc.of(CD_String, CD_String), isInterface = false)
+  }
+
+  /** The `String.equals(Object)` method. */
+  private val StringEqualsMethod: JMethod = {
+    import java.lang.constant.ConstantDescs.*
+    JMethod(CD_String, "equals", java.lang.constant.MethodTypeDesc.of(CD_boolean, CD_Object), isInterface = false)
+  }
+
+  /** The `BigInteger.equals(Object)` method. */
+  private val BigIntEqualsMethod: JMethod = {
+    import java.lang.constant.ConstantDescs.*
+    JMethod(java.lang.constant.ClassDesc.of("java.math.BigInteger"), "equals", java.lang.constant.MethodTypeDesc.of(CD_boolean, CD_Object), isInterface = false)
+  }
 
   def run(root: MonoAst.Root)(implicit flix: Flix): SimplifiedAst.Root = flix.phase("Simplifier") {
     implicit val universe: Set[Symbol.EffSym] = root.effects.keys.toSet
@@ -125,10 +143,8 @@ object Simplifier {
       op match {
         case AtomicOp.Binary(SemanticOp.StringOp.Concat) =>
           // Translate to InvokeMethod exp
-          val strClass = Class.forName("java.lang.String")
-          val method = strClass.getMethod("concat", strClass)
           val t = visitType(tpe)
-          SimplifiedAst.Expr.ApplyAtomic(AtomicOp.InvokeMethod(method), es, t, purity, loc)
+          SimplifiedAst.Expr.ApplyAtomic(AtomicOp.InvokeMethod(StringConcatMethod), es, t, purity, loc)
 
         case AtomicOp.ArrayLit | AtomicOp.ArrayNew =>
           // The region expression is dropped (head of exps / es)
@@ -674,17 +690,11 @@ object Simplifier {
         return SimplifiedAst.Expr.Cst(Constant.Bool(true), SimpleType.Bool, loc)
 
       case (SimpleType.String, _) =>
-        val strClass = Class.forName("java.lang.String")
-        val objClass = Class.forName("java.lang.Object")
-        val method = strClass.getMethod("equals", objClass)
-        val op = AtomicOp.InvokeMethod(method)
+        val op = AtomicOp.InvokeMethod(StringEqualsMethod)
         return SimplifiedAst.Expr.ApplyAtomic(op, List(e1, e2), SimpleType.Bool, Purity.combine(e1.purity, e2.purity), loc)
 
       case (SimpleType.BigInt, _) =>
-        val bigIntClass = Class.forName("java.math.BigInteger")
-        val objClass = Class.forName("java.lang.Object")
-        val method = bigIntClass.getMethod("equals", objClass)
-        val op = AtomicOp.InvokeMethod(method)
+        val op = AtomicOp.InvokeMethod(BigIntEqualsMethod)
         return SimplifiedAst.Expr.ApplyAtomic(op, List(e1, e2), SimpleType.Bool, Purity.combine(e1.purity, e2.purity), loc)
 
       case _ => // fallthrough

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -883,27 +883,23 @@ object GenExpression {
 
         // Evaluate the receiver object.
         compileExpr(exp)
-        val thisType = asm.Type.getInternalName(method.getDeclaringClass)
-        mv.visitTypeInsn(CHECKCAST, thisType)
+        val declaration = internalNameOf(method.owner)
+        mv.visitTypeInsn(CHECKCAST, declaration)
 
-        for ((arg, argType) <- args.zip(method.getParameterTypes)) {
+        for ((arg, argType) <- args.zip(method.descriptor.parameterList.asScala)) {
           compileExpr(arg)
-          if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
+          if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, internalNameOf(argType))
         }
 
-        val declaration = asm.Type.getInternalName(method.getDeclaringClass)
-        val name = method.getName
-        val descriptor = asm.Type.getMethodDescriptor(method)
-
         // Check if we are invoking an interface or class.
-        if (method.getDeclaringClass.isInterface) {
-          mv.visitMethodInsn(INVOKEINTERFACE, declaration, name, descriptor, true)
+        if (method.isInterface) {
+          mv.visitMethodInsn(INVOKEINTERFACE, declaration, method.name, method.descriptor.descriptorString(), true)
         } else {
-          mv.visitMethodInsn(INVOKEVIRTUAL, declaration, name, descriptor, false)
+          mv.visitMethodInsn(INVOKEVIRTUAL, declaration, method.name, method.descriptor.descriptorString(), false)
         }
 
         // If the method is void, put a unit on top of the stack
-        if (asm.Type.getType(method.getReturnType) == asm.Type.VOID_TYPE) {
+        if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
           mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
         }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -513,7 +513,7 @@ object Lowering {
       val javaReturnType = method.getReturnType
       val needsUnbox = isPrimType(t) && !javaReturnType.isPrimitive
       val invokeType = if (needsUnbox) boxedWrapperType(t, loc) else t
-      val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeMethod(method), e :: boxedArgs, invokeType, eff, loc)
+      val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeMethod(JMethod.of(method)), e :: boxedArgs, invokeType, eff, loc)
       unboxIfNecessary(invoke, t, javaReturnType)
 
     case TypedAst.Expr.InvokeSuperMethod(method, exps, tpe, eff, loc) =>
@@ -1053,16 +1053,21 @@ object Lowering {
     * Returns the unboxing method (e.g., `intValue`) for a Flix primitive type.
     * This is the same mechanism javac uses to implement auto-unboxing.
     */
-  private def javaUnboxMethod(tpe: Type): java.lang.reflect.Method = tpe match {
-    case Type.Bool => classOf[java.lang.Boolean].getMethod("booleanValue")
-    case Type.Char => classOf[java.lang.Character].getMethod("charValue")
-    case Type.Int8 => classOf[java.lang.Byte].getMethod("byteValue")
-    case Type.Int16 => classOf[java.lang.Short].getMethod("shortValue")
-    case Type.Int32 => classOf[java.lang.Integer].getMethod("intValue")
-    case Type.Int64 => classOf[java.lang.Long].getMethod("longValue")
-    case Type.Float32 => classOf[java.lang.Float].getMethod("floatValue")
-    case Type.Float64 => classOf[java.lang.Double].getMethod("doubleValue")
-    case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+  private def javaUnboxMethod(tpe: Type): JMethod = {
+    import java.lang.constant.ConstantDescs.*
+    def unbox(box: java.lang.constant.ClassDesc, name: String, prim: java.lang.constant.ClassDesc): JMethod =
+      JMethod(box, name, java.lang.constant.MethodTypeDesc.of(prim), isInterface = false)
+    tpe match {
+      case Type.Bool => unbox(CD_Boolean, "booleanValue", CD_boolean)
+      case Type.Char => unbox(CD_Character, "charValue", CD_char)
+      case Type.Int8 => unbox(CD_Byte, "byteValue", CD_byte)
+      case Type.Int16 => unbox(CD_Short, "shortValue", CD_short)
+      case Type.Int32 => unbox(CD_Integer, "intValue", CD_int)
+      case Type.Int64 => unbox(CD_Long, "longValue", CD_long)
+      case Type.Float32 => unbox(CD_Float, "floatValue", CD_float)
+      case Type.Float64 => unbox(CD_Double, "doubleValue", CD_double)
+      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+    }
   }
 
   /**
@@ -1126,8 +1131,8 @@ object Lowering {
   }
 
   /** Returns `true` if `method` is a Java auto-unboxing method (e.g., `intValue`, `booleanValue`). */
-  private def isAutoUnboxMethod(method: java.lang.reflect.Method): Boolean = {
-    method.getParameterCount == 0 && (method.getName match {
+  private def isAutoUnboxMethod(method: JMethod): Boolean = {
+    method.descriptor.parameterCount() == 0 && (method.name match {
       case "booleanValue" | "charValue" | "byteValue" | "shortValue" |
            "intValue" | "longValue" | "floatValue" | "doubleValue" => true
       case _ => false

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -511,7 +511,7 @@ object SpecializeAndLower {
       val e = visitExp(exp, env0, subst)
       val es = exps.map(visitExp(_, env0, subst))
       val t = visitType(tpe, subst)
-      mkJavaInvoke(method, List(e), es, t, subst(eff), loc, AtomicOp.InvokeMethod.apply)
+      mkJavaInvoke(method, List(e), es, t, subst(eff), loc, m => AtomicOp.InvokeMethod(JMethod.of(m)))
 
     case TypedAst.Expr.InvokeSuperMethod(method, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp(_, env0, subst))
@@ -1107,16 +1107,21 @@ object SpecializeAndLower {
     * Returns the unboxing method (e.g., `intValue`) for a Flix primitive type.
     * This is the same mechanism javac uses to implement auto-unboxing.
     */
-  private def javaUnboxMethod(tpe: Type): java.lang.reflect.Method = tpe match {
-    case Type.Bool => classOf[java.lang.Boolean].getMethod("booleanValue")
-    case Type.Char => classOf[java.lang.Character].getMethod("charValue")
-    case Type.Int8 => classOf[java.lang.Byte].getMethod("byteValue")
-    case Type.Int16 => classOf[java.lang.Short].getMethod("shortValue")
-    case Type.Int32 => classOf[java.lang.Integer].getMethod("intValue")
-    case Type.Int64 => classOf[java.lang.Long].getMethod("longValue")
-    case Type.Float32 => classOf[java.lang.Float].getMethod("floatValue")
-    case Type.Float64 => classOf[java.lang.Double].getMethod("doubleValue")
-    case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+  private def javaUnboxMethod(tpe: Type): JMethod = {
+    import java.lang.constant.ConstantDescs.*
+    def unbox(box: java.lang.constant.ClassDesc, name: String, prim: java.lang.constant.ClassDesc): JMethod =
+      JMethod(box, name, java.lang.constant.MethodTypeDesc.of(prim), isInterface = false)
+    tpe match {
+      case Type.Bool => unbox(CD_Boolean, "booleanValue", CD_boolean)
+      case Type.Char => unbox(CD_Character, "charValue", CD_char)
+      case Type.Int8 => unbox(CD_Byte, "byteValue", CD_byte)
+      case Type.Int16 => unbox(CD_Short, "shortValue", CD_short)
+      case Type.Int32 => unbox(CD_Integer, "intValue", CD_int)
+      case Type.Int64 => unbox(CD_Long, "longValue", CD_long)
+      case Type.Float32 => unbox(CD_Float, "floatValue", CD_float)
+      case Type.Float64 => unbox(CD_Double, "doubleValue", CD_double)
+      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+    }
   }
 
   /**
@@ -1198,8 +1203,8 @@ object SpecializeAndLower {
   }
 
   /** Returns `true` if `method` is a Java auto-unboxing method (e.g., `intValue`, `booleanValue`). */
-  private def isAutoUnboxMethod(method: java.lang.reflect.Method): Boolean = {
-    method.getParameterCount == 0 && (method.getName match {
+  private def isAutoUnboxMethod(method: JMethod): Boolean = {
+    method.descriptor.parameterCount() == 0 && (method.name match {
       case "booleanValue" => true
       case "charValue"    => true
       case "byteValue"    => true

--- a/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
@@ -456,7 +456,7 @@ object TypeVerifier {
 
         case AtomicOp.InvokeMethod(method) =>
           val _ :: pts = ts
-          checkArity(pts, method.getParameterCount, loc)
+          checkArity(pts, method.descriptor.parameterCount(), loc)
           tpe
 
         case AtomicOp.InvokeSuperMethod(_, method) =>


### PR DESCRIPTION
Part of #13091. Follow-up to #13098.

Swaps the `InvokeMethod` payload to `JMethod`, converted at the construction sites in both monomorphizers.

- The `javaUnboxMethod` tables (`intValue`, ...) become `ConstantDescs`-built `JMethod` constants; `stripAutoUnbox`/`isAutoUnboxMethod` port to `MethodTypeDesc` queries.
- The `Simplifier`'s well-known methods — `String.concat`, `String.equals`, `BigInteger.equals` — become static `JMethod` constants, deleting their compile-time `Class.forName`/`getMethod` reflection.
- `GenExpression` emits `INVOKEVIRTUAL`/`INVOKEINTERFACE` from the descriptor string with the precomputed `isInterface` bit; receiver and argument `CHECKCAST`s come from the descriptor.

Smoke-tested: string concat/equality, BigInt equality, void instance call, box-on-add/unbox-on-get round-trip, and interface dispatch via a `List[Int32]` receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)