### PR TITLE
refactor: use nominal JConstructor in constructor operations

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
@@ -15,10 +15,10 @@
  */
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.ast.shared.{JField, JMethod, Mutability}
+import ca.uwaterloo.flix.language.ast.shared.{JConstructor, JField, JMethod, Mutability}
 
 import java.lang.constant.ClassDesc
-import java.lang.reflect.{Constructor, Method}
+import java.lang.reflect.Method
 
 /**
   * A common super-type for control pure expressions.
@@ -85,9 +85,9 @@ object AtomicOp {
 
   case object Box extends AtomicOp
 
-  case class InvokeConstructor(constructor: Constructor[?]) extends AtomicOp
+  case class InvokeConstructor(constructor: JConstructor) extends AtomicOp
 
-  case class InvokeSuperConstructor(constructor: Constructor[?]) extends AtomicOp
+  case class InvokeSuperConstructor(constructor: JConstructor) extends AtomicOp
 
   case class InvokeMethod(method: JMethod) extends AtomicOp
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/JConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/JConstructor.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.ast.shared
+
+import ca.uwaterloo.flix.util.ClassDescs
+
+import java.lang.constant.{ClassDesc, ConstantDescs, MethodTypeDesc}
+import java.lang.reflect.Constructor
+
+object JConstructor {
+
+  /** Returns the [[JConstructor]] of the given reflective `constructor`. */
+  def of(constructor: Constructor[?]): JConstructor = {
+    val paramDescs = constructor.getParameterTypes.map(ClassDescs.of)
+    val descriptor = MethodTypeDesc.of(ConstantDescs.CD_void, paramDescs: _*)
+    JConstructor(ClassDescs.of(constructor.getDeclaringClass), descriptor)
+  }
+
+}
+
+/**
+  * A nominal reference to a Java constructor of the class `owner` with the given method type
+  * `descriptor` (whose return type is always `void`).
+  *
+  * Unlike [[java.lang.reflect.Constructor]], a [[JConstructor]] does not retain a loaded [[Class]].
+  */
+case class JConstructor(owner: ClassDesc, descriptor: MethodTypeDesc)

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -347,6 +347,10 @@ object DocAst {
       App(Native(c.getDeclaringClass), ds)
     }
 
+    def JavaInvokeConstructor(c: JConstructor, ds: List[Expr]): Expr = {
+      App(AsIs(javaClassName(c.owner)), ds)
+    }
+
     def JavaGetField(f: Field, d: Expr): Expr =
       DoubleDot(d, AsIs(f.getName))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -165,6 +165,21 @@ object BackendType {
     }
   }
 
+  /** Converts the given Java class or array descriptor `desc` into its [[BackendType]] representation. */
+  def toBackendType(desc: java.lang.constant.ClassDesc): BackendType = {
+    import java.lang.constant.ConstantDescs.*
+    if (desc == CD_boolean) BackendType.Bool
+    else if (desc == CD_char) BackendType.Char
+    else if (desc == CD_byte) BackendType.Int8
+    else if (desc == CD_short) BackendType.Int16
+    else if (desc == CD_int) BackendType.Int32
+    else if (desc == CD_long) BackendType.Int64
+    else if (desc == CD_float) BackendType.Float32
+    else if (desc == CD_double) BackendType.Float64
+    else if (desc.isArray) Array(toBackendType(desc.componentType()))
+    else Reference(BackendObjType.Native(JvmName.ofClassDesc(desc)))
+  }
+
   /**
     * Contains all the primitive types and `Reference(Native(JvmName.Object))`.
     */

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -17,6 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.shared.JConstructor
 import ca.uwaterloo.flix.language.ast.{AtomicOp, SimpleType}
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.*
@@ -26,6 +27,8 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.{MethodDescriptor, RootPackage}
 import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils}
 import org.objectweb.asm.{MethodVisitor, Opcodes}
+
+import scala.jdk.CollectionConverters.*
 
 /** Generates bytecode for anonymous classes (created through NewObject). */
 object GenAnonymousClasses {
@@ -58,7 +61,7 @@ object GenAnonymousClasses {
       c.exp match {
         case Expr.ApplyAtomic(AtomicOp.InvokeSuperConstructor(constructor), _, _, _, _) =>
           // Super-only: no closure field needed, parameterized <init>
-          val argTypes = constructor.getParameterTypes.toList.map(javaClassToBackendType)
+          val argTypes = constructor.descriptor.parameterList.asScala.toList.map(BackendType.toBackendType)
           cm.mkConstructor(ClassMaker.ConstructorMethod(className, argTypes), IsPublic, constructorInsWithSuperCall(superClass, constructor)(_))
         case _ => throw InternalCompilerException(s"Unexpected non-super constructor body.", c.loc)
       }
@@ -108,9 +111,9 @@ object GenAnonymousClasses {
   }
 
   /** Creates constructor bytecode that forwards parameters directly to the super constructor. */
-  private def constructorInsWithSuperCall(superClass: JvmName, constructor: java.lang.reflect.Constructor[?])(implicit mv: MethodVisitor): Unit = {
+  private def constructorInsWithSuperCall(superClass: JvmName, constructor: JConstructor)(implicit mv: MethodVisitor): Unit = {
     import BytecodeInstructions.*
-    val paramTypes = constructor.getParameterTypes.toList.map(javaClassToBackendType)
+    val paramTypes = constructor.descriptor.parameterList.asScala.toList.map(BackendType.toBackendType)
     // ALOAD 0 (this)
     thisLoad()
     // Load each <init> parameter (starting at slot 1)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -857,19 +857,18 @@ object GenExpression {
       case AtomicOp.InvokeConstructor(constructor) =>
         // Add source line number for debugging (can fail when calling unsafe java methods)
         BytecodeInstructions.addLoc(loc)
-        val descriptor = asm.Type.getConstructorDescriptor(constructor)
-        val declaration = asm.Type.getInternalName(constructor.getDeclaringClass)
+        val declaration = internalNameOf(constructor.owner)
         // Create a new object of the declaration type
         mv.visitTypeInsn(NEW, declaration)
         // Duplicate the reference since the first argument for a constructor call is the reference to the object
         mv.visitInsn(DUP)
-        for ((arg, argType) <- exps.zip(constructor.getParameterTypes)) {
+        for ((arg, argType) <- exps.zip(constructor.descriptor.parameterList.asScala)) {
           compileExpr(arg)
-          if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
+          if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, internalNameOf(argType))
         }
 
         // Call the constructor
-        mv.visitMethodInsn(INVOKESPECIAL, declaration, JvmName.ConstructorMethod, descriptor, false)
+        mv.visitMethodInsn(INVOKESPECIAL, declaration, JvmName.ConstructorMethod, constructor.descriptor.descriptorString(), false)
 
       case AtomicOp.InvokeSuperConstructor(constructor) =>
         // A InvokeSuperConstructor is handled directly in NewObject.
@@ -1603,12 +1602,11 @@ object GenExpression {
         constructors.head.exp match {
           case Expr.ApplyAtomic(AtomicOp.InvokeSuperConstructor(constructor), superArgs, _, _, _) =>
             // Super-only: compile args and call parameterized <init>
-            val descriptor = asm.Type.getConstructorDescriptor(constructor)
-            for ((arg, argType) <- superArgs.zip(constructor.getParameterTypes)) {
+            for ((arg, argType) <- superArgs.zip(constructor.descriptor.parameterList.asScala)) {
               compileExpr(arg)
-              if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
+              if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, internalNameOf(argType))
             }
-            mv.visitMethodInsn(INVOKESPECIAL, className, JvmName.ConstructorMethod, descriptor, false)
+            mv.visitMethodInsn(INVOKESPECIAL, className, JvmName.ConstructorMethod, constructor.descriptor.descriptorString(), false)
           case _ => throw InternalCompilerException(s"Unexpected non-super constructor body.", constructors.head.loc)
         }
       } else {

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.{DefaultHandler, Predicate}
 import ca.uwaterloo.flix.language.ast.MonoAst.{DefContext, Occur}
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.TypedAst.ApplyPosition
-import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, Denotation, Fixity, JField, JMethod, Mutability, Polarity, PredicateAndArity, RegionScope, SolveMode, SymUse, TypeSource}
+import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, Denotation, Fixity, JConstructor, JField, JMethod, Mutability, Polarity, PredicateAndArity, RegionScope, SolveMode, SymUse, TypeSource}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoAst, Name, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization.Context
 import ca.uwaterloo.flix.language.phase.monomorph.Symbols.{Defs, Enums, Types}
@@ -495,12 +495,12 @@ object Lowering {
       // Box primitive args where Java expects Object (e.g., `new SimpleEntry(42, true)`).
       val javaParamTypes = constructor.getParameterTypes
       val boxedArgs = es.zip(javaParamTypes).map { case (arg, paramType) => boxIfNecessary(arg, paramType) }
-      MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeConstructor(constructor), boxedArgs, t, eff, loc)
+      MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeConstructor(JConstructor.of(constructor)), boxedArgs, t, eff, loc)
 
     case TypedAst.Expr.InvokeSuperConstructor(constructor, exps, tpe, eff, loc) =>
       val es = exps.map(lowerExp)
       val t = lowerType(tpe)
-      MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperConstructor(constructor), es, t, eff, loc)
+      MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperConstructor(JConstructor.of(constructor)), es, t, eff, loc)
 
     case TypedAst.Expr.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
       val e = lowerExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.MonoAst.{DefContext, Occur}
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.TypedAst.{ApplyPosition, DefaultHandler}
-import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, JField, JMethod, Mutability, RegionScope, SymUse, TypeSource}
+import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, JConstructor, JField, JMethod, Mutability, RegionScope, SymUse, TypeSource}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoAst, Scheme, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.phase.monomorph2.Specialize.{SpecializationTables, StrictSubstitution, lookupCaseSym, lookupRestrictableCaseSym, lookupStructSym, lookupSym, resolveSigSym, specializeFormalParam, specializeFormalParams}
 import ca.uwaterloo.flix.language.phase.monomorph2.Symbols.{Defs, Enums, Types}
@@ -500,12 +500,12 @@ object SpecializeAndLower {
       // Box primitive args to match the constructor's Object-typed parameters.
       val javaParamTypes = constructor.getParameterTypes
       val boxedArgs = ListOps.zip(es, javaParamTypes.toList).map { case (arg, paramType) => boxIfNecessary(arg, paramType) }
-      MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeConstructor(constructor), boxedArgs, t, subst(eff), loc)
+      MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeConstructor(JConstructor.of(constructor)), boxedArgs, t, subst(eff), loc)
 
     case TypedAst.Expr.InvokeSuperConstructor(constructor, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp(_, env0, subst))
       val t = visitType(tpe, subst)
-      MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperConstructor(constructor), es, t, subst(eff), loc)
+      MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperConstructor(JConstructor.of(constructor)), es, t, subst(eff), loc)
 
     case TypedAst.Expr.InvokeMethod(method, exp, exps, tpe, eff, loc) =>
       val e = visitExp(exp, env0, subst)

--- a/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
@@ -447,11 +447,11 @@ object TypeVerifier {
           check(expected = SimpleType.Bool)(actual = tpe, loc)
 
         case AtomicOp.InvokeConstructor(constructor) =>
-          checkArity(ts, constructor.getParameterCount, loc)
+          checkArity(ts, constructor.descriptor.parameterCount(), loc)
           tpe
 
         case AtomicOp.InvokeSuperConstructor(constructor) =>
-          checkArity(ts, constructor.getParameterCount, loc)
+          checkArity(ts, constructor.descriptor.parameterCount(), loc)
           tpe
 
         case AtomicOp.InvokeMethod(method) =>


### PR DESCRIPTION
Part of #13091. Follow-up to #13099.

Introduces `JConstructor(owner: ClassDesc, descriptor: MethodTypeDesc)` and swaps it into `InvokeConstructor`/`InvokeSuperConstructor`, converted at the construction sites in both monomorphizers.

- `GenExpression` emits `NEW`/`DUP`/`INVOKESPECIAL` from the descriptor string; argument `CHECKCAST`s come from the parameter descriptors (both the direct case and the anonymous-class super-call at `:1604`).
- `GenAnonymousClasses`' constructor forwarding maps descriptor parameters via a new `BackendType.toBackendType(ClassDesc)` overload (which PR 8a will reuse for method signatures).
- `DocAst` gains a `JConstructor` overload; verifier arity checks read `descriptor.parameterCount()`.

Smoke-tested: `new Point(3, 4)` and an anonymous `Exception` subclass calling `super("custom message")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)