### PR TITLE
refactor: use nominal JMethod in InvokeSuperMethod and super bridges

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/AtomicOp.scala
@@ -18,7 +18,6 @@ package ca.uwaterloo.flix.language.ast
 import ca.uwaterloo.flix.language.ast.shared.{JConstructor, JField, JMethod, Mutability}
 
 import java.lang.constant.ClassDesc
-import java.lang.reflect.Method
 
 /**
   * A common super-type for control pure expressions.
@@ -91,7 +90,7 @@ object AtomicOp {
 
   case class InvokeMethod(method: JMethod) extends AtomicOp
 
-  case class InvokeSuperMethod(sym: Symbol.AnonClassSym, method: Method) extends AtomicOp
+  case class InvokeSuperMethod(sym: Symbol.AnonClassSym, method: JMethod) extends AtomicOp
 
   case class InvokeStaticMethod(method: JMethod) extends AtomicOp
 

--- a/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
@@ -117,7 +117,7 @@ object JvmAst {
 
   case class StructField(sym: Symbol.StructFieldSym, tpe: SimpleType, loc: SourceLocation)
 
-  case class AnonClass(name: String, clazz: java.lang.Class[?], tpe: SimpleType, constructors: List[JvmConstructor], methods: List[JvmMethod], superMethods: List[java.lang.reflect.Method], loc: SourceLocation)
+  case class AnonClass(name: String, clazz: java.lang.Class[?], tpe: SimpleType, constructors: List[JvmConstructor], methods: List[JvmMethod], superMethods: List[shared.JMethod], loc: SourceLocation)
 
   case class JvmConstructor(exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.shared.ExpPosition
+import ca.uwaterloo.flix.language.ast.shared.{ExpPosition, JMethod}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, ErasedAst, JvmAst, Purity, SimpleType, Symbol}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
@@ -318,7 +318,7 @@ object Reducer {
     private val defTypes: ConcurrentHashMap[SimpleType, Unit] = new ConcurrentHashMap()
 
     /** Maps anonymous class names to the super methods they invoke, so the backend can generate `invokespecial` bridge methods. */
-    private val superMethods: ConcurrentHashMap[(String, java.lang.reflect.Method), Unit] = new ConcurrentHashMap()
+    private val superMethods: ConcurrentHashMap[(String, JMethod), Unit] = new ConcurrentHashMap()
 
     def addAnonClass(clazz: JvmAst.AnonClass): Unit =
       anonClasses.add(clazz)
@@ -326,10 +326,10 @@ object Reducer {
     def getAnonClasses: List[JvmAst.AnonClass] =
       anonClasses.asScala.toList.map(ac => ac.copy(superMethods = getSuperMethods(ac.name)))
 
-    def addSuperMethod(className: String, method: java.lang.reflect.Method): Unit =
+    def addSuperMethod(className: String, method: JMethod): Unit =
       superMethods.putIfAbsent((className, method), ())
 
-    def getSuperMethods(className: String): List[java.lang.reflect.Method] =
+    def getSuperMethods(className: String): List[JMethod] =
       superMethods.keySet.asScala.collect { case (cn, m) if cn == className => m }.toList
 
     def addDefType(tpe: SimpleType): Unit =

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.shared.JConstructor
+import ca.uwaterloo.flix.language.ast.shared.{JConstructor, JMethod}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, SimpleType}
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.*
@@ -28,6 +28,7 @@ import ca.uwaterloo.flix.language.phase.jvm.JvmName.{MethodDescriptor, RootPacka
 import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils}
 import org.objectweb.asm.{MethodVisitor, Opcodes}
 
+import java.lang.constant.ConstantDescs.CD_void
 import scala.jdk.CollectionConverters.*
 
 /** Generates bytecode for anonymous classes (created through NewObject). */
@@ -93,9 +94,9 @@ object GenAnonymousClasses {
     // Generate bridge methods for super method calls.
     val superMethods = obj.superMethods
     for (method <- superMethods) {
-      val bridgeName = s"super$$${method.getName}"
-      val paramTypes = method.getParameterTypes.toList.map(javaClassToBackendType)
-      val returnTpe = if (method.getReturnType == java.lang.Void.TYPE) VoidableType.Void else javaClassToBackendType(method.getReturnType)
+      val bridgeName = s"super$$${method.name}"
+      val paramTypes = method.descriptor.parameterList.asScala.toList.map(BackendType.toBackendType)
+      val returnTpe = if (method.descriptor.returnType() == CD_void) VoidableType.Void else BackendType.toBackendType(method.descriptor.returnType())
       val descriptor = MethodDescriptor(paramTypes, returnTpe)
       cm.mkMethod(Nil, ClassMaker.InstanceMethod(className, bridgeName, descriptor), IsPublic, NotFinal, superBridgeIns(superClass, method)(_))
     }
@@ -168,10 +169,10 @@ object GenAnonymousClasses {
     *   }
     * }}}
     */
-  private def superBridgeIns(superClass: JvmName, method: java.lang.reflect.Method)(implicit mv: MethodVisitor): Unit = {
-    val paramTypes = method.getParameterTypes.toList.map(javaClassToBackendType)
-    val returnTpe = javaClassToBackendType(method.getReturnType)
-    val descriptor = MethodDescriptor(paramTypes, if (method.getReturnType == java.lang.Void.TYPE) VoidableType.Void else returnTpe)
+  private def superBridgeIns(superClass: JvmName, method: JMethod)(implicit mv: MethodVisitor): Unit = {
+    val paramTypes = method.descriptor.parameterList.asScala.toList.map(BackendType.toBackendType)
+    val isVoid = method.descriptor.returnType() == CD_void
+    val descriptor = MethodDescriptor(paramTypes, if (isVoid) VoidableType.Void else BackendType.toBackendType(method.descriptor.returnType()))
 
     // ALOAD 0 (this)
     thisLoad()
@@ -180,13 +181,13 @@ object GenAnonymousClasses {
       for (arg <- args) arg.load()
     }
     // INVOKESPECIAL superClass.methodName(descriptor)
-    INVOKESPECIAL(superClass, method.getName, descriptor)
+    INVOKESPECIAL(superClass, method.name, descriptor)
 
     // Return
-    if (method.getReturnType == java.lang.Void.TYPE) {
+    if (isVoid) {
       RETURN()
     } else {
-      xReturn(returnTpe)
+      xReturn(BackendType.toBackendType(method.descriptor.returnType()))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -915,18 +915,17 @@ object GenExpression {
         mv.visitTypeInsn(CHECKCAST, anonClassInternalName)
 
         // Evaluate and cast each argument.
-        for ((arg, argType) <- args.zip(method.getParameterTypes)) {
+        for ((arg, argType) <- args.zip(method.descriptor.parameterList.asScala)) {
           compileExpr(arg)
-          if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
+          if (!argType.isPrimitive) mv.visitTypeInsn(CHECKCAST, internalNameOf(argType))
         }
 
         // Call the bridge method super$methodName on the anonymous class.
-        val bridgeName = s"super$$${method.getName}"
-        val descriptor = asm.Type.getMethodDescriptor(method)
-        mv.visitMethodInsn(INVOKEVIRTUAL, anonClassInternalName, bridgeName, descriptor, false)
+        val bridgeName = s"super$$${method.name}"
+        mv.visitMethodInsn(INVOKEVIRTUAL, anonClassInternalName, bridgeName, method.descriptor.descriptorString(), false)
 
         // If the method is void, put a unit on top of the stack
-        if (asm.Type.getType(method.getReturnType) == asm.Type.VOID_TYPE) {
+        if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
           mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
         }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -521,7 +521,7 @@ object Lowering {
       val t = lowerType(tpe)
       (lctx.sym, lctx.thisRef) match {
         case (Some(sym), Some(thisRef)) =>
-          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(sym, method), thisRef :: es, t, eff, loc)
+          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(sym, JMethod.of(method)), thisRef :: es, t, eff, loc)
         case _ =>
           throw InternalCompilerException("InvokeSuperMethod outside NewObject context", loc)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -518,7 +518,7 @@ object SpecializeAndLower {
       val t = visitType(tpe, subst)
       (lctx.sym, lctx.thisRef) match {
         case (Some(sym), Some(thisRef)) =>
-          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(sym, method), thisRef :: es, t, subst(eff), loc)
+          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(sym, JMethod.of(method)), thisRef :: es, t, subst(eff), loc)
         case _ =>
           throw InternalCompilerException("InvokeSuperMethod outside NewObject context", loc)
       }

--- a/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
+++ b/main/test/ca/uwaterloo/flix/verifier/TypeVerifier.scala
@@ -461,7 +461,7 @@ object TypeVerifier {
 
         case AtomicOp.InvokeSuperMethod(_, method) =>
           val _ :: pts = ts
-          checkArity(pts, method.getParameterCount, loc)
+          checkArity(pts, method.descriptor.parameterCount(), loc)
           tpe
 
         case AtomicOp.InvokeStaticMethod(method) =>


### PR DESCRIPTION
Part of #13091. Follow-up to #13101.

Swaps the `InvokeSuperMethod` payload and `AnonClass.superMethods` to `JMethod`, converted at the construction sites in both monomorphizers.

- The `Reducer`'s super-method collection dedups on `JMethod`'s structural equality (previously `Method` identity semantics).
- `GenExpression` emits the `super$name` bridge call from the descriptor; `GenAnonymousClasses` builds the bridge and its `INVOKESPECIAL` body from `MethodTypeDesc` via `BackendType.toBackendType(ClassDesc)`.
- **Fixes a latent crash**: the old `superBridgeIns` eagerly mapped the return type through `javaClassToBackendType`, which has no `void` case — a `super` call to a void method (e.g. `super.clear()`) would have thrown an ICE. The port computes the return type only when non-void; the smoke test covers exactly this case.
- `AtomicOp` no longer imports `java.lang.reflect` — all its Java payloads are now nominal.

Smoke-tested: super constructor + `super.getMessage()` bridge (String return) and a void `super.clear()` bridge on `ArrayList[Int32]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)