### PR TITLE
refactor: precompute overridden Java signatures for anonymous classes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -115,7 +115,7 @@ object ErasedAst {
 
   case class JvmConstructor(exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
@@ -121,7 +121,7 @@ object JvmAst {
 
   case class JvmConstructor(exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, offset: Int, clazz: java.lang.constant.ClassDesc, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
-import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, JvmAnnotation, Modifiers, Source}
+import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, JMethod, JvmAnnotation, Modifiers, Source}
 
 object LiftedAst {
 
@@ -98,7 +98,7 @@ object LiftedAst {
 
   case class JvmConstructor(clo: Expr, retTpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: SimpleType, purity: Purity, loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -166,7 +166,7 @@ object MonoAst {
 
   case class JvmConstructor(exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, retTpe: Type, eff: Type, javaSig: Option[JMethod], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
-import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, ExpPosition, JvmAnnotation, Modifiers, Source}
+import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, ExpPosition, JMethod, JvmAnnotation, Modifiers, Source}
 
 import java.lang.reflect.Method
 
@@ -114,7 +114,7 @@ object ReducedAst {
 
   case class JvmConstructor(exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.ast
 import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.ScalaAnnotations.IntroducedBy
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
-import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, JvmAnnotation, Modifiers, Source}
+import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, JMethod, JvmAnnotation, Modifiers, Source}
 import ca.uwaterloo.flix.language.phase.ClosureConv
 
 object SimplifiedAst {
@@ -114,7 +114,7 @@ object SimplifiedAst {
 
   case class JvmConstructor(exp: Expr, retTpe: SimpleType, purity: Purity, loc: SourceLocation)
 
-  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: SimpleType, purity: Purity, loc: SourceLocation)
+  case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
@@ -93,7 +93,7 @@ object JvmAstPrinter {
 
   /** Returns the [[DocAst.JvmMethod]] representation of `method`. */
   private def printJvmMethod(method: JvmAst.JvmMethod): DocAst.JvmMethod = method match {
-    case JvmAst.JvmMethod(ann, ident, fparams, exp, tpe, _, _) =>
+    case JvmAst.JvmMethod(ann, ident, fparams, exp, tpe, _, _, _) =>
       DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -75,7 +75,7 @@ object LiftedAstPrinter {
           DocAst.JvmConstructor(print(clo), SimpleTypePrinter.print(retTpe))
       }
       val ms = methods.map {
-        case LiftedAst.JvmMethod(ann, ident, fparams, clo, retTpe, _, _) =>
+        case LiftedAst.JvmMethod(ann, ident, fparams, clo, retTpe, _, _, _) =>
           DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.map(printFormalParam), print(clo), SimpleTypePrinter.print(retTpe))
       }
       DocAst.Expr.NewObject(sym, clazz, SimpleTypePrinter.print(tpe), cs, ms)

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -54,7 +54,7 @@ object MonoAstPrinter {
 
   /** Returns the [[DocAst.JvmMethod]] representation of `method`. */
   private def printJvmMethod(method: MonoAst.JvmMethod): DocAst.JvmMethod = method match {
-    case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _) =>
+    case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _, _) =>
       DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
   }
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -99,7 +99,7 @@ object ReducedAstPrinter {
     * Returns the [[DocAst.JvmMethod]] representation of `method`.
     */
   private def printJvmMethod(method: ReducedAst.JvmMethod): DocAst.JvmMethod = method match {
-    case ReducedAst.JvmMethod(ann, ident, fparams, exp, tpe, _, _) =>
+    case ReducedAst.JvmMethod(ann, ident, fparams, exp, tpe, _, _, _) =>
       DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -80,7 +80,7 @@ object SimplifiedAstPrinter {
           DocAst.JvmConstructor(print(exp), SimpleTypePrinter.print(retTpe))
       }
       val ms = methods.map {
-        case SimplifiedAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _) =>
+        case SimplifiedAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _, _) =>
           DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.map(printFormalParam), print(exp), SimpleTypePrinter.print(retTpe))
       }
       DocAst.Expr.NewObject(sym, clazz, SimpleTypePrinter.print(tpe), cs, ms)

--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -153,10 +153,10 @@ object ClosureConv {
           }
       }
       val methods = methods0 map {
-        case JvmMethod(ann, ident, fparams, exp, retTpe, methodPurity, methodLoc) =>
+        case JvmMethod(ann, ident, fparams, exp, retTpe, methodPurity, javaSig, methodLoc) =>
           val cloType = SimpleType.mkArrow(fparams.map(_.tpe), retTpe)
           val clo = mkLambdaClosure(fparams, exp, cloType, methodLoc)
-          JvmMethod(ann, ident, fparams, clo, retTpe, methodPurity, methodLoc)
+          JvmMethod(ann, ident, fparams, clo, retTpe, methodPurity, javaSig, methodLoc)
       }
       Expr.NewObject(sym, clazz, tpe, purity, constructors, methods, loc)
 
@@ -272,7 +272,7 @@ object ClosureConv {
           acc ++ freeVars(exp)
       }
       methods.foldLeft(constructorFvs) {
-        case (acc, JvmMethod(_, _, fparams, exp, _, _, _)) =>
+        case (acc, JvmMethod(_, _, fparams, exp, _, _, _, _)) =>
           acc ++ filterBoundParams(freeVars(exp), fparams)
       }
 
@@ -442,9 +442,9 @@ object ClosureConv {
     }
 
     def visitJvmMethod(method: JvmMethod)(implicit flix: Flix): JvmMethod = method match {
-      case JvmMethod(ann, ident, fparams0, exp, retTpe, purity, loc) =>
+      case JvmMethod(ann, ident, fparams0, exp, retTpe, purity, javaSig, loc) =>
         val fparams = fparams0.map(visitFormalParam)
-        JvmMethod(ann, ident, fparams, applySubst(exp, subst), retTpe, purity, loc)
+        JvmMethod(ann, ident, fparams, applySubst(exp, subst), retTpe, purity, javaSig, loc)
     }
 
     visitExp(e0)
@@ -661,9 +661,9 @@ object ClosureConv {
             JvmConstructor(e, retTpe, constructorPurity, constructorLoc)
         }
         val ms = methods.map {
-          case JvmMethod(ann, ident, fparams, exp, retTpe, methodPurity, methodLoc) =>
+          case JvmMethod(ann, ident, fparams, exp, retTpe, methodPurity, javaSig, methodLoc) =>
             val e = visit(exp)
-            JvmMethod(ann, ident, fparams, e, retTpe, methodPurity, methodLoc)
+            JvmMethod(ann, ident, fparams, e, retTpe, methodPurity, javaSig, methodLoc)
         }
         Expr.NewObject(sym, clazz, tpe, purity, cs, ms, loc)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -126,12 +126,12 @@ object EffectBinder {
   }
 
   private def visitJvmMethod(method: LiftedAst.JvmMethod)(implicit flix: Flix): ReducedAst.JvmMethod = method match {
-    case LiftedAst.JvmMethod(ann, ident, fparams0, clo0, retTpe, purity, loc) =>
+    case LiftedAst.JvmMethod(ann, ident, fparams0, clo0, retTpe, purity, javaSig, loc) =>
       // JvmMethods are generated as their own functions so let-binding do not
       // span across
       val fparams = fparams0.map(visitParam)
       val clo = visitExpr(clo0)
-      ReducedAst.JvmMethod(ann, ident, fparams, clo, retTpe, purity, loc)
+      ReducedAst.JvmMethod(ann, ident, fparams, clo, retTpe, purity, javaSig, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -122,9 +122,9 @@ object Eraser {
   }
 
   private def visitJvmMethod(method: ReducedAst.JvmMethod)(implicit ctx: SharedContext, flix: Flix): ErasedAst.JvmMethod = method match {
-    case ReducedAst.JvmMethod(ann, ident, fparams, clo, retTpe, purity, loc) =>
+    case ReducedAst.JvmMethod(ann, ident, fparams, clo, retTpe, purity, javaSig, loc) =>
       // return type is not erased to maintain class signatures
-      ErasedAst.JvmMethod(ann, ident, fparams.map(visitParam), visitExp(clo), visitType(retTpe), purity, loc)
+      ErasedAst.JvmMethod(ann, ident, fparams.map(visitParam), visitExp(clo), visitType(retTpe), purity, javaSig, loc)
   }
 
   private def visitExp(exp0: ReducedAst.Expr)(implicit ctx: SharedContext, flix: Flix): ErasedAst.Expr = exp0 match {

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -248,9 +248,9 @@ object LambdaLift {
   }
 
   private def visitJvmMethod(method: SimplifiedAst.JvmMethod)(implicit sym0: Symbol.DefnSym, liftedLocalDefs: Map[Symbol.VarSym, Symbol.DefnSym], sctx: SharedContext, flix: Flix): LiftedAst.JvmMethod = method match {
-    case SimplifiedAst.JvmMethod(ann, ident, fparams0, exp, retTpe, purity, loc) =>
+    case SimplifiedAst.JvmMethod(ann, ident, fparams0, exp, retTpe, purity, javaSig, loc) =>
       val fparams = fparams0 map visitFormalParam
-      LiftedAst.JvmMethod(ann, ident, fparams, visitExp(exp), retTpe, purity, loc)
+      LiftedAst.JvmMethod(ann, ident, fparams, visitExp(exp), retTpe, purity, javaSig, loc)
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -221,9 +221,9 @@ object Reducer {
             JvmAst.JvmConstructor(c, retTpe, cnsPurity, cnsLoc)
         }
         val specs = methods.map {
-          case ErasedAst.JvmMethod(ann, ident, fparams, clo, retTpe, methPurity, methLoc) =>
+          case ErasedAst.JvmMethod(ann, ident, fparams, clo, retTpe, methPurity, javaSig, methLoc) =>
             val c = visitExpr(clo)
-            JvmAst.JvmMethod(ann, ident, fparams.map(visitFormalParam), c, retTpe, methPurity, methLoc)
+            JvmAst.JvmMethod(ann, ident, fparams.map(visitFormalParam), c, retTpe, methPurity, javaSig, methLoc)
         }
         ctx.addAnonClass(JvmAst.AnonClass(sym.name, clazz, tpe, cs, specs, Nil, loc))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -650,11 +650,11 @@ object Simplifier {
   }
 
   private def visitJvmMethod(method: MonoAst.JvmMethod)(implicit universe: Set[Symbol.EffSym], root: MonoAst.Root, flix: Flix): SimplifiedAst.JvmMethod = method match {
-    case MonoAst.JvmMethod(ann, ident, fparams0, exp0, retTpe, eff, loc) =>
+    case MonoAst.JvmMethod(ann, ident, fparams0, exp0, retTpe, eff, javaSig, loc) =>
       val fparams = fparams0.toList.map(visitFormalParam)
       val exp = visitExp(exp0)
       val rt = visitType(retTpe)
-      SimplifiedAst.JvmMethod(ann, ident, fparams, exp, rt, simplifyEffect(eff), loc)
+      SimplifiedAst.JvmMethod(ann, ident, fparams, exp, rt, simplifyEffect(eff), javaSig, loc)
   }
 
   private def pat2exp(pat0: MonoAst.Pattern): SimplifiedAst.Expr = pat0 match {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -25,7 +25,7 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.{MethodDescriptor, RootPackage}
-import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils}
+import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.{MethodVisitor, Opcodes}
 
 import java.lang.constant.ConstantDescs.CD_void
@@ -75,17 +75,16 @@ object GenAnonymousClasses {
       // Create the field that will store the closure implementing the body of the method.
       val cloField = ClassMaker.InstanceField(className, s"clo$i", abstractClass.toTpe)
       cm.mkField(cloField, IsPublic, NotFinal, NotVolatile)
-      // Use the Java interface's erased method signature for the JVM descriptor.
-      // This ensures the generated method matches the interface even when the user
-      // declares generic parameter types (e.g., String instead of Object).
-      val javaMethod = findJavaMethod(obj.clazz, m.ident.name, m.fparams.tail.length)
-      val actualArgs = javaMethod match {
-        case Some(jm) => jm.getParameterTypes.toList.map(javaClassToBackendType)
+      // Use the Java interface's erased method signature (resolved during lowering) for the
+      // JVM descriptor. This ensures the generated method matches the interface even when the
+      // user declares generic parameter types (e.g., String instead of Object).
+      val actualArgs = m.javaSig match {
+        case Some(jm) => jm.descriptor.parameterList.asScala.toList.map(BackendType.toBackendType)
         case None => m.fparams.tail.map(_.tpe).map(BackendType.toBackendType)
       }
-      val actualres = javaMethod match {
-        case Some(jm) if jm.getReturnType == java.lang.Void.TYPE => VoidableType.Void
-        case Some(jm) => javaClassToBackendType(jm.getReturnType)
+      val actualres = m.javaSig match {
+        case Some(jm) if jm.descriptor.returnType() == CD_void => VoidableType.Void
+        case Some(jm) => BackendType.toBackendType(jm.descriptor.returnType())
         case None => if (m.tpe == SimpleType.Unit) VoidableType.Void else BackendType.toBackendType(m.tpe)
       }
       cm.mkMethod(m.ann, ClassMaker.InstanceMethod(className, m.ident.name, MethodDescriptor(actualArgs, actualres)), IsPublic, NotFinal, methodIns(abstractClass, cloField, actualres, m)(_, root))
@@ -124,25 +123,6 @@ object GenAnonymousClasses {
     // INVOKESPECIAL superClass.<init>(paramTypes...)
     INVOKESPECIAL(ClassMaker.ConstructorMethod(superClass, paramTypes))
     RETURN()
-  }
-
-  /** Finds the Java method matching the given name and parameter count on `clazz`. */
-  private def findJavaMethod(clazz: Class[?], name: String, arity: Int): Option[java.lang.reflect.Method] = {
-    JvmUtils.getOverridableInstanceMethods(clazz).find(m => m.getName == name && m.getParameterCount == arity)
-  }
-
-  /** Maps a Java `Class[?]` to a `BackendType`. */
-  private def javaClassToBackendType(clazz: Class[?]): BackendType = {
-    if      (clazz == java.lang.Boolean.TYPE)   BackendType.Bool
-    else if (clazz == java.lang.Byte.TYPE)      BackendType.Int8
-    else if (clazz == java.lang.Short.TYPE)     BackendType.Int16
-    else if (clazz == java.lang.Integer.TYPE)   BackendType.Int32
-    else if (clazz == java.lang.Long.TYPE)      BackendType.Int64
-    else if (clazz == java.lang.Float.TYPE)     BackendType.Float32
-    else if (clazz == java.lang.Double.TYPE)    BackendType.Float64
-    else if (clazz == java.lang.Character.TYPE) BackendType.Char
-    else if (clazz.isArray)                     BackendType.Array(javaClassToBackendType(clazz.getComponentType))
-    else BackendType.Reference(BackendObjType.Native(JvmName.ofClass(clazz)))
   }
 
   /** Returns the erased abstract arrow class for the given parameter types and return type. */

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -677,17 +677,23 @@ object Lowering {
       // box it so the value matches the erased JVM signature. This mirrors the boxing applied
       // to generic Java method *calls* above (see `boxIfNecessary` in InvokeMethod), and the
       // call site unboxes the result symmetrically.
-      val e = overriddenJavaReturnType(clazz, ident.name, fparams.tail.length) match {
-        case Some(javaReturnType) => boxIfNecessary(e0, javaReturnType)
+      val overridden = overriddenJavaMethod(clazz, ident.name, fparams.tail.length)
+      val e = overridden match {
+        case Some(m) => boxIfNecessary(e0, m.getReturnType)
         case None => e0
       }
-      MonoAst.JvmMethod(ann, ident, fs, e, e.tpe, eff, loc)
+      MonoAst.JvmMethod(ann, ident, fs, e, e.tpe, eff, overridden.map(JMethod.of), loc)
   }
 
-  /** Returns the erased return type of the Java method on `clazz` matching `name` and `arity` (excluding the receiver). */
-  private def overriddenJavaReturnType(clazz: Class[?], name: String, arity: Int): Option[Class[?]] =
+  /**
+    * Returns the Java method on `clazz` matching `name` and `arity` (excluding the receiver), if any.
+    *
+    * The resolved method's erased signature is carried on the [[MonoAst.JvmMethod]] so the
+    * backend can emit matching descriptors without reflection.
+    */
+  private def overriddenJavaMethod(clazz: Class[?], name: String, arity: Int): Option[java.lang.reflect.Method] =
     JvmUtils.getOverridableInstanceMethods(clazz).collectFirst {
-      case m if m.getName == name && m.getParameterCount == arity => m.getReturnType
+      case m if m.getName == name && m.getParameterCount == arity => m
     }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -570,11 +570,12 @@ object SpecializeAndLower {
           // for a generic interface method) but the Flix result is primitive, box it to match the
           // erased signature. This mirrors the boxing applied to generic Java method calls (see
           // `boxIfNecessary` in `mkJavaInvoke`), and the call site unboxes the result symmetrically.
-          val e = overriddenJavaReturnType(clazz, mIdent.name, fs.tail.length) match {
-            case Some(javaReturnType) => boxIfNecessary(e0, javaReturnType)
+          val overridden = overriddenJavaMethod(clazz, mIdent.name, fs.tail.length)
+          val e = overridden match {
+            case Some(m) => boxIfNecessary(e0, m.getReturnType)
             case None => e0
           }
-          MonoAst.JvmMethod(mAnn, mIdent, fs, e, e.tpe, subst(mEff), mLoc)
+          MonoAst.JvmMethod(mAnn, mIdent, fs, e, e.tpe, subst(mEff), overridden.map(JMethod.of), mLoc)
       }
       val t = visitType(tpe, subst)
       MonoAst.Expr.NewObject(freshSym, clazz, t, subst(eff), cs, ms, loc)
@@ -1158,10 +1159,15 @@ object SpecializeAndLower {
     } else arg
   }
 
-  /** Returns the erased return type of the Java method on `clazz` matching `name` and `arity` (excluding the receiver). */
-  private def overriddenJavaReturnType(clazz: Class[?], name: String, arity: Int): Option[Class[?]] =
+  /**
+    * Returns the Java method on `clazz` matching `name` and `arity` (excluding the receiver), if any.
+    *
+    * The resolved method's erased signature is carried on the [[MonoAst.JvmMethod]] so the
+    * backend can emit matching descriptors without reflection.
+    */
+  private def overriddenJavaMethod(clazz: Class[?], name: String, arity: Int): Option[java.lang.reflect.Method] =
     JvmUtils.getOverridableInstanceMethods(clazz).collectFirst {
-      case m if m.getName == name && m.getParameterCount == arity => m.getReturnType
+      case m if m.getName == name && m.getParameterCount == arity => m
     }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/Inliner.scala
@@ -731,11 +731,11 @@ object Inliner {
   }
 
   private def visitJvmMethod(method: MonoAst.JvmMethod, ctx0: LocalContext)(implicit sym0: Symbol.DefnSym, sctx: SharedContext, root: MonoAst.Root, flix: Flix): MonoAst.JvmMethod = method match {
-    case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, eff1, loc1) =>
+    case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, eff1, javaSig, loc1) =>
       val (fps, varSubsts) = fparams.map(freshFormalParam).unzip
       val ctx = ctx0.addVarSubsts(varSubsts).addInScopeVars(fps.map(fp => fp.sym -> BoundKind.ParameterOrPattern))
       val e = visitExp(exp, ctx)
-      MonoAst.JvmMethod(ann, ident, fps, e, retTpe, eff1, loc1)
+      MonoAst.JvmMethod(ann, ident, fps, e, retTpe, eff1, javaSig, loc1)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/LambdaDrop.scala
@@ -340,9 +340,9 @@ object LambdaDrop {
           MonoAst.JvmConstructor(e, retTpe, eff2, loc2)
       }
       val ms = methods.map {
-        case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, eff2, loc2) =>
+        case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, eff2, javaSig, loc2) =>
           val e = rewriteExp(exp)
-          MonoAst.JvmMethod(ann, ident, fparams, e, retTpe, eff2, loc2)
+          MonoAst.JvmMethod(ann, ident, fparams, e, retTpe, eff2, javaSig, loc2)
       }
       Expr.NewObject(sym, clazz, tpe, eff1, cs, ms, loc1)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/optimizer/OccurrenceAnalyzer.scala
@@ -314,14 +314,14 @@ object OccurrenceAnalyzer {
   }
 
   private def visitJvmMethod(method: MonoAst.JvmMethod)(implicit sym0: Symbol.DefnSym): (MonoAst.JvmMethod, ExprContext) = method match {
-    case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, eff, loc) =>
+    case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, eff, javaSig, loc) =>
       val (e, ctx1) = visitExp(exp)
       val fps = fparams.map(visitFormalParam(_, ctx1))
       val ctx2 = ctx1.removeVars(fps.map(_.sym))
       if ((e eq exp) && fparams.zip(fps).forall { case (fp1, fp2) => fp1 eq fp2 }) {
         (method, ctx2) // Reuse method.
       } else {
-        (MonoAst.JvmMethod(ann, ident, fparams, e, retTpe, eff, loc), ctx2)
+        (MonoAst.JvmMethod(ann, ident, fparams, e, retTpe, eff, javaSig, loc), ctx2)
       }
   }
 


### PR DESCRIPTION
Part of #13091. Follow-up to #13102. (PR 8a of the ladder.)

Both monomorphizers already walk `getOverridableInstanceMethods` once per anonymous-class method (`overriddenJavaReturnType`) but kept only the return type for result boxing. This PR widens that existing lookup to capture the full matched signature as `javaSig: Option[JMethod]`, carried on the `JvmMethod` nodes from MonoAst through JvmAst.

- `GenAnonymousClasses` reads the precomputed signature for the emitted method descriptor (the generic-erasure case: a `Comparator[String]` override is emitted as `(Object,Object)I`) instead of re-resolving via `findJavaMethod` at codegen time.
- Deletes the backend's `JvmUtils.getOverridableInstanceMethods` call, `findJavaMethod`, and the now-dead `javaClassToBackendType` — descriptor parameters map via `BackendType.toBackendType(ClassDesc)`.
- The thread-through of the new field is mechanical (pass-through in Simplifier, ClosureConv, LambdaLift, EffectBinder, Eraser, Reducer, and the MonoAst optimizer phases).

This unlocks PR 8b: `NewObject`/`AnonClass.clazz` becomes a plain payload swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)