### PR TITLE
refactor: always import ClassDesc, MethodTypeDesc, and JMethod

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -20,6 +20,8 @@ import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
 import ca.uwaterloo.flix.language.ast.shared.*
 
+import java.lang.constant.ClassDesc
+
 object ErasedAst {
 
   case class Root(defs: Map[Symbol.DefnSym, Def],
@@ -115,7 +117,7 @@ object ErasedAst {
 
   case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: ClassDesc, exp: Expr)
 
   case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
@@ -19,6 +19,8 @@ import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
 
+import java.lang.constant.ClassDesc
+
 object JvmAst {
 
   case class Root(defs: Map[Symbol.DefnSym, Def],
@@ -117,13 +119,13 @@ object JvmAst {
 
   case class StructField(sym: Symbol.StructFieldSym, tpe: SimpleType, loc: SourceLocation)
 
-  case class AnonClass(name: String, clazz: JClass, tpe: SimpleType, constructors: List[JvmConstructor], methods: List[JvmMethod], superMethods: List[shared.JMethod], loc: SourceLocation)
+  case class AnonClass(name: String, clazz: JClass, tpe: SimpleType, constructors: List[JvmConstructor], methods: List[JvmMethod], superMethods: List[JMethod], loc: SourceLocation)
 
   case class JvmConstructor(exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
 
   case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, offset: Int, clazz: java.lang.constant.ClassDesc, exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, offset: Int, clazz: ClassDesc, exp: Expr)
 
   case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -20,6 +20,8 @@ import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
 import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, JClass, JMethod, JvmAnnotation, Modifiers, Source}
 
+import java.lang.constant.ClassDesc
+
 object LiftedAst {
 
   val empty: Root = Root(Map.empty, Map.empty, Map.empty, Map.empty, None, Set.empty, Map.empty)
@@ -100,7 +102,7 @@ object LiftedAst {
 
   case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: ClassDesc, exp: Expr)
 
   case class HandlerRule(symUse: OpSymUse, fparams: List[FormalParam], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -21,6 +21,8 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.{CaseSymUse, EffSymUse, OpSy
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.util.collection.Nel
 
+import java.lang.constant.ClassDesc
+
 object MonoAst {
 
   val empty: Root = Root(Map.empty, Map.empty, Map.empty, Map.empty, None, Set.empty, Map.empty)
@@ -168,7 +170,7 @@ object MonoAst {
 
   case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, retTpe: Type, eff: Type, javaSig: Option[JMethod], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: ClassDesc, exp: Expr)
 
   case class HandlerRule(op: OpSymUse, fparams: Nel[FormalParam], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
 import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, ExpPosition, JClass, JMethod, JvmAnnotation, Modifiers, Source}
 
+import java.lang.constant.ClassDesc
 
 object ReducedAst {
 
@@ -113,7 +114,7 @@ object ReducedAst {
 
   case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: ClassDesc, exp: Expr)
 
   case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SimpleType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimpleType.scala
@@ -17,6 +17,7 @@ package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.util.{ConcurrentCache, InternalCompilerException}
 
+import java.lang.constant.ClassDesc
 import scala.annotation.tailrec
 
 /**
@@ -102,7 +103,7 @@ object SimpleType {
 
   case class ExtensibleExtend(cons: Name.Pred, tpes: List[SimpleType], rest: SimpleType) extends SimpleType
 
-  case class Native(clazz: java.lang.constant.ClassDesc) extends SimpleType
+  case class Native(clazz: ClassDesc) extends SimpleType
 
   /**
     * Smart constructor for [[SimpleType.Array]].

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -22,6 +22,8 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffSymUse, OpSymUse}
 import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, JClass, JMethod, JvmAnnotation, Modifiers, Source}
 import ca.uwaterloo.flix.language.phase.ClosureConv
 
+import java.lang.constant.ClassDesc
+
 object SimplifiedAst {
 
   val empty: Root = Root(Map.empty, Map.empty, Map.empty, Map.empty, None, Set.empty, Map.empty)
@@ -116,7 +118,7 @@ object SimplifiedAst {
 
   case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: SimpleType, purity: Purity, javaSig: Option[JMethod], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.constant.ClassDesc, exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: ClassDesc, exp: Expr)
 
   case class HandlerRule(op: OpSymUse, fparams: List[FormalParam], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -24,6 +24,7 @@ import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.util.collection.{ListOps, MapOps, Nel}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, ParOps}
 
+import java.lang.constant.{ClassDesc, MethodTypeDesc}
 import scala.annotation.tailrec
 
 /**
@@ -37,19 +38,19 @@ object Simplifier {
   /** The `String.concat(String)` method. */
   private val StringConcatMethod: JMethod = {
     import java.lang.constant.ConstantDescs.*
-    JMethod(CD_String, "concat", java.lang.constant.MethodTypeDesc.of(CD_String, CD_String), isInterface = false)
+    JMethod(CD_String, "concat", MethodTypeDesc.of(CD_String, CD_String), isInterface = false)
   }
 
   /** The `String.equals(Object)` method. */
   private val StringEqualsMethod: JMethod = {
     import java.lang.constant.ConstantDescs.*
-    JMethod(CD_String, "equals", java.lang.constant.MethodTypeDesc.of(CD_boolean, CD_Object), isInterface = false)
+    JMethod(CD_String, "equals", MethodTypeDesc.of(CD_boolean, CD_Object), isInterface = false)
   }
 
   /** The `BigInteger.equals(Object)` method. */
   private val BigIntEqualsMethod: JMethod = {
     import java.lang.constant.ConstantDescs.*
-    JMethod(java.lang.constant.ClassDesc.of("java.math.BigInteger"), "equals", java.lang.constant.MethodTypeDesc.of(CD_boolean, CD_Object), isInterface = false)
+    JMethod(ClassDesc.of("java.math.BigInteger"), "equals", MethodTypeDesc.of(CD_boolean, CD_Object), isInterface = false)
   }
 
   def run(root: MonoAst.Root)(implicit flix: Flix): SimplifiedAst.Root = flix.phase("Simplifier") {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.language.ast.{JvmAst, SimpleType, SourceLocation}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
+import java.lang.constant.ClassDesc
 import scala.annotation.tailrec
 
 /**
@@ -166,7 +167,7 @@ object BackendType {
   }
 
   /** Converts the given Java class or array descriptor `desc` into its [[BackendType]] representation. */
-  def toBackendType(desc: java.lang.constant.ClassDesc): BackendType = {
+  def toBackendType(desc: ClassDesc): BackendType = {
     import java.lang.constant.ConstantDescs.*
     if (desc == CD_boolean) BackendType.Bool
     else if (desc == CD_char) BackendType.Char

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -30,6 +30,7 @@ import org.objectweb.asm
 import org.objectweb.asm.*
 import org.objectweb.asm.Opcodes.*
 
+import java.lang.constant.ClassDesc
 import scala.jdk.CollectionConverters.*
 
 /**
@@ -1625,7 +1626,7 @@ object GenExpression {
     * Returns the JVM internal name of the class, interface, or array descriptor `desc`,
     * e.g. `java/lang/String` or `[Ljava/lang/String;`.
     */
-  private def internalNameOf(desc: java.lang.constant.ClassDesc): String = {
+  private def internalNameOf(desc: ClassDesc): String = {
     if (desc.isArray) {
       // The internal name of an array type is its descriptor.
       desc.descriptorString()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -22,6 +22,7 @@ import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm
 
+import java.lang.constant.ClassDesc
 import java.nio.file.{Path, Paths}
 
 /**
@@ -73,7 +74,7 @@ object JvmName {
 
   /** Returns the [[JvmName]] of `clazz`. Crashes if `clazz` is primitive, an array, or unnamed. */
   /** Returns the JvmName of the given class or interface descriptor `desc`. */
-  def ofClassDesc(desc: java.lang.constant.ClassDesc): JvmName = {
+  def ofClassDesc(desc: ClassDesc): JvmName = {
     if (desc.isPrimitive) throw InternalCompilerException(s"Cannot create a JvmName from the primitive type '${desc.displayName()}'", SourceLocation.Unknown)
     if (desc.isArray) throw InternalCompilerException(s"Cannot create a JvmName from the array type '${desc.displayName()}'", SourceLocation.Unknown)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -29,6 +29,8 @@ import ca.uwaterloo.flix.language.phase.monomorph.Symbols.{Defs, Enums, Types}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, JvmUtils, Result}
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListOps, Nel}
 
+import java.lang.constant.{ClassDesc, MethodTypeDesc}
+
 /**
   * This phase translates AST expressions related to the Datalog subset of the
   * language into `Fixpoint.Ast.Datalog` values (which are ordinary Flix values).
@@ -1040,8 +1042,8 @@ object Lowering {
     */
   private def javaBoxMethod(tpe: Type): JMethod = {
     import java.lang.constant.ConstantDescs.*
-    def valueOf(box: java.lang.constant.ClassDesc, prim: java.lang.constant.ClassDesc): JMethod =
-      JMethod(box, "valueOf", java.lang.constant.MethodTypeDesc.of(box, prim), isInterface = false)
+    def valueOf(box: ClassDesc, prim: ClassDesc): JMethod =
+      JMethod(box, "valueOf", MethodTypeDesc.of(box, prim), isInterface = false)
     tpe match {
       case Type.Bool => valueOf(CD_Boolean, CD_boolean)
       case Type.Char => valueOf(CD_Character, CD_char)
@@ -1061,8 +1063,8 @@ object Lowering {
     */
   private def javaUnboxMethod(tpe: Type): JMethod = {
     import java.lang.constant.ConstantDescs.*
-    def unbox(box: java.lang.constant.ClassDesc, name: String, prim: java.lang.constant.ClassDesc): JMethod =
-      JMethod(box, name, java.lang.constant.MethodTypeDesc.of(prim), isInterface = false)
+    def unbox(box: ClassDesc, name: String, prim: ClassDesc): JMethod =
+      JMethod(box, name, MethodTypeDesc.of(prim), isInterface = false)
     tpe match {
       case Type.Bool => unbox(CD_Boolean, "booleanValue", CD_boolean)
       case Type.Char => unbox(CD_Character, "charValue", CD_char)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -28,6 +28,8 @@ import ca.uwaterloo.flix.language.phase.monomorph2.Symbols.{Defs, Enums, Types}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, JvmUtils, Result}
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListOps, Nel}
 
+import java.lang.constant.{ClassDesc, MethodTypeDesc}
+
 /**
   * Fuses specialization and lowering into a single AST walk: instantiates a declaration's
   * types/symbols to their concrete (ground) form and lowers Datalog, channel, JVM-interop, and
@@ -1089,8 +1091,8 @@ object SpecializeAndLower {
     */
   private def javaBoxMethod(tpe: Type): JMethod = {
     import java.lang.constant.ConstantDescs.*
-    def valueOf(box: java.lang.constant.ClassDesc, prim: java.lang.constant.ClassDesc): JMethod =
-      JMethod(box, "valueOf", java.lang.constant.MethodTypeDesc.of(box, prim), isInterface = false)
+    def valueOf(box: ClassDesc, prim: ClassDesc): JMethod =
+      JMethod(box, "valueOf", MethodTypeDesc.of(box, prim), isInterface = false)
     tpe match {
       case Type.Bool => valueOf(CD_Boolean, CD_boolean)
       case Type.Char => valueOf(CD_Character, CD_char)
@@ -1110,8 +1112,8 @@ object SpecializeAndLower {
     */
   private def javaUnboxMethod(tpe: Type): JMethod = {
     import java.lang.constant.ConstantDescs.*
-    def unbox(box: java.lang.constant.ClassDesc, name: String, prim: java.lang.constant.ClassDesc): JMethod =
-      JMethod(box, name, java.lang.constant.MethodTypeDesc.of(prim), isInterface = false)
+    def unbox(box: ClassDesc, name: String, prim: ClassDesc): JMethod =
+      JMethod(box, name, MethodTypeDesc.of(prim), isInterface = false)
     tpe match {
       case Type.Bool => unbox(CD_Boolean, "booleanValue", CD_boolean)
       case Type.Char => unbox(CD_Character, "charValue", CD_char)


### PR DESCRIPTION
Replaces all fully-qualified and package-qualified uses of `java.lang.constant.ClassDesc`, `java.lang.constant.MethodTypeDesc`, and `shared.JMethod` with imports, matching the prevailing style in the codebase (e.g. `AtomicOp.scala`, `DocAst.scala`, `ast/shared/JMethod.scala`).

- `shared.JMethod` → `JMethod` in `JvmAst.AnonClass` (the `shared.*` wildcard import was already in scope, and the neighboring `JvmMethod` case class already used the bare name).
- Added `import java.lang.constant.ClassDesc` (with `MethodTypeDesc` where used) to the seven `ast/` IR files, the three `phase/jvm/` files, `Simplifier`, `monomorph/Lowering`, and `monomorph2/SpecializeAndLower`, and dropped the `java.lang.constant.` prefixes at all use sites.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)