### PR TITLE
refactor: move MethodDescriptor out of JvmName

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -25,8 +25,8 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.{IsVolatile, NotVolatile}
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, MethodDescriptor, RootPackage}
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, RootPackage}
+import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -19,8 +19,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.Branch.{FalseBranch, TrueBranch}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.*
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
 import org.objectweb.asm
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassConstants.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassConstants.scala
@@ -19,8 +19,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceMethod, InterfaceMethod, StaticMethod}
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
 import org.objectweb.asm.MethodVisitor
 
 object ClassConstants {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -25,7 +25,6 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Static.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.*
 import ca.uwaterloo.flix.language.ast.shared.JvmAnnotation
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import org.objectweb.asm.{ClassWriter, MethodVisitor, Opcodes}
 
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.{MethodDescriptor, RootPackage}
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.{MethodVisitor, Opcodes}
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -7,7 +7,6 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.InstanceField
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.MethodVisitor
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -22,8 +22,7 @@ import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.ast.SemanticOp.*
 import ca.uwaterloo.flix.language.ast.shared.{Constant, ExpPosition, Mutability}
 import ca.uwaterloo.flix.language.ast.{SimpleType, *}
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
 import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.ListOps
 import org.objectweb.asm

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -20,7 +20,6 @@ import ca.uwaterloo.flix.api.{CompilerConstants, Flix, FlixEvent}
 import ca.uwaterloo.flix.language.ast.JvmAst.{Def, Root}
 import ca.uwaterloo.flix.language.ast.{Purity, SimpleType, Symbol}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.StaticMethod
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import ca.uwaterloo.flix.util.ParOps
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.{ClassWriter, Label, MethodVisitor, Opcodes}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -20,7 +20,6 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.util.InternalCompilerException
-import org.objectweb.asm
 
 import java.nio.file.{Path, Paths}
 
@@ -28,32 +27,6 @@ import java.nio.file.{Path, Paths}
   * Companion object for the [[JvmName]] class.
   */
 object JvmName {
-
-  // TODO: Would be nice to allow BackendObjType here to avoid conversions
-  case class MethodDescriptor(arguments: List[BackendType], result: VoidableType) {
-    /**
-      * Returns the type descriptor of this method.
-      */
-    val toDescriptor: String = {
-      // Descriptor of result
-      val resultDescriptor = result.toDescriptor
-
-      // Descriptor of arguments
-      val argumentDescriptor = arguments.map(_.toDescriptor).mkString
-
-      // Descriptor of the method
-      s"($argumentDescriptor)$resultDescriptor"
-    }
-
-    def toAsmType: asm.Type = asm.Type.getType(toDescriptor)
-  }
-
-  object MethodDescriptor {
-    val NothingToVoid: MethodDescriptor = MethodDescriptor(Nil, VoidableType.Void)
-
-    def mkDescriptor(argument: BackendType*)(result: VoidableType): MethodDescriptor =
-      MethodDescriptor(argument.toList, result)
-  }
 
   /**
     * The name of the static constructor method `<clinit>`.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/MethodDescriptor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/MethodDescriptor.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm
+
+import org.objectweb.asm
+
+/**
+  * Companion object for the [[MethodDescriptor]] class.
+  */
+object MethodDescriptor {
+  val NothingToVoid: MethodDescriptor = MethodDescriptor(Nil, VoidableType.Void)
+
+  def mkDescriptor(argument: BackendType*)(result: VoidableType): MethodDescriptor =
+    MethodDescriptor(argument.toList, result)
+}
+
+/**
+  * Represents the type descriptor of a JVM method.
+  */
+// TODO: Would be nice to allow BackendObjType here to avoid conversions
+case class MethodDescriptor(arguments: List[BackendType], result: VoidableType) {
+  /**
+    * Returns the type descriptor of this method.
+    */
+  val toDescriptor: String = {
+    // Descriptor of result
+    val resultDescriptor = result.toDescriptor
+
+    // Descriptor of arguments
+    val argumentDescriptor = arguments.map(_.toDescriptor).mkString
+
+    // Descriptor of the method
+    s"($argumentDescriptor)$resultDescriptor"
+  }
+
+  def toAsmType: asm.Type = asm.Type.getType(toDescriptor)
+}


### PR DESCRIPTION
Moves `MethodDescriptor` (and its companion with `NothingToVoid` / `mkDescriptor`) from the `JvmName` companion object into its own file `phase/jvm/MethodDescriptor.scala`.

`MethodDescriptor` is independent of `JvmName` — it is built from `BackendType` / `VoidableType` — so its placement inside the `JvmName` companion was incidental. This is the first step in a small series that narrows `JvmName.scala` down to the name type itself, continuing the nominal-descriptor cleanup (#13091 series).

Pure move, no behavior change: the class body is unchanged, and since the new file is in the same package, only imports needed updating (the `mkDescriptor` member imports are repointed; plain `MethodDescriptor` imports are dropped). The now-unused `org.objectweb.asm` import is removed from `JvmName.scala`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)