### PR TITLE
refactor: introduce Bytecode.scala with nominal xNewArray

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -173,6 +173,10 @@ object BackendType {
     }
   }
 
+  /** Converts the given [[SimpleType]] into the [[ClassDesc]] of its JVM representation. */
+  def toClassDesc(tpe0: SimpleType)(implicit root: JvmAst.Root): ClassDesc =
+    ClassDesc.ofDescriptor(toBackendType(tpe0).toDescriptor)
+
   /** Converts the given Java class or array descriptor `desc` into its [[BackendType]] representation. */
   def toBackendType(desc: ClassDesc): BackendType = {
     import java.lang.constant.ConstantDescs.*

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Bytecode.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Bytecode.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm
+
+import ca.uwaterloo.flix.language.ast.SourceLocation
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
+import org.objectweb.asm.{MethodVisitor, Opcodes}
+
+import java.lang.constant.ClassDesc
+
+/**
+  * A companion of [[BytecodeInstructions]] where instructions are expressed in terms of
+  * nominal JVM types ([[ClassDesc]]) instead of [[BackendType]].
+  *
+  * Functions are gradually moved here from [[BytecodeInstructions]].
+  */
+object Bytecode {
+
+  /** Emits a `NEWARRAY` or `ANEWARRAY` instruction that creates an array with element type `elmTpe`. */
+  def xNewArray(elmTpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
+    if (elmTpe.isPrimitive) mv.visitIntInsn(Opcodes.NEWARRAY, newArrayOperandOf(elmTpe))
+    else mv.visitTypeInsn(Opcodes.ANEWARRAY, ClassDescs.internalNameOf(elmTpe))
+  }
+
+  /** Returns the `NEWARRAY` type operand (e.g. [[Opcodes.T_INT]]) of the primitive type `tpe`. */
+  private def newArrayOperandOf(tpe: ClassDesc): Int = {
+    import java.lang.constant.ConstantDescs.*
+    if (tpe == CD_boolean) Opcodes.T_BOOLEAN
+    else if (tpe == CD_char) Opcodes.T_CHAR
+    else if (tpe == CD_byte) Opcodes.T_BYTE
+    else if (tpe == CD_short) Opcodes.T_SHORT
+    else if (tpe == CD_int) Opcodes.T_INT
+    else if (tpe == CD_long) Opcodes.T_LONG
+    else if (tpe == CD_float) Opcodes.T_FLOAT
+    else if (tpe == CD_double) Opcodes.T_DOUBLE
+    else throw InternalCompilerException(s"Unexpected primitive array element type '${tpe.descriptorString()}'", SourceLocation.Unknown)
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -501,21 +501,6 @@ object BytecodeInstructions {
     case BackendType.Array(_) | BackendType.Reference(_) => ALOAD(index)
   }
 
-  def xNewArray(elmTpe: BackendType)(implicit mv: MethodVisitor): Unit = elmTpe match {
-    case BackendType.Array(_) => mv.visitTypeInsn(Opcodes.ANEWARRAY, elmTpe.toDescriptor)
-    case BackendType.Reference(ref) => ANEWARRAY(ref.desc)
-    case tpe: BackendType.PrimitiveType => tpe match {
-      case BackendType.Bool => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_BOOLEAN)
-      case BackendType.Char => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_CHAR)
-      case BackendType.Int8 => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_BYTE)
-      case BackendType.Int16 => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_SHORT)
-      case BackendType.Int32 => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_INT)
-      case BackendType.Int64 => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_LONG)
-      case BackendType.Float32 => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_FLOAT)
-      case BackendType.Float64 => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_DOUBLE)
-    }
-  }
-
   /**
     * Pops the top of the stack using `POP` or `POP2` depending on the value size.
     */

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -30,7 +30,6 @@ import org.objectweb.asm
 import org.objectweb.asm.*
 import org.objectweb.asm.Opcodes.*
 
-import java.lang.constant.ClassDesc
 import scala.jdk.CollectionConverters.*
 
 /**
@@ -708,7 +707,7 @@ object GenExpression {
         val backendType = BackendType.toBackendType(innerType)
 
         pushInt(exps.length)
-        xNewArray(backendType)
+        Bytecode.xNewArray(BackendType.toClassDesc(innerType))
         for ((e, i) <- exps.zipWithIndex) {
           DUP()
           pushInt(i)
@@ -725,7 +724,7 @@ object GenExpression {
         val fillMethod = ClassMaker.StaticMethod(JavaClasses.Arrays, "fill", mkDescriptor(BackendType.Array(backendType.toErased), backendType.toErased)(VoidableType.Void))
         compileExpr(exp1) // default
         compileExpr(exp2) // default, length
-        xNewArray(backendType) // default, arr
+        Bytecode.xNewArray(BackendType.toClassDesc(innerType)) // default, arr
         if (backendType.is64BitWidth) DUP_X2() else DUP_X1() // arr, default, arr
         xSwap(lowerLarge = backendType.is64BitWidth, higherLarge = false) // arr, arr, default
         INVOKESTATIC(fillMethod)


### PR DESCRIPTION
Introduces `Bytecode.scala`: a companion of `BytecodeInstructions` where instructions are expressed in terms of nominal JVM types (`ClassDesc`) instead of the structural `BackendType`. Functions will gradually be moved there.

The first function moved is `xNewArray`. It never used the structure of its `BackendType` argument — every branch flattened it to a `NEWARRAY` operand or an internal name — so it collapses from a twelve-case match to a two-way branch on `ClassDesc.isPrimitive`, reusing `ClassDescs.internalNameOf`.

Also adds `BackendType.toClassDesc`, which converts a `SimpleType` to the `ClassDesc` of its JVM representation (currently via `toBackendType`; can later compute descriptors directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)