### PR TITLE
refactor: move name mangling helpers out of JvmName

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -25,7 +25,7 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.{IsVolatile, NotVolatile}
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, RootPackage}
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, RootPackage}
 import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
@@ -42,14 +42,14 @@ sealed trait BackendObjType {
     case BackendObjType.Lazy(tpe) => JvmName(RootPackage, mkClassName("Lazy", tpe))
     case BackendObjType.Tuple(elms) => JvmName(RootPackage, mkClassName("Tuple", elms))
     case BackendObjType.Struct(elms) => JvmName(RootPackage, mkClassName("Struct", elms))
-    case BackendObjType.NullaryTag(enumName, sym, _) => JvmName(RootPackage, JvmName.mkClassName(enumName, sym))
+    case BackendObjType.NullaryTag(enumName, sym, _) => JvmName(RootPackage, Mangle.mkClassName(enumName, sym))
     case BackendObjType.Tagged => JvmName(RootPackage, mkClassName("Tagged"))
     case BackendObjType.Tag(tpes) => JvmName(RootPackage, mkClassName("Tag", tpes))
     case BackendObjType.ExtTagged => JvmName(RootPackage, mkClassName("ExtTagged"))
     case BackendObjType.ExtTag(tpes) => JvmName(RootPackage, mkClassName("ExtTag", tpes))
     case BackendObjType.AbstractArrow(args, result) => JvmName(RootPackage, mkClassName(s"Clo${args.length}", args :+ result))
     case BackendObjType.Arrow(args, result) => JvmName(RootPackage, mkClassName(s"Fn${args.length}", args :+ result))
-    case BackendObjType.Defn(sym) => JvmName(sym.namespace, JvmName.mkClassName("Def", sym.name))
+    case BackendObjType.Defn(sym) => JvmName(sym.namespace, Mangle.mkClassName("Def", sym.name))
     case BackendObjType.RecordEmpty => JvmName(RootPackage, mkClassName(s"RecordEmpty"))
     case BackendObjType.RecordExtend(value) => JvmName(RootPackage, mkClassName("RecordExtend", value))
     case BackendObjType.Record => JvmName(RootPackage, mkClassName("Record"))
@@ -112,15 +112,15 @@ sealed trait BackendObjType {
 object BackendObjType {
 
   private def mkClassName(prefix: String, tpe: BackendType): String = {
-    JvmName.mkClassName(prefix, tpe.toErasedString)
+    Mangle.mkClassName(prefix, tpe.toErasedString)
   }
 
   private def mkClassName(prefix: String, tpes: List[BackendType]): String = {
-    JvmName.mkClassName(prefix, tpes.map(_.toErasedString))
+    Mangle.mkClassName(prefix, tpes.map(_.toErasedString))
   }
 
   private def mkClassName(prefix: String): String = {
-    JvmName.mkClassName(prefix)
+    Mangle.mkClassName(prefix)
   }
 
   case object Unit extends BackendObjType {
@@ -1429,7 +1429,7 @@ object BackendObjType {
       val erasedArgs = defn.fparams.map(_.tpe).map(BackendType.toErasedBackendType)
       val erasedResult = BackendType.toErasedBackendType(defn.unboxedType.tpe)
       // Exported names are checked in Safety, so no mangling is needed.
-      val name = if (defn.ann.isExport) defn.sym.name else "m_" + JvmName.mangle(defn.sym.name)
+      val name = if (defn.ann.isExport) defn.sym.name else "m_" + Mangle.mangle(defn.sym.name)
       StaticMethod(this.jvmName, name, MethodDescriptor(erasedArgs, erasedResult))
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.RootPackage
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.{MethodVisitor, Opcodes}
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1592,7 +1592,7 @@ object GenExpression {
 
     case Expr.NewObject(sym, _, _, _, constructors, methods, _) =>
       val methodExps = methods.map(_.exp)
-      val className = JvmName(ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage, sym.name).toInternalName
+      val className = JvmName(Mangle.RootPackage, sym.name).toInternalName
       mv.visitTypeInsn(NEW, className)
       mv.visitInsn(DUP)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -17,7 +17,6 @@
 
 package ca.uwaterloo.flix.language.phase.jvm
 
-import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.util.InternalCompilerException
 
@@ -55,93 +54,6 @@ object JvmName {
     val descriptor = desc.descriptorString()
     val parts = descriptor.substring(1, descriptor.length - 1).split("/")
     JvmName(parts.init.toList, parts.last)
-  }
-
-  val RootPackage: List[String] = Nil
-
-  /**
-    * Constructs a concatenated string using `JvmName.Delimiter`. The call
-    * `mkClassName("Tuple2", List(Object, Int, String))` would
-    * result in the string `"Tuple2$Obj$Int32$Obj"`.
-    */
-  def mkClassName(prefix: String, args: List[String]): String = {
-    val cPrefix = mangle(prefix)
-    if (args.isEmpty) s"$cPrefix${Flix.Delimiter}"
-    else s"$cPrefix${Flix.Delimiter}${args.map(mangle).mkString(Flix.Delimiter)}"
-  }
-
-  def mkClassName(prefix: String, arg: String): String =
-    mkClassName(prefix, List(arg))
-
-  def mkClassName(prefix: String): String =
-    mkClassName(prefix, Nil)
-
-  /**
-    * Performs name mangling on the given string `s` to avoid issues with special characters.
-    */
-  def mangle(s: String): String = {
-    // Fast path: most names contain no special characters, so we avoid
-    // allocating a new string entirely.
-    if (!containsSpecialChar(s)) s else mangleSlow(s)
-  }
-
-  /**
-    * Returns `true` if `s` contains at least one character that must be mangled.
-    */
-  private def containsSpecialChar(s: String): Boolean = {
-    var i = 0
-    while (i < s.length) {
-      if (mangleReplacement(s.charAt(i)) != null) {
-        return true
-      }
-      i = i + 1
-    }
-    false
-  }
-
-  /**
-    * Mangles `s` in a single pass, replacing every special character with its mangled form.
-    */
-  private def mangleSlow(s: String): String = {
-    val sb = new StringBuilder(s.length + 16)
-    var i = 0
-    while (i < s.length) {
-      val c = s.charAt(i)
-      val replacement = mangleReplacement(c)
-      if (replacement != null) {
-        sb.append(Flix.Delimiter)
-        sb.append(replacement)
-      } else {
-        sb.append(c)
-      }
-      i = i + 1
-    }
-    sb.toString
-  }
-
-  /**
-    * Returns the mangled replacement for the special character `c`, or `null` if `c` is not special.
-    */
-  private def mangleReplacement(c: Char): String = c match {
-    case '+' => "plus"
-    case '-' => "minus"
-    case '*' => "asterisk"
-    case '/' => "fslash"
-    case '\\' => "bslash"
-    case '<' => "less"
-    case '>' => "greater"
-    case '=' => "eq"
-    case '&' => "ampersand"
-    case '|' => "bar"
-    case '^' => "caret"
-    case '~' => "tilde"
-    case '!' => "exclamation"
-    case '#' => "hashtag"
-    case ':' => "colon"
-    case '?' => "question"
-    case '@' => "at"
-    case '.' => "dot"
-    case _ => null
   }
 
   //
@@ -215,9 +127,7 @@ object JvmName {
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flix Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   //
 
-  val DevFlixRuntime: List[String] = List("dev", "flix", "runtime")
-
-  val FlixError: JvmName = JvmName(DevFlixRuntime, mkClassName("FlixError"))
+  val FlixError: JvmName = JvmName(Mangle.DevFlixRuntime, Mangle.mkClassName("FlixError"))
 
 }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.ast.{JvmAst, SimpleType, SourceLocation, Symbol, Type, TypeConstructor}
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.mangle
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.mangle
 import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.ListOps
 
@@ -71,7 +71,7 @@ object JvmOps {
     */
   def getClosureClassName(sym: Symbol.DefnSym): JvmName = {
     // The JVM name is of the form Clo$sym.name
-    val name = JvmName.mkClassName(s"Clo", sym.name)
+    val name = Mangle.mkClassName(s"Clo", sym.name)
 
     // The JVM package is the namespace of the symbol.
     val pkg = sym.namespace
@@ -90,7 +90,7 @@ object JvmOps {
     */
   def getEffectDefinitionClassName(sym: Symbol.EffSym): JvmName = {
     val pkg = sym.namespace
-    val name = JvmName.mkClassName("Eff", sym.name)
+    val name = Mangle.mkClassName("Eff", sym.name)
     JvmName(pkg, name)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
@@ -24,8 +24,10 @@ import ca.uwaterloo.flix.api.Flix
   */
 object Mangle {
 
+  /** The root (unnamed) package. */
   val RootPackage: List[String] = Nil
 
+  /** The `dev.flix.runtime` package of the Flix runtime classes. */
   val DevFlixRuntime: List[String] = List("dev", "flix", "runtime")
 
   /**
@@ -39,9 +41,11 @@ object Mangle {
     else s"$cPrefix${Flix.Delimiter}${args.map(mangle).mkString(Flix.Delimiter)}"
   }
 
+  /** Constructs a class name from `prefix` and the single argument `arg`. */
   def mkClassName(prefix: String, arg: String): String =
     mkClassName(prefix, List(arg))
 
+  /** Constructs a class name from `prefix` alone. */
   def mkClassName(prefix: String): String =
     mkClassName(prefix, Nil)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 Magnus Madsen
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm
+
+import ca.uwaterloo.flix.api.Flix
+
+/**
+  * Name mangling and construction of class names for generated classes.
+  */
+object Mangle {
+
+  val RootPackage: List[String] = Nil
+
+  val DevFlixRuntime: List[String] = List("dev", "flix", "runtime")
+
+  /**
+    * Constructs a concatenated string using `Flix.Delimiter`. The call
+    * `mkClassName("Tuple2", List(Object, Int, String))` would
+    * result in the string `"Tuple2$Obj$Int32$Obj"`.
+    */
+  def mkClassName(prefix: String, args: List[String]): String = {
+    val cPrefix = mangle(prefix)
+    if (args.isEmpty) s"$cPrefix${Flix.Delimiter}"
+    else s"$cPrefix${Flix.Delimiter}${args.map(mangle).mkString(Flix.Delimiter)}"
+  }
+
+  def mkClassName(prefix: String, arg: String): String =
+    mkClassName(prefix, List(arg))
+
+  def mkClassName(prefix: String): String =
+    mkClassName(prefix, Nil)
+
+  /**
+    * Performs name mangling on the given string `s` to avoid issues with special characters.
+    */
+  def mangle(s: String): String = {
+    // Fast path: most names contain no special characters, so we avoid
+    // allocating a new string entirely.
+    if (!containsSpecialChar(s)) s else mangleSlow(s)
+  }
+
+  /**
+    * Returns `true` if `s` contains at least one character that must be mangled.
+    */
+  private def containsSpecialChar(s: String): Boolean = {
+    var i = 0
+    while (i < s.length) {
+      if (mangleReplacement(s.charAt(i)) != null) {
+        return true
+      }
+      i = i + 1
+    }
+    false
+  }
+
+  /**
+    * Mangles `s` in a single pass, replacing every special character with its mangled form.
+    */
+  private def mangleSlow(s: String): String = {
+    val sb = new StringBuilder(s.length + 16)
+    var i = 0
+    while (i < s.length) {
+      val c = s.charAt(i)
+      val replacement = mangleReplacement(c)
+      if (replacement != null) {
+        sb.append(Flix.Delimiter)
+        sb.append(replacement)
+      } else {
+        sb.append(c)
+      }
+      i = i + 1
+    }
+    sb.toString
+  }
+
+  /**
+    * Returns the mangled replacement for the special character `c`, or `null` if `c` is not special.
+    */
+  private def mangleReplacement(c: Char): String = c match {
+    case '+' => "plus"
+    case '-' => "minus"
+    case '*' => "asterisk"
+    case '/' => "fslash"
+    case '\\' => "bslash"
+    case '<' => "less"
+    case '>' => "greater"
+    case '=' => "eq"
+    case '&' => "ampersand"
+    case '|' => "bar"
+    case '^' => "caret"
+    case '~' => "tilde"
+    case '!' => "exclamation"
+    case '#' => "hashtag"
+    case ':' => "colon"
+    case '?' => "question"
+    case '@' => "at"
+    case '.' => "dot"
+    case _ => null
+  }
+}


### PR DESCRIPTION
Moves the name construction machinery from the `JvmName` companion object into a new `phase/jvm/Mangle.scala`:

- `mangle` (with its private helpers `containsSpecialChar`, `mangleSlow`, `mangleReplacement`)
- `mkClassName` (all three overloads)
- the package constants `RootPackage` and `DevFlixRuntime`

This is mangling/name-building logic, not part of the name type itself. Second step (after #13106) in narrowing `JvmName.scala` down to the name type.

The `Java*` package lists (`JavaLang`, `JavaUtil`, …) deliberately stay in `JvmName` — they only feed its JDK constants table and will be retired together with it.

Pure move, no behavior change. Also simplifies an unnecessarily fully-qualified `JvmName.RootPackage` reference in `GenExpression`, and `JvmName.scala` drops its now-unused `Flix` import. The `mkClassName` doc comment now correctly says `Flix.Delimiter` (it referred to a nonexistent `JvmName.Delimiter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)