### PR TITLE
refactor: use ClassDesc in BytecodeInstructions and ClassMaker

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
@@ -18,6 +18,8 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import org.objectweb.asm.ClassWriter
 
+import java.lang.constant.ClassDesc
+
 object AsmOps {
 
   /**
@@ -28,6 +30,21 @@ object AsmOps {
   def mkClassWriter(): ClassWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES) {
     override def getCommonSuperClass(tpe1: String, tpe2: String): String = {
       JvmName.Object.toInternalName
+    }
+  }
+
+  /**
+    * Returns the JVM internal name of the class, interface, or array descriptor `desc`,
+    * e.g. `java/lang/String` or `[Ljava/lang/String;`.
+    */
+  def internalNameOf(desc: ClassDesc): String = {
+    if (desc.isArray) {
+      // The internal name of an array type is its descriptor.
+      desc.descriptorString()
+    } else {
+      // Strip the leading `L` and trailing `;` of the descriptor.
+      val descriptor = desc.descriptorString()
+      descriptor.substring(1, descriptor.length - 1)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -30,6 +30,8 @@ import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 
+import java.lang.constant.ClassDesc
+
 /**
   * Represents all Flix types that are objects on the JVM (array is an exception).
   */
@@ -83,6 +85,11 @@ sealed trait BackendObjType {
   }
 
   /**
+    * The [[ClassDesc]] of this type.
+    */
+  def desc: ClassDesc = jvmName.toClassDesc
+
+  /**
     * The JVM type descriptor of the form `"L<jvmName.toInternalName>;"`.
     */
   def toDescriptor: String = jvmName.toDescriptor
@@ -101,7 +108,7 @@ sealed trait BackendObjType {
 
   /** `[] --> return` */
   protected def singletonStaticConstructor(thisConstructor: ConstructorMethod, singleton: StaticField)(implicit mv: MethodVisitor): Unit = {
-    NEW(this.jvmName)
+    NEW(this.desc)
     DUP()
     INVOKESPECIAL(thisConstructor)
     PUTSTATIC(singleton)
@@ -125,25 +132,25 @@ object BackendObjType {
 
   case object Unit extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal)
+      val cm = mkClass(this.desc, IsFinal)
 
-      cm.mkStaticConstructor(StaticConstructorMethod(this.jvmName), singletonStaticConstructor(Constructor, SingletonField)(_))
+      cm.mkStaticConstructor(StaticConstructorMethod(this.desc), singletonStaticConstructor(Constructor, SingletonField)(_))
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
       cm.mkField(SingletonField, IsPublic, IsFinal, NotVolatile)
 
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def SingletonField: StaticField = StaticField(this.jvmName, "INSTANCE", this.toTpe)
+    def SingletonField: StaticField = StaticField(this.desc, "INSTANCE", this.toTpe)
 
   }
 
   case class Lazy(tpe: BackendType) extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
       cm.mkField(ExpField, IsPublic, NotFinal, IsVolatile)
@@ -154,13 +161,13 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def ExpField: InstanceField = InstanceField(this.jvmName, "expression", BackendType.Object)
+    def ExpField: InstanceField = InstanceField(this.desc, "expression", BackendType.Object)
 
-    def ValueField: InstanceField = InstanceField(this.jvmName, "value", tpe)
+    def ValueField: InstanceField = InstanceField(this.desc, "value", tpe)
 
-    private def LockField: InstanceField = InstanceField(this.jvmName, "lock", JvmName.ReentrantLock.toTpe)
+    private def LockField: InstanceField = InstanceField(this.desc, "lock", JvmName.ReentrantLock.toTpe)
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, List(BackendType.Object))
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(BackendType.Object))
 
     /** `[] --> return` */
     private def constructorIns(implicit mv: MethodVisitor): Unit =
@@ -174,7 +181,7 @@ object BackendObjType {
         PUTFIELD(ExpField)
         // this.lock = new ReentrantLock()
         thisLoad()
-        NEW(JvmName.ReentrantLock)
+        NEW(JvmName.ReentrantLock.toClassDesc)
         DUP()
         INVOKESPECIAL(ClassConstants.ReentrantLock.Constructor)
         PUTFIELD(LockField)
@@ -182,7 +189,7 @@ object BackendObjType {
         RETURN()
       })
 
-    def ForceMethod: InstanceMethod = InstanceMethod(this.jvmName, "force", mkDescriptor()(tpe))
+    def ForceMethod: InstanceMethod = InstanceMethod(this.desc, "force", mkDescriptor()(tpe))
 
     /** `[] --> return tpe` */
     private def forceIns(implicit mv: MethodVisitor): Unit = {
@@ -204,7 +211,7 @@ object BackendObjType {
           // get expression as thunk
           DUP()
           GETFIELD(ExpField)
-          CHECKCAST(Thunk.jvmName)
+          CHECKCAST(Thunk.desc)
           // this.value = thunk.unwind()
           Result.unwindSuspensionFreeThunkToType(tpe, "during call to Lazy.force", SourceLocation.Unknown)
           PUTFIELD(ValueField)
@@ -228,7 +235,7 @@ object BackendObjType {
   case class Tuple(elms: List[BackendType]) extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal)
 
       elms.indices.foreach(i => cm.mkField(IndexField(i), IsPublic, NotFinal, NotVolatile))
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
@@ -236,9 +243,9 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def IndexField(i: Int): InstanceField = InstanceField(this.jvmName, s"field$i", elms(i))
+    def IndexField(i: Int): InstanceField = InstanceField(this.desc, s"field$i", elms(i))
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, elms)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, elms)
 
     /** `[] --> return` */
     private def constructorIns(implicit mv: MethodVisitor): Unit =
@@ -261,7 +268,7 @@ object BackendObjType {
   case class Struct(elms: List[BackendType]) extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal)
 
       elms.indices.foreach(i => cm.mkField(IndexField(i), IsPublic, NotFinal, NotVolatile))
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
@@ -269,9 +276,9 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def IndexField(i: Int): InstanceField = InstanceField(this.jvmName, s"field$i", elms(i))
+    def IndexField(i: Int): InstanceField = InstanceField(this.desc, s"field$i", elms(i))
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, elms)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, elms)
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
       withNames(1, elms) { case (_, variables) =>
@@ -295,7 +302,7 @@ object BackendObjType {
 
   case object Tagged extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkAbstractClass(this.jvmName)
+      val cm = ClassMaker.mkAbstractClass(this.desc)
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
 
@@ -304,9 +311,9 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def OrdinalField: InstanceField = InstanceField(this.jvmName, "ordinal", BackendType.Int32)
+    def OrdinalField: InstanceField = InstanceField(this.desc, "ordinal", BackendType.Int32)
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
   }
 
   sealed trait TagType extends BackendObjType {
@@ -315,18 +322,18 @@ object BackendObjType {
 
   case class NullaryTag(enumName: String, name: String, ordinal: Int) extends TagType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = Tagged.jvmName)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = Tagged.desc)
 
-      cm.mkStaticConstructor(StaticConstructorMethod(this.jvmName), singletonStaticConstructor(Constructor, SingletonField)(_))
+      cm.mkStaticConstructor(StaticConstructorMethod(this.desc), singletonStaticConstructor(Constructor, SingletonField)(_))
       cm.mkField(SingletonField, IsPublic, IsFinal, NotVolatile)
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
 
       cm.closeClassMaker()
     }
 
-    def SingletonField: StaticField = StaticField(this.jvmName, "singleton", this.toTpe)
+    def SingletonField: StaticField = StaticField(this.desc, "singleton", this.toTpe)
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
     /** `[] --> return` */
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
@@ -343,7 +350,7 @@ object BackendObjType {
     if (elms.isEmpty) throw InternalCompilerException(s"Unexpected nullary Tag type", SourceLocation.Unknown)
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = Tagged.jvmName)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = Tagged.desc)
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(Tagged.Constructor)(_))
       elms.indices.foreach(i => cm.mkField(IndexField(i), IsPublic, NotFinal, NotVolatile))
@@ -353,14 +360,14 @@ object BackendObjType {
 
     def OrdinalField: InstanceField = Tagged.OrdinalField
 
-    def IndexField(i: Int): InstanceField = InstanceField(this.jvmName, s"v$i", elms(i))
+    def IndexField(i: Int): InstanceField = InstanceField(this.desc, s"v$i", elms(i))
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
   }
 
   case object ExtTagged extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkAbstractClass(this.jvmName)
+      val cm = ClassMaker.mkAbstractClass(this.desc)
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
 
@@ -369,9 +376,9 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def NameField: InstanceField = InstanceField(this.jvmName, "tag", BackendType.String)
+    def NameField: InstanceField = InstanceField(this.desc, "tag", BackendType.String)
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
     /** [...] -> [..., tagName] */
     def mkTagName(name: String)(implicit mv: MethodVisitor): Unit = pushString(JvmOps.getTagName(name))
@@ -385,7 +392,7 @@ object BackendObjType {
 
   case class ExtTag(elms: List[BackendType]) extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = ExtTagged.jvmName)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = ExtTagged.desc)
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ExtTagged.Constructor)(_))
       elms.indices.foreach(i => cm.mkField(IndexField(i), IsPublic, NotFinal, NotVolatile))
@@ -395,9 +402,9 @@ object BackendObjType {
 
     def NameField: InstanceField = ExtTagged.NameField
 
-    def IndexField(i: Int): InstanceField = InstanceField(this.jvmName, s"v$i", elms(i))
+    def IndexField(i: Int): InstanceField = InstanceField(this.desc, s"v$i", elms(i))
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
   }
 
   /**
@@ -412,7 +419,7 @@ object BackendObjType {
     def superClass: BackendObjType.Arrow = Arrow(args, result)
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkAbstractClass(this.jvmName, superClass.jvmName)
+      val cm = ClassMaker.mkAbstractClass(this.desc, superClass.desc)
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(superClass.Constructor)(_))
 
       cm.mkAbstractMethod(GetUniqueThreadClosureMethod)
@@ -420,9 +427,9 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def GetUniqueThreadClosureMethod: AbstractMethod = AbstractMethod(this.jvmName, "getUniqueThreadClosure", mkDescriptor()(this.toTpe))
+    def GetUniqueThreadClosureMethod: AbstractMethod = AbstractMethod(this.desc, "getUniqueThreadClosure", mkDescriptor()(this.toTpe))
 
   }
 
@@ -454,39 +461,44 @@ object BackendObjType {
       }
 
       /**
+        * The [[ClassDesc]] of the interface.
+        */
+      def desc: ClassDesc = jvmName.toClassDesc
+
+      /**
         * The required method of the interface.
         * These methods should do the same as a non-tail call in genExpression.
         */
       def functionMethod: InstanceMethod = this match {
-        case ObjFunction => InstanceMethod(this.jvmName, "apply",
+        case ObjFunction => InstanceMethod(this.desc, "apply",
           mkDescriptor(BackendType.Object)(BackendType.Object))
-        case ObjConsumer => InstanceMethod(this.jvmName, "accept",
+        case ObjConsumer => InstanceMethod(this.desc, "accept",
           mkDescriptor(BackendType.Object)(VoidableType.Void))
-        case ObjPredicate => InstanceMethod(this.jvmName, "test",
+        case ObjPredicate => InstanceMethod(this.desc, "test",
           mkDescriptor(BackendType.Object)(BackendType.Bool))
-        case IntFunction => InstanceMethod(this.jvmName, "apply",
+        case IntFunction => InstanceMethod(this.desc, "apply",
           mkDescriptor(BackendType.Int32)(BackendType.Object))
-        case IntConsumer => InstanceMethod(this.jvmName, "accept",
+        case IntConsumer => InstanceMethod(this.desc, "accept",
           mkDescriptor(BackendType.Int32)(VoidableType.Void))
-        case IntPredicate => InstanceMethod(this.jvmName, "test",
+        case IntPredicate => InstanceMethod(this.desc, "test",
           mkDescriptor(BackendType.Int32)(BackendType.Bool))
-        case IntUnaryOperator => InstanceMethod(this.jvmName, "applyAsInt",
+        case IntUnaryOperator => InstanceMethod(this.desc, "applyAsInt",
           mkDescriptor(BackendType.Int32)(BackendType.Int32))
-        case LongFunction => InstanceMethod(this.jvmName, "apply",
+        case LongFunction => InstanceMethod(this.desc, "apply",
           mkDescriptor(BackendType.Int64)(BackendType.Object))
-        case LongConsumer => InstanceMethod(this.jvmName, "accept",
+        case LongConsumer => InstanceMethod(this.desc, "accept",
           mkDescriptor(BackendType.Int64)(VoidableType.Void))
-        case LongPredicate => InstanceMethod(this.jvmName, "test",
+        case LongPredicate => InstanceMethod(this.desc, "test",
           mkDescriptor(BackendType.Int64)(BackendType.Bool))
-        case LongUnaryOperator => InstanceMethod(this.jvmName, "applyAsLong",
+        case LongUnaryOperator => InstanceMethod(this.desc, "applyAsLong",
           mkDescriptor(BackendType.Int64)(BackendType.Int64))
-        case DoubleFunction => InstanceMethod(this.jvmName, "apply",
+        case DoubleFunction => InstanceMethod(this.desc, "apply",
           mkDescriptor(BackendType.Float64)(BackendType.Object))
-        case DoubleConsumer => InstanceMethod(this.jvmName, "accept",
+        case DoubleConsumer => InstanceMethod(this.desc, "accept",
           mkDescriptor(BackendType.Float64)(VoidableType.Void))
-        case DoublePredicate => InstanceMethod(this.jvmName, "test",
+        case DoublePredicate => InstanceMethod(this.desc, "test",
           mkDescriptor(BackendType.Float64)(BackendType.Bool))
-        case DoubleUnaryOperator => InstanceMethod(this.jvmName, "applyAsDouble",
+        case DoubleUnaryOperator => InstanceMethod(this.desc, "applyAsDouble",
           mkDescriptor(BackendType.Float64)(BackendType.Float64))
       }
 
@@ -667,9 +679,9 @@ object BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
       val specializedInterface = specialization()
-      val interfaces = Thunk.jvmName :: specializedInterface.map(_.jvmName)
+      val interfaces = Thunk.desc :: specializedInterface.map(_.desc)
 
-      val cm = ClassMaker.mkAbstractClass(this.jvmName, superClass = JvmName.Object, interfaces)
+      val cm = ClassMaker.mkAbstractClass(this.desc, superClass = JvmName.Object.toClassDesc, interfaces)
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
       args.indices.foreach(argIndex => cm.mkField(ArgField(argIndex), IsPublic, NotFinal, NotVolatile))
@@ -678,18 +690,18 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def ArgField(index: Int): InstanceField = InstanceField(this.jvmName, s"arg$index", args(index))
+    def ArgField(index: Int): InstanceField = InstanceField(this.desc, s"arg$index", args(index))
   }
 
   case class Defn(sym: Symbol.DefnSym) extends BackendObjType
 
   case object RecordEmpty extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, interfaces = List(this.interface.jvmName))
+      val cm = ClassMaker.mkClass(this.desc, IsFinal, interfaces = List(this.interface.desc))
 
-      cm.mkStaticConstructor(StaticConstructorMethod(this.jvmName), singletonStaticConstructor(Constructor, SingletonField)(_))
+      cm.mkStaticConstructor(StaticConstructorMethod(this.desc), singletonStaticConstructor(Constructor, SingletonField)(_))
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
       cm.mkField(SingletonField, IsPublic, IsFinal, NotVolatile)
       cm.mkMethod(Nil, LookupFieldMethod, IsPublic, IsFinal, throwUnsupportedExc(_))
@@ -698,15 +710,15 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
     def interface: Record.type = Record
 
-    def SingletonField: StaticField = StaticField(this.jvmName, "INSTANCE", this.toTpe)
+    def SingletonField: StaticField = StaticField(this.desc, "INSTANCE", this.toTpe)
 
-    private def LookupFieldMethod: InstanceMethod = interface.LookupFieldMethod.implementation(this.jvmName)
+    private def LookupFieldMethod: InstanceMethod = interface.LookupFieldMethod.implementation(this.desc)
 
-    private def RestrictFieldMethod: InstanceMethod = interface.RestrictFieldMethod.implementation(this.jvmName)
+    private def RestrictFieldMethod: InstanceMethod = interface.RestrictFieldMethod.implementation(this.desc)
 
     private def throwUnsupportedExc(implicit mv: MethodVisitor): Unit = {
       throwUnsupportedOperationException(
@@ -716,25 +728,25 @@ object BackendObjType {
 
   case class RecordExtend(value: BackendType) extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, interfaces = List(Record.jvmName))
+      val cm = ClassMaker.mkClass(this.desc, IsFinal, interfaces = List(Record.desc))
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
       cm.mkField(LabelField, IsPublic, NotFinal, NotVolatile)
       cm.mkField(ValueField, IsPublic, NotFinal, NotVolatile)
       cm.mkField(RestField, IsPublic, NotFinal, NotVolatile)
-      cm.mkMethod(Nil, Record.LookupFieldMethod.implementation(this.jvmName), IsPublic, IsFinal, lookupFieldIns(_))
+      cm.mkMethod(Nil, Record.LookupFieldMethod.implementation(this.desc), IsPublic, IsFinal, lookupFieldIns(_))
       cm.mkMethod(Nil, RestrictFieldMethod, IsPublic, IsFinal, restrictFieldIns(_))
 
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def LabelField: InstanceField = InstanceField(this.jvmName, "label", BackendType.String)
+    def LabelField: InstanceField = InstanceField(this.desc, "label", BackendType.String)
 
-    def ValueField: InstanceField = InstanceField(this.jvmName, "value", value)
+    def ValueField: InstanceField = InstanceField(this.desc, "value", value)
 
-    def RestField: InstanceField = InstanceField(this.jvmName, "rest", Record.toTpe)
+    def RestField: InstanceField = InstanceField(this.desc, "rest", Record.toTpe)
 
     private def lookupFieldIns(implicit mv: MethodVisitor): Unit = {
       caseOnLabelEquality {
@@ -750,7 +762,7 @@ object BackendObjType {
       }
     }
 
-    def RestrictFieldMethod: InstanceMethod = Record.RestrictFieldMethod.implementation(this.jvmName)
+    def RestrictFieldMethod: InstanceMethod = Record.RestrictFieldMethod.implementation(this.desc)
 
     private def restrictFieldIns(implicit mv: MethodVisitor): Unit = {
       caseOnLabelEquality {
@@ -759,7 +771,7 @@ object BackendObjType {
           GETFIELD(RestField)
           ARETURN()
         case FalseBranch =>
-          NEW(this.jvmName)
+          NEW(this.desc)
           DUP()
           INVOKESPECIAL(this.Constructor)
           DUP()
@@ -794,7 +806,7 @@ object BackendObjType {
 
   case object Record extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkInterface(this.jvmName)
+      val cm = ClassMaker.mkInterface(this.desc)
 
       cm.mkInterfaceMethod(LookupFieldMethod)
       cm.mkInterfaceMethod(RestrictFieldMethod)
@@ -802,10 +814,10 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def LookupFieldMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "lookupField",
+    def LookupFieldMethod: InterfaceMethod = InterfaceMethod(this.desc, "lookupField",
       mkDescriptor(BackendType.String)(this.toTpe))
 
-    def RestrictFieldMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "restrictField",
+    def RestrictFieldMethod: InterfaceMethod = InterfaceMethod(this.desc, "restrictField",
       mkDescriptor(BackendType.String)(this.toTpe))
   }
 
@@ -818,7 +830,7 @@ object BackendObjType {
 
   case object ReifiedSourceLocation extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
 
@@ -834,7 +846,7 @@ object BackendObjType {
     }
 
     def Constructor: ConstructorMethod = ConstructorMethod(
-      this.jvmName, List(BackendType.String, BackendType.Int32, BackendType.Int32, BackendType.Int32, BackendType.Int32)
+      this.desc, List(BackendType.String, BackendType.Int32, BackendType.Int32, BackendType.Int32, BackendType.Int32)
     )
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
@@ -859,25 +871,25 @@ object BackendObjType {
     }
 
     private def SourceField: InstanceField =
-      InstanceField(this.jvmName, "source", BackendType.String)
+      InstanceField(this.desc, "source", BackendType.String)
 
     private def BeginLineField: InstanceField =
-      InstanceField(this.jvmName, "beginLine", BackendType.Int32)
+      InstanceField(this.desc, "beginLine", BackendType.Int32)
 
     private def BeginColField: InstanceField =
-      InstanceField(this.jvmName, "beginCol", BackendType.Int32)
+      InstanceField(this.desc, "beginCol", BackendType.Int32)
 
     private def EndLineField: InstanceField =
-      InstanceField(this.jvmName, "endLine", BackendType.Int32)
+      InstanceField(this.desc, "endLine", BackendType.Int32)
 
     private def EndColField: InstanceField =
-      InstanceField(this.jvmName, "endCol", BackendType.Int32)
+      InstanceField(this.desc, "endCol", BackendType.Int32)
 
-    private def ToStringMethod: InstanceMethod = ClassConstants.Object.ToStringMethod.implementation(this.jvmName)
+    private def ToStringMethod: InstanceMethod = ClassConstants.Object.ToStringMethod.implementation(this.desc)
 
     private def toStringIns(implicit mv: MethodVisitor): Unit = {
       // create string builder
-      NEW(JvmName.StringBuilder)
+      NEW(JvmName.StringBuilder.toClassDesc)
       DUP()
       INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
       // build string
@@ -902,10 +914,10 @@ object BackendObjType {
 
   case object Global extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal)
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-      cm.mkStaticConstructor(StaticConstructorMethod(this.jvmName), staticConstructorIns(_))
+      cm.mkStaticConstructor(StaticConstructorMethod(this.desc), staticConstructorIns(_))
 
       cm.mkField(CounterField, IsPrivate, IsFinal, NotVolatile)
       cm.mkStaticMethod(NewIdMethod, IsPublic, IsFinal, newIdIns(_))
@@ -917,34 +929,34 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
     private def staticConstructorIns(implicit mv: MethodVisitor): Unit = {
-      NEW(JvmName.AtomicLong)
+      NEW(JvmName.AtomicLong.toClassDesc)
       DUP()
-      invokeConstructor(JvmName.AtomicLong, MethodDescriptor.NothingToVoid)
+      invokeConstructor(JvmName.AtomicLong.toClassDesc, MethodDescriptor.NothingToVoid)
       PUTSTATIC(CounterField)
       ICONST_0()
-      ANEWARRAY(JvmName.String)
+      ANEWARRAY(JvmName.String.toClassDesc)
       PUTSTATIC(ArgsField)
       RETURN()
     }
 
-    private def NewIdMethod: StaticMethod = StaticMethod(this.jvmName, "newId", mkDescriptor()(BackendType.Int64))
+    private def NewIdMethod: StaticMethod = StaticMethod(this.desc, "newId", mkDescriptor()(BackendType.Int64))
 
     private def newIdIns(implicit mv: MethodVisitor): Unit = {
       GETSTATIC(CounterField)
-      INVOKEVIRTUAL(JvmName.AtomicLong, "getAndIncrement",
+      INVOKEVIRTUAL(JvmName.AtomicLong.toClassDesc, "getAndIncrement",
         MethodDescriptor(Nil, BackendType.Int64))
       LRETURN()
     }
 
-    private def GetArgsMethod: StaticMethod = StaticMethod(this.jvmName, "getArgs", mkDescriptor()(BackendType.Array(BackendType.String)))
+    private def GetArgsMethod: StaticMethod = StaticMethod(this.desc, "getArgs", mkDescriptor()(BackendType.Array(BackendType.String)))
 
     private def getArgsIns(implicit mv: MethodVisitor): Unit = {
       GETSTATIC(ArgsField)
       ARRAYLENGTH()
-      ANEWARRAY(JvmName.String)
+      ANEWARRAY(JvmName.String.toClassDesc)
       ASTORE(0)
       // the new array is now created, now to copy the args
       GETSTATIC(ArgsField)
@@ -959,12 +971,12 @@ object BackendObjType {
     }
 
     def SetArgsMethod: StaticMethod =
-      StaticMethod(this.jvmName, "setArgs", mkDescriptor(BackendType.Array(BackendType.String))(VoidableType.Void))
+      StaticMethod(this.desc, "setArgs", mkDescriptor(BackendType.Array(BackendType.String))(VoidableType.Void))
 
     private def setArgsIns(implicit mv: MethodVisitor): Unit = {
       ALOAD(0)
       ARRAYLENGTH()
-      ANEWARRAY(JvmName.String)
+      ANEWARRAY(JvmName.String.toClassDesc)
       ASTORE(1)
       ALOAD(0)
       ICONST_0()
@@ -978,12 +990,12 @@ object BackendObjType {
       RETURN()
     }
 
-    private def CounterField: StaticField = StaticField(this.jvmName, "counter", JvmName.AtomicLong.toTpe)
+    private def CounterField: StaticField = StaticField(this.desc, "counter", JvmName.AtomicLong.toTpe)
 
-    private def ArgsField: StaticField = StaticField(this.jvmName, "args", BackendType.Array(BackendType.String))
+    private def ArgsField: StaticField = StaticField(this.desc, "args", BackendType.Array(BackendType.String))
 
     private def arrayCopy()(implicit mv: MethodVisitor): Unit = {
-      mv.visitMethodInstruction(Opcodes.INVOKESTATIC, JvmName.System, "arraycopy",
+      mv.visitMethodInstruction(Opcodes.INVOKESTATIC, JvmName.System.toClassDesc, "arraycopy",
         MethodDescriptor(List(BackendType.Object, BackendType.Int32, BackendType.Object, BackendType.Int32,
           BackendType.Int32), VoidableType.Void), isInterface = false)
     }
@@ -991,7 +1003,7 @@ object BackendObjType {
 
   case object HoleError extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, JvmName.FlixError)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal, JvmName.FlixError.toClassDesc)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
       // These fields allow external equality checking.
@@ -1001,18 +1013,18 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    private def HoleField: InstanceField = InstanceField(this.jvmName, "hole", BackendType.String)
+    private def HoleField: InstanceField = InstanceField(this.desc, "hole", BackendType.String)
 
-    private def LocationField: InstanceField = InstanceField(this.jvmName, "location", ReifiedSourceLocation.toTpe)
+    private def LocationField: InstanceField = InstanceField(this.desc, "location", ReifiedSourceLocation.toTpe)
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, List(BackendType.String, ReifiedSourceLocation.toTpe))
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(BackendType.String, ReifiedSourceLocation.toTpe))
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
       withName(1, BackendType.String) { hole =>
         withName(2, ReifiedSourceLocation.toTpe) { loc =>
           thisLoad()
           // create an error msg
-          NEW(JvmName.StringBuilder)
+          NEW(JvmName.StringBuilder.toClassDesc)
           DUP()
           INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
           pushString("Hole '")
@@ -1042,7 +1054,7 @@ object BackendObjType {
   case object MatchError extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(MatchError.jvmName, IsFinal, superClass = JvmName.FlixError)
+      val cm = ClassMaker.mkClass(MatchError.desc, IsFinal, superClass = JvmName.FlixError.toClassDesc)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
       // This field allows external equality checking.
@@ -1051,13 +1063,13 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    private def LocationField: InstanceField = InstanceField(this.jvmName, "location", ReifiedSourceLocation.toTpe)
+    private def LocationField: InstanceField = InstanceField(this.desc, "location", ReifiedSourceLocation.toTpe)
 
-    def Constructor: ConstructorMethod = ConstructorMethod(MatchError.jvmName, List(ReifiedSourceLocation.toTpe))
+    def Constructor: ConstructorMethod = ConstructorMethod(MatchError.desc, List(ReifiedSourceLocation.toTpe))
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
-      NEW(JvmName.StringBuilder)
+      NEW(JvmName.StringBuilder.toClassDesc)
       DUP()
       INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
       pushString("Non-exhaustive match at ")
@@ -1078,19 +1090,19 @@ object BackendObjType {
   case object CastError extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = JvmName.FlixError)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = JvmName.FlixError.toClassDesc)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
 
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, List(ReifiedSourceLocation.toTpe, BackendType.String))
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(ReifiedSourceLocation.toTpe, BackendType.String))
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
       withName(1, ReifiedSourceLocation.toTpe)(loc => withName(2, BackendType.String)(msg => {
         thisLoad()
-        NEW(JvmName.StringBuilder)
+        NEW(JvmName.StringBuilder.toClassDesc)
         DUP()
         INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
         msg.load()
@@ -1110,7 +1122,7 @@ object BackendObjType {
   case object UnhandledEffectError extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = JvmName.FlixError)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = JvmName.FlixError.toClassDesc)
 
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
       // This field allows external equality checking.
@@ -1120,18 +1132,18 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    private def EffectNameField: InstanceField = InstanceField(this.jvmName, "effectName", BackendType.String)
+    private def EffectNameField: InstanceField = InstanceField(this.desc, "effectName", BackendType.String)
 
-    private def LocationField: InstanceField = InstanceField(this.jvmName, "location", ReifiedSourceLocation.toTpe)
+    private def LocationField: InstanceField = InstanceField(this.desc, "location", ReifiedSourceLocation.toTpe)
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, List(Suspension.toTpe, BackendType.String, ReifiedSourceLocation.toTpe))
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(Suspension.toTpe, BackendType.String, ReifiedSourceLocation.toTpe))
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Suspension.toTpe)(suspension => withName(2, BackendType.String)(info => withName(3, ReifiedSourceLocation.toTpe)(loc => {
         def appendString(): Unit = INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
 
         thisLoad()
-        NEW(JvmName.StringBuilder)
+        NEW(JvmName.StringBuilder.toClassDesc)
         DUP()
         INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
         pushString("Unhandled effect '")
@@ -1167,7 +1179,7 @@ object BackendObjType {
   case object Region extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal)
+      val cm = mkClass(this.desc, IsFinal)
 
       cm.mkField(ThreadsField, IsPrivate, IsFinal, NotVolatile)
       cm.mkField(RegionThreadField, IsPrivate, IsFinal, NotVolatile)
@@ -1186,26 +1198,26 @@ object BackendObjType {
     }
 
     // private final ConcurrentLinkedQueue<Thread> threads = new ConcurrentLinkedQueue<Thread>();
-    private def ThreadsField: InstanceField = InstanceField(this.jvmName, "threads", JvmName.ConcurrentLinkedQueue.toTpe)
+    private def ThreadsField: InstanceField = InstanceField(this.desc, "threads", JvmName.ConcurrentLinkedQueue.toTpe)
 
     // private final LinkedList<Runnable> onExit = new LinkedList<Runnable>();
-    private def OnExitField: InstanceField = InstanceField(this.jvmName, "onExit", JvmName.LinkedList.toTpe)
+    private def OnExitField: InstanceField = InstanceField(this.desc, "onExit", JvmName.LinkedList.toTpe)
 
     // private final Thread regionThread = Thread.currentThread();
-    private def RegionThreadField: InstanceField = InstanceField(this.jvmName, "regionThread", JvmName.Thread.toTpe)
+    private def RegionThreadField: InstanceField = InstanceField(this.desc, "regionThread", JvmName.Thread.toTpe)
 
     // private volatile Throwable childException = null;
-    private def ChildExceptionField: InstanceField = InstanceField(this.jvmName, "childException", JvmName.Throwable.toTpe)
+    private def ChildExceptionField: InstanceField = InstanceField(this.desc, "childException", JvmName.Throwable.toTpe)
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
       INVOKESPECIAL(ClassConstants.Object.Constructor)
       thisLoad()
-      NEW(JvmName.ConcurrentLinkedQueue)
+      NEW(JvmName.ConcurrentLinkedQueue.toClassDesc)
       DUP()
-      invokeConstructor(JvmName.ConcurrentLinkedQueue, MethodDescriptor.NothingToVoid)
+      invokeConstructor(JvmName.ConcurrentLinkedQueue.toClassDesc, MethodDescriptor.NothingToVoid)
       PUTFIELD(ThreadsField)
       thisLoad()
       INVOKESTATIC(ClassConstants.Thread.CurrentThreadMethod)
@@ -1214,9 +1226,9 @@ object BackendObjType {
       ACONST_NULL()
       PUTFIELD(ChildExceptionField)
       thisLoad()
-      NEW(JvmName.LinkedList)
+      NEW(JvmName.LinkedList.toClassDesc)
       DUP()
-      invokeConstructor(JvmName.LinkedList, MethodDescriptor.NothingToVoid)
+      invokeConstructor(JvmName.LinkedList.toClassDesc, MethodDescriptor.NothingToVoid)
       PUTFIELD(OnExitField)
       RETURN()
     }
@@ -1227,7 +1239,7 @@ object BackendObjType {
     //   t.start();
     //   threads.add(t);
     // }
-    def SpawnMethod: InstanceMethod = InstanceMethod(this.jvmName, "spawn", mkDescriptor(JvmName.Runnable.toTpe)(VoidableType.Void))
+    def SpawnMethod: InstanceMethod = InstanceMethod(this.desc, "spawn", mkDescriptor(JvmName.Runnable.toTpe)(VoidableType.Void))
 
     private def spawnIns(implicit mv: MethodVisitor): Unit = {
       INVOKESTATIC(ClassConstants.Thread.OfVirtualMethod)
@@ -1235,10 +1247,10 @@ object BackendObjType {
       INVOKEINTERFACE(ClassConstants.ThreadBuilderOfVirtual.UnstartedMethod)
       storeWithName(2, JvmName.Thread.toTpe) { thread =>
         thread.load()
-        NEW(BackendObjType.UncaughtExceptionHandler.jvmName)
+        NEW(BackendObjType.UncaughtExceptionHandler.desc)
         DUP()
         thisLoad()
-        invokeConstructor(BackendObjType.UncaughtExceptionHandler.jvmName, mkDescriptor(BackendObjType.Region.toTpe)(VoidableType.Void))
+        invokeConstructor(BackendObjType.UncaughtExceptionHandler.desc, mkDescriptor(BackendObjType.Region.toTpe)(VoidableType.Void))
         INVOKEVIRTUAL(ClassConstants.Thread.SetUncaughtExceptionHandlerMethod)
         thread.load()
         INVOKEVIRTUAL(ClassConstants.Thread.StartMethod)
@@ -1258,7 +1270,7 @@ object BackendObjType {
     //   for (Runnable r: onExit)
     //     r.run();
     // }
-    def ExitMethod: InstanceMethod = InstanceMethod(this.jvmName, "exit", MethodDescriptor.NothingToVoid)
+    def ExitMethod: InstanceMethod = InstanceMethod(this.desc, "exit", MethodDescriptor.NothingToVoid)
 
     private def exitIns(implicit mv: MethodVisitor): Unit = {
       withName(1, JvmName.Thread.toTpe) { t =>
@@ -1266,7 +1278,7 @@ object BackendObjType {
           thisLoad()
           GETFIELD(ThreadsField)
           INVOKEVIRTUAL(ClassConstants.ConcurrentLinkedQueue.PollMethod)
-          CHECKCAST(JvmName.Thread)
+          CHECKCAST(JvmName.Thread.toClassDesc)
           DUP()
           t.store()
         } {
@@ -1284,7 +1296,7 @@ object BackendObjType {
           } {
             i.load()
             INVOKEINTERFACE(ClassConstants.Iterator.NextMethod)
-            CHECKCAST(JvmName.Runnable)
+            CHECKCAST(JvmName.Runnable.toClassDesc)
             INVOKEINTERFACE(ClassConstants.Runnable.RunMethod)
           }
         }
@@ -1296,7 +1308,7 @@ object BackendObjType {
     //   childException = e;
     //   regionThread.interrupt();
     // }
-    def ReportChildExceptionMethod: InstanceMethod = InstanceMethod(this.jvmName, "reportChildException", mkDescriptor(JvmName.Throwable.toTpe)(VoidableType.Void))
+    def ReportChildExceptionMethod: InstanceMethod = InstanceMethod(this.desc, "reportChildException", mkDescriptor(JvmName.Throwable.toTpe)(VoidableType.Void))
 
     private def reportChildExceptionIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
@@ -1312,7 +1324,7 @@ object BackendObjType {
     //   if (childException != null)
     //     throw childException;
     // }
-    def ReThrowChildExceptionMethod: InstanceMethod = InstanceMethod(this.jvmName, "reThrowChildException", MethodDescriptor.NothingToVoid)
+    def ReThrowChildExceptionMethod: InstanceMethod = InstanceMethod(this.desc, "reThrowChildException", MethodDescriptor.NothingToVoid)
 
     private def reThrowChildExceptionIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
@@ -1328,7 +1340,7 @@ object BackendObjType {
     // final public void runOnExit(Runnable r) {
     //   onExit.addFirst(r);
     // }
-    private def RunOnExitMethod: InstanceMethod = InstanceMethod(this.jvmName, "runOnExit", mkDescriptor(JvmName.Runnable.toTpe)(VoidableType.Void))
+    private def RunOnExitMethod: InstanceMethod = InstanceMethod(this.desc, "runOnExit", mkDescriptor(JvmName.Runnable.toTpe)(VoidableType.Void))
 
     private def runOnExitIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
@@ -1342,7 +1354,7 @@ object BackendObjType {
   case object UncaughtExceptionHandler extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal, interfaces = List(JvmName.Thread$UncaughtExceptionHandler))
+      val cm = mkClass(this.desc, IsFinal, interfaces = List(JvmName.Thread$UncaughtExceptionHandler.toClassDesc))
 
       cm.mkField(RegionField, IsPrivate, IsFinal, NotVolatile)
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
@@ -1352,10 +1364,10 @@ object BackendObjType {
     }
 
     // private final Region r;
-    private def RegionField: InstanceField = InstanceField(this.jvmName, "r", BackendObjType.Region.toTpe)
+    private def RegionField: InstanceField = InstanceField(this.desc, "r", BackendObjType.Region.toTpe)
 
     // UncaughtExceptionHandler(Region r) { this.r = r; }
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, BackendObjType.Region.toTpe :: Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, BackendObjType.Region.toTpe :: Nil)
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
@@ -1368,7 +1380,7 @@ object BackendObjType {
 
     // public void uncaughtException(Thread t, Throwable e) { r.reportChildException(e); }
     private def UncaughtExceptionMethod: InstanceMethod =
-      InstanceMethod(this.jvmName, "uncaughtException", ClassConstants.ThreadUncaughtExceptionHandler.UncaughtExceptionMethod.d)
+      InstanceMethod(this.desc, "uncaughtException", ClassConstants.ThreadUncaughtExceptionHandler.UncaughtExceptionMethod.d)
 
     private def uncaughtExceptionsIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
@@ -1382,17 +1394,17 @@ object BackendObjType {
   case object Main extends BackendObjType {
 
     def genByteCode(sym: Symbol.DefnSym)(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal)
 
       cm.mkStaticMethod(MainMethod, IsPublic, NotFinal, mainIns(sym)(_))
 
       cm.closeClassMaker()
     }
 
-    def MainMethod: StaticMethod = StaticMethod(this.jvmName, "main", mkDescriptor(BackendType.Array(BackendType.String))(VoidableType.Void))
+    def MainMethod: StaticMethod = StaticMethod(this.desc, "main", mkDescriptor(BackendType.Array(BackendType.String))(VoidableType.Void))
 
     private def mainIns(sym: Symbol.DefnSym)(implicit mv: MethodVisitor): Unit = {
-      val defName = BackendObjType.Defn(sym).jvmName
+      val defName = BackendObjType.Defn(sym).desc
       withName(0, BackendType.Array(BackendType.String))(args => {
         args.load()
         INVOKESTATIC(Global.SetArgsMethod)
@@ -1402,7 +1414,7 @@ object BackendObjType {
         DUP()
         GETSTATIC(Unit.SingletonField)
         PUTFIELD(InstanceField(defName, "arg0", BackendType.Object))
-        Result.unwindSuspensionFreeThunk(s"in ${this.jvmName.toBinaryName}", SourceLocation.Unknown)
+        Result.unwindSuspensionFreeThunk(s"in ${jvmName.toBinaryName}", SourceLocation.Unknown)
         POP()
         RETURN()
       })
@@ -1412,7 +1424,7 @@ object BackendObjType {
   case class Namespace(ns: List[String]) extends BackendObjType {
 
     def genByteCode(defs: List[JvmAst.Def])(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.jvmName, IsFinal)
+      val cm = ClassMaker.mkClass(this.desc, IsFinal)
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
 
@@ -1423,14 +1435,14 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
     def ShimMethod(defn: JvmAst.Def): StaticMethod = {
       val erasedArgs = defn.fparams.map(_.tpe).map(BackendType.toErasedBackendType)
       val erasedResult = BackendType.toErasedBackendType(defn.unboxedType.tpe)
       // Exported names are checked in Safety, so no mangling is needed.
       val name = if (defn.ann.isExport) defn.sym.name else "m_" + Mangle.mangle(defn.sym.name)
-      StaticMethod(this.jvmName, name, MethodDescriptor(erasedArgs, erasedResult))
+      StaticMethod(this.desc, name, MethodDescriptor(erasedArgs, erasedResult))
     }
 
     private def shimIns(defn: JvmAst.Def)(implicit mv: MethodVisitor): Unit = {
@@ -1439,13 +1451,13 @@ object BackendObjType {
       withNames(0, paramTypes) {
         case (_, args) =>
           val erasedResult = BackendType.toErasedBackendType(defn.unboxedType.tpe)
-          NEW(defnT.jvmName)
+          NEW(defnT.desc)
           DUP()
-          INVOKESPECIAL(ConstructorMethod(defnT.jvmName, Nil))
+          INVOKESPECIAL(ConstructorMethod(defnT.desc, Nil))
           for ((arg, index) <- args.zipWithIndex) {
             DUP()
             arg.load()
-            PUTFIELD(InstanceField(defnT.jvmName, s"arg$index", arg.tpe))
+            PUTFIELD(InstanceField(defnT.desc, s"arg$index", arg.tpe))
           }
           Result.unwindSuspensionFreeThunkToType(erasedResult, s"in shim method of ${defn.sym}", defn.loc)
           xReturn(erasedResult)
@@ -1460,7 +1472,7 @@ object BackendObjType {
   case object Result extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.jvmName)
+      val cm = mkInterface(this.desc)
       cm.closeClassMaker()
     }
 
@@ -1471,9 +1483,9 @@ object BackendObjType {
     def unwindThunk()(implicit mv: MethodVisitor): Unit = {
       whileLoop(Condition.NE) {
         DUP()
-        INSTANCEOF(Thunk.jvmName)
+        INSTANCEOF(Thunk.desc)
       } {
-        CHECKCAST(Thunk.jvmName)
+        CHECKCAST(Thunk.desc)
         INVOKEINTERFACE(Thunk.InvokeMethod)
       }
     }
@@ -1487,12 +1499,12 @@ object BackendObjType {
       */
     private def handleSuspension(pc: Int, newFrame: MethodVisitor => Unit, setPc: MethodVisitor => Unit)(implicit mv: MethodVisitor): Unit = {
       DUP()
-      INSTANCEOF(Suspension.jvmName)
+      INSTANCEOF(Suspension.desc)
       ifCondition(Condition.NE) {
         DUP()
-        CHECKCAST(Suspension.jvmName) // [..., s]
+        CHECKCAST(Suspension.desc) // [..., s]
         // Add our new frame
-        NEW(Suspension.jvmName)
+        NEW(Suspension.desc)
         DUP()
         INVOKESPECIAL(Suspension.Constructor) // [..., s, s']
         SWAP() // [..., s', s]
@@ -1529,7 +1541,7 @@ object BackendObjType {
     def unwindThunkToValue(pc: Int, newFrame: MethodVisitor => Unit, setPc: MethodVisitor => Unit)(implicit mv: MethodVisitor): Unit = {
       unwindThunk()
       handleSuspension(pc, newFrame, setPc)
-      CHECKCAST(Value.jvmName) // Cannot fail
+      CHECKCAST(Value.desc) // Cannot fail
     }
 
     /**
@@ -1541,7 +1553,7 @@ object BackendObjType {
     def unwindSuspensionFreeThunkToType(tpe: BackendType, errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
       unwindThunk()
       crashIfSuspension(errorHint, loc)
-      CHECKCAST(Value.jvmName) // Cannot fail
+      CHECKCAST(Value.desc) // Cannot fail
       GETFIELD(Value.fieldFromType(tpe))
       castIfNotPrim(tpe)
     }
@@ -1555,7 +1567,7 @@ object BackendObjType {
     def unwindSuspensionFreeThunk(errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
       unwindThunk()
       crashIfSuspension(errorHint, loc)
-      CHECKCAST(Value.jvmName)
+      CHECKCAST(Value.desc)
     }
 
     /**
@@ -1564,10 +1576,10 @@ object BackendObjType {
       */
     def crashIfSuspension(errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
       DUP()
-      INSTANCEOF(Suspension.jvmName)
+      INSTANCEOF(Suspension.desc)
       ifCondition(Condition.NE) {
-        CHECKCAST(Suspension.jvmName)
-        NEW(UnhandledEffectError.jvmName)
+        CHECKCAST(Suspension.desc)
+        NEW(UnhandledEffectError.desc)
         // [.., suspension, UEE] -> [.., suspension, UEE, UEE, suspension]
         DUP2()
         SWAP()
@@ -1583,7 +1595,7 @@ object BackendObjType {
   case object Value extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal, interfaces = List(Result.jvmName))
+      val cm = mkClass(this.desc, IsFinal, interfaces = List(Result.desc))
 
       // The fields of all erased types, only one will be relevant
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
@@ -1601,14 +1613,14 @@ object BackendObjType {
       cm.mkField(UnitField, IsPublic, IsFinal, NotVolatile)
       cm.mkField(TrueField, IsPublic, IsFinal, NotVolatile)
       cm.mkField(FalseField, IsPublic, IsFinal, NotVolatile)
-      cm.mkStaticConstructor(StaticConstructorMethod(this.jvmName), staticConstructorIns(_))
+      cm.mkStaticConstructor(StaticConstructorMethod(this.desc), staticConstructorIns(_))
 
       cm.closeClassMaker()
     }
 
     private def staticConstructorIns(implicit mv: MethodVisitor): Unit = {
       // Value.UNIT = new Value(); Value.UNIT.o = Unit.INSTANCE
-      NEW(this.jvmName)
+      NEW(this.desc)
       DUP()
       INVOKESPECIAL(Constructor)
       DUP()
@@ -1616,7 +1628,7 @@ object BackendObjType {
       PUTFIELD(ObjectField)
       PUTSTATIC(UnitField)
       // Value.TRUE = new Value(); Value.TRUE.b = true
-      NEW(this.jvmName)
+      NEW(this.desc)
       DUP()
       INVOKESPECIAL(Constructor)
       DUP()
@@ -1624,38 +1636,38 @@ object BackendObjType {
       PUTFIELD(BoolField)
       PUTSTATIC(TrueField)
       // Value.FALSE = new Value(); Value.FALSE.b = false (default, but explicit)
-      NEW(this.jvmName)
+      NEW(this.desc)
       DUP()
       INVOKESPECIAL(Constructor)
       PUTSTATIC(FalseField)
       RETURN()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    private def BoolField: InstanceField = InstanceField(this.jvmName, "b", BackendType.Bool)
+    private def BoolField: InstanceField = InstanceField(this.desc, "b", BackendType.Bool)
 
-    private def CharField: InstanceField = InstanceField(this.jvmName, "c", BackendType.Char)
+    private def CharField: InstanceField = InstanceField(this.desc, "c", BackendType.Char)
 
-    private def Int8Field: InstanceField = InstanceField(this.jvmName, "i8", BackendType.Int8)
+    private def Int8Field: InstanceField = InstanceField(this.desc, "i8", BackendType.Int8)
 
-    private def Int16Field: InstanceField = InstanceField(this.jvmName, "i16", BackendType.Int16)
+    private def Int16Field: InstanceField = InstanceField(this.desc, "i16", BackendType.Int16)
 
-    private def Int32Field: InstanceField = InstanceField(this.jvmName, "i32", BackendType.Int32)
+    private def Int32Field: InstanceField = InstanceField(this.desc, "i32", BackendType.Int32)
 
-    private def Int64Field: InstanceField = InstanceField(this.jvmName, "i64", BackendType.Int64)
+    private def Int64Field: InstanceField = InstanceField(this.desc, "i64", BackendType.Int64)
 
-    private def Float32Field: InstanceField = InstanceField(this.jvmName, "f32", BackendType.Float32)
+    private def Float32Field: InstanceField = InstanceField(this.desc, "f32", BackendType.Float32)
 
-    private def Float64Field: InstanceField = InstanceField(this.jvmName, "f64", BackendType.Float64)
+    private def Float64Field: InstanceField = InstanceField(this.desc, "f64", BackendType.Float64)
 
-    private def ObjectField: InstanceField = InstanceField(this.jvmName, "o", BackendType.Object)
+    private def ObjectField: InstanceField = InstanceField(this.desc, "o", BackendType.Object)
 
-    def UnitField: StaticField = StaticField(this.jvmName, "UNIT", this.toTpe)
+    def UnitField: StaticField = StaticField(this.desc, "UNIT", this.toTpe)
 
-    def TrueField: StaticField = StaticField(this.jvmName, "TRUE", this.toTpe)
+    def TrueField: StaticField = StaticField(this.desc, "TRUE", this.toTpe)
 
-    def FalseField: StaticField = StaticField(this.jvmName, "FALSE", this.toTpe)
+    def FalseField: StaticField = StaticField(this.desc, "FALSE", this.toTpe)
 
     /**
       * Returns the field of Value corresponding to the given type
@@ -1680,7 +1692,7 @@ object BackendObjType {
   case object Frame extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.jvmName)
+      val cm = mkInterface(this.desc)
 
       cm.mkInterfaceMethod(ApplyMethod)
       cm.mkStaticInterfaceMethod(StaticApplyMethod, IsPublic, NotFinal, staticApplyIns(_))
@@ -1688,10 +1700,10 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "applyFrame", mkDescriptor(Value.toTpe)(Result.toTpe))
+    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "applyFrame", mkDescriptor(Value.toTpe)(Result.toTpe))
 
     def StaticApplyMethod: StaticInterfaceMethod = StaticInterfaceMethod(
-      this.jvmName,
+      this.desc,
       "applyFrameStatic",
       mkDescriptor(Frame.toTpe, Value.toTpe)(Result.toTpe)
     )
@@ -1711,7 +1723,7 @@ object BackendObjType {
   case object Thunk extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.jvmName, interfaces = List(Result.jvmName, JvmName.Runnable))
+      val cm = mkInterface(this.desc, interfaces = List(Result.desc, JvmName.Runnable.toClassDesc))
 
       cm.mkInterfaceMethod(InvokeMethod)
       cm.mkDefaultMethod(RunMethod, IsPublic, NotFinal, runIns(_))
@@ -1719,9 +1731,9 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def InvokeMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "invoke", mkDescriptor()(Result.toTpe))
+    def InvokeMethod: InterfaceMethod = InterfaceMethod(this.desc, "invoke", mkDescriptor()(Result.toTpe))
 
-    private def RunMethod: DefaultMethod = DefaultMethod(this.jvmName, "run", mkDescriptor()(VoidableType.Void))
+    private def RunMethod: DefaultMethod = DefaultMethod(this.desc, "run", mkDescriptor()(VoidableType.Void))
 
     private def runIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
@@ -1734,7 +1746,7 @@ object BackendObjType {
   case object Suspension extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal, interfaces = List(Result.jvmName))
+      val cm = mkClass(this.desc, IsFinal, interfaces = List(Result.desc))
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
       cm.mkField(EffSymField, IsPublic, NotFinal, NotVolatile)
@@ -1745,22 +1757,22 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def EffSymField: InstanceField = InstanceField(this.jvmName, "effSym", BackendType.String)
+    def EffSymField: InstanceField = InstanceField(this.desc, "effSym", BackendType.String)
 
-    def EffOpField: InstanceField = InstanceField(this.jvmName, "effOp", EffectCall.toTpe)
+    def EffOpField: InstanceField = InstanceField(this.desc, "effOp", EffectCall.toTpe)
 
-    def PrefixField: InstanceField = InstanceField(this.jvmName, "prefix", Frames.toTpe)
+    def PrefixField: InstanceField = InstanceField(this.desc, "prefix", Frames.toTpe)
 
-    def ResumptionField: InstanceField = InstanceField(this.jvmName, "resumption", Resumption.toTpe)
+    def ResumptionField: InstanceField = InstanceField(this.desc, "resumption", Resumption.toTpe)
 
   }
 
   case object Frames extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.jvmName)
+      val cm = mkInterface(this.desc)
 
       cm.mkInterfaceMethod(PushMethod)
       cm.mkInterfaceMethod(ReverseOntoMethod)
@@ -1768,13 +1780,13 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def PushMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "push", mkDescriptor(Frame.toTpe)(Frames.toTpe))
+    def PushMethod: InterfaceMethod = InterfaceMethod(this.desc, "push", mkDescriptor(Frame.toTpe)(Frames.toTpe))
 
-    def ReverseOntoMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "reverseOnto", mkDescriptor(Frames.toTpe)(Frames.toTpe))
+    def ReverseOntoMethod: InterfaceMethod = InterfaceMethod(this.desc, "reverseOnto", mkDescriptor(Frames.toTpe)(Frames.toTpe))
 
     def pushImplementation(implicit mv: MethodVisitor): Unit = {
       withName(1, Frame.toTpe) { frame =>
-        NEW(FramesCons.jvmName)
+        NEW(FramesCons.desc)
         DUP()
         INVOKESPECIAL(FramesCons.Constructor)
         DUP()
@@ -1791,30 +1803,30 @@ object BackendObjType {
   case object FramesCons extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal, interfaces = List(Frames.jvmName))
+      val cm = mkClass(this.desc, IsFinal, interfaces = List(Frames.desc))
 
       cm.mkField(HeadField, IsPublic, NotFinal, NotVolatile)
       cm.mkField(TailField, IsPublic, NotFinal, NotVolatile)
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
       cm.mkMethod(Nil, PushMethod, IsPublic, IsFinal, Frames.pushImplementation(_))
-      cm.mkMethod(Nil, Frames.ReverseOntoMethod.implementation(this.jvmName), IsPublic, IsFinal, reverseOntoIns(_))
+      cm.mkMethod(Nil, Frames.ReverseOntoMethod.implementation(this.desc), IsPublic, IsFinal, reverseOntoIns(_))
 
       cm.closeClassMaker()
     }
 
-    def HeadField: InstanceField = InstanceField(this.jvmName, "head", Frame.toTpe)
+    def HeadField: InstanceField = InstanceField(this.desc, "head", Frame.toTpe)
 
-    def TailField: InstanceField = InstanceField(this.jvmName, "tail", Frames.toTpe)
+    def TailField: InstanceField = InstanceField(this.desc, "tail", Frames.toTpe)
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.jvmName)
+    def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.desc)
 
     private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Frames.toTpe) { rest =>
         thisLoad()
         GETFIELD(TailField)
-        NEW(FramesCons.jvmName)
+        NEW(FramesCons.desc)
         DUP()
         INVOKESPECIAL(FramesCons.Constructor)
         DUP()
@@ -1833,18 +1845,18 @@ object BackendObjType {
   case object FramesNil extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal, interfaces = List(Frames.jvmName))
+      val cm = mkClass(this.desc, IsFinal, interfaces = List(Frames.desc))
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
       cm.mkMethod(Nil, PushMethod, IsPublic, IsFinal, Frames.pushImplementation(_))
-      cm.mkMethod(Nil, Frames.ReverseOntoMethod.implementation(this.jvmName), IsPublic, IsFinal, reverseOntoIns(_))
+      cm.mkMethod(Nil, Frames.ReverseOntoMethod.implementation(this.desc), IsPublic, IsFinal, reverseOntoIns(_))
 
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.jvmName)
+    def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.desc)
 
     private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Frames.toTpe) { rest =>
@@ -1856,15 +1868,15 @@ object BackendObjType {
 
   case object Resumption extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.jvmName)
+      val cm = mkInterface(this.desc)
       cm.mkInterfaceMethod(RewindMethod)
       cm.mkStaticInterfaceMethod(StaticRewindMethod, IsPublic, NotFinal, staticRewindIns(_))
       cm.closeClassMaker()
     }
 
-    def RewindMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "rewind", mkDescriptor(Value.toTpe)(Result.toTpe))
+    def RewindMethod: InterfaceMethod = InterfaceMethod(this.desc, "rewind", mkDescriptor(Value.toTpe)(Result.toTpe))
 
-    def StaticRewindMethod: StaticInterfaceMethod = StaticInterfaceMethod(this.jvmName, "staticRewind", mkDescriptor(Resumption.toTpe, Value.toTpe)(Result.toTpe))
+    def StaticRewindMethod: StaticInterfaceMethod = StaticInterfaceMethod(this.desc, "staticRewind", mkDescriptor(Resumption.toTpe, Value.toTpe)(Result.toTpe))
 
     private def staticRewindIns(implicit mv: MethodVisitor): Unit = {
       withName(0, Resumption.toTpe) { resumption =>
@@ -1881,7 +1893,7 @@ object BackendObjType {
   case object ResumptionCons extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal, interfaces = List(Resumption.jvmName))
+      val cm = mkClass(this.desc, IsFinal, interfaces = List(Resumption.desc))
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
 
@@ -1890,20 +1902,20 @@ object BackendObjType {
       cm.mkField(FramesField, IsPublic, NotFinal, NotVolatile)
       cm.mkField(TailField, IsPublic, NotFinal, NotVolatile)
 
-      cm.mkMethod(Nil, Resumption.RewindMethod.implementation(this.jvmName), IsPublic, IsFinal, rewindIns(_))
+      cm.mkMethod(Nil, Resumption.RewindMethod.implementation(this.desc), IsPublic, IsFinal, rewindIns(_))
 
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def SymField: InstanceField = InstanceField(this.jvmName, "sym", BackendType.String)
+    def SymField: InstanceField = InstanceField(this.desc, "sym", BackendType.String)
 
-    def HandlerField: InstanceField = InstanceField(this.jvmName, "handler", Handler.toTpe)
+    def HandlerField: InstanceField = InstanceField(this.desc, "handler", Handler.toTpe)
 
-    def FramesField: InstanceField = InstanceField(this.jvmName, "frames", Frames.toTpe)
+    def FramesField: InstanceField = InstanceField(this.desc, "frames", Frames.toTpe)
 
-    def TailField: InstanceField = InstanceField(this.jvmName, "tail", Resumption.toTpe)
+    def TailField: InstanceField = InstanceField(this.desc, "tail", Resumption.toTpe)
 
     private def rewindIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Value.toTpe) { v =>
@@ -1927,15 +1939,15 @@ object BackendObjType {
   case object ResumptionNil extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal, interfaces = List(Resumption.jvmName))
+      val cm = mkClass(this.desc, IsFinal, interfaces = List(Resumption.desc))
 
       cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-      cm.mkMethod(Nil, Resumption.RewindMethod.implementation(this.jvmName), IsPublic, IsFinal, rewindIns(_))
+      cm.mkMethod(Nil, Resumption.RewindMethod.implementation(this.desc), IsPublic, IsFinal, rewindIns(_))
 
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, Nil)
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
     private def rewindIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Value.toTpe) { v =>
@@ -1948,13 +1960,13 @@ object BackendObjType {
   case object Handler extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.jvmName)
+      val cm = mkInterface(this.desc)
       cm.mkStaticInterfaceMethod(InstallHandlerMethod, IsPublic, NotFinal, installHandlerIns(_))
       cm.closeClassMaker()
     }
 
     def InstallHandlerMethod: StaticInterfaceMethod = StaticInterfaceMethod(
-      this.jvmName,
+      this.desc,
       "installHandler",
       mkDescriptor(BackendType.String, Handler.toTpe, Frames.toTpe, Thunk.toTpe)(Result.toTpe)
     )
@@ -1970,12 +1982,12 @@ object BackendObjType {
               // Value|Suspension
               // handle suspension
               DUP()
-              INSTANCEOF(Suspension.jvmName)
+              INSTANCEOF(Suspension.desc)
               ifCondition(Condition.NE) {
                 DUP()
-                CHECKCAST(Suspension.jvmName)
+                CHECKCAST(Suspension.desc)
                 storeWithName(4, Suspension.toTpe) { s =>
-                  NEW(ResumptionCons.jvmName)
+                  NEW(ResumptionCons.desc)
                   DUP()
                   INVOKESPECIAL(ResumptionCons.Constructor)
                   DUP()
@@ -2007,7 +2019,7 @@ object BackendObjType {
                       INVOKEINTERFACE(EffectCall.ApplyMethod)
                       xReturn(Result.toTpe)
                     }
-                    NEW(Suspension.jvmName)
+                    NEW(Suspension.desc)
                     DUP()
                     INVOKESPECIAL(Suspension.Constructor)
                     DUP()
@@ -2019,7 +2031,7 @@ object BackendObjType {
                     GETFIELD(Suspension.EffOpField)
                     PUTFIELD(Suspension.EffOpField)
                     DUP()
-                    NEW(FramesNil.jvmName)
+                    NEW(FramesNil.desc)
                     DUP()
                     INVOKESPECIAL(FramesNil.Constructor)
                     PUTFIELD(Suspension.PrefixField)
@@ -2032,20 +2044,20 @@ object BackendObjType {
               }
 
               // Value
-              CHECKCAST(Value.jvmName)
+              CHECKCAST(Value.desc)
               storeWithName(6, Value.toTpe) { res =>
                 //
                 // Case on frames
                 // FramesNil
                 frames.load()
-                INSTANCEOF(FramesNil.jvmName)
+                INSTANCEOF(FramesNil.desc)
                 ifCondition(Condition.NE) {
                   res.load()
                   xReturn(Value.toTpe)
                 }
                 // FramesCons
                 frames.load()
-                CHECKCAST(FramesCons.jvmName)
+                CHECKCAST(FramesCons.desc)
                 storeWithName(7, FramesCons.toTpe) { cons => {
                   effSym.load()
                   handler.load()
@@ -2071,12 +2083,12 @@ object BackendObjType {
   case object EffectCall extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.jvmName)
+      val cm = mkInterface(this.desc)
       cm.mkInterfaceMethod(ApplyMethod)
       cm.closeClassMaker()
     }
 
-    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "apply", mkDescriptor(Handler.toTpe, Resumption.toTpe)(Result.toTpe))
+    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "apply", mkDescriptor(Handler.toTpe, Resumption.toTpe)(Result.toTpe))
 
   }
 
@@ -2086,7 +2098,7 @@ object BackendObjType {
     private val superClass: AbstractArrow = AbstractArrow(List(tpe.toErased), BackendType.Object)
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.jvmName, IsFinal, superClass.jvmName)
+      val cm = mkClass(this.desc, IsFinal, superClass.desc)
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
       cm.mkField(ResumptionField, IsPrivate, IsFinal, NotVolatile)
       cm.mkMethod(Nil, InvokeMethod, IsPublic, NotFinal, invokeIns(_))
@@ -2094,12 +2106,12 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, List(Resumption.toTpe))
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(Resumption.toTpe))
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Resumption.toTpe) { resumption =>
         thisLoad()
-        INVOKESPECIAL(superClass.jvmName, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid)
+        INVOKESPECIAL(superClass.desc, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid)
         thisLoad()
         resumption.load()
         PUTFIELD(ResumptionField)
@@ -2107,9 +2119,9 @@ object BackendObjType {
       }
     }
 
-    def ResumptionField: InstanceField = InstanceField(this.jvmName, "resumption", Resumption.toTpe)
+    def ResumptionField: InstanceField = InstanceField(this.desc, "resumption", Resumption.toTpe)
 
-    def InvokeMethod: InstanceMethod = Thunk.InvokeMethod.implementation(this.jvmName)
+    def InvokeMethod: InstanceMethod = Thunk.InvokeMethod.implementation(this.desc)
 
     private def invokeIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
@@ -2118,7 +2130,7 @@ object BackendObjType {
         case BackendType.Bool =>
           // Use cached Value.TRUE / Value.FALSE singletons
           thisLoad()
-          mv.visitFieldInsn(Opcodes.GETFIELD, this.jvmName.toInternalName, "arg0", tpe.toErased.toDescriptor)
+          mv.visitFieldInsn(Opcodes.GETFIELD, jvmName.toInternalName, "arg0", tpe.toErased.toDescriptor)
           val falseLabel = new Label()
           val doneLabel = new Label()
           mv.visitJumpInsn(Opcodes.IFEQ, falseLabel)
@@ -2128,19 +2140,19 @@ object BackendObjType {
           GETSTATIC(Value.FalseField)
           mv.visitLabel(doneLabel)
         case _ =>
-          NEW(Value.jvmName)
+          NEW(Value.desc)
           DUP()
           INVOKESPECIAL(Value.Constructor)
           DUP()
           thisLoad()
-          mv.visitFieldInsn(Opcodes.GETFIELD, this.jvmName.toInternalName, "arg0", tpe.toErased.toDescriptor)
+          mv.visitFieldInsn(Opcodes.GETFIELD, jvmName.toInternalName, "arg0", tpe.toErased.toDescriptor)
           PUTFIELD(Value.fieldFromType(tpe.toErased))
       }
       INVOKEINTERFACE(Resumption.RewindMethod)
       xReturn(Result.toTpe)
     }
 
-    private def UniqueMethod: InstanceMethod = InstanceMethod(this.jvmName, "getUniqueThreadClosure", mkDescriptor()(this.superClass.toTpe))
+    private def UniqueMethod: InstanceMethod = InstanceMethod(this.desc, "getUniqueThreadClosure", mkDescriptor()(this.superClass.toTpe))
 
     private def uniqueIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -23,29 +23,30 @@ import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
 import org.objectweb.asm
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 
+import java.lang.constant.ClassDesc
 import scala.annotation.tailrec
 
 object BytecodeInstructions {
 
   /** A wrapper of [[MethodVisitor]] to improve its interface. */
   implicit class RichMethodVisitor(visitor: MethodVisitor) {
-    def visitTypeInstruction(opcode: Int, tpe: JvmName): Unit =
-      visitor.visitTypeInsn(opcode, tpe.toInternalName)
+    def visitTypeInstruction(opcode: Int, tpe: ClassDesc): Unit =
+      visitor.visitTypeInsn(opcode, AsmOps.internalNameOf(tpe))
 
     def visitTypeInstructionDirect(opcode: Int, tpe: String): Unit =
       visitor.visitTypeInsn(opcode, tpe)
 
     def visitInstruction(opcode: Int): Unit = visitor.visitInsn(opcode)
 
-    def visitMethodInstruction(opcode: Int, owner: JvmName, methodName: String, descriptor: MethodDescriptor, isInterface: Boolean): Unit =
-      visitor.visitMethodInsn(opcode, owner.toInternalName, methodName, descriptor.toDescriptor, isInterface)
+    def visitMethodInstruction(opcode: Int, owner: ClassDesc, methodName: String, descriptor: MethodDescriptor, isInterface: Boolean): Unit =
+      visitor.visitMethodInsn(opcode, AsmOps.internalNameOf(owner), methodName, descriptor.toDescriptor, isInterface)
 
     // TODO: sanitize varags
     def visitInvokeDynamicInstruction(methodName: String, descriptor: MethodDescriptor, bootstrapMethodHandle: Handle, bootstrapMethodArguments: Any*): Unit =
       visitor.visitInvokeDynamicInsn(methodName, descriptor.toDescriptor, bootstrapMethodHandle.handle, bootstrapMethodArguments *)
 
-    def visitFieldInstruction(opcode: Int, owner: JvmName, fieldName: String, fieldType: BackendType): Unit =
-      visitor.visitFieldInsn(opcode, owner.toInternalName, fieldName, fieldType.toDescriptor)
+    def visitFieldInstruction(opcode: Int, owner: ClassDesc, fieldName: String, fieldType: BackendType): Unit =
+      visitor.visitFieldInsn(opcode, AsmOps.internalNameOf(owner), fieldName, fieldType.toDescriptor)
 
     def visitVarInstruction(opcode: Int, v: Int): Unit =
       visitor.visitVarInsn(opcode, v)
@@ -72,11 +73,11 @@ object BytecodeInstructions {
   sealed case class Handle(handle: asm.Handle)
 
   def mkStaticHandle(m: StaticMethod): Handle = {
-    Handle(new asm.Handle(Opcodes.H_INVOKESTATIC, m.clazz.toInternalName, m.name, m.d.toDescriptor, false))
+    Handle(new asm.Handle(Opcodes.H_INVOKESTATIC, AsmOps.internalNameOf(m.clazz), m.name, m.d.toDescriptor, false))
   }
 
   def mkStaticHandle(m: StaticInterfaceMethod): Handle = {
-    Handle(new asm.Handle(Opcodes.H_INVOKESTATIC, m.clazz.toInternalName, m.name, m.d.toDescriptor, true))
+    Handle(new asm.Handle(Opcodes.H_INVOKESTATIC, AsmOps.internalNameOf(m.clazz), m.name, m.d.toDescriptor, true))
   }
 
   //
@@ -136,7 +137,7 @@ object BytecodeInstructions {
 
   def ALOAD(index: Int)(implicit mv: MethodVisitor): Unit = mv.visitVarInstruction(Opcodes.ALOAD, index)
 
-  def ANEWARRAY(className: JvmName)(implicit mv: MethodVisitor): Unit = mv.visitTypeInstruction(Opcodes.ANEWARRAY, className)
+  def ANEWARRAY(className: ClassDesc)(implicit mv: MethodVisitor): Unit = mv.visitTypeInstruction(Opcodes.ANEWARRAY, className)
 
   def ARETURN()(implicit mv: MethodVisitor): Unit = mv.visitInstruction(Opcodes.ARETURN)
 
@@ -151,7 +152,7 @@ object BytecodeInstructions {
   def BIPUSH(i: Byte)(implicit mv: MethodVisitor): Unit =
     mv.visitIntInstruction(Opcodes.BIPUSH, i)
 
-  def CHECKCAST(className: JvmName)(implicit mv: MethodVisitor): Unit =
+  def CHECKCAST(className: ClassDesc)(implicit mv: MethodVisitor): Unit =
     mv.visitTypeInstruction(Opcodes.CHECKCAST, className)
 
   def DLOAD(index: Int)(implicit mv: MethodVisitor): Unit =
@@ -205,7 +206,7 @@ object BytecodeInstructions {
   def ILOAD(index: Int)(implicit mv: MethodVisitor): Unit =
     mv.visitVarInstruction(Opcodes.ILOAD, index)
 
-  def INSTANCEOF(tpe: JvmName)(implicit mv: MethodVisitor): Unit =
+  def INSTANCEOF(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit =
     mv.visitTypeInstruction(Opcodes.INSTANCEOF, tpe)
 
   /**
@@ -230,7 +231,7 @@ object BytecodeInstructions {
   def mkStaticLambda(lambdaMethod: InterfaceMethod, callD: MethodDescriptor, callHandle: Handle, drop: Int)(implicit mv: MethodVisitor): Unit =
     mv.visitInvokeDynamicInstruction(
       lambdaMethod.name,
-      mkDescriptor(callD.arguments.dropRight(drop) *)(lambdaMethod.clazz.toTpe),
+      mkDescriptor(callD.arguments.dropRight(drop) *)(BackendType.toBackendType(lambdaMethod.clazz)),
       mkStaticHandle(ClassConstants.LambdaMetafactory.MetafactoryMethod),
       lambdaMethod.d.toAsmType,
       callHandle.handle,
@@ -243,13 +244,13 @@ object BytecodeInstructions {
   def mkStaticLambda(lambdaMethod: InterfaceMethod, call: StaticInterfaceMethod, drop: Int)(implicit mv: MethodVisitor): Unit =
     mkStaticLambda(lambdaMethod, call.d, mkStaticHandle(call), drop)
 
-  def INVOKEINTERFACE(interfaceName: JvmName, methodName: String, descriptor: MethodDescriptor)(implicit mv: MethodVisitor): Unit =
+  def INVOKEINTERFACE(interfaceName: ClassDesc, methodName: String, descriptor: MethodDescriptor)(implicit mv: MethodVisitor): Unit =
     mv.visitMethodInstruction(Opcodes.INVOKEINTERFACE, interfaceName, methodName, descriptor, isInterface = true)
 
   def INVOKEINTERFACE(m: InterfaceMethod)(implicit mv: MethodVisitor): Unit =
     mv.visitMethodInstruction(Opcodes.INVOKEINTERFACE, m.clazz, m.name, m.d, isInterface = true)
 
-  def INVOKESPECIAL(className: JvmName, methodName: String, descriptor: MethodDescriptor)(implicit mv: MethodVisitor): Unit = {
+  def INVOKESPECIAL(className: ClassDesc, methodName: String, descriptor: MethodDescriptor)(implicit mv: MethodVisitor): Unit = {
     val isInterface = false // OBS this is not technically true if you use it to call private interface methods(?)
     mv.visitMethodInstruction(Opcodes.INVOKESPECIAL, className, methodName, descriptor, isInterface = isInterface)
   }
@@ -257,7 +258,7 @@ object BytecodeInstructions {
   def INVOKESPECIAL(c: ConstructorMethod)(implicit mv: MethodVisitor): Unit =
     mv.visitMethodInstruction(Opcodes.INVOKESPECIAL, c.clazz, c.name, c.d, isInterface = false)
 
-  def INVOKESTATIC(className: JvmName, methodName: String, descriptor: MethodDescriptor, isInterface: Boolean = false)(implicit mv: MethodVisitor): Unit =
+  def INVOKESTATIC(className: ClassDesc, methodName: String, descriptor: MethodDescriptor, isInterface: Boolean = false)(implicit mv: MethodVisitor): Unit =
     mv.visitMethodInstruction(Opcodes.INVOKESTATIC, className, methodName, descriptor, isInterface)
 
   def INVOKESTATIC(m: StaticMethod)(implicit mv: MethodVisitor): Unit =
@@ -266,7 +267,7 @@ object BytecodeInstructions {
   def INVOKESTATIC(m: StaticInterfaceMethod)(implicit mv: MethodVisitor): Unit =
     mv.visitMethodInstruction(Opcodes.INVOKESTATIC, m.clazz, m.name, m.d, isInterface = true)
 
-  def INVOKEVIRTUAL(className: JvmName, methodName: String, descriptor: MethodDescriptor, isInterface: Boolean = false)(implicit mv: MethodVisitor): Unit =
+  def INVOKEVIRTUAL(className: ClassDesc, methodName: String, descriptor: MethodDescriptor, isInterface: Boolean = false)(implicit mv: MethodVisitor): Unit =
     mv.visitMethodInstruction(Opcodes.INVOKEVIRTUAL, className, methodName, descriptor, isInterface)
 
   def INVOKEVIRTUAL(m: AbstractMethod)(implicit mv: MethodVisitor): Unit =
@@ -293,7 +294,7 @@ object BytecodeInstructions {
   def LRETURN()(implicit mv: MethodVisitor): Unit =
     mv.visitInstruction(Opcodes.LRETURN)
 
-  def NEW(className: JvmName)(implicit mv: MethodVisitor): Unit =
+  def NEW(className: ClassDesc)(implicit mv: MethodVisitor): Unit =
     mv.visitTypeInstruction(Opcodes.NEW, className)
 
   def POP()(implicit mv: MethodVisitor): Unit =
@@ -343,7 +344,7 @@ object BytecodeInstructions {
   def castIfNotPrim(tpe: BackendType)(implicit mv: MethodVisitor): Unit = {
     tpe match {
       case arr: BackendType.Array => mv.visitTypeInstructionDirect(Opcodes.CHECKCAST, arr.toDescriptor)
-      case BackendType.Reference(ref) => CHECKCAST(ref.jvmName)
+      case BackendType.Reference(ref) => CHECKCAST(ref.desc)
       case _: BackendType.PrimitiveType => nop()
     }
   }
@@ -397,7 +398,7 @@ object BytecodeInstructions {
     mv.visitLabel(afterEverything)
   }
 
-  def invokeConstructor(className: JvmName, descriptor: MethodDescriptor)(implicit mv: MethodVisitor): Unit =
+  def invokeConstructor(className: ClassDesc, descriptor: MethodDescriptor)(implicit mv: MethodVisitor): Unit =
     INVOKESPECIAL(className, JvmName.ConstructorMethod, descriptor)
 
   def nop(): Unit =
@@ -426,7 +427,7 @@ object BytecodeInstructions {
   }
 
   def pushLoc(loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
-    NEW(BackendObjType.ReifiedSourceLocation.jvmName)
+    NEW(BackendObjType.ReifiedSourceLocation.desc)
     DUP()
     pushString(loc.source.name)
     pushInt(loc.startLine)
@@ -444,10 +445,10 @@ object BytecodeInstructions {
   def thisLoad()(implicit mv: MethodVisitor): Unit = ALOAD(0)
 
   def throwUnsupportedOperationException(msg: String)(implicit mv: MethodVisitor): Unit = {
-    NEW(JvmName.UnsupportedOperationException)
+    NEW(JvmName.UnsupportedOperationException.toClassDesc)
     DUP()
     pushString(msg)
-    INVOKESPECIAL(JvmName.UnsupportedOperationException, JvmName.ConstructorMethod,
+    INVOKESPECIAL(JvmName.UnsupportedOperationException.toClassDesc, JvmName.ConstructorMethod,
       mkDescriptor(BackendType.String)(VoidableType.Void))
     ATHROW()
   }
@@ -501,7 +502,7 @@ object BytecodeInstructions {
 
   def xNewArray(elmTpe: BackendType)(implicit mv: MethodVisitor): Unit = elmTpe match {
     case BackendType.Array(_) => mv.visitTypeInsn(Opcodes.ANEWARRAY, elmTpe.toDescriptor)
-    case BackendType.Reference(ref) => ANEWARRAY(ref.jvmName)
+    case BackendType.Reference(ref) => ANEWARRAY(ref.desc)
     case tpe: BackendType.PrimitiveType => tpe match {
       case BackendType.Bool => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_BOOLEAN)
       case BackendType.Char => mv.visitIntInstruction(Opcodes.NEWARRAY, Opcodes.T_CHAR)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassConstants.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassConstants.scala
@@ -28,10 +28,10 @@ object ClassConstants {
 
   object FlixError {
 
-    val Constructor: ConstructorMethod = ConstructorMethod(JvmName.FlixError, List(BackendType.String))
+    val Constructor: ConstructorMethod = ConstructorMethod(JvmName.FlixError.toClassDesc, List(BackendType.String))
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkAbstractClass(JvmName.FlixError, JvmName.Error)
+      val cm = ClassMaker.mkAbstractClass(JvmName.FlixError.toClassDesc, JvmName.Error.toClassDesc)
       cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
       cm.closeClassMaker()
     }
@@ -40,7 +40,7 @@ object ClassConstants {
       import BytecodeInstructions.*
       thisLoad()
       ALOAD(1)
-      invokeConstructor(JvmName.Error, mkDescriptor(BackendType.String)(VoidableType.Void))
+      invokeConstructor(JvmName.Error.toClassDesc, mkDescriptor(BackendType.String)(VoidableType.Void))
       RETURN()
     }
 
@@ -49,125 +49,125 @@ object ClassConstants {
   // Java Constants.
 
   object BigDecimal {
-    val Constructor: ConstructorMethod = ClassMaker.ConstructorMethod(JvmName.BigDecimal, List(BackendType.String))
+    val Constructor: ConstructorMethod = ClassMaker.ConstructorMethod(JvmName.BigDecimal.toClassDesc, List(BackendType.String))
   }
 
   object BigInteger {
-    val Constructor: ConstructorMethod = ClassMaker.ConstructorMethod(JvmName.BigInteger, List(BackendType.String))
+    val Constructor: ConstructorMethod = ClassMaker.ConstructorMethod(JvmName.BigInteger.toClassDesc, List(BackendType.String))
   }
 
   object ConcurrentLinkedQueue {
 
     val AddMethod: InstanceMethod =
-      InstanceMethod(JvmName.ConcurrentLinkedQueue, "add", mkDescriptor(BackendType.Object)(BackendType.Bool))
+      InstanceMethod(JvmName.ConcurrentLinkedQueue.toClassDesc, "add", mkDescriptor(BackendType.Object)(BackendType.Bool))
 
     val PollMethod: InstanceMethod =
-      InstanceMethod(JvmName.ConcurrentLinkedQueue, "poll", mkDescriptor()(BackendType.Object))
+      InstanceMethod(JvmName.ConcurrentLinkedQueue.toClassDesc, "poll", mkDescriptor()(BackendType.Object))
 
   }
 
   object Iterator {
 
     val HasNextMethod: InterfaceMethod =
-      InterfaceMethod(JvmName.Iterator, "hasNext", mkDescriptor()(BackendType.Bool))
+      InterfaceMethod(JvmName.Iterator.toClassDesc, "hasNext", mkDescriptor()(BackendType.Bool))
 
     val NextMethod: InterfaceMethod =
-      InterfaceMethod(JvmName.Iterator, "next", mkDescriptor()(BackendType.Object))
+      InterfaceMethod(JvmName.Iterator.toClassDesc, "next", mkDescriptor()(BackendType.Object))
 
   }
 
   object LambdaMetafactory {
     val MetafactoryMethod: StaticMethod =
-      StaticMethod(JvmName.LambdaMetafactory, "metafactory", mkDescriptor(JvmName.MethodHandles$Lookup.toTpe, BackendType.String, JvmName.MethodType.toTpe, JvmName.MethodType.toTpe, JvmName.MethodHandle.toTpe, JvmName.MethodType.toTpe)(JvmName.CallSite.toTpe))
+      StaticMethod(JvmName.LambdaMetafactory.toClassDesc, "metafactory", mkDescriptor(JvmName.MethodHandles$Lookup.toTpe, BackendType.String, JvmName.MethodType.toTpe, JvmName.MethodType.toTpe, JvmName.MethodHandle.toTpe, JvmName.MethodType.toTpe)(JvmName.CallSite.toTpe))
   }
 
   object LinkedList {
 
     val AddFirstMethod: InstanceMethod =
-      InstanceMethod(JvmName.LinkedList, "addFirst", mkDescriptor(BackendType.Object)(VoidableType.Void))
+      InstanceMethod(JvmName.LinkedList.toClassDesc, "addFirst", mkDescriptor(BackendType.Object)(VoidableType.Void))
 
     val IteratorMethod: InstanceMethod =
-      InstanceMethod(JvmName.LinkedList, "iterator", mkDescriptor()(JvmName.Iterator.toTpe))
+      InstanceMethod(JvmName.LinkedList.toClassDesc, "iterator", mkDescriptor()(JvmName.Iterator.toTpe))
 
   }
 
   object Object {
 
-    val Constructor: ConstructorMethod = ConstructorMethod(JvmName.Object, Nil)
+    val Constructor: ConstructorMethod = ConstructorMethod(JvmName.Object.toClassDesc, Nil)
 
     val EqualsMethod: InstanceMethod =
-      InstanceMethod(JvmName.Object, "equals", mkDescriptor(BackendType.Object)(BackendType.Bool))
+      InstanceMethod(JvmName.Object.toClassDesc, "equals", mkDescriptor(BackendType.Object)(BackendType.Bool))
 
     val ToStringMethod: InstanceMethod =
-      InstanceMethod(JvmName.Object, "toString", mkDescriptor()(BackendType.String))
+      InstanceMethod(JvmName.Object.toClassDesc, "toString", mkDescriptor()(BackendType.String))
 
   }
 
   object ReentrantLock {
 
-    val Constructor: ConstructorMethod = ConstructorMethod(JvmName.ReentrantLock, Nil)
+    val Constructor: ConstructorMethod = ConstructorMethod(JvmName.ReentrantLock.toClassDesc, Nil)
 
-    val UnlockMethod: InstanceMethod = InstanceMethod(JvmName.ReentrantLock, "unlock", MethodDescriptor.NothingToVoid)
+    val UnlockMethod: InstanceMethod = InstanceMethod(JvmName.ReentrantLock.toClassDesc, "unlock", MethodDescriptor.NothingToVoid)
 
     val LockInterruptiblyMethod: InstanceMethod =
-      InstanceMethod(JvmName.ReentrantLock, "lockInterruptibly", MethodDescriptor.NothingToVoid)
+      InstanceMethod(JvmName.ReentrantLock.toClassDesc, "lockInterruptibly", MethodDescriptor.NothingToVoid)
 
   }
 
   object Regex {
     val CompileMethod: StaticMethod =
-      StaticMethod(JvmName.Regex, "compile", mkDescriptor(BackendType.String)(JvmName.Regex.toTpe))
+      StaticMethod(JvmName.Regex.toClassDesc, "compile", mkDescriptor(BackendType.String)(JvmName.Regex.toTpe))
   }
 
   object Runnable {
-    val RunMethod: InterfaceMethod = InterfaceMethod(JvmName.Runnable, "run", MethodDescriptor.NothingToVoid)
+    val RunMethod: InterfaceMethod = InterfaceMethod(JvmName.Runnable.toClassDesc, "run", MethodDescriptor.NothingToVoid)
   }
 
   object StringBuilder {
 
-    val Constructor: ConstructorMethod = ConstructorMethod(JvmName.StringBuilder, Nil)
+    val Constructor: ConstructorMethod = ConstructorMethod(JvmName.StringBuilder.toClassDesc, Nil)
 
     val AppendStringMethod: InstanceMethod =
-      InstanceMethod(JvmName.StringBuilder, "append", mkDescriptor(BackendType.String)(JvmName.StringBuilder.toTpe))
+      InstanceMethod(JvmName.StringBuilder.toClassDesc, "append", mkDescriptor(BackendType.String)(JvmName.StringBuilder.toTpe))
 
     val AppendInt32Method: InstanceMethod =
-      InstanceMethod(JvmName.StringBuilder, "append", mkDescriptor(BackendType.Int32)(JvmName.StringBuilder.toTpe))
+      InstanceMethod(JvmName.StringBuilder.toClassDesc, "append", mkDescriptor(BackendType.Int32)(JvmName.StringBuilder.toTpe))
 
   }
 
   object Thread {
 
     val CurrentThreadMethod: StaticMethod =
-      StaticMethod(JvmName.Thread, "currentThread", mkDescriptor()(JvmName.Thread.toTpe))
+      StaticMethod(JvmName.Thread.toClassDesc, "currentThread", mkDescriptor()(JvmName.Thread.toTpe))
 
     val InterruptMethod: InstanceMethod =
-      InstanceMethod(JvmName.Thread, "interrupt", MethodDescriptor.NothingToVoid)
+      InstanceMethod(JvmName.Thread.toClassDesc, "interrupt", MethodDescriptor.NothingToVoid)
 
     val JoinMethod: InstanceMethod =
-      InstanceMethod(JvmName.Thread, "join", MethodDescriptor.NothingToVoid)
+      InstanceMethod(JvmName.Thread.toClassDesc, "join", MethodDescriptor.NothingToVoid)
 
     val OfVirtualMethod: StaticMethod =
-      StaticMethod(JvmName.Thread, "ofVirtual", mkDescriptor()(JvmName.Thread$Builder$OfVirtual.toTpe))
+      StaticMethod(JvmName.Thread.toClassDesc, "ofVirtual", mkDescriptor()(JvmName.Thread$Builder$OfVirtual.toTpe))
 
     val SetUncaughtExceptionHandlerMethod: InstanceMethod =
-      InstanceMethod(JvmName.Thread, "setUncaughtExceptionHandler", mkDescriptor(JvmName.Thread$UncaughtExceptionHandler.toTpe)(VoidableType.Void))
+      InstanceMethod(JvmName.Thread.toClassDesc, "setUncaughtExceptionHandler", mkDescriptor(JvmName.Thread$UncaughtExceptionHandler.toTpe)(VoidableType.Void))
 
     val StartMethod: InstanceMethod =
-      InstanceMethod(JvmName.Thread, "start", MethodDescriptor.NothingToVoid)
+      InstanceMethod(JvmName.Thread.toClassDesc, "start", MethodDescriptor.NothingToVoid)
 
     val StartVirtualThreadMethod: StaticMethod =
-      ClassMaker.StaticMethod(JvmName.Thread, "startVirtualThread", MethodDescriptor.mkDescriptor(JvmName.Runnable.toTpe)(JvmName.Thread.toTpe))
+      ClassMaker.StaticMethod(JvmName.Thread.toClassDesc, "startVirtualThread", MethodDescriptor.mkDescriptor(JvmName.Runnable.toTpe)(JvmName.Thread.toTpe))
 
   }
 
   object ThreadBuilderOfVirtual {
     val UnstartedMethod: InterfaceMethod =
-      InterfaceMethod(JvmName.Thread$Builder$OfVirtual, "unstarted", mkDescriptor(JvmName.Runnable.toTpe)(JvmName.Thread.toTpe))
+      InterfaceMethod(JvmName.Thread$Builder$OfVirtual.toClassDesc, "unstarted", mkDescriptor(JvmName.Runnable.toTpe)(JvmName.Thread.toTpe))
   }
 
   object ThreadUncaughtExceptionHandler {
     val UncaughtExceptionMethod: InstanceMethod =
-      InstanceMethod(JvmName.Thread$UncaughtExceptionHandler, "uncaughtException", mkDescriptor(JvmName.Thread.toTpe, JvmName.Throwable.toTpe)(VoidableType.Void))
+      InstanceMethod(JvmName.Thread$UncaughtExceptionHandler.toClassDesc, "uncaughtException", mkDescriptor(JvmName.Thread.toTpe, JvmName.Throwable.toTpe)(VoidableType.Void))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -27,6 +27,9 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.*
 import ca.uwaterloo.flix.language.ast.shared.JvmAnnotation
 import org.objectweb.asm.{ClassWriter, MethodVisitor, Opcodes}
 
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.CD_Object
+
 
 // TODO: There are further things you can constrain and assert, e.g. final classes have implicitly final methods.
 sealed trait ClassMaker {
@@ -132,23 +135,24 @@ object ClassMaker {
     }
   }
 
-  def mkClass(className: JvmName, f: Final, superClass: JvmName = JvmName.Object, interfaces: List[JvmName] = Nil)(implicit flix: Flix): InstanceClassMaker = {
+  def mkClass(className: ClassDesc, f: Final, superClass: ClassDesc = CD_Object, interfaces: List[ClassDesc] = Nil)(implicit flix: Flix): InstanceClassMaker = {
     new InstanceClassMaker(mkClassWriter(className, IsPublic, f, NotAbstract, NotInterface, superClass, interfaces))
   }
 
-  def mkAbstractClass(className: JvmName, superClass: JvmName = JvmName.Object, interfaces: List[JvmName] = Nil)(implicit flix: Flix): AbstractClassMaker = {
+  def mkAbstractClass(className: ClassDesc, superClass: ClassDesc = CD_Object, interfaces: List[ClassDesc] = Nil)(implicit flix: Flix): AbstractClassMaker = {
     new AbstractClassMaker(mkClassWriter(className, IsPublic, NotFinal, IsAbstract, NotInterface, superClass, interfaces))
   }
 
-  def mkInterface(interfaceName: JvmName, interfaces: List[JvmName] = Nil)(implicit flix: Flix): InterfaceMaker = {
-    new InterfaceMaker(mkClassWriter(interfaceName, IsPublic, NotFinal, IsAbstract, IsInterface, JvmName.Object, interfaces))
+  def mkInterface(interfaceName: ClassDesc, interfaces: List[ClassDesc] = Nil)(implicit flix: Flix): InterfaceMaker = {
+    new InterfaceMaker(mkClassWriter(interfaceName, IsPublic, NotFinal, IsAbstract, IsInterface, CD_Object, interfaces))
   }
 
-  private def mkClassWriter(name: JvmName, v: Visibility, f: Final, a: Abstract, i: Interface, superClass: JvmName, interfaces: List[JvmName])(implicit flix: Flix): ClassWriter = {
+  private def mkClassWriter(name: ClassDesc, v: Visibility, f: Final, a: Abstract, i: Interface, superClass: ClassDesc, interfaces: List[ClassDesc])(implicit flix: Flix): ClassWriter = {
     val cw = AsmOps.mkClassWriter()
     val m = v.toInt + f.toInt + a.toInt + i.toInt
-    cw.visit(CompilerConstants.JvmTargetVersion, m, name.toInternalName, null, superClass.toInternalName, interfaces.map(_.toInternalName).toArray)
-    cw.visitSource(name.toInternalName, null)
+    val internalName = AsmOps.internalNameOf(name)
+    cw.visit(CompilerConstants.JvmTargetVersion, m, internalName, null, AsmOps.internalNameOf(superClass), interfaces.map(AsmOps.internalNameOf).toArray)
+    cw.visitSource(internalName, null)
     cw
   }
 
@@ -235,53 +239,53 @@ object ClassMaker {
   }
 
   sealed trait Field {
-    def clazz: JvmName
+    def clazz: ClassDesc
 
     def name: String
 
     def tpe: BackendType
   }
 
-  sealed case class InstanceField(clazz: JvmName, name: String, tpe: BackendType) extends Field
+  sealed case class InstanceField(clazz: ClassDesc, name: String, tpe: BackendType) extends Field
 
-  sealed case class StaticField(clazz: JvmName, name: String, tpe: BackendType) extends Field
+  sealed case class StaticField(clazz: ClassDesc, name: String, tpe: BackendType) extends Field
 
   sealed trait Method {
-    def clazz: JvmName
+    def clazz: ClassDesc
 
     def name: String
 
     def d: MethodDescriptor
   }
 
-  sealed case class ConstructorMethod(clazz: JvmName, args: List[BackendType]) extends Method {
+  sealed case class ConstructorMethod(clazz: ClassDesc, args: List[BackendType]) extends Method {
     override def name: String = JvmName.ConstructorMethod
 
     override def d: MethodDescriptor = MethodDescriptor(args, VoidableType.Void)
   }
 
-  case class StaticConstructorMethod(clazz: JvmName) extends Method {
+  case class StaticConstructorMethod(clazz: ClassDesc) extends Method {
     override def name: String = JvmName.StaticConstructorMethod
 
     override def d: MethodDescriptor = MethodDescriptor.NothingToVoid
   }
 
-  sealed case class InstanceMethod(clazz: JvmName, name: String, d: MethodDescriptor) extends Method {
-    def implementation(clazz: JvmName): InstanceMethod = InstanceMethod(clazz, name, d)
+  sealed case class InstanceMethod(clazz: ClassDesc, name: String, d: MethodDescriptor) extends Method {
+    def implementation(clazz: ClassDesc): InstanceMethod = InstanceMethod(clazz, name, d)
   }
 
-  sealed case class DefaultMethod(clazz: JvmName, name: String, d: MethodDescriptor) extends Method
+  sealed case class DefaultMethod(clazz: ClassDesc, name: String, d: MethodDescriptor) extends Method
 
-  sealed case class InterfaceMethod(clazz: JvmName, name: String, d: MethodDescriptor) extends Method {
-    def implementation(clazz: JvmName): InstanceMethod = InstanceMethod(clazz, name, d)
+  sealed case class InterfaceMethod(clazz: ClassDesc, name: String, d: MethodDescriptor) extends Method {
+    def implementation(clazz: ClassDesc): InstanceMethod = InstanceMethod(clazz, name, d)
   }
 
-  sealed case class AbstractMethod(clazz: JvmName, name: String, d: MethodDescriptor) extends Method {
-    def implementation(clazz: JvmName): InstanceMethod = InstanceMethod(clazz, name, d)
+  sealed case class AbstractMethod(clazz: ClassDesc, name: String, d: MethodDescriptor) extends Method {
+    def implementation(clazz: ClassDesc): InstanceMethod = InstanceMethod(clazz, name, d)
   }
 
-  sealed case class StaticMethod(clazz: JvmName, name: String, d: MethodDescriptor) extends Method
+  sealed case class StaticMethod(clazz: ClassDesc, name: String, d: MethodDescriptor) extends Method
 
-  sealed case class StaticInterfaceMethod(clazz: JvmName, name: String, d: MethodDescriptor) extends Method
+  sealed case class StaticInterfaceMethod(clazz: ClassDesc, name: String, d: MethodDescriptor) extends Method
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -28,6 +28,7 @@ import ca.uwaterloo.flix.language.phase.jvm.Mangle.RootPackage
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.{MethodVisitor, Opcodes}
 
+import java.lang.constant.ClassDesc
 import java.lang.constant.ConstantDescs.CD_void
 import scala.jdk.CollectionConverters.*
 
@@ -38,18 +39,18 @@ object GenAnonymousClasses {
   def gen(objs: List[AnonClass])(implicit root: Root, flix: Flix): List[JvmClass] = {
     for (obj <- objs) yield {
       val className = JvmName(RootPackage, obj.name)
-      JvmClass(className, genByteCode(className, obj))
+      JvmClass(className, genByteCode(className.toClassDesc, obj))
     }
   }
 
-  private def genByteCode(className: JvmName, obj: AnonClass)(implicit root: Root, flix: Flix): Array[Byte] = {
+  private def genByteCode(className: ClassDesc, obj: AnonClass)(implicit root: Root, flix: Flix): Array[Byte] = {
     val superClass = if (obj.clazz.isInterface)
-      JvmName.Object
+      JvmName.Object.toClassDesc
     else
-      JvmName.ofClassDesc(obj.clazz.desc)
+      obj.clazz.desc
 
     val interfaces = if (obj.clazz.isInterface)
-      List(JvmName.ofClassDesc(obj.clazz.desc))
+      List(obj.clazz.desc)
     else
       Nil
 
@@ -103,7 +104,7 @@ object GenAnonymousClasses {
     cm.closeClassMaker()
   }
 
-  private def constructorIns(superClass: JvmName)(implicit mv: MethodVisitor): Unit = {
+  private def constructorIns(superClass: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     import BytecodeInstructions.*
     ALOAD(0)
     INVOKESPECIAL(ClassMaker.ConstructorMethod(superClass, Nil))
@@ -111,7 +112,7 @@ object GenAnonymousClasses {
   }
 
   /** Creates constructor bytecode that forwards parameters directly to the super constructor. */
-  private def constructorInsWithSuperCall(superClass: JvmName, constructor: JConstructor)(implicit mv: MethodVisitor): Unit = {
+  private def constructorInsWithSuperCall(superClass: ClassDesc, constructor: JConstructor)(implicit mv: MethodVisitor): Unit = {
     import BytecodeInstructions.*
     val paramTypes = constructor.descriptor.parameterList.asScala.toList.map(BackendType.toBackendType)
     // ALOAD 0 (this)
@@ -149,7 +150,7 @@ object GenAnonymousClasses {
     *   }
     * }}}
     */
-  private def superBridgeIns(superClass: JvmName, method: JMethod)(implicit mv: MethodVisitor): Unit = {
+  private def superBridgeIns(superClass: ClassDesc, method: JMethod)(implicit mv: MethodVisitor): Unit = {
     val paramTypes = method.descriptor.parameterList.asScala.toList.map(BackendType.toBackendType)
     val isVoid = method.descriptor.returnType() == CD_void
     val descriptor = MethodDescriptor(paramTypes, if (isVoid) VoidableType.Void else BackendType.toBackendType(method.descriptor.returnType()))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -10,6 +10,8 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.MethodVisitor
 
+import java.lang.constant.ClassDesc
+
 /** An effect class like this:
   * {{{
   * eff SomeEffect {
@@ -52,12 +54,12 @@ object GenEffectClasses {
   def gen(effects: Iterable[Effect])(implicit root: Root, flix: Flix): List[JvmClass] = {
     for (effect <- effects.toList) yield {
       val className = JvmOps.getEffectDefinitionClassName(effect.sym)
-      JvmClass(className, genByteCode(className, effect))
+      JvmClass(className, genByteCode(className.toClassDesc, effect))
     }
   }
 
-  private def genByteCode(effectName: JvmName, effect: Effect)(implicit root: Root, flix: Flix): Array[Byte] = {
-    val cm = ClassMaker.mkClass(effectName, IsFinal, interfaces = List(BackendObjType.Handler.jvmName))
+  private def genByteCode(effectName: ClassDesc, effect: Effect)(implicit root: Root, flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(effectName, IsFinal, interfaces = List(BackendObjType.Handler.desc))
 
     cm.mkConstructor(ClassMaker.ConstructorMethod(effectName, Nil), IsPublic, constructorIns(_))
 
@@ -82,7 +84,7 @@ object GenEffectClasses {
     RETURN()
   }
 
-  private def methodIns(effectName: JvmName, opFunction: BackendObjType.Arrow, opField: InstanceField, erasedParams: List[BackendType], returnType: BackendType)(implicit mv: MethodVisitor): Unit = {
+  private def methodIns(effectName: ClassDesc, opFunction: BackendObjType.Arrow, opField: InstanceField, erasedParams: List[BackendType], returnType: BackendType)(implicit mv: MethodVisitor): Unit = {
     import BytecodeInstructions.*
     val wrapperType = BackendObjType.ResumptionWrapper(returnType)
 
@@ -97,7 +99,7 @@ object GenEffectClasses {
           // copy (preserving captures, but with fresh argument/local/pc slots) so that re-entrant
           // invocations from deep or multi-shot resumptions do not clobber each other's arguments.
           val absArrow = BackendObjType.AbstractArrow(opFunction.args, opFunction.result)
-          CHECKCAST(absArrow.jvmName)
+          CHECKCAST(absArrow.desc)
           INVOKEVIRTUAL(absArrow.GetUniqueThreadClosureMethod)
           for ((par, i) <- params.zipWithIndex) {
             DUP()
@@ -106,11 +108,11 @@ object GenEffectClasses {
           }
           // Convert the resumption to a function.
           DUP()
-          NEW(wrapperType.jvmName)
+          NEW(wrapperType.desc)
           DUP()
           resumption.load()
           INVOKESPECIAL(wrapperType.Constructor)
-          PUTFIELD(ClassMaker.InstanceField(opFunction.jvmName, s"arg${params.size}", BackendObjType.Resumption.toTpe.toErased))
+          PUTFIELD(ClassMaker.InstanceField(opFunction.desc, s"arg${params.size}", BackendObjType.Resumption.toTpe.toErased))
           // Call invoke.
           INVOKEINTERFACE(BackendObjType.Thunk.InvokeMethod)
           ARETURN()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -22,6 +22,7 @@ import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.ast.SemanticOp.*
 import ca.uwaterloo.flix.language.ast.shared.{Constant, ExpPosition, Mutability}
 import ca.uwaterloo.flix.language.ast.{SimpleType, *}
+import ca.uwaterloo.flix.language.phase.jvm.AsmOps.internalNameOf
 import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
 import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.ListOps
@@ -138,7 +139,7 @@ object GenExpression {
         import BytecodeInstructions.*
         // Can fail with NumberFormatException
         addLoc(loc)
-        NEW(JvmName.BigDecimal)
+        NEW(JvmName.BigDecimal.toClassDesc)
         DUP()
         pushString(dd.toString)
         INVOKESPECIAL(ClassConstants.BigDecimal.Constructor)
@@ -159,7 +160,7 @@ object GenExpression {
         import BytecodeInstructions.*
         // Add source line number for debugging (can fail with NumberFormatException)
         addLoc(loc)
-        NEW(JvmName.BigInteger)
+        NEW(JvmName.BigInteger.toClassDesc)
         DUP()
         pushString(ii.toString)
         INVOKESPECIAL(ClassConstants.BigInteger.Constructor)
@@ -181,7 +182,7 @@ object GenExpression {
         import BytecodeInstructions.*
         //!TODO: For now, just emit null
         ACONST_NULL()
-        CHECKCAST(BackendObjType.Region.jvmName)
+        CHECKCAST(BackendObjType.Region.desc)
 
     }
 
@@ -637,7 +638,7 @@ object GenExpression {
         import BytecodeInstructions.*
         val SimpleType.Tuple(elmTypes) = tpe
         val tupleType = BackendObjType.Tuple(elmTypes.map(BackendType.toBackendType))
-        NEW(tupleType.jvmName)
+        NEW(tupleType.desc)
         DUP()
         exps.foreach(compileExpr)
         INVOKESPECIAL(tupleType.Constructor)
@@ -651,7 +652,7 @@ object GenExpression {
         pushString(field.name)
         INVOKEINTERFACE(BackendObjType.Record.LookupFieldMethod)
         // Now that the specific RecordExtend object is found, we cast it to its exact class and extract the value.
-        CHECKCAST(recordType.jvmName)
+        CHECKCAST(recordType.desc)
         GETFIELD(recordType.ValueField)
         castIfNotPrim(BackendType.toBackendType(tpe))
 
@@ -659,7 +660,7 @@ object GenExpression {
         import BytecodeInstructions.*
         val List(exp1, exp2) = exps
         val recordType = BackendObjType.RecordExtend(BackendType.toErasedBackendType(exp1.tpe))
-        NEW(recordType.jvmName)
+        NEW(recordType.desc)
         DUP()
         INVOKESPECIAL(recordType.Constructor)
         DUP()
@@ -718,7 +719,7 @@ object GenExpression {
         // We get the inner type of the array
         val innerType = tpe.asInstanceOf[SimpleType.Array].tpe
         val backendType = BackendType.toBackendType(innerType)
-        val fillMethod = ClassMaker.StaticMethod(JvmName.Arrays, "fill", mkDescriptor(BackendType.Array(backendType.toErased), backendType.toErased)(VoidableType.Void))
+        val fillMethod = ClassMaker.StaticMethod(JvmName.Arrays.toClassDesc, "fill", mkDescriptor(BackendType.Array(backendType.toErased), backendType.toErased)(VoidableType.Void))
         compileExpr(exp1) // default
         compileExpr(exp2) // default, length
         xNewArray(backendType) // default, arr
@@ -774,7 +775,7 @@ object GenExpression {
             compileExpr(region)
             xPop(BackendType.toBackendType(region.tpe))
         }
-        NEW(structType.jvmName)
+        NEW(structType.desc)
         DUP()
         fieldExps.foreach(compileExpr)
         INVOKESPECIAL(structType.Constructor)
@@ -820,7 +821,7 @@ object GenExpression {
         val List(exp) = exps
         val bType = BackendType.toBackendType(tpe)
         compileExpr(exp)
-        CHECKCAST(BackendObjType.Value.jvmName)
+        CHECKCAST(BackendObjType.Value.desc)
         GETFIELD(BackendObjType.Value.fieldFromType(bType))
         castIfNotPrim(bType)
 
@@ -846,7 +847,7 @@ object GenExpression {
             val erasedExpTpe = BackendType.toErasedBackendType(exp.tpe)
             val valueField = BackendObjType.Value.fieldFromType(erasedExpTpe)
             compileExpr(exp)
-            NEW(BackendObjType.Value.jvmName)
+            NEW(BackendObjType.Value.desc)
             DUP()
             INVOKESPECIAL(BackendObjType.Value.Constructor)
             DUP()
@@ -995,16 +996,16 @@ object GenExpression {
           case Expr.Cst(Constant.Static, _) =>
             addLoc(loc)
             compileExpr(exp1)
-            CHECKCAST(JvmName.Runnable)
+            CHECKCAST(JvmName.Runnable.toClassDesc)
             INVOKESTATIC(ClassConstants.Thread.StartVirtualThreadMethod)
             POP()
             GETSTATIC(BackendObjType.Unit.SingletonField)
           case _ =>
             addLoc(loc)
             compileExpr(exp2)
-            CHECKCAST(BackendObjType.Region.jvmName)
+            CHECKCAST(BackendObjType.Region.desc)
             compileExpr(exp1)
-            CHECKCAST(JvmName.Runnable)
+            CHECKCAST(JvmName.Runnable.toClassDesc)
             INVOKEVIRTUAL(BackendObjType.Region.SpawnMethod)
             GETSTATIC(BackendObjType.Unit.SingletonField)
         }
@@ -1017,7 +1018,7 @@ object GenExpression {
         val SimpleType.Lazy(elmType) = tpe
         val lazyType = BackendObjType.Lazy(BackendType.toBackendType(elmType))
 
-        NEW(lazyType.jvmName)
+        NEW(lazyType.desc)
         DUP()
         compileExpr(exp)
         INVOKESPECIAL(lazyType.Constructor)
@@ -1033,7 +1034,7 @@ object GenExpression {
 
         // Emit code for the lazy expression.
         compileExpr(exp)
-        CHECKCAST(lazyType.jvmName)
+        CHECKCAST(lazyType.desc)
         DUP()
         GETFIELD(lazyType.ExpField)
         ifConditionElse(Condition.NONNULL)(
@@ -1046,7 +1047,7 @@ object GenExpression {
         import BytecodeInstructions.*
         // Add source line number for debugging (failable by design).
         addLoc(loc)
-        NEW(BackendObjType.HoleError.jvmName) // HoleError
+        NEW(BackendObjType.HoleError.desc) // HoleError
         DUP() // HoleError, HoleError
         pushString(sym.toString) // HoleError, HoleError, Sym
         pushLoc(loc) // HoleError, HoleError, Sym, Loc
@@ -1057,7 +1058,7 @@ object GenExpression {
         import BytecodeInstructions.*
         // Add source line number for debugging (failable by design)
         addLoc(loc)
-        NEW(BackendObjType.MatchError.jvmName) // MatchError
+        NEW(BackendObjType.MatchError.desc) // MatchError
         DUP() // MatchError, MatchError
         pushLoc(loc) // MatchError, MatchError, Loc
         INVOKESPECIAL(BackendObjType.MatchError.Constructor) // MatchError
@@ -1067,7 +1068,7 @@ object GenExpression {
         import BytecodeInstructions.*
         // Add source line number for debugging (failable by design)
         addLoc(loc)
-        NEW(BackendObjType.CastError.jvmName) // CastError
+        NEW(BackendObjType.CastError.desc) // CastError
         DUP() // CastError, CastError
         pushLoc(loc) // CastError, CastError, Loc
         pushString(s"Cannot cast from type '$from' to '$to'") // CastError, CastError, Loc, String
@@ -1237,11 +1238,11 @@ object GenExpression {
 
         val effectName = JvmOps.getEffectDefinitionClassName(sym.eff)
         val effectStaticMethod = ClassMaker.StaticMethod(
-          effectName,
+          effectName.toClassDesc,
           JvmOps.getEffectOpName(sym),
           GenEffectClasses.opStaticFunctionDescriptor(sym)
         )
-        NEW(Suspension.jvmName)
+        NEW(Suspension.desc)
         DUP()
         INVOKESPECIAL(Suspension.Constructor)
         DUP()
@@ -1255,7 +1256,7 @@ object GenExpression {
         PUTFIELD(Suspension.EffOpField)
         DUP()
         // create continuation
-        NEW(BackendObjType.FramesNil.jvmName)
+        NEW(BackendObjType.FramesNil.desc)
         DUP()
         INVOKESPECIAL(BackendObjType.FramesNil.Constructor)
         newFrame(mv)
@@ -1266,7 +1267,7 @@ object GenExpression {
         // store continuation
         PUTFIELD(Suspension.PrefixField)
         DUP()
-        NEW(BackendObjType.ResumptionNil.jvmName)
+        NEW(BackendObjType.ResumptionNil.desc)
         DUP()
         INVOKESPECIAL(BackendObjType.ResumptionNil.Constructor)
         PUTFIELD(Suspension.ResumptionField)
@@ -1548,7 +1549,7 @@ object GenExpression {
       // eff name
       pushString(effUse.sym.toString)
       // handler
-      NEW(effectJvmName)
+      NEW(effectJvmName.toClassDesc)
       DUP()
       mv.visitMethodInsn(Opcodes.INVOKESPECIAL, effectJvmName.toInternalName, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid.toDescriptor, false)
       // bind handler closures
@@ -1558,7 +1559,7 @@ object GenExpression {
         mv.visitFieldInsn(Opcodes.PUTFIELD, effectJvmName.toInternalName, JvmOps.getEffectOpName(op.sym), GenEffectClasses.opFieldType(op.sym).toDescriptor)
       }
       // frames
-      NEW(BackendObjType.FramesNil.jvmName)
+      NEW(BackendObjType.FramesNil.desc)
       DUP()
       INVOKESPECIAL(BackendObjType.FramesNil.Constructor)
       // continuation
@@ -1621,21 +1622,6 @@ object GenExpression {
 
   }
 
-  /**
-    * Returns the JVM internal name of the class, interface, or array descriptor `desc`,
-    * e.g. `java/lang/String` or `[Ljava/lang/String;`.
-    */
-  private def internalNameOf(desc: ClassDesc): String = {
-    if (desc.isArray) {
-      // The internal name of an array type is its descriptor.
-      desc.descriptorString()
-    } else {
-      // Strip the leading `L` and trailing `;` of the descriptor.
-      val descriptor = desc.descriptorString()
-      descriptor.substring(1, descriptor.length - 1)
-    }
-  }
-
   private def getStructType(struct: Struct)(implicit root: Root): BackendObjType.Struct = {
     BackendObjType.Struct(struct.fields.map(field => BackendType.toBackendType(field.tpe)))
   }
@@ -1643,7 +1629,7 @@ object GenExpression {
   private def compileIsTag(ordinal: Int, exp: Expr, tpes: List[BackendType])(implicit mv: MethodVisitor, ctx: MethodContext, root: Root, flix: Flix): Unit = {
     import BytecodeInstructions.*
     compileExpr(exp)
-    CHECKCAST(BackendObjType.Tagged.jvmName)
+    CHECKCAST(BackendObjType.Tagged.desc)
     GETFIELD(BackendObjType.Tagged.OrdinalField)
     pushInt(ordinal)
     ifConditionElse(Condition.ICMPEQ)(pushBool(true))(pushBool(false))
@@ -1656,7 +1642,7 @@ object GenExpression {
         GETSTATIC(BackendObjType.NullaryTag(enumName, name, -1).SingletonField)
       case _ =>
         val tagType = BackendObjType.Tag(tpes)
-        NEW(tagType.jvmName)
+        NEW(tagType.desc)
         DUP()
         INVOKESPECIAL(tagType.Constructor)
         DUP()
@@ -1676,14 +1662,14 @@ object GenExpression {
     if (tpes.isEmpty) throw InternalCompilerException(s"Unexpected empty tag types", exp.loc)
     val tagType = BackendObjType.Tag(tpes)
     compileExpr(exp)
-    CHECKCAST(tagType.jvmName)
+    CHECKCAST(tagType.desc)
     GETFIELD(tagType.IndexField(idx))
   }
 
   private def compileExtIsTag(name: String, exp: Expr, tpes: List[BackendType])(implicit mv: MethodVisitor, ctx: MethodContext, root: Root, flix: Flix): Unit = {
     import BytecodeInstructions.*
     compileExpr(exp)
-    CHECKCAST(BackendObjType.ExtTagged.jvmName)
+    CHECKCAST(BackendObjType.ExtTagged.desc)
     GETFIELD(BackendObjType.ExtTagged.NameField)
     BackendObjType.ExtTagged.mkTagName(name)
     BackendObjType.ExtTagged.eqTagName()
@@ -1692,7 +1678,7 @@ object GenExpression {
   private def compileExtTag(name: String, exps: List[Expr], tpes: List[BackendType])(implicit mv: MethodVisitor, ctx: MethodContext, root: Root, flix: Flix): Unit = {
     import BytecodeInstructions.*
     val tagType = BackendObjType.ExtTag(tpes)
-    NEW(tagType.jvmName)
+    NEW(tagType.desc)
     DUP()
     INVOKESPECIAL(tagType.Constructor)
     DUP()
@@ -1709,7 +1695,7 @@ object GenExpression {
     import BytecodeInstructions.*
     val tagType = BackendObjType.ExtTag(tpes)
     compileExpr(exp)
-    CHECKCAST(tagType.jvmName)
+    CHECKCAST(tagType.desc)
     GETFIELD(tagType.IndexField(idx))
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -278,7 +278,7 @@ object GenFunAndClosureClasses {
   }
 
   private def staticApplyMethod(className: JvmName, defn: Def)(implicit root: Root): StaticMethod =
-    StaticMethod(className, JvmName.StaticApply, MethodDescriptor(defn.fparams.map(fp => BackendType.toBackendType(fp.tpe)), BackendObjType.Result.toTpe))
+    StaticMethod(className.toClassDesc, JvmName.StaticApply, MethodDescriptor(defn.fparams.map(fp => BackendType.toBackendType(fp.tpe)), BackendObjType.Result.toTpe))
 
   private def compileStaticApplyMethod(visitor: ClassWriter, className: JvmName, defn: Def)(implicit root: Root, flix: Flix): Unit = {
     // Method header
@@ -470,9 +470,9 @@ object GenFunAndClosureClasses {
     val lparams = defn.lparams.zipWithIndex.map(p => (s"l${p._2}", BackendType.toErasedBackendType(p._1.tpe)))
     val params = pc ++ fparams ++ cparams ++ lparams
 
-    NEW(className)
+    NEW(className.toClassDesc)
     DUP()
-    INVOKESPECIAL(className, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid)
+    INVOKESPECIAL(className.toClassDesc, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid)
     for ((name, fieldType) <- params) {
       DUP()
       thisLoad()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -175,6 +175,13 @@ case class JvmName(pkg: List[String], name: String) {
   lazy val toClassFileName: String = toInternalName + ".class"
 
   /**
+    * Returns `this` Java name as a [[ClassDesc]].
+    *
+    * Temporary bridge while the backend migrates from [[JvmName]] to [[ClassDesc]].
+    */
+  lazy val toClassDesc: ClassDesc = ClassDesc.ofDescriptor(toDescriptor)
+
+  /**
     * Wraps this name in `BackendType.Reference(BackendObjType.Native(...))`.
     */
   def toTpe: BackendType.Reference = BackendObjType.Native(this).toTpe


### PR DESCRIPTION
Switches the bytecode-emission DSL from `JvmName` to `java.lang.constant.ClassDesc`:

- `BytecodeInstructions`: the type/method/field instruction primitives (`NEW`, `CHECKCAST`, `INSTANCEOF`, `ANEWARRAY`, `INVOKE*`, `invokeConstructor`, …) now take `ClassDesc`.
- `ClassMaker`: the `Field`/`Method` wrappers carry `clazz: ClassDesc`, and `mkClass` / `mkAbstractClass` / `mkInterface` take `ClassDesc` (defaulting to `ConstantDescs.CD_Object`).
- `GenExpression`'s private `internalNameOf` helper (ClassDesc → internal name by descriptor substring, no parsing) is promoted to `AsmOps.internalNameOf` and used by the whole layer.
- `BackendObjType` gains `desc: ClassDesc` alongside `jvmName`, and all DSL call sites use it.
- `GenAnonymousClasses` passes `obj.clazz.desc` straight through, deleting two of the four remaining `JvmName.ofClassDesc` back-conversions (the last two, in `BackendType`, fall in a follow-up).
- `JvmName.toClassDesc` (`ClassDesc.ofDescriptor(toDescriptor)`, cached) bridges the remaining `JvmName`-typed producers — the JDK constants table, `JvmOps` class names — until follow-up PRs move those to `ClassDesc`.

Output keying is untouched: `JvmClass` and `BytecodeAst` still use `JvmName`. No behavior change intended; benchmark results will be posted below.

Part of the `JvmName` retirement series (#13106, #13108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)