### PR TITLE
refactor: compute ClassDesc directly in BackendObjType

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{JvmAst, SourceLocation, Symbol}
-import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.mkClassName
+import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.{mkClassName, mkDesc}
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.*
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.Branch.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.*
@@ -31,68 +31,71 @@ import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 
 import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.CD_Object
 
 /**
   * Represents all Flix types that are objects on the JVM (array is an exception).
   */
 sealed trait BackendObjType {
   /**
-    * The `JvmName` that represents the type `Ref(Int)` refers to `"Ref$Int"`.
+    * The [[ClassDesc]] of this type, e.g. the type `Ref(Int)` refers to `"Ref$Int"`.
     */
-  val jvmName: JvmName = this match {
-    case BackendObjType.Unit => JvmName(DevFlixRuntime, mkClassName("Unit"))
-    case BackendObjType.Lazy(tpe) => JvmName(RootPackage, mkClassName("Lazy", tpe))
-    case BackendObjType.Tuple(elms) => JvmName(RootPackage, mkClassName("Tuple", elms))
-    case BackendObjType.Struct(elms) => JvmName(RootPackage, mkClassName("Struct", elms))
-    case BackendObjType.NullaryTag(enumName, sym, _) => JvmName(RootPackage, Mangle.mkClassName(enumName, sym))
-    case BackendObjType.Tagged => JvmName(RootPackage, mkClassName("Tagged"))
-    case BackendObjType.Tag(tpes) => JvmName(RootPackage, mkClassName("Tag", tpes))
-    case BackendObjType.ExtTagged => JvmName(RootPackage, mkClassName("ExtTagged"))
-    case BackendObjType.ExtTag(tpes) => JvmName(RootPackage, mkClassName("ExtTag", tpes))
-    case BackendObjType.AbstractArrow(args, result) => JvmName(RootPackage, mkClassName(s"Clo${args.length}", args :+ result))
-    case BackendObjType.Arrow(args, result) => JvmName(RootPackage, mkClassName(s"Fn${args.length}", args :+ result))
-    case BackendObjType.Defn(sym) => JvmName(sym.namespace, Mangle.mkClassName("Def", sym.name))
-    case BackendObjType.RecordEmpty => JvmName(RootPackage, mkClassName(s"RecordEmpty"))
-    case BackendObjType.RecordExtend(value) => JvmName(RootPackage, mkClassName("RecordExtend", value))
-    case BackendObjType.Record => JvmName(RootPackage, mkClassName("Record"))
-    case BackendObjType.ReifiedSourceLocation => JvmName(DevFlixRuntime, mkClassName("ReifiedSourceLocation"))
-    case BackendObjType.Global => JvmName(DevFlixRuntime, "Global") // "Global" is fixed in source code, so should not be mangled and $ suffixed
-    case BackendObjType.HoleError => JvmName(DevFlixRuntime, mkClassName("HoleError"))
-    case BackendObjType.MatchError => JvmName(DevFlixRuntime, mkClassName("MatchError"))
-    case BackendObjType.CastError => JvmName(DevFlixRuntime, mkClassName("CastError"))
-    case BackendObjType.UnhandledEffectError => JvmName(DevFlixRuntime, mkClassName("UnhandledEffectError"))
-    case BackendObjType.Region => JvmName(DevFlixRuntime, mkClassName("Region"))
-    case BackendObjType.UncaughtExceptionHandler => JvmName(DevFlixRuntime, mkClassName("UncaughtExceptionHandler"))
-    case BackendObjType.Main => JvmName(RootPackage, "Main")
-    case BackendObjType.Namespace(ns) => JvmName(ns.dropRight(1), ns.lastOption.getOrElse(s"Root${Flix.Delimiter}"))
+  val desc: ClassDesc = this match {
+    case BackendObjType.Unit => mkDesc(DevFlixRuntime, mkClassName("Unit"))
+    case BackendObjType.Lazy(tpe) => mkDesc(RootPackage, mkClassName("Lazy", tpe))
+    case BackendObjType.Tuple(elms) => mkDesc(RootPackage, mkClassName("Tuple", elms))
+    case BackendObjType.Struct(elms) => mkDesc(RootPackage, mkClassName("Struct", elms))
+    case BackendObjType.NullaryTag(enumName, sym, _) => mkDesc(RootPackage, Mangle.mkClassName(enumName, sym))
+    case BackendObjType.Tagged => mkDesc(RootPackage, mkClassName("Tagged"))
+    case BackendObjType.Tag(tpes) => mkDesc(RootPackage, mkClassName("Tag", tpes))
+    case BackendObjType.ExtTagged => mkDesc(RootPackage, mkClassName("ExtTagged"))
+    case BackendObjType.ExtTag(tpes) => mkDesc(RootPackage, mkClassName("ExtTag", tpes))
+    case BackendObjType.AbstractArrow(args, result) => mkDesc(RootPackage, mkClassName(s"Clo${args.length}", args :+ result))
+    case BackendObjType.Arrow(args, result) => mkDesc(RootPackage, mkClassName(s"Fn${args.length}", args :+ result))
+    case BackendObjType.Defn(sym) => mkDesc(sym.namespace, Mangle.mkClassName("Def", sym.name))
+    case BackendObjType.RecordEmpty => mkDesc(RootPackage, mkClassName(s"RecordEmpty"))
+    case BackendObjType.RecordExtend(value) => mkDesc(RootPackage, mkClassName("RecordExtend", value))
+    case BackendObjType.Record => mkDesc(RootPackage, mkClassName("Record"))
+    case BackendObjType.ReifiedSourceLocation => mkDesc(DevFlixRuntime, mkClassName("ReifiedSourceLocation"))
+    case BackendObjType.Global => mkDesc(DevFlixRuntime, "Global") // "Global" is fixed in source code, so should not be mangled and $ suffixed
+    case BackendObjType.HoleError => mkDesc(DevFlixRuntime, mkClassName("HoleError"))
+    case BackendObjType.MatchError => mkDesc(DevFlixRuntime, mkClassName("MatchError"))
+    case BackendObjType.CastError => mkDesc(DevFlixRuntime, mkClassName("CastError"))
+    case BackendObjType.UnhandledEffectError => mkDesc(DevFlixRuntime, mkClassName("UnhandledEffectError"))
+    case BackendObjType.Region => mkDesc(DevFlixRuntime, mkClassName("Region"))
+    case BackendObjType.UncaughtExceptionHandler => mkDesc(DevFlixRuntime, mkClassName("UncaughtExceptionHandler"))
+    case BackendObjType.Main => mkDesc(RootPackage, "Main")
+    case BackendObjType.Namespace(ns) => mkDesc(ns.dropRight(1), ns.lastOption.getOrElse(s"Root${Flix.Delimiter}"))
     // Java classes
-    case BackendObjType.Native(className) => className
+    case BackendObjType.Native(clazz) => clazz
     // Effects Runtime
-    case BackendObjType.Result => JvmName(DevFlixRuntime, mkClassName("Result"))
-    case BackendObjType.Value => JvmName(DevFlixRuntime, mkClassName("Value"))
-    case BackendObjType.Frame => JvmName(DevFlixRuntime, mkClassName("Frame"))
-    case BackendObjType.Thunk => JvmName(DevFlixRuntime, mkClassName("Thunk"))
-    case BackendObjType.Suspension => JvmName(DevFlixRuntime, mkClassName("Suspension"))
-    case BackendObjType.Frames => JvmName(DevFlixRuntime, mkClassName("Frames"))
-    case BackendObjType.FramesCons => JvmName(DevFlixRuntime, mkClassName("FramesCons"))
-    case BackendObjType.FramesNil => JvmName(DevFlixRuntime, mkClassName("FramesNil"))
-    case BackendObjType.Resumption => JvmName(DevFlixRuntime, mkClassName("Resumption"))
-    case BackendObjType.ResumptionCons => JvmName(DevFlixRuntime, mkClassName("ResumptionCons"))
-    case BackendObjType.ResumptionNil => JvmName(DevFlixRuntime, mkClassName("ResumptionNil"))
-    case BackendObjType.Handler => JvmName(DevFlixRuntime, mkClassName("Handler"))
-    case BackendObjType.EffectCall => JvmName(DevFlixRuntime, mkClassName("EffectCall"))
-    case BackendObjType.ResumptionWrapper(t) => JvmName(DevFlixRuntime, mkClassName("ResumptionWrapper", t))
+    case BackendObjType.Result => mkDesc(DevFlixRuntime, mkClassName("Result"))
+    case BackendObjType.Value => mkDesc(DevFlixRuntime, mkClassName("Value"))
+    case BackendObjType.Frame => mkDesc(DevFlixRuntime, mkClassName("Frame"))
+    case BackendObjType.Thunk => mkDesc(DevFlixRuntime, mkClassName("Thunk"))
+    case BackendObjType.Suspension => mkDesc(DevFlixRuntime, mkClassName("Suspension"))
+    case BackendObjType.Frames => mkDesc(DevFlixRuntime, mkClassName("Frames"))
+    case BackendObjType.FramesCons => mkDesc(DevFlixRuntime, mkClassName("FramesCons"))
+    case BackendObjType.FramesNil => mkDesc(DevFlixRuntime, mkClassName("FramesNil"))
+    case BackendObjType.Resumption => mkDesc(DevFlixRuntime, mkClassName("Resumption"))
+    case BackendObjType.ResumptionCons => mkDesc(DevFlixRuntime, mkClassName("ResumptionCons"))
+    case BackendObjType.ResumptionNil => mkDesc(DevFlixRuntime, mkClassName("ResumptionNil"))
+    case BackendObjType.Handler => mkDesc(DevFlixRuntime, mkClassName("Handler"))
+    case BackendObjType.EffectCall => mkDesc(DevFlixRuntime, mkClassName("EffectCall"))
+    case BackendObjType.ResumptionWrapper(t) => mkDesc(DevFlixRuntime, mkClassName("ResumptionWrapper", t))
   }
 
   /**
-    * The [[ClassDesc]] of this type.
+    * The [[JvmName]] of this type.
+    *
+    * Kept only for `JvmClass` keying until the output side migrates to [[ClassDesc]].
     */
-  def desc: ClassDesc = jvmName.toClassDesc
+  def jvmName: JvmName = JvmName.ofClassDesc(desc)
 
   /**
-    * The JVM type descriptor of the form `"L<jvmName.toInternalName>;"`.
+    * The JVM type descriptor of the form `"L<internal name>;"`.
     */
-  def toDescriptor: String = jvmName.toDescriptor
+  def toDescriptor: String = desc.descriptorString()
 
   /**
     * Returns `this` wrapped in `BackendType.Reference`.
@@ -117,6 +120,12 @@ sealed trait BackendObjType {
 }
 
 object BackendObjType {
+
+  /** Returns the [[ClassDesc]] of the class `name` in the package `pkg`. */
+  private def mkDesc(pkg: List[String], name: String): ClassDesc = {
+    val prefix = if (pkg.isEmpty) "" else pkg.mkString("", "/", "/")
+    ClassDesc.ofInternalName(prefix + name)
+  }
 
   private def mkClassName(prefix: String, tpe: BackendType): String = {
     Mangle.mkClassName(prefix, tpe.toErasedString)
@@ -665,7 +674,7 @@ object BackendObjType {
       */
     private def specialization(): List[FunctionInterface] = {
       (args, result) match {
-        case (BackendType.Reference(BackendObjType.Native(JvmName.Object)) :: Nil, _) =>
+        case (BackendType.Reference(BackendObjType.Native(CD_Object)) :: Nil, _) =>
           ObjFunction :: ObjConsumer :: ObjPredicate :: Nil
         case (BackendType.Int32 :: Nil, _) =>
           IntFunction :: IntConsumer :: IntPredicate :: IntUnaryOperator :: Nil
@@ -826,7 +835,7 @@ object BackendObjType {
     * This should not be used for `java.lang.String` for example since `BackendObjType.String`
     * represents this type.
     */
-  case class Native(className: JvmName) extends BackendObjType
+  case class Native(clazz: ClassDesc) extends BackendObjType
 
   case object ReifiedSourceLocation extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
@@ -2130,7 +2139,7 @@ object BackendObjType {
         case BackendType.Bool =>
           // Use cached Value.TRUE / Value.FALSE singletons
           thisLoad()
-          mv.visitFieldInsn(Opcodes.GETFIELD, jvmName.toInternalName, "arg0", tpe.toErased.toDescriptor)
+          mv.visitFieldInsn(Opcodes.GETFIELD, AsmOps.internalNameOf(desc), "arg0", tpe.toErased.toDescriptor)
           val falseLabel = new Label()
           val doneLabel = new Label()
           mv.visitJumpInsn(Opcodes.IFEQ, falseLabel)
@@ -2145,7 +2154,7 @@ object BackendObjType {
           INVOKESPECIAL(Value.Constructor)
           DUP()
           thisLoad()
-          mv.visitFieldInsn(Opcodes.GETFIELD, jvmName.toInternalName, "arg0", tpe.toErased.toDescriptor)
+          mv.visitFieldInsn(Opcodes.GETFIELD, AsmOps.internalNameOf(desc), "arg0", tpe.toErased.toDescriptor)
           PUTFIELD(Value.fieldFromType(tpe.toErased))
       }
       INVOKEINTERFACE(Resumption.RewindMethod)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.language.ast.{JvmAst, SimpleType, SourceLocation}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
 import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.{CD_Object, CD_String}
 import scala.annotation.tailrec
 
 /**
@@ -119,11 +120,11 @@ object BackendType {
     * Holds a reference to some object type.
     */
   case class Reference(ref: BackendObjType) extends BackendType {
-    def name: JvmName = ref.jvmName
+    def name: ClassDesc = ref.desc
   }
 
-  val Object: BackendType = Reference(BackendObjType.Native(JvmName.Object))
-  val String: BackendType = Reference(BackendObjType.Native(JvmName.String))
+  val Object: BackendType = Reference(BackendObjType.Native(CD_Object))
+  val String: BackendType = Reference(BackendObjType.Native(CD_String))
 
   /**
     * Converts the given [[SimpleType]] into its [[BackendType]] representation.
@@ -160,7 +161,7 @@ object BackendType {
       case SimpleType.RecordExtend(_, _, _) => BackendObjType.Record.toTpe
       case SimpleType.ExtensibleEmpty => BackendObjType.ExtTagged.toTpe
       case SimpleType.ExtensibleExtend(_, _, _) => BackendObjType.ExtTagged.toTpe
-      case SimpleType.Native(clazz) => BackendObjType.Native(JvmName.ofClassDesc(clazz)).toTpe
+      case SimpleType.Native(clazz) => BackendObjType.Native(clazz).toTpe
       case SimpleType.Enum(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe0'", SourceLocation.Unknown)
       case SimpleType.Struct(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe0'", SourceLocation.Unknown)
     }
@@ -178,11 +179,11 @@ object BackendType {
     else if (desc == CD_float) BackendType.Float32
     else if (desc == CD_double) BackendType.Float64
     else if (desc.isArray) Array(toBackendType(desc.componentType()))
-    else Reference(BackendObjType.Native(JvmName.ofClassDesc(desc)))
+    else Reference(BackendObjType.Native(desc))
   }
 
   /**
-    * Contains all the primitive types and `Reference(Native(JvmName.Object))`.
+    * Contains all the primitive types and `Reference(Native(CD_Object))`.
     */
   def erasedTypes: List[BackendType] = List(
     BackendType.Bool,

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -246,8 +246,8 @@ object GenExpression {
             throw InternalCompilerException("ReflectOp should have been resolved in Specialization", loc)
 
           case ObjectOp.Ordinal =>
-            mv.visitTypeInsn(CHECKCAST, BackendObjType.Tagged.jvmName.toInternalName)
-            mv.visitFieldInsn(GETFIELD, BackendObjType.Tagged.jvmName.toInternalName, "ordinal", BackendType.Int32.toDescriptor)
+            mv.visitTypeInsn(CHECKCAST, internalNameOf(BackendObjType.Tagged.desc))
+            mv.visitFieldInsn(GETFIELD, internalNameOf(BackendObjType.Tagged.desc), "ordinal", BackendType.Int32.toDescriptor)
         }
 
       case AtomicOp.Binary(sop) =>
@@ -900,7 +900,7 @@ object GenExpression {
 
         // If the method is void, put a unit on top of the stack
         if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
-          mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
+          mv.visitFieldInsn(GETSTATIC, internalNameOf(BackendObjType.Unit.desc), BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.toDescriptor)
         }
 
       case AtomicOp.InvokeSuperMethod(sym, method) =>
@@ -927,7 +927,7 @@ object GenExpression {
 
         // If the method is void, put a unit on top of the stack
         if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
-          mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
+          mv.visitFieldInsn(GETSTATIC, internalNameOf(BackendObjType.Unit.desc), BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.toDescriptor)
         }
 
       case AtomicOp.InvokeStaticMethod(method) =>
@@ -940,7 +940,7 @@ object GenExpression {
         val declaration = internalNameOf(method.owner)
         mv.visitMethodInsn(INVOKESTATIC, declaration, method.name, method.descriptor.descriptorString(), method.isInterface)
         if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
-          mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
+          mv.visitFieldInsn(GETSTATIC, internalNameOf(BackendObjType.Unit.desc), BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.toDescriptor)
         }
 
       case AtomicOp.GetField(field) =>
@@ -961,7 +961,7 @@ object GenExpression {
         mv.visitFieldInsn(PUTFIELD, declaration, field.name, BackendType.toBackendType(exp2.tpe).toDescriptor)
 
         // Push Unit on the stack.
-        mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
+        mv.visitFieldInsn(GETSTATIC, internalNameOf(BackendObjType.Unit.desc), BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.toDescriptor)
 
       case AtomicOp.GetStaticField(field) =>
         // Add source line number for debugging (can fail when calling java)
@@ -978,7 +978,7 @@ object GenExpression {
         mv.visitFieldInsn(PUTSTATIC, declaration, field.name, BackendType.toBackendType(exp.tpe).toDescriptor)
 
         // Push Unit on the stack.
-        mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
+        mv.visitFieldInsn(GETSTATIC, internalNameOf(BackendObjType.Unit.desc), BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.toDescriptor)
 
       case AtomicOp.Throw =>
         import BytecodeInstructions.*
@@ -1090,9 +1090,9 @@ object GenExpression {
           // Evaluating the closure
           compileExpr(exp1)
           // Casting to JvmType of closure abstract class
-          mv.visitTypeInsn(CHECKCAST, closureAbstractClass.jvmName.toInternalName)
+          mv.visitTypeInsn(CHECKCAST, internalNameOf(closureAbstractClass.desc))
           // retrieving the unique thread object
-          mv.visitMethodInsn(INVOKEVIRTUAL, closureAbstractClass.jvmName.toInternalName, closureAbstractClass.GetUniqueThreadClosureMethod.name, MethodDescriptor.mkDescriptor()(closureAbstractClass.toTpe).toDescriptor, false)
+          mv.visitMethodInsn(INVOKEVIRTUAL, internalNameOf(closureAbstractClass.desc), closureAbstractClass.GetUniqueThreadClosureMethod.name, MethodDescriptor.mkDescriptor()(closureAbstractClass.toTpe).toDescriptor, false)
           // Putting arg on the Fn class
           // Duplicate the FunctionInterface
           mv.visitInsn(DUP)
@@ -1105,9 +1105,9 @@ object GenExpression {
         case ExpPosition.NonTail =>
           compileExpr(exp1)
           // Casting to JvmType of closure abstract class
-          mv.visitTypeInsn(CHECKCAST, closureAbstractClass.jvmName.toInternalName)
+          mv.visitTypeInsn(CHECKCAST, internalNameOf(closureAbstractClass.desc))
           // retrieving the unique thread object
-          mv.visitMethodInsn(INVOKEVIRTUAL, closureAbstractClass.jvmName.toInternalName, closureAbstractClass.GetUniqueThreadClosureMethod.name, MethodDescriptor.mkDescriptor()(closureAbstractClass.toTpe).toDescriptor, false)
+          mv.visitMethodInsn(INVOKEVIRTUAL, internalNameOf(closureAbstractClass.desc), closureAbstractClass.GetUniqueThreadClosureMethod.name, MethodDescriptor.mkDescriptor()(closureAbstractClass.toTpe).toDescriptor, false)
           // Putting arg on the Fn class
           // Duplicate the FunctionInterface
           mv.visitInsn(DUP)
@@ -1143,14 +1143,14 @@ object GenExpression {
 
     case Expr.ApplyDef(sym, exps, ct, _, _, loc) => ct match {
       case ExpPosition.Tail =>
-        val defJvmName = BackendObjType.Defn(sym).jvmName
+        val defInternalName = internalNameOf(BackendObjType.Defn(sym).desc)
         // Type of the function abstract class
         val functionInterface = JvmOps.getErasedFunctionInterfaceType(root.defs(sym).arrowType)
 
         // Put the def on the stack
-        mv.visitTypeInsn(NEW, defJvmName.toInternalName)
+        mv.visitTypeInsn(NEW, defInternalName)
         mv.visitInsn(DUP)
-        mv.visitMethodInsn(INVOKESPECIAL, defJvmName.toInternalName, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid.toDescriptor, false)
+        mv.visitMethodInsn(INVOKESPECIAL, defInternalName, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid.toDescriptor, false)
         // Putting args on the Fn class
         for ((arg, i) <- exps.zipWithIndex) {
           // Duplicate the FunctionInterface
@@ -1175,17 +1175,17 @@ object GenExpression {
           }
           val resultTpe = BackendObjType.Result.toTpe
           val desc = MethodDescriptor(paramTpes, resultTpe)
-          val className = BackendObjType.Defn(sym).jvmName
-          mv.visitMethodInsn(INVOKESTATIC, className.toInternalName, JvmName.StaticApply, desc.toDescriptor, false)
+          val className = internalNameOf(BackendObjType.Defn(sym).desc)
+          mv.visitMethodInsn(INVOKESTATIC, className, JvmName.StaticApply, desc.toDescriptor, false)
           BackendObjType.Result.unwindSuspensionFreeThunk("in pure function call", loc)
         } else {
           // JvmType of Def
-          val defJvmName = BackendObjType.Defn(sym).jvmName
+          val defInternalName = internalNameOf(BackendObjType.Defn(sym).desc)
 
           // Put the def on the stack
-          mv.visitTypeInsn(NEW, defJvmName.toInternalName)
+          mv.visitTypeInsn(NEW, defInternalName)
           mv.visitInsn(DUP)
-          mv.visitMethodInsn(INVOKESPECIAL, defJvmName.toInternalName, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid.toDescriptor, false)
+          mv.visitMethodInsn(INVOKESPECIAL, defInternalName, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid.toDescriptor, false)
 
           // Putting args on the Fn class
           for ((arg, i) <- exps.zipWithIndex) {
@@ -1193,7 +1193,7 @@ object GenExpression {
             mv.visitInsn(DUP)
             // Evaluating the expression
             compileExpr(arg)
-            mv.visitFieldInsn(PUTFIELD, defJvmName.toInternalName,
+            mv.visitFieldInsn(PUTFIELD, defInternalName,
               s"arg$i", BackendType.toErasedBackendType(arg.tpe).toDescriptor)
           }
           // Calling unwind and unboxing
@@ -1366,8 +1366,8 @@ object GenExpression {
       // Compile the scrutinee (pushes enum value onto stack)
       compileExpr(exp)
       // Extract ordinal: checkcast Tagged, getfield ordinal
-      mv.visitTypeInsn(CHECKCAST, BackendObjType.Tagged.jvmName.toInternalName)
-      mv.visitFieldInsn(GETFIELD, BackendObjType.Tagged.jvmName.toInternalName, "ordinal", BackendType.Int32.toDescriptor)
+      mv.visitTypeInsn(CHECKCAST, internalNameOf(BackendObjType.Tagged.desc))
+      mv.visitFieldInsn(GETFIELD, internalNameOf(BackendObjType.Tagged.desc), "ordinal", BackendType.Int32.toDescriptor)
       // Build labels
       val defaultLabel = new Label()
       val endLabel = new Label()
@@ -1458,9 +1458,9 @@ object GenExpression {
       val afterFinally = new Label()
 
       // Create an instance of Region
-      mv.visitTypeInsn(NEW, BackendObjType.Region.jvmName.toInternalName)
+      mv.visitTypeInsn(NEW, internalNameOf(BackendObjType.Region.desc))
       mv.visitInsn(DUP)
-      mv.visitMethodInsn(INVOKESPECIAL, BackendObjType.Region.jvmName.toInternalName, JvmName.ConstructorMethod,
+      mv.visitMethodInsn(INVOKESPECIAL, internalNameOf(BackendObjType.Region.desc), JvmName.ConstructorMethod,
         MethodDescriptor.NothingToVoid.toDescriptor, false)
 
       BytecodeInstructions.xStore(BackendObjType.Region.toTpe, JvmOps.getIndex(offset, ctx.localOffset))
@@ -1475,23 +1475,23 @@ object GenExpression {
 
       // When we exit the scope, call the region's `exit` method
       BytecodeInstructions.xLoad(BackendObjType.Region.toTpe, JvmOps.getIndex(offset, ctx.localOffset))
-      mv.visitTypeInsn(CHECKCAST, BackendObjType.Region.jvmName.toInternalName)
-      mv.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Region.jvmName.toInternalName, BackendObjType.Region.ExitMethod.name,
+      mv.visitTypeInsn(CHECKCAST, internalNameOf(BackendObjType.Region.desc))
+      mv.visitMethodInsn(INVOKEVIRTUAL, internalNameOf(BackendObjType.Region.desc), BackendObjType.Region.ExitMethod.name,
         BackendObjType.Region.ExitMethod.d.toDescriptor, false)
       mv.visitLabel(afterTryBlock)
 
       // Compile the finally block which gets called if no exception is thrown
       BytecodeInstructions.xLoad(BackendObjType.Region.toTpe, JvmOps.getIndex(offset, ctx.localOffset))
-      mv.visitTypeInsn(CHECKCAST, BackendObjType.Region.jvmName.toInternalName)
-      mv.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Region.jvmName.toInternalName, BackendObjType.Region.ReThrowChildExceptionMethod.name,
+      mv.visitTypeInsn(CHECKCAST, internalNameOf(BackendObjType.Region.desc))
+      mv.visitMethodInsn(INVOKEVIRTUAL, internalNameOf(BackendObjType.Region.desc), BackendObjType.Region.ReThrowChildExceptionMethod.name,
         BackendObjType.Region.ReThrowChildExceptionMethod.d.toDescriptor, false)
       mv.visitJumpInsn(GOTO, afterFinally)
 
       // Compile the finally block which gets called if an exception is thrown
       mv.visitLabel(finallyBlock)
       BytecodeInstructions.xLoad(BackendObjType.Region.toTpe, JvmOps.getIndex(offset, ctx.localOffset))
-      mv.visitTypeInsn(CHECKCAST, BackendObjType.Region.jvmName.toInternalName)
-      mv.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Region.jvmName.toInternalName, BackendObjType.Region.ReThrowChildExceptionMethod.name,
+      mv.visitTypeInsn(CHECKCAST, internalNameOf(BackendObjType.Region.desc))
+      mv.visitMethodInsn(INVOKEVIRTUAL, internalNameOf(BackendObjType.Region.desc), BackendObjType.Region.ReThrowChildExceptionMethod.name,
         BackendObjType.Region.ReThrowChildExceptionMethod.d.toDescriptor, false)
       mv.visitInsn(ATHROW)
       mv.visitLabel(afterFinally)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -24,6 +24,8 @@ import ca.uwaterloo.flix.util.ParOps
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.{ClassWriter, Label, MethodVisitor, Opcodes}
 
+import java.lang.constant.ClassDesc
+
 /**
   * Generates byte code for the function and closure classes.
   */
@@ -93,9 +95,9 @@ object GenFunAndClosureClasses {
     val visitor = AsmOps.mkClassWriter()
 
     // Header
-    val functionInterface = JvmOps.getErasedFunctionInterfaceType(defn.arrowType).jvmName
+    val functionInterface = JvmOps.getErasedFunctionInterfaceType(defn.arrowType).desc
     visitor.visit(CompilerConstants.JvmTargetVersion, ACC_PUBLIC + ACC_FINAL, className.toInternalName, null,
-      functionInterface.toInternalName, null)
+      AsmOps.internalNameOf(functionInterface), null)
     visitor.visitSource(defn.loc.source.name, null)
 
     compileConstructor(functionInterface, visitor)
@@ -153,10 +155,10 @@ object GenFunAndClosureClasses {
     val visitor = AsmOps.mkClassWriter()
 
     // Header
-    val functionInterface = JvmOps.getErasedFunctionInterfaceType(defn.arrowType).jvmName
+    val functionInterface = JvmOps.getErasedFunctionInterfaceType(defn.arrowType).desc
     val frameInterface = BackendObjType.Frame
     visitor.visit(CompilerConstants.JvmTargetVersion, ACC_PUBLIC + ACC_FINAL, className.toInternalName, null,
-      functionInterface.toInternalName, Array(frameInterface.jvmName.toInternalName))
+      AsmOps.internalNameOf(functionInterface), Array(AsmOps.internalNameOf(frameInterface.desc)))
     visitor.visitSource(defn.loc.source.name, null)
 
     // Fields — lparams use erased types (like fparams) so setPc can store without casting
@@ -235,10 +237,10 @@ object GenFunAndClosureClasses {
     val visitor = AsmOps.mkClassWriter()
 
     // Header
-    val functionInterface = JvmOps.getErasedClosureAbstractClassType(defn.arrowType).jvmName
+    val functionInterface = JvmOps.getErasedClosureAbstractClassType(defn.arrowType).desc
     val frameInterface = BackendObjType.Frame
     visitor.visit(CompilerConstants.JvmTargetVersion, ACC_PUBLIC + ACC_FINAL, className.toInternalName, null,
-      functionInterface.toInternalName, Array(frameInterface.jvmName.toInternalName))
+      AsmOps.internalNameOf(functionInterface), Array(AsmOps.internalNameOf(frameInterface.desc)))
     visitor.visitSource(defn.loc.source.name, null)
 
     // Fields
@@ -265,11 +267,11 @@ object GenFunAndClosureClasses {
     visitor.toByteArray
   }
 
-  private def compileConstructor(superClass: JvmName, visitor: ClassWriter): Unit = {
+  private def compileConstructor(superClass: ClassDesc, visitor: ClassWriter): Unit = {
     val constructor = visitor.visitMethod(ACC_PUBLIC, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid.toDescriptor, null, null)
 
     constructor.visitVarInsn(ALOAD, 0)
-    constructor.visitMethodInsn(INVOKESPECIAL, superClass.toInternalName, JvmName.ConstructorMethod,
+    constructor.visitMethodInsn(INVOKESPECIAL, AsmOps.internalNameOf(superClass), JvmName.ConstructorMethod,
       MethodDescriptor.NothingToVoid.toDescriptor, false)
     constructor.visitInsn(RETURN)
 
@@ -310,13 +312,13 @@ object GenFunAndClosureClasses {
       MethodDescriptor.mkDescriptor()(BackendObjType.Result.toTpe).toDescriptor, null, null)
     m.visitCode()
 
-    val functionInterface = JvmOps.getErasedFunctionInterfaceType(defn.arrowType).jvmName
+    val functionInterface = JvmOps.getErasedFunctionInterfaceType(defn.arrowType).desc
     // Putting args on the Fn class
     for ((fp, i) <- defn.fparams.zipWithIndex) {
       // Load the `this` pointer
       m.visitVarInsn(ALOAD, 0)
       // Load arg i
-      m.visitFieldInsn(GETFIELD, functionInterface.toInternalName,
+      m.visitFieldInsn(GETFIELD, AsmOps.internalNameOf(functionInterface),
         s"arg$i", BackendType.toErasedBackendType(fp.tpe).toDescriptor)
       // Insert cast to concrete type
       val bTpe = BackendType.toBackendType(fp.tpe)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -184,5 +184,5 @@ case class JvmName(pkg: List[String], name: String) {
   /**
     * Wraps this name in `BackendType.Reference(BackendObjType.Native(...))`.
     */
-  def toTpe: BackendType.Reference = BackendObjType.Native(this).toTpe
+  def toTpe: BackendType.Reference = BackendObjType.Native(toClassDesc).toTpe
 }


### PR DESCRIPTION
Inverts the derivation introduced in #13109: `BackendObjType.desc` is now the computed value — built via `ClassDesc.ofInternalName` from the same mangled parts (a new private `mkDesc` helper) — and `jvmName` becomes a small derived `def`, kept only for `JvmClass` keying until the output side migrates.

- `BackendObjType.Native` now wraps a `ClassDesc` instead of a `JvmName`, which deletes the last two `JvmName.ofClassDesc` back-conversions in `BackendType` (`SimpleType.Native` handling). No reflective or parsing conversions remain on the frontend→backend path.
- `BackendType.Reference.name` is now a `ClassDesc`; `BackendType.Object`/`String` use the JDK's `CD_Object`/`CD_String` constants.
- The raw-asm `.jvmName.toInternalName` uses in `GenExpression`, `GenFunAndClosureClasses`, and `BackendObjType` now go through `AsmOps.internalNameOf(desc)`.
- `CodeGen`'s `JvmClass` construction is untouched — it uses the derived `jvmName`, which disappears when the output side re-keys to `ClassDesc`.

No behavior change intended; benchmark results will be posted below.

Part of the `JvmName` retirement series (#13106, #13108, #13109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)