### PR TITLE
refactor: consolidate ClassDesc helpers in ClassDescs

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
@@ -16,9 +16,8 @@
 
 package ca.uwaterloo.flix.language.phase.jvm
 
+import ca.uwaterloo.flix.util.ClassDescs
 import org.objectweb.asm.ClassWriter
-
-import java.lang.constant.ClassDesc
 
 object AsmOps {
 
@@ -29,22 +28,7 @@ object AsmOps {
     */
   def mkClassWriter(): ClassWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES) {
     override def getCommonSuperClass(tpe1: String, tpe2: String): String = {
-      internalNameOf(JavaClasses.Object)
-    }
-  }
-
-  /**
-    * Returns the JVM internal name of the class, interface, or array descriptor `desc`,
-    * e.g. `java/lang/String` or `[Ljava/lang/String;`.
-    */
-  def internalNameOf(desc: ClassDesc): String = {
-    if (desc.isArray) {
-      // The internal name of an array type is its descriptor.
-      desc.descriptorString()
-    } else {
-      // Strip the leading `L` and trailing `;` of the descriptor.
-      val descriptor = desc.descriptorString()
-      descriptor.substring(1, descriptor.length - 1)
+      ClassDescs.internalNameOf(JavaClasses.Object)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -2128,7 +2128,7 @@ object BackendObjType {
         case BackendType.Bool =>
           // Use cached Value.TRUE / Value.FALSE singletons
           thisLoad()
-          mv.visitFieldInsn(Opcodes.GETFIELD, AsmOps.internalNameOf(desc), "arg0", tpe.toErased.toDescriptor)
+          mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc), "arg0", tpe.toErased.toDescriptor)
           val falseLabel = new Label()
           val doneLabel = new Label()
           mv.visitJumpInsn(Opcodes.IFEQ, falseLabel)
@@ -2143,7 +2143,7 @@ object BackendObjType {
           INVOKESPECIAL(Value.Constructor)
           DUP()
           thisLoad()
-          mv.visitFieldInsn(Opcodes.GETFIELD, AsmOps.internalNameOf(desc), "arg0", tpe.toErased.toDescriptor)
+          mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc), "arg0", tpe.toErased.toDescriptor)
           PUTFIELD(Value.fieldFromType(tpe.toErased))
       }
       INVOKEINTERFACE(Resumption.RewindMethod)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.Branch.{FalseBranch, TrueBranch}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.*
 import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
+import ca.uwaterloo.flix.util.ClassDescs
 import org.objectweb.asm
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 
@@ -31,7 +32,7 @@ object BytecodeInstructions {
   /** A wrapper of [[MethodVisitor]] to improve its interface. */
   implicit class RichMethodVisitor(visitor: MethodVisitor) {
     def visitTypeInstruction(opcode: Int, tpe: ClassDesc): Unit =
-      visitor.visitTypeInsn(opcode, AsmOps.internalNameOf(tpe))
+      visitor.visitTypeInsn(opcode, ClassDescs.internalNameOf(tpe))
 
     def visitTypeInstructionDirect(opcode: Int, tpe: String): Unit =
       visitor.visitTypeInsn(opcode, tpe)
@@ -39,14 +40,14 @@ object BytecodeInstructions {
     def visitInstruction(opcode: Int): Unit = visitor.visitInsn(opcode)
 
     def visitMethodInstruction(opcode: Int, owner: ClassDesc, methodName: String, descriptor: MethodDescriptor, isInterface: Boolean): Unit =
-      visitor.visitMethodInsn(opcode, AsmOps.internalNameOf(owner), methodName, descriptor.toDescriptor, isInterface)
+      visitor.visitMethodInsn(opcode, ClassDescs.internalNameOf(owner), methodName, descriptor.toDescriptor, isInterface)
 
     // TODO: sanitize varags
     def visitInvokeDynamicInstruction(methodName: String, descriptor: MethodDescriptor, bootstrapMethodHandle: Handle, bootstrapMethodArguments: Any*): Unit =
       visitor.visitInvokeDynamicInsn(methodName, descriptor.toDescriptor, bootstrapMethodHandle.handle, bootstrapMethodArguments *)
 
     def visitFieldInstruction(opcode: Int, owner: ClassDesc, fieldName: String, fieldType: BackendType): Unit =
-      visitor.visitFieldInsn(opcode, AsmOps.internalNameOf(owner), fieldName, fieldType.toDescriptor)
+      visitor.visitFieldInsn(opcode, ClassDescs.internalNameOf(owner), fieldName, fieldType.toDescriptor)
 
     def visitVarInstruction(opcode: Int, v: Int): Unit =
       visitor.visitVarInsn(opcode, v)
@@ -73,11 +74,11 @@ object BytecodeInstructions {
   sealed case class Handle(handle: asm.Handle)
 
   def mkStaticHandle(m: StaticMethod): Handle = {
-    Handle(new asm.Handle(Opcodes.H_INVOKESTATIC, AsmOps.internalNameOf(m.clazz), m.name, m.d.toDescriptor, false))
+    Handle(new asm.Handle(Opcodes.H_INVOKESTATIC, ClassDescs.internalNameOf(m.clazz), m.name, m.d.toDescriptor, false))
   }
 
   def mkStaticHandle(m: StaticInterfaceMethod): Handle = {
-    Handle(new asm.Handle(Opcodes.H_INVOKESTATIC, AsmOps.internalNameOf(m.clazz), m.name, m.d.toDescriptor, true))
+    Handle(new asm.Handle(Opcodes.H_INVOKESTATIC, ClassDescs.internalNameOf(m.clazz), m.name, m.d.toDescriptor, true))
   }
 
   //

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -25,6 +25,7 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Static.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.*
 import ca.uwaterloo.flix.language.ast.shared.JvmAnnotation
+import ca.uwaterloo.flix.util.ClassDescs
 import org.objectweb.asm.{ClassWriter, MethodVisitor, Opcodes}
 
 import java.lang.constant.ClassDesc
@@ -159,8 +160,8 @@ object ClassMaker {
   private def mkClassWriter(name: ClassDesc, v: Visibility, f: Final, a: Abstract, i: Interface, superClass: ClassDesc, interfaces: List[ClassDesc])(implicit flix: Flix): ClassWriter = {
     val cw = AsmOps.mkClassWriter()
     val m = v.toInt + f.toInt + a.toInt + i.toInt
-    val internalName = AsmOps.internalNameOf(name)
-    cw.visit(CompilerConstants.JvmTargetVersion, m, internalName, null, AsmOps.internalNameOf(superClass), interfaces.map(AsmOps.internalNameOf).toArray)
+    val internalName = ClassDescs.internalNameOf(name)
+    cw.visit(CompilerConstants.JvmTargetVersion, m, internalName, null, ClassDescs.internalNameOf(superClass), interfaces.map(ClassDescs.internalNameOf).toArray)
     cw.visitSource(internalName, null)
     cw
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{BytecodeAst, SimpleType, SourceLocation}
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugNoOp
-import ca.uwaterloo.flix.util.InternalCompilerException
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 import ca.uwaterloo.flix.util.collection.MapOps
 
 
@@ -159,7 +159,7 @@ object CodeGen {
     // Check for duplicate JVM class names.
     val duplicates = allClasses.groupBy(_.name).collect { case (name, classes) if classes.length > 1 => name }
     if (duplicates.nonEmpty) {
-      val names = duplicates.map(AsmOps.internalNameOf).mkString(", ")
+      val names = duplicates.map(ClassDescs.internalNameOf).mkString(", ")
       throw InternalCompilerException(s"Duplicate JVM class names: $names", SourceLocation.Unknown)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.ast.SemanticOp.*
 import ca.uwaterloo.flix.language.ast.shared.{Constant, ExpPosition, Mutability}
 import ca.uwaterloo.flix.language.ast.{SimpleType, *}
-import ca.uwaterloo.flix.language.phase.jvm.AsmOps.internalNameOf
+import ca.uwaterloo.flix.util.ClassDescs.internalNameOf
 import ca.uwaterloo.flix.language.phase.jvm.MethodDescriptor.mkDescriptor
 import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.ListOps

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.JvmAst.{Def, Root}
 import ca.uwaterloo.flix.language.ast.{Purity, SimpleType, Symbol}
 import ca.uwaterloo.flix.language.phase.jvm.BackendType.RichClassDesc
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.StaticMethod
-import ca.uwaterloo.flix.util.ParOps
+import ca.uwaterloo.flix.util.{ClassDescs, ParOps}
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.{ClassWriter, Label, MethodVisitor, Opcodes}
 
@@ -97,8 +97,8 @@ object GenFunAndClosureClasses {
 
     // Header
     val functionInterface = JvmOps.getErasedFunctionInterfaceType(defn.arrowType).desc
-    visitor.visit(CompilerConstants.JvmTargetVersion, ACC_PUBLIC + ACC_FINAL, AsmOps.internalNameOf(className), null,
-      AsmOps.internalNameOf(functionInterface), null)
+    visitor.visit(CompilerConstants.JvmTargetVersion, ACC_PUBLIC + ACC_FINAL, ClassDescs.internalNameOf(className), null,
+      ClassDescs.internalNameOf(functionInterface), null)
     visitor.visitSource(defn.loc.source.name, null)
 
     compileConstructor(functionInterface, visitor)
@@ -158,8 +158,8 @@ object GenFunAndClosureClasses {
     // Header
     val functionInterface = JvmOps.getErasedFunctionInterfaceType(defn.arrowType).desc
     val frameInterface = BackendObjType.Frame
-    visitor.visit(CompilerConstants.JvmTargetVersion, ACC_PUBLIC + ACC_FINAL, AsmOps.internalNameOf(className), null,
-      AsmOps.internalNameOf(functionInterface), Array(AsmOps.internalNameOf(frameInterface.desc)))
+    visitor.visit(CompilerConstants.JvmTargetVersion, ACC_PUBLIC + ACC_FINAL, ClassDescs.internalNameOf(className), null,
+      ClassDescs.internalNameOf(functionInterface), Array(ClassDescs.internalNameOf(frameInterface.desc)))
     visitor.visitSource(defn.loc.source.name, null)
 
     // Fields — lparams use erased types (like fparams) so setPc can store without casting
@@ -240,8 +240,8 @@ object GenFunAndClosureClasses {
     // Header
     val functionInterface = JvmOps.getErasedClosureAbstractClassType(defn.arrowType).desc
     val frameInterface = BackendObjType.Frame
-    visitor.visit(CompilerConstants.JvmTargetVersion, ACC_PUBLIC + ACC_FINAL, AsmOps.internalNameOf(className), null,
-      AsmOps.internalNameOf(functionInterface), Array(AsmOps.internalNameOf(frameInterface.desc)))
+    visitor.visit(CompilerConstants.JvmTargetVersion, ACC_PUBLIC + ACC_FINAL, ClassDescs.internalNameOf(className), null,
+      ClassDescs.internalNameOf(functionInterface), Array(ClassDescs.internalNameOf(frameInterface.desc)))
     visitor.visitSource(defn.loc.source.name, null)
 
     // Fields
@@ -272,7 +272,7 @@ object GenFunAndClosureClasses {
     val constructor = visitor.visitMethod(ACC_PUBLIC, ClassMaker.ConstructorMethodName, MethodDescriptor.NothingToVoid.toDescriptor, null, null)
 
     constructor.visitVarInsn(ALOAD, 0)
-    constructor.visitMethodInsn(INVOKESPECIAL, AsmOps.internalNameOf(superClass), ClassMaker.ConstructorMethodName,
+    constructor.visitMethodInsn(INVOKESPECIAL, ClassDescs.internalNameOf(superClass), ClassMaker.ConstructorMethodName,
       MethodDescriptor.NothingToVoid.toDescriptor, false)
     constructor.visitInsn(RETURN)
 
@@ -319,7 +319,7 @@ object GenFunAndClosureClasses {
       // Load the `this` pointer
       m.visitVarInsn(ALOAD, 0)
       // Load arg i
-      m.visitFieldInsn(GETFIELD, AsmOps.internalNameOf(functionInterface),
+      m.visitFieldInsn(GETFIELD, ClassDescs.internalNameOf(functionInterface),
         s"arg$i", BackendType.toErasedBackendType(fp.tpe).toDescriptor)
       // Insert cast to concrete type
       val bTpe = BackendType.toBackendType(fp.tpe)
@@ -327,7 +327,7 @@ object GenFunAndClosureClasses {
     }
 
     val method = staticApplyMethod(className, defn)
-    m.visitMethodInsn(INVOKESTATIC, AsmOps.internalNameOf(className), method.name, method.d.toDescriptor, false)
+    m.visitMethodInsn(INVOKESTATIC, ClassDescs.internalNameOf(className), method.name, method.d.toDescriptor, false)
 
     BytecodeInstructions.xReturn(BackendObjType.Result.toTpe)
 
@@ -343,7 +343,7 @@ object GenFunAndClosureClasses {
     val applyMethod = BackendObjType.Frame.ApplyMethod
     m.visitVarInsn(ALOAD, 0)
     m.visitInsn(ACONST_NULL)
-    m.visitMethodInsn(INVOKEVIRTUAL, AsmOps.internalNameOf(className), applyMethod.name, applyMethod.d.toDescriptor, false)
+    m.visitMethodInsn(INVOKEVIRTUAL, ClassDescs.internalNameOf(className), applyMethod.name, applyMethod.d.toDescriptor, false)
 
     BytecodeInstructions.xReturn(BackendObjType.Result.toTpe)
 
@@ -355,7 +355,7 @@ object GenFunAndClosureClasses {
                                  className: ClassDesc,
                                  defn: Def)(implicit root: Root, flix: Flix): Unit = {
     // Method header
-    val classInternalName = AsmOps.internalNameOf(className)
+    val classInternalName = ClassDescs.internalNameOf(className)
     val applyMethod = BackendObjType.Frame.ApplyMethod
     implicit val m: MethodVisitor = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL, applyMethod.name, applyMethod.d.toDescriptor, null, null)
     val localOffset = 2 // [this: Obj, value: Obj, ...]
@@ -451,7 +451,7 @@ object GenFunAndClosureClasses {
     implicit val mm: MethodVisitor = m
     // retrieve the erased field
     m.visitVarInsn(ALOAD, 0)
-    m.visitFieldInsn(GETFIELD, AsmOps.internalNameOf(className), name, fieldType.toDescriptor)
+    m.visitFieldInsn(GETFIELD, ClassDescs.internalNameOf(className), name, fieldType.toDescriptor)
     // cast the value and store it
     castTo match {
       case Some(targetType) =>
@@ -468,7 +468,7 @@ object GenFunAndClosureClasses {
     */
   private def mkCopy(className: ClassDesc, defn: Def)(implicit mv: MethodVisitor, root: Root): Unit = {
     import BytecodeInstructions.*
-    val classInternalName = AsmOps.internalNameOf(className)
+    val classInternalName = ClassDescs.internalNameOf(className)
     val pc = List(("pc", BackendType.Int32))
     val fparams = defn.fparams.zipWithIndex.map(p => (s"arg${p._2}", BackendType.toErasedBackendType(p._1.tpe)))
     val cparams = defn.cparams.zipWithIndex.map(p => (s"clo${p._2}", BackendType.toBackendType(p._1.tpe)))

--- a/main/src/ca/uwaterloo/flix/util/ClassDescs.scala
+++ b/main/src/ca/uwaterloo/flix/util/ClassDescs.scala
@@ -32,6 +32,21 @@ object ClassDescs {
     )
 
   /**
+    * Returns the JVM internal name of the class, interface, or array descriptor `desc`,
+    * e.g. `java/lang/String` or `[Ljava/lang/String;`.
+    */
+  def internalNameOf(desc: ClassDesc): String = {
+    if (desc.isArray) {
+      // The internal name of an array type is its descriptor.
+      desc.descriptorString()
+    } else {
+      // Strip the leading `L` and trailing `;` of the descriptor.
+      val descriptor = desc.descriptorString()
+      descriptor.substring(1, descriptor.length - 1)
+    }
+  }
+
+  /**
     * Returns the class file name (e.g. `java/lang/String.class`) of the class or interface `desc`.
     */
   def classFileNameOf(desc: ClassDesc): String = {


### PR DESCRIPTION
Moves `AsmOps.internalNameOf` into `util/ClassDescs`, completing the consolidation: every `ClassDesc` string derivation — internal name, binary name, class file name — now lives in one file alongside `ClassDescs.of(Class[?])`, and `AsmOps` is back to being purely the `ClassWriter` factory.

Pure move: the method body is unchanged; the eight referencing files just re-point (`GenExpression` keeps its bare `internalNameOf` calls via the updated member import).

Final step of the `JvmName` retirement series (#13106, #13108, #13109, #13110, #13111, #13112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)