### PR TITLE
refactor: use nominal castIfNotPrim

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -1615,7 +1615,7 @@ object BackendObjType {
       crashIfSuspension(errorHint, loc)
       CHECKCAST(Value.desc) // Cannot fail
       GETFIELD(Value.fieldFromType(tpe))
-      castIfNotPrim(tpe)
+      Bytecode.castIfNotPrim(tpe.toClassDesc)
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -54,6 +54,9 @@ sealed trait BackendType extends VoidableType {
     }
   }
 
+  /** Returns the [[ClassDesc]] of `this` type. */
+  def toClassDesc: ClassDesc = ClassDesc.ofDescriptor(toDescriptor)
+
   /**
     * Returns the erased type, either itself if `this` is primitive or `java.lang.Object`
     * if `this` is an array or a reference.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Bytecode.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Bytecode.scala
@@ -30,6 +30,11 @@ import java.lang.constant.ClassDesc
   */
 object Bytecode {
 
+  /** Emits a `CHECKCAST` of the top of the stack to `tpe`, unless `tpe` is a primitive type. */
+  def castIfNotPrim(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
+    if (!tpe.isPrimitive) mv.visitTypeInsn(Opcodes.CHECKCAST, ClassDescs.internalNameOf(tpe))
+  }
+
   /** Emits a `NEWARRAY` or `ANEWARRAY` instruction that creates an array with element type `elmTpe`. */
   def xNewArray(elmTpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     if (elmTpe.isPrimitive) mv.visitIntInsn(Opcodes.NEWARRAY, newArrayOperandOf(elmTpe))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -342,14 +342,6 @@ object BytecodeInstructions {
     mv.visitLabel(skipLabel)
   }
 
-  def castIfNotPrim(tpe: BackendType)(implicit mv: MethodVisitor): Unit = {
-    tpe match {
-      case arr: BackendType.Array => mv.visitTypeInstructionDirect(Opcodes.CHECKCAST, arr.toDescriptor)
-      case BackendType.Reference(ref) => CHECKCAST(ref.desc)
-      case _: BackendType.PrimitiveType => nop()
-    }
-  }
-
   /// while(c(t)) { i }
   def whileLoop(c: Condition)(t: => Unit)(i: => Unit)(implicit mv: MethodVisitor): Unit = {
     val startLabel = new Label()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -206,7 +206,7 @@ object GenExpression {
           val argType = BackendType.toBackendType(arg.tpe)
           mv.visitInsn(DUP)
           compileExpr(arg)
-          BytecodeInstructions.castIfNotPrim(argType)
+          Bytecode.castIfNotPrim(argType.toClassDesc)
           mv.visitFieldInsn(PUTFIELD, closureName, s"clo$i", argType.toDescriptor)
         }
 
@@ -624,7 +624,7 @@ object GenExpression {
         val termTypes = root.enums(sym.enumSym).cases(sym).tpes.map(BackendType.toBackendType)
 
         compileUntag(exp, idx, termTypes)
-        castIfNotPrim(BackendType.toBackendType(tpe))
+        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.Index(idx) =>
         import BytecodeInstructions.*
@@ -634,7 +634,7 @@ object GenExpression {
 
         compileExpr(exp)
         GETFIELD(tupleType.IndexField(idx))
-        castIfNotPrim(BackendType.toBackendType(tpe))
+        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.Tuple =>
         import BytecodeInstructions.*
@@ -656,7 +656,7 @@ object GenExpression {
         // Now that the specific RecordExtend object is found, we cast it to its exact class and extract the value.
         CHECKCAST(recordType.desc)
         GETFIELD(recordType.ValueField)
-        castIfNotPrim(BackendType.toBackendType(tpe))
+        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.RecordExtend(field) =>
         import BytecodeInstructions.*
@@ -699,7 +699,7 @@ object GenExpression {
         val tpes = SimpleType.findExtensibleTermTypes(sym, exp.tpe).map(BackendType.toBackendType)
 
         compileExtUntag(exp, idx, tpes)
-        castIfNotPrim(BackendType.toBackendType(tpe))
+        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.ArrayLit =>
         import BytecodeInstructions.*
@@ -739,7 +739,7 @@ object GenExpression {
         compileExpr(exp1)
         compileExpr(exp2)
         xArrayLoad(elmTpe)
-        castIfNotPrim(elmTpe)
+        Bytecode.castIfNotPrim(elmTpe.toClassDesc)
 
       case AtomicOp.ArrayStore =>
         import BytecodeInstructions.*
@@ -749,7 +749,7 @@ object GenExpression {
         // Add source line number for debugging (can fail with out of bounds).
         addLoc(loc)
         compileExpr(exp1) // Evaluating the array
-        castIfNotPrim(BackendType.Array(elmTpe))
+        Bytecode.castIfNotPrim(elmTpe.toClassDesc.arrayType())
         compileExpr(exp2) // Evaluating the index
         compileExpr(exp3) // Evaluating the element
         xArrayStore(elmTpe)
@@ -792,7 +792,7 @@ object GenExpression {
 
         compileExpr(exp)
         GETFIELD(structType.IndexField(idx))
-        castIfNotPrim(BackendType.toBackendType(tpe))
+        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.StructPut(field) =>
         import BytecodeInstructions.*
@@ -816,7 +816,7 @@ object GenExpression {
         import BytecodeInstructions.*
         val List(exp) = exps
         compileExpr(exp)
-        castIfNotPrim(BackendType.toBackendType(tpe))
+        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.Unbox =>
         import BytecodeInstructions.*
@@ -825,7 +825,7 @@ object GenExpression {
         compileExpr(exp)
         CHECKCAST(BackendObjType.Value.desc)
         GETFIELD(BackendObjType.Value.fieldFromType(bType))
-        castIfNotPrim(bType)
+        Bytecode.castIfNotPrim(bType.toClassDesc)
 
       case AtomicOp.Box =>
         import BytecodeInstructions.*
@@ -1173,7 +1173,7 @@ object GenExpression {
           // Call the static method, using exact types
           for ((arg, tpe) <- ListOps.zip(exps, paramTpes)) {
             compileExpr(arg)
-            BytecodeInstructions.castIfNotPrim(tpe)
+            Bytecode.castIfNotPrim(tpe.toClassDesc)
           }
           val resultTpe = BackendObjType.Result.toTpe
           val desc = MethodDescriptor(paramTpes, resultTpe)
@@ -1281,7 +1281,7 @@ object GenExpression {
         GETFIELD(BackendObjType.Value.fieldFromType(erasedResult))
 
         mv.visitLabel(afterUnboxing)
-        castIfNotPrim(BackendType.toBackendType(tpe))
+        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
     }
 
     case Expr.ApplySelfTail(sym, exps, _, _, _) => ctx match {
@@ -1429,7 +1429,7 @@ object GenExpression {
       // classes) where the JVM verifier cannot resolve the generated subclass
       // name and needs an explicit cast to the declared superclass type.
       exp1 match {
-        case _: Expr.NewObject => castIfNotPrim(bType)
+        case _: Expr.NewObject => Bytecode.castIfNotPrim(bType.toClassDesc)
         case _ => ()
       }
       xStore(bType, ctx.getIndex(offset))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -322,8 +322,7 @@ object GenFunAndClosureClasses {
       m.visitFieldInsn(GETFIELD, ClassDescs.internalNameOf(functionInterface),
         s"arg$i", BackendType.toErasedBackendType(fp.tpe).toDescriptor)
       // Insert cast to concrete type
-      val bTpe = BackendType.toBackendType(fp.tpe)
-      BytecodeInstructions.castIfNotPrim(bTpe)
+      Bytecode.castIfNotPrim(BackendType.toClassDesc(fp.tpe))
     }
 
     val method = staticApplyMethod(className, defn)
@@ -429,7 +428,7 @@ object GenFunAndClosureClasses {
               case _: BackendType.PrimitiveType => () // primitives don't need narrowing
               case _ =>
                 BytecodeInstructions.xLoad(erasedType, index)(mv)
-                BytecodeInstructions.castIfNotPrim(realType)(mv)
+                Bytecode.castIfNotPrim(realType.toClassDesc)(mv)
                 BytecodeInstructions.xStore(realType, index)(mv)
             }
           }
@@ -455,7 +454,7 @@ object GenFunAndClosureClasses {
     // cast the value and store it
     castTo match {
       case Some(targetType) =>
-        BytecodeInstructions.castIfNotPrim(targetType)
+        Bytecode.castIfNotPrim(targetType.toClassDesc)
         BytecodeInstructions.xStore(targetType, localIndex)
       case None =>
         BytecodeInstructions.xStore(fieldType, localIndex)


### PR DESCRIPTION
Moves `castIfNotPrim` from `BytecodeInstructions` to `Bytecode`, expressed in terms of `ClassDesc` instead of `BackendType`: the three-case match collapses to an `isPrimitive` check plus a `CHECKCAST` on `ClassDescs.internalNameOf`.

Also adds the instance bridge `BackendType.toClassDesc`, used to migrate call sites that hold a `BackendType`; call sites that convert from a `SimpleType` anyway now use `BackendType.toClassDesc(tpe)` directly. Two small cleanups fall out: `ArrayStore` uses `ClassDesc.arrayType()` instead of allocating a `BackendType.Array`, and `compileStaticInvokeMethod` drops a local that existed only for the cast.

Follow-up to #13107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)