### PR TITLE
refactor: use nominal xArrayLoad and xArrayStore

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Bytecode.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Bytecode.scala
@@ -35,6 +35,34 @@ object Bytecode {
     if (!tpe.isPrimitive) mv.visitTypeInsn(Opcodes.CHECKCAST, ClassDescs.internalNameOf(tpe))
   }
 
+  /** Emits a `?ALOAD` instruction that loads an element from an array with element type `elmTpe`. */
+  def xArrayLoad(elmTpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
+    import java.lang.constant.ConstantDescs.*
+    if (elmTpe == CD_boolean) mv.visitInsn(Opcodes.BALOAD)
+    else if (elmTpe == CD_char) mv.visitInsn(Opcodes.CALOAD)
+    else if (elmTpe == CD_byte) mv.visitInsn(Opcodes.BALOAD)
+    else if (elmTpe == CD_short) mv.visitInsn(Opcodes.SALOAD)
+    else if (elmTpe == CD_int) mv.visitInsn(Opcodes.IALOAD)
+    else if (elmTpe == CD_long) mv.visitInsn(Opcodes.LALOAD)
+    else if (elmTpe == CD_float) mv.visitInsn(Opcodes.FALOAD)
+    else if (elmTpe == CD_double) mv.visitInsn(Opcodes.DALOAD)
+    else mv.visitInsn(Opcodes.AALOAD)
+  }
+
+  /** Emits a `?ASTORE` instruction that stores an element into an array with element type `elmTpe`. */
+  def xArrayStore(elmTpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
+    import java.lang.constant.ConstantDescs.*
+    if (elmTpe == CD_boolean) mv.visitInsn(Opcodes.BASTORE)
+    else if (elmTpe == CD_char) mv.visitInsn(Opcodes.CASTORE)
+    else if (elmTpe == CD_byte) mv.visitInsn(Opcodes.BASTORE)
+    else if (elmTpe == CD_short) mv.visitInsn(Opcodes.SASTORE)
+    else if (elmTpe == CD_int) mv.visitInsn(Opcodes.IASTORE)
+    else if (elmTpe == CD_long) mv.visitInsn(Opcodes.LASTORE)
+    else if (elmTpe == CD_float) mv.visitInsn(Opcodes.FASTORE)
+    else if (elmTpe == CD_double) mv.visitInsn(Opcodes.DASTORE)
+    else mv.visitInsn(Opcodes.AASTORE)
+  }
+
   /** Emits a `NEWARRAY` or `ANEWARRAY` instruction that creates an array with element type `elmTpe`. */
   def xNewArray(elmTpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     if (elmTpe.isPrimitive) mv.visitIntInsn(Opcodes.NEWARRAY, newArrayOperandOf(elmTpe))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -459,32 +459,6 @@ object BytecodeInstructions {
     body(runningIndex, variables)
   }
 
-  def xArrayLoad(elmTpe: BackendType)(implicit mv: MethodVisitor): Unit = elmTpe match {
-    case BackendType.Array(_) => mv.visitInstruction(Opcodes.AALOAD)
-    case BackendType.Reference(_) => mv.visitInstruction(Opcodes.AALOAD)
-    case BackendType.Bool => mv.visitInstruction(Opcodes.BALOAD)
-    case BackendType.Char => mv.visitInstruction(Opcodes.CALOAD)
-    case BackendType.Int8 => mv.visitInstruction(Opcodes.BALOAD)
-    case BackendType.Int16 => mv.visitInstruction(Opcodes.SALOAD)
-    case BackendType.Int32 => mv.visitInstruction(Opcodes.IALOAD)
-    case BackendType.Int64 => mv.visitInstruction(Opcodes.LALOAD)
-    case BackendType.Float32 => mv.visitInstruction(Opcodes.FALOAD)
-    case BackendType.Float64 => mv.visitInstruction(Opcodes.DALOAD)
-  }
-
-  def xArrayStore(elmTpe: BackendType)(implicit mv: MethodVisitor): Unit = elmTpe match {
-    case BackendType.Array(_) => mv.visitInstruction(Opcodes.AASTORE)
-    case BackendType.Reference(_) => mv.visitInstruction(Opcodes.AASTORE)
-    case BackendType.Bool => mv.visitInstruction(Opcodes.BASTORE)
-    case BackendType.Char => mv.visitInstruction(Opcodes.CASTORE)
-    case BackendType.Int8 => mv.visitInstruction(Opcodes.BASTORE)
-    case BackendType.Int16 => mv.visitInstruction(Opcodes.SASTORE)
-    case BackendType.Int32 => mv.visitInstruction(Opcodes.IASTORE)
-    case BackendType.Int64 => mv.visitInstruction(Opcodes.LASTORE)
-    case BackendType.Float32 => mv.visitInstruction(Opcodes.FASTORE)
-    case BackendType.Float64 => mv.visitInstruction(Opcodes.DASTORE)
-  }
-
   def xLoad(tpe: BackendType, index: Int)(implicit mv: MethodVisitor): Unit = tpe match {
     case BackendType.Bool | BackendType.Char | BackendType.Int8 | BackendType.Int16 | BackendType.Int32 => ILOAD(index)
     case BackendType.Int64 => LLOAD(index)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -704,15 +704,15 @@ object GenExpression {
       case AtomicOp.ArrayLit =>
         import BytecodeInstructions.*
         val innerType = tpe.asInstanceOf[SimpleType.Array].tpe
-        val backendType = BackendType.toBackendType(innerType)
+        val elmTpe = BackendType.toClassDesc(innerType)
 
         pushInt(exps.length)
-        Bytecode.xNewArray(BackendType.toClassDesc(innerType))
+        Bytecode.xNewArray(elmTpe)
         for ((e, i) <- exps.zipWithIndex) {
           DUP()
           pushInt(i)
           compileExpr(e)
-          xArrayStore(backendType)
+          Bytecode.xArrayStore(elmTpe)
         }
 
       case AtomicOp.ArrayNew =>
@@ -732,27 +732,27 @@ object GenExpression {
       case AtomicOp.ArrayLoad =>
         import BytecodeInstructions.*
         val List(exp1, exp2) = exps
-        val elmTpe = BackendType.toBackendType(tpe)
+        val elmTpe = BackendType.toClassDesc(tpe)
 
         // Add source line number for debugging (can fail with out of bounds).
         addLoc(loc)
         compileExpr(exp1)
         compileExpr(exp2)
-        xArrayLoad(elmTpe)
-        Bytecode.castIfNotPrim(elmTpe.toClassDesc)
+        Bytecode.xArrayLoad(elmTpe)
+        Bytecode.castIfNotPrim(elmTpe)
 
       case AtomicOp.ArrayStore =>
         import BytecodeInstructions.*
         val List(exp1, exp2, exp3) = exps
-        val elmTpe = BackendType.toBackendType(exp3.tpe)
+        val elmTpe = BackendType.toClassDesc(exp3.tpe)
 
         // Add source line number for debugging (can fail with out of bounds).
         addLoc(loc)
         compileExpr(exp1) // Evaluating the array
-        Bytecode.castIfNotPrim(elmTpe.toClassDesc.arrayType())
+        Bytecode.castIfNotPrim(elmTpe.arrayType())
         compileExpr(exp2) // Evaluating the index
         compileExpr(exp3) // Evaluating the element
-        xArrayStore(elmTpe)
+        Bytecode.xArrayStore(elmTpe)
         GETSTATIC(BackendObjType.Unit.SingletonField)
 
       case AtomicOp.ArrayLength =>


### PR DESCRIPTION
Moves `xArrayLoad`/`xArrayStore` from `BytecodeInstructions` to `Bytecode`, expressed in terms of `ClassDesc` instead of `BackendType` — the opcode choice only ever depended on which primitive the element type is (arrays and references both take `AALOAD`/`AASTORE`).

With this, the `ArrayLit`, `ArrayLoad`, and `ArrayStore` cases in `GenExpression` are fully `BackendType`-free: their element-type locals are plain `ClassDesc`s.

Follow-up to #13107 and #13117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)