### PR TITLE
feat: add Byte Buddy

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -20,6 +20,8 @@ object flix extends ScalaModule {
     mvn"org.java-websocket:Java-WebSocket:1.6.0",
     mvn"org.jline:jline:3.30.9",
     mvn"org.json4s::json4s-native:4.0.7",
+    mvn"net.bytebuddy:byte-buddy:1.18.11",
+    mvn"com.google.code.findbugs:jsr305:3.0.2", // Byte Buddy's nullability annotations (needed by scalac)
     mvn"org.ow2.asm:asm:9.9.1",
     mvn"org.commonmark:commonmark:0.24.0",
     mvn"org.commonmark:commonmark-ext-gfm-tables:0.24.0",


### PR DESCRIPTION
_This PR adds the Byte Buddy library as a dependency. We will use Byte Buddy to parse Java class files for use during type inference. That is, instead of loading `.class` files via reflection (which is slow, dangerous, and not possible on Graal), we will actually parse the bytecode into an in memory data structure using Byte Buddy._

_Meanwhile, separate work is liberating the backend from Java reflection_.

_ChatGPT Sol summary below_

## Summary

- add Byte Buddy as a production dependency
- add JSR-305 for the nullability annotations referenced by Byte Buddy and required by the Scala compiler configuration

## Validation

- clean compile passed
- flix.assembly passed
- assembly size increased from 33,278,108 to 38,032,177 bytes: 4,754,069 bytes / 4.53 MiB / 14.29%