### PR TITLE
refactor: use nominal xReturn and xPop

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -233,7 +233,7 @@ object BackendObjType {
         ATHROW()
       }
       unlockLock()
-      xReturn(tpe)
+      Bytecode.xReturn(tpe.toClassDesc)
     }
   }
 
@@ -1520,7 +1520,7 @@ object BackendObjType {
             PUTFIELD(InstanceField(defnT.desc, s"arg$index", arg.tpe))
           }
           Result.unwindSuspensionFreeThunkToType(erasedResult, s"in shim method of ${defn.sym}", defn.loc)
-          xReturn(erasedResult)
+          Bytecode.xReturn(erasedResult.toClassDesc)
       }
     }
   }
@@ -1588,7 +1588,7 @@ object BackendObjType {
         PUTFIELD(Suspension.PrefixField) // [..., s', s]
         POP() // [..., s']
         // Return the suspension up the stack
-        xReturn(Suspension.toTpe)
+        Bytecode.xReturn(Suspension.desc)
       }
     }
 
@@ -1855,7 +1855,7 @@ object BackendObjType {
         DUP()
         thisLoad()
         PUTFIELD(FramesCons.TailField)
-        xReturn(FramesCons.toTpe)
+        Bytecode.xReturn(FramesCons.desc)
       }
     }
   }
@@ -1897,7 +1897,7 @@ object BackendObjType {
         rest.load()
         PUTFIELD(TailField)
         INVOKEINTERFACE(Frames.ReverseOntoMethod)
-        xReturn(Frames.toTpe)
+        Bytecode.xReturn(Frames.desc)
       }
     }
   }
@@ -1921,7 +1921,7 @@ object BackendObjType {
     private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Frames.toTpe) { rest =>
         rest.load()
-        xReturn(rest.tpe)
+        Bytecode.xReturn(rest.tpe.toClassDesc)
       }
     }
   }
@@ -1991,7 +1991,7 @@ object BackendObjType {
         v.load()
         mkStaticLambda(Thunk.InvokeMethod, Resumption.StaticRewindMethod, drop = 0)
         mkStaticLambda(Thunk.InvokeMethod, Handler.InstallHandlerMethod, drop = 0)
-        xReturn(Thunk.toTpe)
+        Bytecode.xReturn(Thunk.desc)
       }
     }
   }
@@ -2012,7 +2012,7 @@ object BackendObjType {
     private def rewindIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Value.toTpe) { v =>
         v.load()
-        xReturn(v.tpe)
+        Bytecode.xReturn(v.tpe.toClassDesc)
       }
     }
   }
@@ -2077,7 +2077,7 @@ object BackendObjType {
                       handler.load()
                       r.load()
                       INVOKEINTERFACE(EffectCall.ApplyMethod)
-                      xReturn(Result.toTpe)
+                      Bytecode.xReturn(Result.desc)
                     }
                     NEW(Suspension.desc)
                     DUP()
@@ -2098,7 +2098,7 @@ object BackendObjType {
                     DUP()
                     r.load()
                     PUTFIELD(Suspension.ResumptionField)
-                    xReturn(Suspension.toTpe)
+                    Bytecode.xReturn(Suspension.desc)
                   }
                 }
               }
@@ -2113,7 +2113,7 @@ object BackendObjType {
                 INSTANCEOF(FramesNil.desc)
                 ifCondition(Condition.NE) {
                   res.load()
-                  xReturn(Value.toTpe)
+                  Bytecode.xReturn(Value.desc)
                 }
                 // FramesCons
                 frames.load()
@@ -2129,7 +2129,7 @@ object BackendObjType {
                   res.load()
                   mkStaticLambda(Thunk.InvokeMethod, Frame.StaticApplyMethod, drop = 0)
                   INVOKESTATIC(InstallHandlerMethod)
-                  xReturn(Result.toTpe)
+                  Bytecode.xReturn(Result.desc)
                 }
                 }
               }
@@ -2209,7 +2209,7 @@ object BackendObjType {
           PUTFIELD(Value.fieldFromType(tpe.toErased))
       }
       INVOKEINTERFACE(Resumption.RewindMethod)
-      xReturn(Result.toTpe)
+      Bytecode.xReturn(Result.desc)
     }
 
     private def UniqueMethod: InstanceMethod = InstanceMethod(this.desc, "getUniqueThreadClosure", mkDescriptor()(this.superClass.toTpe))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Bytecode.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Bytecode.scala
@@ -69,6 +69,23 @@ object Bytecode {
     else mv.visitTypeInsn(Opcodes.ANEWARRAY, ClassDescs.internalNameOf(elmTpe))
   }
 
+  /** Emits a `POP` or `POP2` instruction that pops a value of type `tpe` off the stack. */
+  def xPop(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
+    import java.lang.constant.ConstantDescs.*
+    if (tpe == CD_long || tpe == CD_double) mv.visitInsn(Opcodes.POP2)
+    else mv.visitInsn(Opcodes.POP)
+  }
+
+  /** Emits a `?RETURN` instruction that returns a value of type `tpe`. */
+  def xReturn(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
+    import java.lang.constant.ConstantDescs.*
+    if (tpe == CD_boolean || tpe == CD_char || tpe == CD_byte || tpe == CD_short || tpe == CD_int) mv.visitInsn(Opcodes.IRETURN)
+    else if (tpe == CD_long) mv.visitInsn(Opcodes.LRETURN)
+    else if (tpe == CD_float) mv.visitInsn(Opcodes.FRETURN)
+    else if (tpe == CD_double) mv.visitInsn(Opcodes.DRETURN)
+    else mv.visitInsn(Opcodes.ARETURN)
+  }
+
   /** Returns the `NEWARRAY` type operand (e.g. [[Opcodes.T_INT]]) of the primitive type `tpe`. */
   private def newArrayOperandOf(tpe: ClassDesc): Int = {
     import java.lang.constant.ConstantDescs.*

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -467,23 +467,6 @@ object BytecodeInstructions {
     case BackendType.Array(_) | BackendType.Reference(_) => ALOAD(index)
   }
 
-  /**
-    * Pops the top of the stack using `POP` or `POP2` depending on the value size.
-    */
-  def xPop(tpe: BackendType)(implicit mv: MethodVisitor): Unit = tpe match {
-    case BackendType.Bool | BackendType.Char | BackendType.Int8 | BackendType.Int16 | BackendType.Int32 |
-         BackendType.Float32 | BackendType.Array(_) | BackendType.Reference(_) => POP()
-    case BackendType.Int64 | BackendType.Float64 => POP2()
-  }
-
-  def xReturn(tpe: BackendType)(implicit mv: MethodVisitor): Unit = tpe match {
-    case BackendType.Bool | BackendType.Char | BackendType.Int8 | BackendType.Int16 | BackendType.Int32 => IRETURN()
-    case BackendType.Int64 => LRETURN()
-    case BackendType.Float32 => mv.visitInstruction(Opcodes.FRETURN)
-    case BackendType.Float64 => DRETURN()
-    case BackendType.Array(_) | BackendType.Reference(_) => ARETURN()
-  }
-
   def xStore(tpe: BackendType, index: Int)(implicit mv: MethodVisitor): Unit = tpe match {
     case BackendType.Bool | BackendType.Char | BackendType.Int8 | BackendType.Int16 | BackendType.Int32 =>
       mv.visitVarInstruction(Opcodes.ISTORE, index)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -167,7 +167,7 @@ object GenAnonymousClasses {
     if (isVoid) {
       RETURN()
     } else {
-      xReturn(BackendType.toBackendType(method.descriptor.returnType()))
+      Bytecode.xReturn(method.descriptor.returnType())
     }
   }
 
@@ -196,7 +196,7 @@ object GenAnonymousClasses {
     // been applied in Lowering, so the value on the stack already matches `actualRes`.
     actualRes match {
       case VoidableType.Void => RETURN()
-      case res: BackendType => xReturn(res)
+      case res: BackendType => Bytecode.xReturn(res.toClassDesc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -775,7 +775,7 @@ object GenExpression {
           case None => ()
           case Some(region) =>
             compileExpr(region)
-            xPop(BackendType.toBackendType(region.tpe))
+            Bytecode.xPop(BackendType.toClassDesc(region.tpe))
         }
         NEW(structType.desc)
         DUP()
@@ -1273,7 +1273,7 @@ object GenExpression {
         DUP()
         INVOKESPECIAL(BackendObjType.ResumptionNil.Constructor)
         PUTFIELD(Suspension.ResumptionField)
-        xReturn(Suspension.toTpe)
+        Bytecode.xReturn(Suspension.desc)
 
         mv.visitLabel(pcPointLabel)
         narrowLocals(mv)
@@ -1439,7 +1439,7 @@ object GenExpression {
       import BytecodeInstructions.*
       exps.foreach { e =>
         compileExpr(e)
-        xPop(BackendType.toBackendType(e.tpe))
+        Bytecode.xPop(BackendType.toClassDesc(e.tpe))
       }
       compileExpr(exp)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -301,7 +301,7 @@ object GenFunAndClosureClasses {
     val ctx = GenExpression.DirectStaticContext(enterLabel, labelEnv, localOffset)
     GenExpression.compileExpr(defn.expr)(m, ctx, root, flix)
 
-    BytecodeInstructions.xReturn(BackendObjType.Result.toTpe)
+    Bytecode.xReturn(BackendObjType.Result.desc)
 
 
     m.visitMaxs(999, 999)
@@ -328,7 +328,7 @@ object GenFunAndClosureClasses {
     val method = staticApplyMethod(className, defn)
     m.visitMethodInsn(INVOKESTATIC, ClassDescs.internalNameOf(className), method.name, method.d.toDescriptor, false)
 
-    BytecodeInstructions.xReturn(BackendObjType.Result.toTpe)
+    Bytecode.xReturn(BackendObjType.Result.desc)
 
     m.visitMaxs(999, 999)
     m.visitEnd()
@@ -344,7 +344,7 @@ object GenFunAndClosureClasses {
     m.visitInsn(ACONST_NULL)
     m.visitMethodInsn(INVOKEVIRTUAL, ClassDescs.internalNameOf(className), applyMethod.name, applyMethod.d.toDescriptor, false)
 
-    BytecodeInstructions.xReturn(BackendObjType.Result.toTpe)
+    Bytecode.xReturn(BackendObjType.Result.desc)
 
     m.visitMaxs(999, 999)
     m.visitEnd()
@@ -440,7 +440,7 @@ object GenFunAndClosureClasses {
       assert(ctx.pcCounter(0) == pcLabels.size, s"${(className, ctx.pcCounter(0), pcLabels.size)}")
     }
 
-    BytecodeInstructions.xReturn(BackendObjType.Result.toTpe)
+    Bytecode.xReturn(BackendObjType.Result.desc)
 
     m.visitMaxs(999, 999)
     m.visitEnd()


### PR DESCRIPTION
Moves `xReturn`/`xPop` from `BytecodeInstructions` to `Bytecode`, expressed in terms of `ClassDesc` instead of `BackendType` — both only ever depended on the primitive kind (or width) of the type.

Two nice fallouts at the call sites:

- `GenAnonymousClasses` no longer round-trips `ClassDesc → BackendType → opcode` for Java method return types; it passes `method.descriptor.returnType()` straight through.
- Eleven `xReturn(X.toTpe)` sites stop allocating a `BackendType.Reference` wrapper just to mean "reference return" — they pass `X.desc` directly.

Follow-up to #13107, #13117, #13118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)