### PR TITLE
refactor: rename Bytecode.scala to Instructions.scala

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -233,7 +233,7 @@ object BackendObjType {
         ATHROW()
       }
       unlockLock()
-      Bytecode.xReturn(tpe.toClassDesc)
+      Instructions.xReturn(tpe.toClassDesc)
     }
   }
 
@@ -1520,7 +1520,7 @@ object BackendObjType {
             PUTFIELD(InstanceField(defnT.desc, s"arg$index", arg.tpe))
           }
           Result.unwindSuspensionFreeThunkToType(erasedResult, s"in shim method of ${defn.sym}", defn.loc)
-          Bytecode.xReturn(erasedResult.toClassDesc)
+          Instructions.xReturn(erasedResult.toClassDesc)
       }
     }
   }
@@ -1588,7 +1588,7 @@ object BackendObjType {
         PUTFIELD(Suspension.PrefixField) // [..., s', s]
         POP() // [..., s']
         // Return the suspension up the stack
-        Bytecode.xReturn(Suspension.desc)
+        Instructions.xReturn(Suspension.desc)
       }
     }
 
@@ -1615,7 +1615,7 @@ object BackendObjType {
       crashIfSuspension(errorHint, loc)
       CHECKCAST(Value.desc) // Cannot fail
       GETFIELD(Value.fieldFromType(tpe))
-      Bytecode.castIfNotPrim(tpe.toClassDesc)
+      Instructions.castIfNotPrim(tpe.toClassDesc)
     }
 
     /**
@@ -1855,7 +1855,7 @@ object BackendObjType {
         DUP()
         thisLoad()
         PUTFIELD(FramesCons.TailField)
-        Bytecode.xReturn(FramesCons.desc)
+        Instructions.xReturn(FramesCons.desc)
       }
     }
   }
@@ -1897,7 +1897,7 @@ object BackendObjType {
         rest.load()
         PUTFIELD(TailField)
         INVOKEINTERFACE(Frames.ReverseOntoMethod)
-        Bytecode.xReturn(Frames.desc)
+        Instructions.xReturn(Frames.desc)
       }
     }
   }
@@ -1921,7 +1921,7 @@ object BackendObjType {
     private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Frames.toTpe) { rest =>
         rest.load()
-        Bytecode.xReturn(rest.tpe.toClassDesc)
+        Instructions.xReturn(rest.tpe.toClassDesc)
       }
     }
   }
@@ -1991,7 +1991,7 @@ object BackendObjType {
         v.load()
         mkStaticLambda(Thunk.InvokeMethod, Resumption.StaticRewindMethod, drop = 0)
         mkStaticLambda(Thunk.InvokeMethod, Handler.InstallHandlerMethod, drop = 0)
-        Bytecode.xReturn(Thunk.desc)
+        Instructions.xReturn(Thunk.desc)
       }
     }
   }
@@ -2012,7 +2012,7 @@ object BackendObjType {
     private def rewindIns(implicit mv: MethodVisitor): Unit = {
       withName(1, Value.toTpe) { v =>
         v.load()
-        Bytecode.xReturn(v.tpe.toClassDesc)
+        Instructions.xReturn(v.tpe.toClassDesc)
       }
     }
   }
@@ -2077,7 +2077,7 @@ object BackendObjType {
                       handler.load()
                       r.load()
                       INVOKEINTERFACE(EffectCall.ApplyMethod)
-                      Bytecode.xReturn(Result.desc)
+                      Instructions.xReturn(Result.desc)
                     }
                     NEW(Suspension.desc)
                     DUP()
@@ -2098,7 +2098,7 @@ object BackendObjType {
                     DUP()
                     r.load()
                     PUTFIELD(Suspension.ResumptionField)
-                    Bytecode.xReturn(Suspension.desc)
+                    Instructions.xReturn(Suspension.desc)
                   }
                 }
               }
@@ -2113,7 +2113,7 @@ object BackendObjType {
                 INSTANCEOF(FramesNil.desc)
                 ifCondition(Condition.NE) {
                   res.load()
-                  Bytecode.xReturn(Value.desc)
+                  Instructions.xReturn(Value.desc)
                 }
                 // FramesCons
                 frames.load()
@@ -2129,7 +2129,7 @@ object BackendObjType {
                   res.load()
                   mkStaticLambda(Thunk.InvokeMethod, Frame.StaticApplyMethod, drop = 0)
                   INVOKESTATIC(InstallHandlerMethod)
-                  Bytecode.xReturn(Result.desc)
+                  Instructions.xReturn(Result.desc)
                 }
                 }
               }
@@ -2209,7 +2209,7 @@ object BackendObjType {
           PUTFIELD(Value.fieldFromType(tpe.toErased))
       }
       INVOKEINTERFACE(Resumption.RewindMethod)
-      Bytecode.xReturn(Result.desc)
+      Instructions.xReturn(Result.desc)
     }
 
     private def UniqueMethod: InstanceMethod = InstanceMethod(this.desc, "getUniqueThreadClosure", mkDescriptor()(this.superClass.toTpe))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -167,7 +167,7 @@ object GenAnonymousClasses {
     if (isVoid) {
       RETURN()
     } else {
-      Bytecode.xReturn(method.descriptor.returnType())
+      Instructions.xReturn(method.descriptor.returnType())
     }
   }
 
@@ -196,7 +196,7 @@ object GenAnonymousClasses {
     // been applied in Lowering, so the value on the stack already matches `actualRes`.
     actualRes match {
       case VoidableType.Void => RETURN()
-      case res: BackendType => Bytecode.xReturn(res.toClassDesc)
+      case res: BackendType => Instructions.xReturn(res.toClassDesc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -206,7 +206,7 @@ object GenExpression {
           val argType = BackendType.toBackendType(arg.tpe)
           mv.visitInsn(DUP)
           compileExpr(arg)
-          Bytecode.castIfNotPrim(argType.toClassDesc)
+          Instructions.castIfNotPrim(argType.toClassDesc)
           mv.visitFieldInsn(PUTFIELD, closureName, s"clo$i", argType.toDescriptor)
         }
 
@@ -624,7 +624,7 @@ object GenExpression {
         val termTypes = root.enums(sym.enumSym).cases(sym).tpes.map(BackendType.toBackendType)
 
         compileUntag(exp, idx, termTypes)
-        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
+        Instructions.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.Index(idx) =>
         import BytecodeInstructions.*
@@ -634,7 +634,7 @@ object GenExpression {
 
         compileExpr(exp)
         GETFIELD(tupleType.IndexField(idx))
-        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
+        Instructions.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.Tuple =>
         import BytecodeInstructions.*
@@ -656,7 +656,7 @@ object GenExpression {
         // Now that the specific RecordExtend object is found, we cast it to its exact class and extract the value.
         CHECKCAST(recordType.desc)
         GETFIELD(recordType.ValueField)
-        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
+        Instructions.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.RecordExtend(field) =>
         import BytecodeInstructions.*
@@ -699,7 +699,7 @@ object GenExpression {
         val tpes = SimpleType.findExtensibleTermTypes(sym, exp.tpe).map(BackendType.toBackendType)
 
         compileExtUntag(exp, idx, tpes)
-        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
+        Instructions.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.ArrayLit =>
         import BytecodeInstructions.*
@@ -707,12 +707,12 @@ object GenExpression {
         val elmTpe = BackendType.toClassDesc(innerType)
 
         pushInt(exps.length)
-        Bytecode.xNewArray(elmTpe)
+        Instructions.xNewArray(elmTpe)
         for ((e, i) <- exps.zipWithIndex) {
           DUP()
           pushInt(i)
           compileExpr(e)
-          Bytecode.xArrayStore(elmTpe)
+          Instructions.xArrayStore(elmTpe)
         }
 
       case AtomicOp.ArrayNew =>
@@ -724,7 +724,7 @@ object GenExpression {
         val fillMethod = ClassMaker.StaticMethod(JavaClasses.Arrays, "fill", mkDescriptor(BackendType.Array(backendType.toErased), backendType.toErased)(VoidableType.Void))
         compileExpr(exp1) // default
         compileExpr(exp2) // default, length
-        Bytecode.xNewArray(BackendType.toClassDesc(innerType)) // default, arr
+        Instructions.xNewArray(BackendType.toClassDesc(innerType)) // default, arr
         if (backendType.is64BitWidth) DUP_X2() else DUP_X1() // arr, default, arr
         xSwap(lowerLarge = backendType.is64BitWidth, higherLarge = false) // arr, arr, default
         INVOKESTATIC(fillMethod)
@@ -738,8 +738,8 @@ object GenExpression {
         addLoc(loc)
         compileExpr(exp1)
         compileExpr(exp2)
-        Bytecode.xArrayLoad(elmTpe)
-        Bytecode.castIfNotPrim(elmTpe)
+        Instructions.xArrayLoad(elmTpe)
+        Instructions.castIfNotPrim(elmTpe)
 
       case AtomicOp.ArrayStore =>
         import BytecodeInstructions.*
@@ -749,10 +749,10 @@ object GenExpression {
         // Add source line number for debugging (can fail with out of bounds).
         addLoc(loc)
         compileExpr(exp1) // Evaluating the array
-        Bytecode.castIfNotPrim(elmTpe.arrayType())
+        Instructions.castIfNotPrim(elmTpe.arrayType())
         compileExpr(exp2) // Evaluating the index
         compileExpr(exp3) // Evaluating the element
-        Bytecode.xArrayStore(elmTpe)
+        Instructions.xArrayStore(elmTpe)
         GETSTATIC(BackendObjType.Unit.SingletonField)
 
       case AtomicOp.ArrayLength =>
@@ -775,7 +775,7 @@ object GenExpression {
           case None => ()
           case Some(region) =>
             compileExpr(region)
-            Bytecode.xPop(BackendType.toClassDesc(region.tpe))
+            Instructions.xPop(BackendType.toClassDesc(region.tpe))
         }
         NEW(structType.desc)
         DUP()
@@ -792,7 +792,7 @@ object GenExpression {
 
         compileExpr(exp)
         GETFIELD(structType.IndexField(idx))
-        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
+        Instructions.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.StructPut(field) =>
         import BytecodeInstructions.*
@@ -816,7 +816,7 @@ object GenExpression {
         import BytecodeInstructions.*
         val List(exp) = exps
         compileExpr(exp)
-        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
+        Instructions.castIfNotPrim(BackendType.toClassDesc(tpe))
 
       case AtomicOp.Unbox =>
         import BytecodeInstructions.*
@@ -825,7 +825,7 @@ object GenExpression {
         compileExpr(exp)
         CHECKCAST(BackendObjType.Value.desc)
         GETFIELD(BackendObjType.Value.fieldFromType(bType))
-        Bytecode.castIfNotPrim(bType.toClassDesc)
+        Instructions.castIfNotPrim(bType.toClassDesc)
 
       case AtomicOp.Box =>
         import BytecodeInstructions.*
@@ -1173,7 +1173,7 @@ object GenExpression {
           // Call the static method, using exact types
           for ((arg, tpe) <- ListOps.zip(exps, paramTpes)) {
             compileExpr(arg)
-            Bytecode.castIfNotPrim(tpe.toClassDesc)
+            Instructions.castIfNotPrim(tpe.toClassDesc)
           }
           val resultTpe = BackendObjType.Result.toTpe
           val desc = MethodDescriptor(paramTpes, resultTpe)
@@ -1273,7 +1273,7 @@ object GenExpression {
         DUP()
         INVOKESPECIAL(BackendObjType.ResumptionNil.Constructor)
         PUTFIELD(Suspension.ResumptionField)
-        Bytecode.xReturn(Suspension.desc)
+        Instructions.xReturn(Suspension.desc)
 
         mv.visitLabel(pcPointLabel)
         narrowLocals(mv)
@@ -1281,7 +1281,7 @@ object GenExpression {
         GETFIELD(BackendObjType.Value.fieldFromType(erasedResult))
 
         mv.visitLabel(afterUnboxing)
-        Bytecode.castIfNotPrim(BackendType.toClassDesc(tpe))
+        Instructions.castIfNotPrim(BackendType.toClassDesc(tpe))
     }
 
     case Expr.ApplySelfTail(sym, exps, _, _, _) => ctx match {
@@ -1429,7 +1429,7 @@ object GenExpression {
       // classes) where the JVM verifier cannot resolve the generated subclass
       // name and needs an explicit cast to the declared superclass type.
       exp1 match {
-        case _: Expr.NewObject => Bytecode.castIfNotPrim(bType.toClassDesc)
+        case _: Expr.NewObject => Instructions.castIfNotPrim(bType.toClassDesc)
         case _ => ()
       }
       xStore(bType, ctx.getIndex(offset))
@@ -1439,7 +1439,7 @@ object GenExpression {
       import BytecodeInstructions.*
       exps.foreach { e =>
         compileExpr(e)
-        Bytecode.xPop(BackendType.toClassDesc(e.tpe))
+        Instructions.xPop(BackendType.toClassDesc(e.tpe))
       }
       compileExpr(exp)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -301,7 +301,7 @@ object GenFunAndClosureClasses {
     val ctx = GenExpression.DirectStaticContext(enterLabel, labelEnv, localOffset)
     GenExpression.compileExpr(defn.expr)(m, ctx, root, flix)
 
-    Bytecode.xReturn(BackendObjType.Result.desc)
+    Instructions.xReturn(BackendObjType.Result.desc)
 
 
     m.visitMaxs(999, 999)
@@ -322,13 +322,13 @@ object GenFunAndClosureClasses {
       m.visitFieldInsn(GETFIELD, ClassDescs.internalNameOf(functionInterface),
         s"arg$i", BackendType.toErasedBackendType(fp.tpe).toDescriptor)
       // Insert cast to concrete type
-      Bytecode.castIfNotPrim(BackendType.toClassDesc(fp.tpe))
+      Instructions.castIfNotPrim(BackendType.toClassDesc(fp.tpe))
     }
 
     val method = staticApplyMethod(className, defn)
     m.visitMethodInsn(INVOKESTATIC, ClassDescs.internalNameOf(className), method.name, method.d.toDescriptor, false)
 
-    Bytecode.xReturn(BackendObjType.Result.desc)
+    Instructions.xReturn(BackendObjType.Result.desc)
 
     m.visitMaxs(999, 999)
     m.visitEnd()
@@ -344,7 +344,7 @@ object GenFunAndClosureClasses {
     m.visitInsn(ACONST_NULL)
     m.visitMethodInsn(INVOKEVIRTUAL, ClassDescs.internalNameOf(className), applyMethod.name, applyMethod.d.toDescriptor, false)
 
-    Bytecode.xReturn(BackendObjType.Result.desc)
+    Instructions.xReturn(BackendObjType.Result.desc)
 
     m.visitMaxs(999, 999)
     m.visitEnd()
@@ -428,7 +428,7 @@ object GenFunAndClosureClasses {
               case _: BackendType.PrimitiveType => () // primitives don't need narrowing
               case _ =>
                 BytecodeInstructions.xLoad(erasedType, index)(mv)
-                Bytecode.castIfNotPrim(realType.toClassDesc)(mv)
+                Instructions.castIfNotPrim(realType.toClassDesc)(mv)
                 BytecodeInstructions.xStore(realType, index)(mv)
             }
           }
@@ -440,7 +440,7 @@ object GenFunAndClosureClasses {
       assert(ctx.pcCounter(0) == pcLabels.size, s"${(className, ctx.pcCounter(0), pcLabels.size)}")
     }
 
-    Bytecode.xReturn(BackendObjType.Result.desc)
+    Instructions.xReturn(BackendObjType.Result.desc)
 
     m.visitMaxs(999, 999)
     m.visitEnd()
@@ -454,7 +454,7 @@ object GenFunAndClosureClasses {
     // cast the value and store it
     castTo match {
       case Some(targetType) =>
-        Bytecode.castIfNotPrim(targetType.toClassDesc)
+        Instructions.castIfNotPrim(targetType.toClassDesc)
         BytecodeInstructions.xStore(targetType, localIndex)
       case None =>
         BytecodeInstructions.xStore(fieldType, localIndex)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
@@ -28,7 +28,7 @@ import java.lang.constant.ClassDesc
   *
   * Functions are gradually moved here from [[BytecodeInstructions]].
   */
-object Bytecode {
+object Instructions {
 
   /** Emits a `CHECKCAST` of the top of the stack to `tpe`, unless `tpe` is a primitive type. */
   def castIfNotPrim(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {


### PR DESCRIPTION
Renames `Bytecode.scala` to `Instructions.scala` (`object Bytecode` → `object Instructions`) and updates the qualified call sites. Purely mechanical; no behavior change.

Done now rather than later so the remaining migration PRs target the final name directly instead of accumulating references that would need rewriting.

Follow-up to #13107, #13117, #13118, #13120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)