### PR TITLE
refactor: use nominal local-variable operations

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -176,7 +176,7 @@ object BackendObjType {
 
     /** `[] --> return` */
     private def constructorIns(implicit mv: MethodVisitor): Unit =
-      withName(1, BackendType.Object)(exp => {
+      Instructions.withName(1, CD_Object)(exp => {
         // super()
         thisLoad()
         INVOKESPECIAL(ClassConstants.Object.Constructor)
@@ -254,7 +254,7 @@ object BackendObjType {
 
     /** `[] --> return` */
     private def constructorIns(implicit mv: MethodVisitor): Unit =
-      withNames(1, elms) { case (_, variables) =>
+      Instructions.withNames(1, elms.map(_.toClassDesc)) { case (_, variables) =>
         thisLoad()
         // super()
         DUP()
@@ -292,7 +292,7 @@ object BackendObjType {
     def Constructor: ConstructorMethod = ConstructorMethod(this.desc, elms)
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withNames(1, elms) { case (_, variables) =>
+      Instructions.withNames(1, elms.map(_.toClassDesc)) { case (_, variables) =>
         thisLoad()
         // super()
         DUP()
@@ -1080,8 +1080,8 @@ object BackendObjType {
     def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(BackendType.String, ReifiedSourceLocation.toTpe))
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, BackendType.String) { hole =>
-        withName(2, ReifiedSourceLocation.toTpe) { loc =>
+      Instructions.withName(1, JavaClasses.String) { hole =>
+        Instructions.withName(2, ReifiedSourceLocation.desc) { loc =>
           thisLoad()
           // create an error msg
           NEW(JavaClasses.StringBuilder)
@@ -1160,7 +1160,7 @@ object BackendObjType {
     def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(ReifiedSourceLocation.toTpe, BackendType.String))
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, ReifiedSourceLocation.toTpe)(loc => withName(2, BackendType.String)(msg => {
+      Instructions.withName(1, ReifiedSourceLocation.desc)(loc => Instructions.withName(2, JavaClasses.String)(msg => {
         thisLoad()
         NEW(JavaClasses.StringBuilder)
         DUP()
@@ -1199,7 +1199,7 @@ object BackendObjType {
     def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(Suspension.toTpe, BackendType.String, ReifiedSourceLocation.toTpe))
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Suspension.toTpe)(suspension => withName(2, BackendType.String)(info => withName(3, ReifiedSourceLocation.toTpe)(loc => {
+      Instructions.withName(1, Suspension.desc)(suspension => Instructions.withName(2, JavaClasses.String)(info => Instructions.withName(3, ReifiedSourceLocation.desc)(loc => {
         def appendString(): Unit = INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
 
         thisLoad()
@@ -1305,7 +1305,7 @@ object BackendObjType {
       INVOKESTATIC(ClassConstants.Thread.OfVirtualMethod)
       ALOAD(1)
       INVOKEINTERFACE(ClassConstants.ThreadBuilderOfVirtual.UnstartedMethod)
-      storeWithName(2, JavaClasses.Thread.toTpe) { thread =>
+      Instructions.storeWithName(2, JavaClasses.Thread) { thread =>
         thread.load()
         NEW(BackendObjType.UncaughtExceptionHandler.desc)
         DUP()
@@ -1333,7 +1333,7 @@ object BackendObjType {
     def ExitMethod: InstanceMethod = InstanceMethod(this.desc, "exit", MethodDescriptor.NothingToVoid)
 
     private def exitIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, JavaClasses.Thread.toTpe) { t =>
+      Instructions.withName(1, JavaClasses.Thread) { t =>
         whileLoop(Condition.NONNULL) {
           thisLoad()
           GETFIELD(ThreadsField)
@@ -1345,7 +1345,7 @@ object BackendObjType {
           t.load()
           INVOKEVIRTUAL(ClassConstants.Thread.JoinMethod)
         }
-        withName(2, JavaClasses.Iterator.toTpe) { i =>
+        Instructions.withName(2, JavaClasses.Iterator) { i =>
           thisLoad()
           GETFIELD(OnExitField)
           INVOKEVIRTUAL(ClassConstants.LinkedList.IteratorMethod)
@@ -1465,7 +1465,7 @@ object BackendObjType {
 
     private def mainIns(sym: Symbol.DefnSym)(implicit mv: MethodVisitor): Unit = {
       val defName = BackendObjType.Defn(sym).desc
-      withName(0, BackendType.Array(BackendType.String))(args => {
+      Instructions.withName(0, JavaClasses.String.arrayType())(args => {
         args.load()
         INVOKESTATIC(Global.SetArgsMethod)
         NEW(defName)
@@ -1508,7 +1508,7 @@ object BackendObjType {
     private def shimIns(defn: JvmAst.Def)(implicit mv: MethodVisitor): Unit = {
       val defnT = Defn(defn.sym)
       val paramTypes = defn.fparams.map(fp => BackendType.toErasedBackendType(fp.tpe))
-      withNames(0, paramTypes) {
+      Instructions.withNames(0, paramTypes.map(_.toClassDesc)) {
         case (_, args) =>
           val erasedResult = BackendType.toErasedBackendType(defn.unboxedType.tpe)
           NEW(defnT.desc)
@@ -1517,7 +1517,7 @@ object BackendObjType {
           for ((arg, index) <- args.zipWithIndex) {
             DUP()
             arg.load()
-            PUTFIELD(InstanceField(defnT.desc, s"arg$index", arg.tpe))
+            PUTFIELD(InstanceField(defnT.desc, s"arg$index", paramTypes(index)))
           }
           Result.unwindSuspensionFreeThunkToType(erasedResult, s"in shim method of ${defn.sym}", defn.loc)
           Instructions.xReturn(erasedResult.toClassDesc)
@@ -1769,8 +1769,8 @@ object BackendObjType {
     )
 
     private def staticApplyIns(implicit mv: MethodVisitor): Unit = {
-      withName(0, Frame.toTpe) { fun =>
-        withName(1, Value.toTpe) { resumeArg =>
+      Instructions.withName(0, Frame.desc) { fun =>
+        Instructions.withName(1, Value.desc) { resumeArg =>
           fun.load()
           resumeArg.load()
           INVOKEINTERFACE(Frame.ApplyMethod)
@@ -1845,7 +1845,7 @@ object BackendObjType {
     def ReverseOntoMethod: InterfaceMethod = InterfaceMethod(this.desc, "reverseOnto", mkDescriptor(Frames.toTpe)(Frames.toTpe))
 
     def pushImplementation(implicit mv: MethodVisitor): Unit = {
-      withName(1, Frame.toTpe) { frame =>
+      Instructions.withName(1, Frame.desc) { frame =>
         NEW(FramesCons.desc)
         DUP()
         INVOKESPECIAL(FramesCons.Constructor)
@@ -1883,7 +1883,7 @@ object BackendObjType {
     def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.desc)
 
     private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Frames.toTpe) { rest =>
+      Instructions.withName(1, Frames.desc) { rest =>
         thisLoad()
         GETFIELD(TailField)
         NEW(FramesCons.desc)
@@ -1919,9 +1919,9 @@ object BackendObjType {
     def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.desc)
 
     private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Frames.toTpe) { rest =>
+      Instructions.withName(1, Frames.desc) { rest =>
         rest.load()
-        Instructions.xReturn(rest.tpe.toClassDesc)
+        Instructions.xReturn(rest.tpe)
       }
     }
   }
@@ -1939,8 +1939,8 @@ object BackendObjType {
     def StaticRewindMethod: StaticInterfaceMethod = StaticInterfaceMethod(this.desc, "staticRewind", mkDescriptor(Resumption.toTpe, Value.toTpe)(Result.toTpe))
 
     private def staticRewindIns(implicit mv: MethodVisitor): Unit = {
-      withName(0, Resumption.toTpe) { resumption =>
-        withName(1, Value.toTpe) { v =>
+      Instructions.withName(0, Resumption.desc) { resumption =>
+        Instructions.withName(1, Value.desc) { v =>
           resumption.load()
           v.load()
           INVOKEINTERFACE(Resumption.RewindMethod)
@@ -1978,7 +1978,7 @@ object BackendObjType {
     def TailField: InstanceField = InstanceField(this.desc, "tail", Resumption.toTpe)
 
     private def rewindIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Value.toTpe) { v =>
+      Instructions.withName(1, Value.desc) { v =>
         thisLoad()
         GETFIELD(SymField)
         thisLoad()
@@ -2010,9 +2010,9 @@ object BackendObjType {
     def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
     private def rewindIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Value.toTpe) { v =>
+      Instructions.withName(1, Value.desc) { v =>
         v.load()
-        Instructions.xReturn(v.tpe.toClassDesc)
+        Instructions.xReturn(v.tpe)
       }
     }
   }
@@ -2032,10 +2032,10 @@ object BackendObjType {
     )
 
     private def installHandlerIns(implicit mv: MethodVisitor): Unit = {
-      withName(0, BackendType.String) { effSym =>
-        withName(1, Handler.toTpe) { handler =>
-          withName(2, Frames.toTpe) { frames =>
-            withName(3, Thunk.toTpe) { thunk =>
+      Instructions.withName(0, JavaClasses.String) { effSym =>
+        Instructions.withName(1, Handler.desc) { handler =>
+          Instructions.withName(2, Frames.desc) { frames =>
+            Instructions.withName(3, Thunk.desc) { thunk =>
               thunk.load()
               // Thunk|Value|Suspension
               Result.unwindThunk()
@@ -2046,7 +2046,7 @@ object BackendObjType {
               ifCondition(Condition.NE) {
                 DUP()
                 CHECKCAST(Suspension.desc)
-                storeWithName(4, Suspension.toTpe) { s =>
+                Instructions.storeWithName(4, Suspension.desc) { s =>
                   NEW(ResumptionCons.desc)
                   DUP()
                   INVOKESPECIAL(ResumptionCons.Constructor)
@@ -2066,7 +2066,7 @@ object BackendObjType {
                   s.load()
                   GETFIELD(Suspension.ResumptionField)
                   PUTFIELD(ResumptionCons.TailField)
-                  storeWithName(5, ResumptionCons.toTpe) { r =>
+                  Instructions.storeWithName(5, ResumptionCons.desc) { r =>
                     s.load()
                     GETFIELD(Suspension.EffSymField)
                     effSym.load()
@@ -2105,7 +2105,7 @@ object BackendObjType {
 
               // Value
               CHECKCAST(Value.desc)
-              storeWithName(6, Value.toTpe) { res =>
+              Instructions.storeWithName(6, Value.desc) { res =>
                 //
                 // Case on frames
                 // FramesNil
@@ -2118,7 +2118,7 @@ object BackendObjType {
                 // FramesCons
                 frames.load()
                 CHECKCAST(FramesCons.desc)
-                storeWithName(7, FramesCons.toTpe) { cons => {
+                Instructions.storeWithName(7, FramesCons.desc) { cons => {
                   effSym.load()
                   handler.load()
                   cons.load()
@@ -2169,7 +2169,7 @@ object BackendObjType {
     def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(Resumption.toTpe))
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Resumption.toTpe) { resumption =>
+      Instructions.withName(1, Resumption.desc) { resumption =>
         thisLoad()
         INVOKESPECIAL(superClass.desc, ConstructorMethodName, MethodDescriptor.NothingToVoid)
         thisLoad()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -123,13 +123,6 @@ object BytecodeInstructions {
     case object FalseBranch extends Branch
   }
 
-  // TODO: do this for methods
-  class Variable(val tpe: BackendType, index: Int) {
-    def load()(implicit mv: MethodVisitor): Unit = xLoad(tpe, index)
-
-    def store()(implicit mv: MethodVisitor): Unit = xStore(tpe, index)
-  }
-
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~ Direct JVM Instructions ~~~~~~~~~~~~~~~~~~~~~~~~~
   //
@@ -430,11 +423,6 @@ object BytecodeInstructions {
     INVOKESPECIAL(BackendObjType.ReifiedSourceLocation.Constructor)
   }
 
-  def storeWithName(index: Int, tpe: BackendType)(body: Variable => Unit)(implicit mv: MethodVisitor): Unit = {
-    xStore(tpe, index)
-    body(new Variable(tpe, index))
-  }
-
   def thisLoad()(implicit mv: MethodVisitor): Unit = ALOAD(0)
 
   def throwUnsupportedOperationException(msg: String)(implicit mv: MethodVisitor): Unit = {
@@ -444,36 +432,6 @@ object BytecodeInstructions {
     INVOKESPECIAL(JavaClasses.UnsupportedOperationException, ConstructorMethodName,
       mkDescriptor(BackendType.String)(VoidableType.Void))
     ATHROW()
-  }
-
-  def withName(index: Int, tpe: BackendType)(body: Variable => Unit): Unit =
-    body(new Variable(tpe, index))
-
-  def withNames(index: Int, tpes: List[BackendType])(body: (Int, List[Variable]) => Unit): Unit = {
-    var runningIndex = index
-    val variables = tpes.map(tpe => {
-      val variable = new Variable(tpe, runningIndex)
-      runningIndex = runningIndex + tpe.stackSlots
-      variable
-    })
-    body(runningIndex, variables)
-  }
-
-  def xLoad(tpe: BackendType, index: Int)(implicit mv: MethodVisitor): Unit = tpe match {
-    case BackendType.Bool | BackendType.Char | BackendType.Int8 | BackendType.Int16 | BackendType.Int32 => ILOAD(index)
-    case BackendType.Int64 => LLOAD(index)
-    case BackendType.Float32 => mv.visitVarInstruction(Opcodes.FLOAD, index)
-    case BackendType.Float64 => DLOAD(index)
-    case BackendType.Array(_) | BackendType.Reference(_) => ALOAD(index)
-  }
-
-  def xStore(tpe: BackendType, index: Int)(implicit mv: MethodVisitor): Unit = tpe match {
-    case BackendType.Bool | BackendType.Char | BackendType.Int8 | BackendType.Int16 | BackendType.Int32 =>
-      mv.visitVarInstruction(Opcodes.ISTORE, index)
-    case BackendType.Int64 => mv.visitVarInstruction(Opcodes.LSTORE, index)
-    case BackendType.Float32 => mv.visitVarInstruction(Opcodes.FSTORE, index)
-    case BackendType.Float64 => mv.visitVarInstruction(Opcodes.DSTORE, index)
-    case BackendType.Array(_) | BackendType.Reference(_) => ASTORE(index)
   }
 
   def xSwap(lowerLarge: Boolean, higherLarge: Boolean)(implicit mv: MethodVisitor): Unit = (lowerLarge, higherLarge) match {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -117,7 +117,7 @@ object GenAnonymousClasses {
     // ALOAD 0 (this)
     thisLoad()
     // Load each <init> parameter (starting at slot 1)
-    withNames(1, paramTypes) { case (_, args) =>
+    Instructions.withNames(1, paramTypes.map(_.toClassDesc)) { case (_, args) =>
       for (arg <- args) arg.load()
     }
     // INVOKESPECIAL superClass.<init>(paramTypes...)
@@ -157,7 +157,7 @@ object GenAnonymousClasses {
     // ALOAD 0 (this)
     thisLoad()
     // Load each parameter (starting at slot 1)
-    withNames(1, paramTypes) { case (_, args) =>
+    Instructions.withNames(1, paramTypes.map(_.toClassDesc)) { case (_, args) =>
       for (arg <- args) arg.load()
     }
     // INVOKESPECIAL superClass.methodName(descriptor)
@@ -180,7 +180,7 @@ object GenAnonymousClasses {
     GETFIELD(cloField)
     INVOKEVIRTUAL(abstractClass.GetUniqueThreadClosureMethod)
     // Load the actual arguments into the erased closure arguments.
-    withNames(0, m.fparams.map(_.tpe).map(BackendType.toBackendType)) {
+    Instructions.withNames(0, m.fparams.map(_.tpe).map(BackendType.toClassDesc)) {
       case (_, args) =>
         for ((arg, i) <- args.zipWithIndex) {
           DUP()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -88,9 +88,9 @@ object GenEffectClasses {
     import BytecodeInstructions.*
     val wrapperType = BackendObjType.ResumptionWrapper(returnType)
 
-    withNames(0, erasedParams) { case (paramsOffset, params) =>
-      withName(paramsOffset, BackendObjType.Handler.toTpe) { handler =>
-        withName(paramsOffset + 1, BackendObjType.Resumption.toTpe) { resumption =>
+    Instructions.withNames(0, erasedParams.map(_.toClassDesc)) { case (paramsOffset, params) =>
+      Instructions.withName(paramsOffset, BackendObjType.Handler.desc) { handler =>
+        Instructions.withName(paramsOffset + 1, BackendObjType.Resumption.desc) { resumption =>
           // Cast the given generic handler to the current effect.
           handler.load()
           CHECKCAST(effectName)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -189,7 +189,7 @@ object GenExpression {
     }
 
     case Expr.Var(_, offset, tpe, _) =>
-      BytecodeInstructions.xLoad(BackendType.toBackendType(tpe), ctx.getIndex(offset))
+      Instructions.xLoad(BackendType.toClassDesc(tpe), ctx.getIndex(offset))
 
     case Expr.ApplyAtomic(op, exps, tpe, _, loc) => op match {
 
@@ -1322,9 +1322,9 @@ object GenExpression {
         }
         for ((arg, fp) <- ListOps.zip(exps, defn.fparams).reverse) {
           // Store it in the ith parameter.
-          val tpe = BackendType.toBackendType(arg.tpe)
+          val tpe = BackendType.toClassDesc(arg.tpe)
           val offset = ctx.getIndex(fp.offset)
-          BytecodeInstructions.xStore(tpe, offset)
+          Instructions.xStore(tpe, offset)
         }
         // Jump to the entry point of the method.
         mv.visitJumpInsn(GOTO, ctx.entryPoint)
@@ -1421,7 +1421,7 @@ object GenExpression {
 
     case Expr.Let(_, offset, exp1, exp2, _) =>
       import BytecodeInstructions.*
-      val bType = BackendType.toBackendType(exp1.tpe)
+      val bType = BackendType.toClassDesc(exp1.tpe)
       compileExpr(exp1)
       // No cast needed in most cases: operations self-cast (Untag, Index, etc.),
       // function calls are wrapped in Cast by the Eraser, and effect resume
@@ -1429,10 +1429,10 @@ object GenExpression {
       // classes) where the JVM verifier cannot resolve the generated subclass
       // name and needs an explicit cast to the declared superclass type.
       exp1 match {
-        case _: Expr.NewObject => Instructions.castIfNotPrim(bType.toClassDesc)
+        case _: Expr.NewObject => Instructions.castIfNotPrim(bType)
         case _ => ()
       }
-      xStore(bType, ctx.getIndex(offset))
+      Instructions.xStore(bType, ctx.getIndex(offset))
       compileExpr(exp2)
 
     case Expr.Stm(exps, exp, _) =>
@@ -1465,7 +1465,7 @@ object GenExpression {
       mv.visitMethodInsn(INVOKESPECIAL, internalNameOf(BackendObjType.Region.desc), ClassMaker.ConstructorMethodName,
         MethodDescriptor.NothingToVoid.toDescriptor, false)
 
-      BytecodeInstructions.xStore(BackendObjType.Region.toTpe, ctx.getIndex(offset))
+      Instructions.xStore(BackendObjType.Region.desc, ctx.getIndex(offset))
 
       // Compile the scope body
       mv.visitLabel(beforeTryBlock)
@@ -1476,14 +1476,14 @@ object GenExpression {
       mv.visitTryCatchBlock(beforeTryBlock, afterTryBlock, finallyBlock, null)
 
       // When we exit the scope, call the region's `exit` method
-      BytecodeInstructions.xLoad(BackendObjType.Region.toTpe, ctx.getIndex(offset))
+      Instructions.xLoad(BackendObjType.Region.desc, ctx.getIndex(offset))
       mv.visitTypeInsn(CHECKCAST, internalNameOf(BackendObjType.Region.desc))
       mv.visitMethodInsn(INVOKEVIRTUAL, internalNameOf(BackendObjType.Region.desc), BackendObjType.Region.ExitMethod.name,
         BackendObjType.Region.ExitMethod.d.toDescriptor, false)
       mv.visitLabel(afterTryBlock)
 
       // Compile the finally block which gets called if no exception is thrown
-      BytecodeInstructions.xLoad(BackendObjType.Region.toTpe, ctx.getIndex(offset))
+      Instructions.xLoad(BackendObjType.Region.desc, ctx.getIndex(offset))
       mv.visitTypeInsn(CHECKCAST, internalNameOf(BackendObjType.Region.desc))
       mv.visitMethodInsn(INVOKEVIRTUAL, internalNameOf(BackendObjType.Region.desc), BackendObjType.Region.ReThrowChildExceptionMethod.name,
         BackendObjType.Region.ReThrowChildExceptionMethod.d.toDescriptor, false)
@@ -1491,7 +1491,7 @@ object GenExpression {
 
       // Compile the finally block which gets called if an exception is thrown
       mv.visitLabel(finallyBlock)
-      BytecodeInstructions.xLoad(BackendObjType.Region.toTpe, ctx.getIndex(offset))
+      Instructions.xLoad(BackendObjType.Region.desc, ctx.getIndex(offset))
       mv.visitTypeInsn(CHECKCAST, internalNameOf(BackendObjType.Region.desc))
       mv.visitMethodInsn(INVOKEVIRTUAL, internalNameOf(BackendObjType.Region.desc), BackendObjType.Region.ReThrowChildExceptionMethod.name,
         BackendObjType.Region.ReThrowChildExceptionMethod.d.toDescriptor, false)
@@ -1528,7 +1528,7 @@ object GenExpression {
         mv.visitLabel(handlerLabel)
 
         // Store the exception in a local variable.
-        BytecodeInstructions.xStore(BackendType.Object, ctx.getIndex(offset))
+        Instructions.xStore(JavaClasses.Object, ctx.getIndex(offset))
 
         // Emit code for the handler body expression.
         compileExpr(body)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -410,7 +410,7 @@ object GenFunAndClosureClasses {
           } else {
             DUP()(mv)
             // fieldType is erased (Object for refs), so xLoad always matches the verifier type
-            xLoad(fieldType, index)(mv)
+            Instructions.xLoad(fieldType.toClassDesc, index)(mv)
             mv.visitFieldInsn(Opcodes.PUTFIELD, classInternalName, name, fieldType.toDescriptor)
           }
         }
@@ -427,9 +427,9 @@ object GenFunAndClosureClasses {
             realType match {
               case _: BackendType.PrimitiveType => () // primitives don't need narrowing
               case _ =>
-                BytecodeInstructions.xLoad(erasedType, index)(mv)
+                Instructions.xLoad(erasedType.toClassDesc, index)(mv)
                 Instructions.castIfNotPrim(realType.toClassDesc)(mv)
-                BytecodeInstructions.xStore(realType, index)(mv)
+                Instructions.xStore(realType.toClassDesc, index)(mv)
             }
           }
         }
@@ -455,9 +455,9 @@ object GenFunAndClosureClasses {
     castTo match {
       case Some(targetType) =>
         Instructions.castIfNotPrim(targetType.toClassDesc)
-        BytecodeInstructions.xStore(targetType, localIndex)
+        Instructions.xStore(targetType.toClassDesc, localIndex)
       case None =>
-        BytecodeInstructions.xStore(fieldType, localIndex)
+        Instructions.xStore(fieldType.toClassDesc, localIndex)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
@@ -30,9 +30,37 @@ import java.lang.constant.ClassDesc
   */
 object Instructions {
 
+  /** A local variable of type `tpe` at index `index`. */
+  class Variable(val tpe: ClassDesc, index: Int) {
+    def load()(implicit mv: MethodVisitor): Unit = xLoad(tpe, index)
+
+    def store()(implicit mv: MethodVisitor): Unit = xStore(tpe, index)
+  }
+
   /** Emits a `CHECKCAST` of the top of the stack to `tpe`, unless `tpe` is a primitive type. */
   def castIfNotPrim(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     if (!tpe.isPrimitive) mv.visitTypeInsn(Opcodes.CHECKCAST, ClassDescs.internalNameOf(tpe))
+  }
+
+  /** Emits an `xStore` of `tpe` at `index` and runs `body` with the corresponding [[Variable]]. */
+  def storeWithName(index: Int, tpe: ClassDesc)(body: Variable => Unit)(implicit mv: MethodVisitor): Unit = {
+    xStore(tpe, index)
+    body(new Variable(tpe, index))
+  }
+
+  /** Runs `body` with the [[Variable]] of type `tpe` at `index`. */
+  def withName(index: Int, tpe: ClassDesc)(body: Variable => Unit): Unit =
+    body(new Variable(tpe, index))
+
+  /** Runs `body` with the [[Variable]]s of types `tpes` starting at `index`, and the next free index. */
+  def withNames(index: Int, tpes: List[ClassDesc])(body: (Int, List[Variable]) => Unit): Unit = {
+    var runningIndex = index
+    val variables = tpes.map(tpe => {
+      val variable = new Variable(tpe, runningIndex)
+      runningIndex = runningIndex + stackSlotsOf(tpe)
+      variable
+    })
+    body(runningIndex, variables)
   }
 
   /** Emits a `?ALOAD` instruction that loads an element from an array with element type `elmTpe`. */
@@ -63,6 +91,16 @@ object Instructions {
     else mv.visitInsn(Opcodes.AASTORE)
   }
 
+  /** Emits a `?LOAD` instruction that loads the local variable of type `tpe` at `index`. */
+  def xLoad(tpe: ClassDesc, index: Int)(implicit mv: MethodVisitor): Unit = {
+    import java.lang.constant.ConstantDescs.*
+    if (tpe == CD_boolean || tpe == CD_char || tpe == CD_byte || tpe == CD_short || tpe == CD_int) mv.visitVarInsn(Opcodes.ILOAD, index)
+    else if (tpe == CD_long) mv.visitVarInsn(Opcodes.LLOAD, index)
+    else if (tpe == CD_float) mv.visitVarInsn(Opcodes.FLOAD, index)
+    else if (tpe == CD_double) mv.visitVarInsn(Opcodes.DLOAD, index)
+    else mv.visitVarInsn(Opcodes.ALOAD, index)
+  }
+
   /** Emits a `NEWARRAY` or `ANEWARRAY` instruction that creates an array with element type `elmTpe`. */
   def xNewArray(elmTpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     if (elmTpe.isPrimitive) mv.visitIntInsn(Opcodes.NEWARRAY, newArrayOperandOf(elmTpe))
@@ -84,6 +122,22 @@ object Instructions {
     else if (tpe == CD_float) mv.visitInsn(Opcodes.FRETURN)
     else if (tpe == CD_double) mv.visitInsn(Opcodes.DRETURN)
     else mv.visitInsn(Opcodes.ARETURN)
+  }
+
+  /** Emits a `?STORE` instruction that stores the top of the stack into the local variable of type `tpe` at `index`. */
+  def xStore(tpe: ClassDesc, index: Int)(implicit mv: MethodVisitor): Unit = {
+    import java.lang.constant.ConstantDescs.*
+    if (tpe == CD_boolean || tpe == CD_char || tpe == CD_byte || tpe == CD_short || tpe == CD_int) mv.visitVarInsn(Opcodes.ISTORE, index)
+    else if (tpe == CD_long) mv.visitVarInsn(Opcodes.LSTORE, index)
+    else if (tpe == CD_float) mv.visitVarInsn(Opcodes.FSTORE, index)
+    else if (tpe == CD_double) mv.visitVarInsn(Opcodes.DSTORE, index)
+    else mv.visitVarInsn(Opcodes.ASTORE, index)
+  }
+
+  /** Returns the number of stack slots (1 or 2) that a value of type `tpe` occupies. */
+  private def stackSlotsOf(tpe: ClassDesc): Int = {
+    import java.lang.constant.ConstantDescs.*
+    if (tpe == CD_long || tpe == CD_double) 2 else 1
   }
 
   /** Returns the `NEWARRAY` type operand (e.g. [[Opcodes.T_INT]]) of the primitive type `tpe`. */


### PR DESCRIPTION
Moves the local-variable cluster — `xLoad`, `xStore`, `Variable`, `withName`, `withNames`, `storeWithName` — from `BytecodeInstructions` to `Instructions`, expressed in terms of `ClassDesc` instead of `BackendType`. The opcode family and slot width only ever depended on the primitive kind of the type.

Fallout at the call sites:

- ~25 `withName(i, X.toTpe)` sites stop allocating a `BackendType.Reference` wrapper and pass `X.desc` directly; the `JavaClasses.*` sites pass the `ClassDesc` constants as-is.
- `withName(0, BackendType.Array(BackendType.String))` becomes `JavaClasses.String.arrayType()`.
- Since `Variable.tpe` is now a `ClassDesc`, the `xReturn(v.tpe.toClassDesc)` bridges from #13120 simplify to `xReturn(v.tpe)`.

Follow-up to #13107, #13117, #13118, #13120, #13121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)