### PR TITLE
refactor: prune BackendType and add direct erased conversion

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -31,8 +31,8 @@ import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoi
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 
-import java.lang.constant.ClassDesc
-import java.lang.constant.ConstantDescs.{CD_Object, CD_boolean, CD_byte, CD_char, CD_double, CD_float, CD_int, CD_long, CD_short}
+import java.lang.constant.{ClassDesc, MethodTypeDesc}
+import java.lang.constant.ConstantDescs.{CD_Object, CD_boolean, CD_byte, CD_char, CD_double, CD_float, CD_int, CD_long, CD_short, CD_void}
 
 /**
   * Represents all Flix types that are objects on the JVM (array is an exception).
@@ -1031,7 +1031,7 @@ object BackendObjType {
     }
 
     def SetArgsMethod: StaticMethod =
-      StaticMethod(this.desc, "setArgs", mkVoidDescriptor(BackendType.Array(BackendType.String)))
+      StaticMethod(this.desc, "setArgs", MethodTypeDesc.of(CD_void, JavaClasses.String.arrayType()))
 
     private def setArgsIns(implicit mv: MethodVisitor): Unit = {
       ALOAD(0)
@@ -1507,8 +1507,8 @@ object BackendObjType {
 
     private def shimIns(defn: JvmAst.Def)(implicit mv: MethodVisitor): Unit = {
       val defnT = Defn(defn.sym)
-      val paramTypes = defn.fparams.map(fp => BackendType.toErasedBackendType(fp.tpe))
-      Instructions.withNames(0, paramTypes.map(_.toClassDesc)) {
+      val paramTypes = defn.fparams.map(fp => BackendType.toErasedClassDesc(fp.tpe))
+      Instructions.withNames(0, paramTypes) {
         case (_, args) =>
           val erasedResult = BackendType.toErasedBackendType(defn.unboxedType.tpe)
           NEW(defnT.desc)
@@ -1517,7 +1517,7 @@ object BackendObjType {
           for ((arg, index) <- args.zipWithIndex) {
             DUP()
             arg.load()
-            PUTFIELD(InstanceField(defnT.desc, s"arg$index", paramTypes(index).toClassDesc))
+            PUTFIELD(InstanceField(defnT.desc, s"arg$index", paramTypes(index)))
           }
           Result.unwindSuspensionFreeThunkToType(erasedResult, s"in shim method of ${defn.sym}", defn.loc)
           Instructions.xReturn(erasedResult.toClassDesc)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.language.ast.{JvmAst, SimpleType, SourceLocation}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
 import java.lang.constant.ClassDesc
-import java.lang.constant.ConstantDescs.{CD_Object, CD_String}
+import java.lang.constant.ConstantDescs.{CD_Object, CD_String, CD_boolean, CD_byte, CD_char, CD_double, CD_float, CD_int, CD_long, CD_short}
 import scala.annotation.tailrec
 
 /**
@@ -91,11 +91,6 @@ sealed trait BackendType {
     case BackendType.Bool | BackendType.Char | BackendType.Int8 | BackendType.Int16 |
          BackendType.Int32 | BackendType.Float32 | BackendType.Array(_) | BackendType.Reference(_) => false
   }
-
-  /**
-    * Returns `2` if `this` is a 64 bit value, or `1` if it is a 32 bit value.
-    */
-  def stackSlots: Int = if (is64BitWidth) 2 else 1
 
 }
 
@@ -180,21 +175,6 @@ object BackendType {
   def toClassDesc(tpe0: SimpleType)(implicit root: JvmAst.Root): ClassDesc =
     ClassDesc.ofDescriptor(toBackendType(tpe0).toDescriptor)
 
-  /** Converts the given Java class or array descriptor `desc` into its [[BackendType]] representation. */
-  def toBackendType(desc: ClassDesc): BackendType = {
-    import java.lang.constant.ConstantDescs.*
-    if (desc == CD_boolean) BackendType.Bool
-    else if (desc == CD_char) BackendType.Char
-    else if (desc == CD_byte) BackendType.Int8
-    else if (desc == CD_short) BackendType.Int16
-    else if (desc == CD_int) BackendType.Int32
-    else if (desc == CD_long) BackendType.Int64
-    else if (desc == CD_float) BackendType.Float32
-    else if (desc == CD_double) BackendType.Float64
-    else if (desc.isArray) Array(toBackendType(desc.componentType()))
-    else Reference(BackendObjType.Native(desc))
-  }
-
   /**
     * Contains all the primitive types and `Reference(Native(CD_Object))`.
     */
@@ -229,6 +209,25 @@ object BackendType {
          SimpleType.ExtensibleExtend(_, _, _) | SimpleType.ExtensibleEmpty | SimpleType.Native(_) |
          SimpleType.Region | SimpleType.Null =>
       BackendType.Object
+  }
+
+  /** Computes the [[ClassDesc]] of the erased JVM representation of the given [[SimpleType]]. */
+  def toErasedClassDesc(tpe: SimpleType): ClassDesc = tpe match {
+    case SimpleType.Bool => CD_boolean
+    case SimpleType.Char => CD_char
+    case SimpleType.Int8 => CD_byte
+    case SimpleType.Int16 => CD_short
+    case SimpleType.Int32 => CD_int
+    case SimpleType.Int64 => CD_long
+    case SimpleType.Float32 => CD_float
+    case SimpleType.Float64 => CD_double
+    case SimpleType.Void | SimpleType.AnyType | SimpleType.Unit | SimpleType.BigDecimal | SimpleType.BigInt |
+         SimpleType.String | SimpleType.Regex | SimpleType.Array(_) | SimpleType.Lazy(_) |
+         SimpleType.Tuple(_) | SimpleType.Enum(_, _) | SimpleType.Struct(_, _) | SimpleType.Arrow(_, _) |
+         SimpleType.RecordEmpty | SimpleType.RecordExtend(_, _, _) |
+         SimpleType.ExtensibleExtend(_, _, _) | SimpleType.ExtensibleEmpty | SimpleType.Native(_) |
+         SimpleType.Region | SimpleType.Null =>
+      CD_Object
   }
 
   sealed trait PrimitiveType extends BackendType

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -23,7 +23,9 @@ import ca.uwaterloo.flix.language.ast.SemanticOp.*
 import ca.uwaterloo.flix.language.ast.shared.{Constant, ExpPosition, Mutability}
 import ca.uwaterloo.flix.language.ast.{SimpleType, *}
 import ca.uwaterloo.flix.util.ClassDescs.internalNameOf
-import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoidDescriptor}
+import java.lang.constant.MethodTypeDesc
+import java.lang.constant.ConstantDescs.{CD_double, CD_long, CD_void}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkDescriptor
 import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.ListOps
 import org.objectweb.asm
@@ -203,11 +205,11 @@ object GenExpression {
         mv.visitMethodInsn(INVOKESPECIAL, closureName, ClassMaker.ConstructorMethodName, MethodTypeDescs.NothingToVoid.descriptorString(), false)
         // Capturing free args
         for ((arg, i) <- exps.zipWithIndex) {
-          val argType = BackendType.toBackendType(arg.tpe)
+          val argType = BackendType.toClassDesc(arg.tpe)
           mv.visitInsn(DUP)
           compileExpr(arg)
-          Instructions.castIfNotPrim(argType.toClassDesc)
-          mv.visitFieldInsn(PUTFIELD, closureName, s"clo$i", argType.toDescriptor)
+          Instructions.castIfNotPrim(argType)
+          mv.visitFieldInsn(PUTFIELD, closureName, s"clo$i", argType.descriptorString())
         }
 
       case AtomicOp.Unary(sop) =>
@@ -720,13 +722,14 @@ object GenExpression {
         val List(exp1, exp2) = exps
         // We get the inner type of the array
         val innerType = tpe.asInstanceOf[SimpleType.Array].tpe
-        val backendType = BackendType.toBackendType(innerType)
-        val fillMethod = ClassMaker.StaticMethod(JavaClasses.Arrays, "fill", mkVoidDescriptor(BackendType.Array(backendType.toErased), backendType.toErased))
+        val erasedElmTpe = BackendType.toErasedClassDesc(innerType)
+        val elmIs64BitWidth = erasedElmTpe == CD_long || erasedElmTpe == CD_double
+        val fillMethod = ClassMaker.StaticMethod(JavaClasses.Arrays, "fill", MethodTypeDesc.of(CD_void, erasedElmTpe.arrayType(), erasedElmTpe))
         compileExpr(exp1) // default
         compileExpr(exp2) // default, length
         Instructions.xNewArray(BackendType.toClassDesc(innerType)) // default, arr
-        if (backendType.is64BitWidth) DUP_X2() else DUP_X1() // arr, default, arr
-        xSwap(lowerLarge = backendType.is64BitWidth, higherLarge = false) // arr, arr, default
+        if (elmIs64BitWidth) DUP_X2() else DUP_X1() // arr, default, arr
+        xSwap(lowerLarge = elmIs64BitWidth, higherLarge = false) // arr, arr, default
         INVOKESTATIC(fillMethod)
 
       case AtomicOp.ArrayLoad =>
@@ -951,7 +954,7 @@ object GenExpression {
         Instructions.addLoc(loc)
         compileExpr(exp)
         val declaration = internalNameOf(field.owner)
-        mv.visitFieldInsn(GETFIELD, declaration, field.name, BackendType.toBackendType(tpe).toDescriptor)
+        mv.visitFieldInsn(GETFIELD, declaration, field.name, BackendType.toClassDesc(tpe).descriptorString())
 
       case AtomicOp.PutField(field) =>
         val List(exp1, exp2) = exps
@@ -960,7 +963,7 @@ object GenExpression {
         compileExpr(exp1)
         compileExpr(exp2)
         val declaration = internalNameOf(field.owner)
-        mv.visitFieldInsn(PUTFIELD, declaration, field.name, BackendType.toBackendType(exp2.tpe).toDescriptor)
+        mv.visitFieldInsn(PUTFIELD, declaration, field.name, BackendType.toClassDesc(exp2.tpe).descriptorString())
 
         // Push Unit on the stack.
         mv.visitFieldInsn(GETSTATIC, internalNameOf(BackendObjType.Unit.desc), BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.toDescriptor)
@@ -969,7 +972,7 @@ object GenExpression {
         // Add source line number for debugging (can fail when calling java)
         Instructions.addLoc(loc)
         val declaration = internalNameOf(field.owner)
-        mv.visitFieldInsn(GETSTATIC, declaration, field.name, BackendType.toBackendType(tpe).toDescriptor)
+        mv.visitFieldInsn(GETSTATIC, declaration, field.name, BackendType.toClassDesc(tpe).descriptorString())
 
       case AtomicOp.PutStaticField(field) =>
         val List(exp) = exps
@@ -977,7 +980,7 @@ object GenExpression {
         Instructions.addLoc(loc)
         compileExpr(exp)
         val declaration = internalNameOf(field.owner)
-        mv.visitFieldInsn(PUTSTATIC, declaration, field.name, BackendType.toBackendType(exp.tpe).toDescriptor)
+        mv.visitFieldInsn(PUTSTATIC, declaration, field.name, BackendType.toClassDesc(exp.tpe).descriptorString())
 
         // Push Unit on the stack.
         mv.visitFieldInsn(GETSTATIC, internalNameOf(BackendObjType.Unit.desc), BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.toDescriptor)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -26,6 +26,7 @@ import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.{ClassWriter, Label, MethodVisitor, Opcodes}
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
+import java.lang.constant.ConstantDescs.CD_int
 
 /**
   * Generates byte code for the function and closure classes.
@@ -164,9 +165,9 @@ object GenFunAndClosureClasses {
 
     // Fields — lparams use erased types (like fparams) so setPc can store without casting
     for ((x, i) <- defn.lparams.zipWithIndex) {
-      visitor.visitField(ACC_PUBLIC, s"l$i", BackendType.toErasedBackendType(x.tpe).toDescriptor, null, null)
+      visitor.visitField(ACC_PUBLIC, s"l$i", BackendType.toErasedClassDesc(x.tpe).descriptorString(), null, null)
     }
-    visitor.visitField(ACC_PUBLIC, "pc", BackendType.Int32.toDescriptor, null, null)
+    visitor.visitField(ACC_PUBLIC, "pc", CD_int.descriptorString(), null, null)
 
     compileConstructor(functionInterface, visitor)
 
@@ -252,9 +253,9 @@ object GenFunAndClosureClasses {
     }
     // lparams use erased types (like fparams) so setPc can store without casting
     for ((x, i) <- defn.lparams.zipWithIndex) {
-      visitor.visitField(ACC_PUBLIC, s"l$i", BackendType.toErasedBackendType(x.tpe).toDescriptor, null, null)
+      visitor.visitField(ACC_PUBLIC, s"l$i", BackendType.toErasedClassDesc(x.tpe).descriptorString(), null, null)
     }
-    visitor.visitField(ACC_PUBLIC, "pc", BackendType.Int32.toDescriptor, null, null)
+    visitor.visitField(ACC_PUBLIC, "pc", CD_int.descriptorString(), null, null)
 
     compileConstructor(functionInterface, visitor)
 
@@ -320,7 +321,7 @@ object GenFunAndClosureClasses {
       m.visitVarInsn(ALOAD, 0)
       // Load arg i
       m.visitFieldInsn(GETFIELD, ClassDescs.internalNameOf(functionInterface),
-        s"arg$i", BackendType.toErasedBackendType(fp.tpe).toDescriptor)
+        s"arg$i", BackendType.toErasedClassDesc(fp.tpe).descriptorString())
       // Insert cast to concrete type
       Instructions.castIfNotPrim(BackendType.toClassDesc(fp.tpe))
     }
@@ -359,11 +360,11 @@ object GenFunAndClosureClasses {
     implicit val m: MethodVisitor = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL, applyMethod.name, applyMethod.d.descriptorString(), null, null)
     val localOffset = 2 // [this: Obj, value: Obj, ...]
 
-    val lparams = defn.lparams.zipWithIndex.map { case (lp, i) => (s"l$i", lp.offset + localOffset, lp.sym.isWild, BackendType.toErasedBackendType(lp.tpe), Some(BackendType.toBackendType(lp.tpe))) }
-    val cparams = defn.cparams.zipWithIndex.map { case (cp, i) => (s"clo$i", cp.offset + localOffset, false, BackendType.toBackendType(cp.tpe), None) }
-    val fparams = defn.fparams.zipWithIndex.map { case (fp, i) => (s"arg$i", fp.offset + localOffset, false, BackendType.toErasedBackendType(fp.tpe), Some(BackendType.toBackendType(fp.tpe))) }
+    val lparams = defn.lparams.zipWithIndex.map { case (lp, i) => (s"l$i", lp.offset + localOffset, lp.sym.isWild, BackendType.toErasedClassDesc(lp.tpe), Some(BackendType.toClassDesc(lp.tpe))) }
+    val cparams = defn.cparams.zipWithIndex.map { case (cp, i) => (s"clo$i", cp.offset + localOffset, false, BackendType.toClassDesc(cp.tpe), None) }
+    val fparams = defn.fparams.zipWithIndex.map { case (fp, i) => (s"arg$i", fp.offset + localOffset, false, BackendType.toErasedClassDesc(fp.tpe), Some(BackendType.toClassDesc(fp.tpe))) }
 
-    def loadParamsOf(params: List[(String, Int, Boolean, BackendType, Option[BackendType])]): Unit = {
+    def loadParamsOf(params: List[(String, Int, Boolean, ClassDesc, Option[ClassDesc])]): Unit = {
       params.foreach { case (name, offset, _, fieldType, castTo) => loadFromField(m, className, name, offset, fieldType, castTo) }
     }
 
@@ -387,7 +388,7 @@ object GenFunAndClosureClasses {
         // the default label is the starting point of the function if pc = 0
         val defaultLabel = new Label()
         m.visitVarInsn(ALOAD, 0)
-        m.visitFieldInsn(GETFIELD, classInternalName, "pc", BackendType.Int32.toDescriptor)
+        m.visitFieldInsn(GETFIELD, classInternalName, "pc", CD_int.descriptorString())
         m.visitTableSwitchInsn(1, pcLabels.length, defaultLabel, pcLabels *)
         m.visitLabel(defaultLabel)
       }
@@ -403,15 +404,15 @@ object GenFunAndClosureClasses {
         SWAP()(mv)
         DUP_X1()(mv)
         SWAP()(mv) // clo, pc ---> clo, clo, pc
-        mv.visitFieldInsn(Opcodes.PUTFIELD, classInternalName, "pc", BackendType.Int32.toDescriptor)
+        mv.visitFieldInsn(Opcodes.PUTFIELD, classInternalName, "pc", CD_int.descriptorString())
         for ((name, index, isWild, fieldType, _) <- lparams) {
           if (isWild) {
             nop()
           } else {
             DUP()(mv)
             // fieldType is erased (Object for refs), so xLoad always matches the verifier type
-            Instructions.xLoad(fieldType.toClassDesc, index)(mv)
-            mv.visitFieldInsn(Opcodes.PUTFIELD, classInternalName, name, fieldType.toDescriptor)
+            Instructions.xLoad(fieldType, index)(mv)
+            mv.visitFieldInsn(Opcodes.PUTFIELD, classInternalName, name, fieldType.descriptorString())
           }
         }
         POP()(mv)
@@ -424,12 +425,10 @@ object GenFunAndClosureClasses {
       def narrowLocals(mv: MethodVisitor): Unit = {
         for ((_, index, isWild, erasedType, Some(realType)) <- lparams) {
           if (!isWild) {
-            realType match {
-              case _: BackendType.PrimitiveType => () // primitives don't need narrowing
-              case _ =>
-                Instructions.xLoad(erasedType.toClassDesc, index)(mv)
-                Instructions.castIfNotPrim(realType.toClassDesc)(mv)
-                Instructions.xStore(realType.toClassDesc, index)(mv)
+            if (!realType.isPrimitive) { // primitives don't need narrowing
+              Instructions.xLoad(erasedType, index)(mv)
+              Instructions.castIfNotPrim(realType)(mv)
+              Instructions.xStore(realType, index)(mv)
             }
           }
         }
@@ -446,18 +445,18 @@ object GenFunAndClosureClasses {
     m.visitEnd()
   }
 
-  private def loadFromField(m: MethodVisitor, className: ClassDesc, name: String, localIndex: Int, fieldType: BackendType, castTo: Option[BackendType]): Unit = {
+  private def loadFromField(m: MethodVisitor, className: ClassDesc, name: String, localIndex: Int, fieldType: ClassDesc, castTo: Option[ClassDesc]): Unit = {
     implicit val mm: MethodVisitor = m
     // retrieve the erased field
     m.visitVarInsn(ALOAD, 0)
-    m.visitFieldInsn(GETFIELD, ClassDescs.internalNameOf(className), name, fieldType.toDescriptor)
+    m.visitFieldInsn(GETFIELD, ClassDescs.internalNameOf(className), name, fieldType.descriptorString())
     // cast the value and store it
     castTo match {
       case Some(targetType) =>
-        Instructions.castIfNotPrim(targetType.toClassDesc)
-        Instructions.xStore(targetType.toClassDesc, localIndex)
+        Instructions.castIfNotPrim(targetType)
+        Instructions.xStore(targetType, localIndex)
       case None =>
-        Instructions.xStore(fieldType.toClassDesc, localIndex)
+        Instructions.xStore(fieldType, localIndex)
     }
   }
 
@@ -468,10 +467,10 @@ object GenFunAndClosureClasses {
   private def mkCopy(className: ClassDesc, defn: Def)(implicit mv: MethodVisitor, root: Root): Unit = {
     import Instructions.*
     val classInternalName = ClassDescs.internalNameOf(className)
-    val pc = List(("pc", BackendType.Int32))
-    val fparams = defn.fparams.zipWithIndex.map(p => (s"arg${p._2}", BackendType.toErasedBackendType(p._1.tpe)))
-    val cparams = defn.cparams.zipWithIndex.map(p => (s"clo${p._2}", BackendType.toBackendType(p._1.tpe)))
-    val lparams = defn.lparams.zipWithIndex.map(p => (s"l${p._2}", BackendType.toErasedBackendType(p._1.tpe)))
+    val pc = List(("pc", CD_int))
+    val fparams = defn.fparams.zipWithIndex.map(p => (s"arg${p._2}", BackendType.toErasedClassDesc(p._1.tpe)))
+    val cparams = defn.cparams.zipWithIndex.map(p => (s"clo${p._2}", BackendType.toClassDesc(p._1.tpe)))
+    val lparams = defn.lparams.zipWithIndex.map(p => (s"l${p._2}", BackendType.toErasedClassDesc(p._1.tpe)))
     val params = pc ++ fparams ++ cparams ++ lparams
 
     NEW(className)
@@ -480,8 +479,8 @@ object GenFunAndClosureClasses {
     for ((name, fieldType) <- params) {
       DUP()
       thisLoad()
-      mv.visitFieldInsn(Opcodes.GETFIELD, classInternalName, name, fieldType.toDescriptor)
-      mv.visitFieldInsn(Opcodes.PUTFIELD, classInternalName, name, fieldType.toDescriptor)
+      mv.visitFieldInsn(Opcodes.GETFIELD, classInternalName, name, fieldType.descriptorString())
+      mv.visitFieldInsn(Opcodes.PUTFIELD, classInternalName, name, fieldType.descriptorString())
     }
   }
 


### PR DESCRIPTION
Adds `BackendType.toErasedClassDesc(SimpleType)` — a direct, allocation-free erased conversion mirroring `toErasedBackendType` — and migrates the sites that built `BackendType`s only to immediately flatten them to descriptors:

- `GenFunAndClosureClasses`: the erased param/local tuples are `ClassDesc` end-to-end (field generation, `loadFromField`, `narrowLocals`, `mkCopy`, `setPc`).
- `GenExpression`: `ArrayNew` is now fully `BackendType`-free (including the `Arrays.fill` descriptor), plus closure capture and the four Java field-access descriptor sites.
- `BackendObjType`: `shimIns` and the `Global.setArgs` descriptor (the last `BackendType.Array` allocation).

Also deletes dead code: `BackendType.stackSlots` and the unused `toBackendType(ClassDesc)` overload.

Benchmarked with `Xperf --par --n 50` (full pipeline, one warmup + three adjacent A/B pairs vs master): per-pair median deltas +1.5%, −2.8%, −1.4% — within the noise floor, i.e. performance-neutral.

The remaining `BackendType` surface (the `toClassDesc` bridges, `MethodTypeDescs`' `BackendType` varargs, and `BackendObjType`'s parametrization) is scheduled for the `jvm.classes` breakup series.

Follow-up to #13107, #13117, #13118, #13120–#13122, #13125, #13126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)