### PR TITLE
fix(pkg): remove dead InterruptedException handling in GitHub.download

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/github/GitHub.scala
@@ -248,9 +248,6 @@ object GitHub {
       Client.sendStreamingRequest(request)
     } catch {
       case ex: IOException => return Err(PackageError.DownloadUnreachable(url, ex.getMessage))
-      case ex: InterruptedException =>
-        Thread.currentThread().interrupt()
-        return Err(PackageError.DownloadUnreachable(url, ex.getMessage))
     }
 
     response.statusCode() match {


### PR DESCRIPTION
## Summary

Follow-up to #13071, which proposed extending `download()`'s `InterruptedException` handling to the other blocking HTTP calls in `GitHub.scala`. That PR was closed because the premise was wrong in the other direction: the package manager's blocking calls run on the main thread during bootstrap, so nothing interrupts them and the catch clause is dead code.

Per @magnus-madsen's comment on that PR ("We should remove the other catches and rethrow of `InterruptedException` that we added a bit earlier"), this removes the remaining catch in `download()`, leaving only the `IOException` clause. `GitHub.scala` now has no `InterruptedException` handling at all.
