### PR TITLE
refactor: make MethodTypeDescs nominal and seed the jvm.classes package

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -18,15 +18,15 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{JvmAst, SimpleType, SourceLocation, Symbol}
-import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.{mkClassName, mkDesc}
-import ca.uwaterloo.flix.language.phase.jvm.BackendType.RichClassDesc
+import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.mkClassName
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.Branch.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.{IsVolatile, NotVolatile}
-import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, RootPackage}
+import ca.uwaterloo.flix.language.phase.jvm.classes.GenGlobal
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, RootPackage, mkDesc}
 import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoidDescriptor}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
@@ -60,7 +60,6 @@ sealed trait BackendObjType {
     case BackendObjType.RecordExtend(value) => mkDesc(RootPackage, mkClassName("RecordExtend", value))
     case BackendObjType.Record => mkDesc(RootPackage, mkClassName("Record"))
     case BackendObjType.ReifiedSourceLocation => mkDesc(DevFlixRuntime, mkClassName("ReifiedSourceLocation"))
-    case BackendObjType.Global => mkDesc(DevFlixRuntime, "Global") // "Global" is fixed in source code, so should not be mangled and $ suffixed
     case BackendObjType.HoleError => mkDesc(DevFlixRuntime, mkClassName("HoleError"))
     case BackendObjType.MatchError => mkDesc(DevFlixRuntime, mkClassName("MatchError"))
     case BackendObjType.CastError => mkDesc(DevFlixRuntime, mkClassName("CastError"))
@@ -97,31 +96,9 @@ sealed trait BackendObjType {
     * Returns `this` wrapped in `BackendType.Reference`.
     */
   def toTpe: BackendType.Reference = BackendType.Reference(this)
-
-  /** `[] --> return` */
-  protected def nullarySuperConstructor(superClass: ConstructorMethod)(implicit mv: MethodVisitor): Unit = {
-    thisLoad()
-    INVOKESPECIAL(superClass)
-    RETURN()
-  }
-
-  /** `[] --> return` */
-  protected def singletonStaticConstructor(thisConstructor: ConstructorMethod, singleton: StaticField)(implicit mv: MethodVisitor): Unit = {
-    NEW(this.desc)
-    DUP()
-    INVOKESPECIAL(thisConstructor)
-    PUTSTATIC(singleton)
-    RETURN()
-  }
 }
 
 object BackendObjType {
-
-  /** Returns the [[ClassDesc]] of the class `name` in the package `pkg`. */
-  private def mkDesc(pkg: List[String], name: String): ClassDesc = {
-    val prefix = if (pkg.isEmpty) "" else pkg.mkString("", "/", "/")
-    ClassDesc.ofInternalName(prefix + name)
-  }
 
   private def mkClassName(prefix: String, tpe: BackendType): String = {
     Mangle.mkClassName(prefix, tpe.toErasedString)
@@ -194,7 +171,7 @@ object BackendObjType {
         RETURN()
       })
 
-    def ForceMethod: InstanceMethod = InstanceMethod(this.desc, "force", mkDescriptor()(tpe))
+    def ForceMethod: InstanceMethod = InstanceMethod(this.desc, "force", mkDescriptor()(tpe.toClassDesc))
 
     /** `[] --> return tpe` */
     private def forceIns(implicit mv: MethodVisitor): Unit = {
@@ -458,7 +435,7 @@ object BackendObjType {
 
     def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def GetUniqueThreadClosureMethod: AbstractMethod = AbstractMethod(this.desc, "getUniqueThreadClosure", mkDescriptor()(this.toTpe))
+    def GetUniqueThreadClosureMethod: AbstractMethod = AbstractMethod(this.desc, "getUniqueThreadClosure", mkDescriptor()(this.desc))
 
   }
 
@@ -514,35 +491,35 @@ object BackendObjType {
         */
       def functionMethod: InstanceMethod = this match {
         case ObjFunction => InstanceMethod(this.desc, "apply",
-          mkDescriptor(BackendType.Object)(BackendType.Object))
+          mkDescriptor(JavaClasses.Object)(JavaClasses.Object))
         case ObjConsumer => InstanceMethod(this.desc, "accept",
-          mkVoidDescriptor(BackendType.Object))
+          mkVoidDescriptor(JavaClasses.Object))
         case ObjPredicate => InstanceMethod(this.desc, "test",
-          mkDescriptor(BackendType.Object)(BackendType.Bool))
+          mkDescriptor(JavaClasses.Object)(CD_boolean))
         case IntFunction => InstanceMethod(this.desc, "apply",
-          mkDescriptor(BackendType.Int32)(BackendType.Object))
+          mkDescriptor(CD_int)(JavaClasses.Object))
         case IntConsumer => InstanceMethod(this.desc, "accept",
-          mkVoidDescriptor(BackendType.Int32))
+          mkVoidDescriptor(CD_int))
         case IntPredicate => InstanceMethod(this.desc, "test",
-          mkDescriptor(BackendType.Int32)(BackendType.Bool))
+          mkDescriptor(CD_int)(CD_boolean))
         case IntUnaryOperator => InstanceMethod(this.desc, "applyAsInt",
-          mkDescriptor(BackendType.Int32)(BackendType.Int32))
+          mkDescriptor(CD_int)(CD_int))
         case LongFunction => InstanceMethod(this.desc, "apply",
-          mkDescriptor(BackendType.Int64)(BackendType.Object))
+          mkDescriptor(CD_long)(JavaClasses.Object))
         case LongConsumer => InstanceMethod(this.desc, "accept",
-          mkVoidDescriptor(BackendType.Int64))
+          mkVoidDescriptor(CD_long))
         case LongPredicate => InstanceMethod(this.desc, "test",
-          mkDescriptor(BackendType.Int64)(BackendType.Bool))
+          mkDescriptor(CD_long)(CD_boolean))
         case LongUnaryOperator => InstanceMethod(this.desc, "applyAsLong",
-          mkDescriptor(BackendType.Int64)(BackendType.Int64))
+          mkDescriptor(CD_long)(CD_long))
         case DoubleFunction => InstanceMethod(this.desc, "apply",
-          mkDescriptor(BackendType.Float64)(BackendType.Object))
+          mkDescriptor(CD_double)(JavaClasses.Object))
         case DoubleConsumer => InstanceMethod(this.desc, "accept",
-          mkVoidDescriptor(BackendType.Float64))
+          mkVoidDescriptor(CD_double))
         case DoublePredicate => InstanceMethod(this.desc, "test",
-          mkDescriptor(BackendType.Float64)(BackendType.Bool))
+          mkDescriptor(CD_double)(CD_boolean))
         case DoubleUnaryOperator => InstanceMethod(this.desc, "applyAsDouble",
-          mkDescriptor(BackendType.Float64)(BackendType.Float64))
+          mkDescriptor(CD_double)(CD_double))
       }
 
       /**
@@ -875,10 +852,10 @@ object BackendObjType {
     }
 
     def LookupFieldMethod: InterfaceMethod = InterfaceMethod(this.desc, "lookupField",
-      mkDescriptor(BackendType.String)(this.toTpe))
+      mkDescriptor(JavaClasses.String)(this.desc))
 
     def RestrictFieldMethod: InterfaceMethod = InterfaceMethod(this.desc, "restrictField",
-      mkDescriptor(BackendType.String)(this.toTpe))
+      mkDescriptor(JavaClasses.String)(this.desc))
   }
 
   /**
@@ -969,95 +946,6 @@ object BackendObjType {
       // create the string
       INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
       ARETURN()
-    }
-  }
-
-  case object Global extends BackendObjType {
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.desc, IsFinal)
-
-      cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-      cm.mkStaticConstructor(StaticConstructorMethod(this.desc), staticConstructorIns(_))
-
-      cm.mkField(CounterField, IsPrivate, IsFinal, NotVolatile)
-      cm.mkStaticMethod(NewIdMethod, IsPublic, IsFinal, newIdIns(_))
-
-      cm.mkField(ArgsField, IsPrivate, NotFinal, NotVolatile)
-      cm.mkStaticMethod(GetArgsMethod, IsPublic, IsFinal, getArgsIns(_))
-      cm.mkStaticMethod(SetArgsMethod, IsPublic, IsFinal, setArgsIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
-
-    private def staticConstructorIns(implicit mv: MethodVisitor): Unit = {
-      NEW(JavaClasses.AtomicLong)
-      DUP()
-      invokeConstructor(JavaClasses.AtomicLong, MethodTypeDescs.NothingToVoid)
-      PUTSTATIC(CounterField)
-      ICONST_0()
-      ANEWARRAY(JavaClasses.String)
-      PUTSTATIC(ArgsField)
-      RETURN()
-    }
-
-    private def NewIdMethod: StaticMethod = StaticMethod(this.desc, "newId", mkDescriptor()(BackendType.Int64))
-
-    private def newIdIns(implicit mv: MethodVisitor): Unit = {
-      GETSTATIC(CounterField)
-      INVOKEVIRTUAL(JavaClasses.AtomicLong, "getAndIncrement",
-        mkDescriptor()(BackendType.Int64))
-      LRETURN()
-    }
-
-    private def GetArgsMethod: StaticMethod = StaticMethod(this.desc, "getArgs", mkDescriptor()(BackendType.Array(BackendType.String)))
-
-    private def getArgsIns(implicit mv: MethodVisitor): Unit = {
-      GETSTATIC(ArgsField)
-      ARRAYLENGTH()
-      ANEWARRAY(JavaClasses.String)
-      ASTORE(0)
-      // the new array is now created, now to copy the args
-      GETSTATIC(ArgsField)
-      ICONST_0()
-      ALOAD(0)
-      ICONST_0()
-      GETSTATIC(ArgsField)
-      ARRAYLENGTH()
-      arrayCopy()
-      ALOAD(0)
-      ARETURN()
-    }
-
-    def SetArgsMethod: StaticMethod =
-      StaticMethod(this.desc, "setArgs", MethodTypeDesc.of(CD_void, JavaClasses.String.arrayType()))
-
-    private def setArgsIns(implicit mv: MethodVisitor): Unit = {
-      ALOAD(0)
-      ARRAYLENGTH()
-      ANEWARRAY(JavaClasses.String)
-      ASTORE(1)
-      ALOAD(0)
-      ICONST_0()
-      ALOAD(1)
-      ICONST_0()
-      ALOAD(0)
-      ARRAYLENGTH()
-      arrayCopy()
-      ALOAD(1)
-      PUTSTATIC(ArgsField)
-      RETURN()
-    }
-
-    private def CounterField: StaticField = StaticField(this.desc, "counter", JavaClasses.AtomicLong)
-
-    private def ArgsField: StaticField = StaticField(this.desc, "args", JavaClasses.String.arrayType())
-
-    private def arrayCopy()(implicit mv: MethodVisitor): Unit = {
-      mv.visitMethodInstruction(Opcodes.INVOKESTATIC, JavaClasses.System, "arraycopy",
-        mkVoidDescriptor(BackendType.Object, BackendType.Int32, BackendType.Object, BackendType.Int32,
-          BackendType.Int32), isInterface = false)
     }
   }
 
@@ -1299,7 +1187,7 @@ object BackendObjType {
     //   t.start();
     //   threads.add(t);
     // }
-    def SpawnMethod: InstanceMethod = InstanceMethod(this.desc, "spawn", mkVoidDescriptor(JavaClasses.Runnable.toTpe))
+    def SpawnMethod: InstanceMethod = InstanceMethod(this.desc, "spawn", mkVoidDescriptor(JavaClasses.Runnable))
 
     private def spawnIns(implicit mv: MethodVisitor): Unit = {
       INVOKESTATIC(ClassConstants.Thread.OfVirtualMethod)
@@ -1310,7 +1198,7 @@ object BackendObjType {
         NEW(BackendObjType.UncaughtExceptionHandler.desc)
         DUP()
         thisLoad()
-        invokeConstructor(BackendObjType.UncaughtExceptionHandler.desc, mkVoidDescriptor(BackendObjType.Region.toTpe))
+        invokeConstructor(BackendObjType.UncaughtExceptionHandler.desc, mkVoidDescriptor(BackendObjType.Region.desc))
         INVOKEVIRTUAL(ClassConstants.Thread.SetUncaughtExceptionHandlerMethod)
         thread.load()
         INVOKEVIRTUAL(ClassConstants.Thread.StartMethod)
@@ -1368,7 +1256,7 @@ object BackendObjType {
     //   childException = e;
     //   regionThread.interrupt();
     // }
-    def ReportChildExceptionMethod: InstanceMethod = InstanceMethod(this.desc, "reportChildException", mkVoidDescriptor(JavaClasses.Throwable.toTpe))
+    def ReportChildExceptionMethod: InstanceMethod = InstanceMethod(this.desc, "reportChildException", mkVoidDescriptor(JavaClasses.Throwable))
 
     private def reportChildExceptionIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
@@ -1400,7 +1288,7 @@ object BackendObjType {
     // final public void runOnExit(Runnable r) {
     //   onExit.addFirst(r);
     // }
-    private def RunOnExitMethod: InstanceMethod = InstanceMethod(this.desc, "runOnExit", mkVoidDescriptor(JavaClasses.Runnable.toTpe))
+    private def RunOnExitMethod: InstanceMethod = InstanceMethod(this.desc, "runOnExit", mkVoidDescriptor(JavaClasses.Runnable))
 
     private def runOnExitIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
@@ -1461,13 +1349,13 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def MainMethod: StaticMethod = StaticMethod(this.desc, "main", mkVoidDescriptor(BackendType.Array(BackendType.String)))
+    def MainMethod: StaticMethod = StaticMethod(this.desc, "main", mkVoidDescriptor(JavaClasses.String.arrayType()))
 
     private def mainIns(sym: Symbol.DefnSym)(implicit mv: MethodVisitor): Unit = {
       val defName = BackendObjType.Defn(sym).desc
       withName(0, JavaClasses.String.arrayType())(args => {
         args.load()
-        INVOKESTATIC(Global.SetArgsMethod)
+        INVOKESTATIC(GenGlobal.SetArgsMethod)
         NEW(defName)
         DUP()
         INVOKESPECIAL(defName, ConstructorMethodName, MethodTypeDescs.NothingToVoid)
@@ -1498,8 +1386,8 @@ object BackendObjType {
     def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
     def ShimMethod(defn: JvmAst.Def): StaticMethod = {
-      val erasedArgs = defn.fparams.map(_.tpe).map(BackendType.toErasedBackendType)
-      val erasedResult = BackendType.toErasedBackendType(defn.unboxedType.tpe)
+      val erasedArgs = defn.fparams.map(_.tpe).map(BackendType.toErasedClassDesc)
+      val erasedResult = BackendType.toErasedClassDesc(defn.unboxedType.tpe)
       // Exported names are checked in Safety, so no mangling is needed.
       val name = if (defn.ann.isExport) defn.sym.name else "m_" + Mangle.mangle(defn.sym.name)
       StaticMethod(this.desc, name, mkDescriptor(erasedArgs *)(erasedResult))
@@ -1760,12 +1648,12 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "applyFrame", mkDescriptor(Value.toTpe)(Result.toTpe))
+    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "applyFrame", mkDescriptor(Value.desc)(Result.desc))
 
     def StaticApplyMethod: StaticInterfaceMethod = StaticInterfaceMethod(
       this.desc,
       "applyFrameStatic",
-      mkDescriptor(Frame.toTpe, Value.toTpe)(Result.toTpe)
+      mkDescriptor(Frame.desc, Value.desc)(Result.desc)
     )
 
     private def staticApplyIns(implicit mv: MethodVisitor): Unit = {
@@ -1791,7 +1679,7 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def InvokeMethod: InterfaceMethod = InterfaceMethod(this.desc, "invoke", mkDescriptor()(Result.toTpe))
+    def InvokeMethod: InterfaceMethod = InterfaceMethod(this.desc, "invoke", mkDescriptor()(Result.desc))
 
     private def RunMethod: DefaultMethod = DefaultMethod(this.desc, "run", mkVoidDescriptor())
 
@@ -1840,9 +1728,9 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def PushMethod: InterfaceMethod = InterfaceMethod(this.desc, "push", mkDescriptor(Frame.toTpe)(Frames.toTpe))
+    def PushMethod: InterfaceMethod = InterfaceMethod(this.desc, "push", mkDescriptor(Frame.desc)(Frames.desc))
 
-    def ReverseOntoMethod: InterfaceMethod = InterfaceMethod(this.desc, "reverseOnto", mkDescriptor(Frames.toTpe)(Frames.toTpe))
+    def ReverseOntoMethod: InterfaceMethod = InterfaceMethod(this.desc, "reverseOnto", mkDescriptor(Frames.desc)(Frames.desc))
 
     def pushImplementation(implicit mv: MethodVisitor): Unit = {
       withName(1, Frame.desc) { frame =>
@@ -1934,9 +1822,9 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def RewindMethod: InterfaceMethod = InterfaceMethod(this.desc, "rewind", mkDescriptor(Value.toTpe)(Result.toTpe))
+    def RewindMethod: InterfaceMethod = InterfaceMethod(this.desc, "rewind", mkDescriptor(Value.desc)(Result.desc))
 
-    def StaticRewindMethod: StaticInterfaceMethod = StaticInterfaceMethod(this.desc, "staticRewind", mkDescriptor(Resumption.toTpe, Value.toTpe)(Result.toTpe))
+    def StaticRewindMethod: StaticInterfaceMethod = StaticInterfaceMethod(this.desc, "staticRewind", mkDescriptor(Resumption.desc, Value.desc)(Result.desc))
 
     private def staticRewindIns(implicit mv: MethodVisitor): Unit = {
       withName(0, Resumption.desc) { resumption =>
@@ -2028,7 +1916,7 @@ object BackendObjType {
     def InstallHandlerMethod: StaticInterfaceMethod = StaticInterfaceMethod(
       this.desc,
       "installHandler",
-      mkDescriptor(BackendType.String, Handler.toTpe, Frames.toTpe, Thunk.toTpe)(Result.toTpe)
+      mkDescriptor(JavaClasses.String, Handler.desc, Frames.desc, Thunk.desc)(Result.desc)
     )
 
     private def installHandlerIns(implicit mv: MethodVisitor): Unit = {
@@ -2148,7 +2036,7 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "apply", mkDescriptor(Handler.toTpe, Resumption.toTpe)(Result.toTpe))
+    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "apply", mkDescriptor(Handler.desc, Resumption.desc)(Result.desc))
 
   }
 
@@ -2212,7 +2100,7 @@ object BackendObjType {
       xReturn(Result.desc)
     }
 
-    private def UniqueMethod: InstanceMethod = InstanceMethod(this.desc, "getUniqueThreadClosure", mkDescriptor()(this.superClass.toTpe))
+    private def UniqueMethod: InstanceMethod = InstanceMethod(this.desc, "getUniqueThreadClosure", mkDescriptor()(this.superClass.desc))
 
     private def uniqueIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassConstants.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassConstants.scala
@@ -18,13 +18,13 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
-import ca.uwaterloo.flix.language.phase.jvm.BackendType.RichClassDesc
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceMethod, InterfaceMethod, StaticMethod}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
 import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoidDescriptor}
 import org.objectweb.asm.MethodVisitor
 
 import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.{CD_boolean, CD_int}
 
 object ClassConstants {
 
@@ -32,7 +32,7 @@ object ClassConstants {
 
   object FlixError {
 
-    val Desc: ClassDesc = ClassDesc.ofInternalName((Mangle.DevFlixRuntime :+ Mangle.mkClassName("FlixError")).mkString("/"))
+    val Desc: ClassDesc = Mangle.mkDesc(Mangle.DevFlixRuntime, Mangle.mkClassName("FlixError"))
 
     val Constructor: ConstructorMethod = ConstructorMethod(Desc, List(JavaClasses.String))
 
@@ -45,7 +45,7 @@ object ClassConstants {
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
       thisLoad()
       ALOAD(1)
-      invokeConstructor(JavaClasses.Error, mkVoidDescriptor(BackendType.String))
+      invokeConstructor(JavaClasses.Error, mkVoidDescriptor(JavaClasses.String))
       RETURN()
     }
 
@@ -64,35 +64,35 @@ object ClassConstants {
   object ConcurrentLinkedQueue {
 
     val AddMethod: InstanceMethod =
-      InstanceMethod(JavaClasses.ConcurrentLinkedQueue, "add", mkDescriptor(BackendType.Object)(BackendType.Bool))
+      InstanceMethod(JavaClasses.ConcurrentLinkedQueue, "add", mkDescriptor(JavaClasses.Object)(CD_boolean))
 
     val PollMethod: InstanceMethod =
-      InstanceMethod(JavaClasses.ConcurrentLinkedQueue, "poll", mkDescriptor()(BackendType.Object))
+      InstanceMethod(JavaClasses.ConcurrentLinkedQueue, "poll", mkDescriptor()(JavaClasses.Object))
 
   }
 
   object Iterator {
 
     val HasNextMethod: InterfaceMethod =
-      InterfaceMethod(JavaClasses.Iterator, "hasNext", mkDescriptor()(BackendType.Bool))
+      InterfaceMethod(JavaClasses.Iterator, "hasNext", mkDescriptor()(CD_boolean))
 
     val NextMethod: InterfaceMethod =
-      InterfaceMethod(JavaClasses.Iterator, "next", mkDescriptor()(BackendType.Object))
+      InterfaceMethod(JavaClasses.Iterator, "next", mkDescriptor()(JavaClasses.Object))
 
   }
 
   object LambdaMetafactory {
     val MetafactoryMethod: StaticMethod =
-      StaticMethod(JavaClasses.LambdaMetafactory, "metafactory", mkDescriptor(JavaClasses.MethodHandles$Lookup.toTpe, BackendType.String, JavaClasses.MethodType.toTpe, JavaClasses.MethodType.toTpe, JavaClasses.MethodHandle.toTpe, JavaClasses.MethodType.toTpe)(JavaClasses.CallSite.toTpe))
+      StaticMethod(JavaClasses.LambdaMetafactory, "metafactory", mkDescriptor(JavaClasses.MethodHandles$Lookup, JavaClasses.String, JavaClasses.MethodType, JavaClasses.MethodType, JavaClasses.MethodHandle, JavaClasses.MethodType)(JavaClasses.CallSite))
   }
 
   object LinkedList {
 
     val AddFirstMethod: InstanceMethod =
-      InstanceMethod(JavaClasses.LinkedList, "addFirst", mkVoidDescriptor(BackendType.Object))
+      InstanceMethod(JavaClasses.LinkedList, "addFirst", mkVoidDescriptor(JavaClasses.Object))
 
     val IteratorMethod: InstanceMethod =
-      InstanceMethod(JavaClasses.LinkedList, "iterator", mkDescriptor()(JavaClasses.Iterator.toTpe))
+      InstanceMethod(JavaClasses.LinkedList, "iterator", mkDescriptor()(JavaClasses.Iterator))
 
   }
 
@@ -101,10 +101,10 @@ object ClassConstants {
     val Constructor: ConstructorMethod = ConstructorMethod(JavaClasses.Object, Nil)
 
     val EqualsMethod: InstanceMethod =
-      InstanceMethod(JavaClasses.Object, "equals", mkDescriptor(BackendType.Object)(BackendType.Bool))
+      InstanceMethod(JavaClasses.Object, "equals", mkDescriptor(JavaClasses.Object)(CD_boolean))
 
     val ToStringMethod: InstanceMethod =
-      InstanceMethod(JavaClasses.Object, "toString", mkDescriptor()(BackendType.String))
+      InstanceMethod(JavaClasses.Object, "toString", mkDescriptor()(JavaClasses.String))
 
   }
 
@@ -121,7 +121,7 @@ object ClassConstants {
 
   object Regex {
     val CompileMethod: StaticMethod =
-      StaticMethod(JavaClasses.Regex, "compile", mkDescriptor(BackendType.String)(JavaClasses.Regex.toTpe))
+      StaticMethod(JavaClasses.Regex, "compile", mkDescriptor(JavaClasses.String)(JavaClasses.Regex))
   }
 
   object Runnable {
@@ -133,17 +133,17 @@ object ClassConstants {
     val Constructor: ConstructorMethod = ConstructorMethod(JavaClasses.StringBuilder, Nil)
 
     val AppendStringMethod: InstanceMethod =
-      InstanceMethod(JavaClasses.StringBuilder, "append", mkDescriptor(BackendType.String)(JavaClasses.StringBuilder.toTpe))
+      InstanceMethod(JavaClasses.StringBuilder, "append", mkDescriptor(JavaClasses.String)(JavaClasses.StringBuilder))
 
     val AppendInt32Method: InstanceMethod =
-      InstanceMethod(JavaClasses.StringBuilder, "append", mkDescriptor(BackendType.Int32)(JavaClasses.StringBuilder.toTpe))
+      InstanceMethod(JavaClasses.StringBuilder, "append", mkDescriptor(CD_int)(JavaClasses.StringBuilder))
 
   }
 
   object Thread {
 
     val CurrentThreadMethod: StaticMethod =
-      StaticMethod(JavaClasses.Thread, "currentThread", mkDescriptor()(JavaClasses.Thread.toTpe))
+      StaticMethod(JavaClasses.Thread, "currentThread", mkDescriptor()(JavaClasses.Thread))
 
     val InterruptMethod: InstanceMethod =
       InstanceMethod(JavaClasses.Thread, "interrupt", MethodTypeDescs.NothingToVoid)
@@ -152,27 +152,27 @@ object ClassConstants {
       InstanceMethod(JavaClasses.Thread, "join", MethodTypeDescs.NothingToVoid)
 
     val OfVirtualMethod: StaticMethod =
-      StaticMethod(JavaClasses.Thread, "ofVirtual", mkDescriptor()(JavaClasses.Thread$Builder$OfVirtual.toTpe))
+      StaticMethod(JavaClasses.Thread, "ofVirtual", mkDescriptor()(JavaClasses.Thread$Builder$OfVirtual))
 
     val SetUncaughtExceptionHandlerMethod: InstanceMethod =
-      InstanceMethod(JavaClasses.Thread, "setUncaughtExceptionHandler", mkVoidDescriptor(JavaClasses.Thread$UncaughtExceptionHandler.toTpe))
+      InstanceMethod(JavaClasses.Thread, "setUncaughtExceptionHandler", mkVoidDescriptor(JavaClasses.Thread$UncaughtExceptionHandler))
 
     val StartMethod: InstanceMethod =
       InstanceMethod(JavaClasses.Thread, "start", MethodTypeDescs.NothingToVoid)
 
     val StartVirtualThreadMethod: StaticMethod =
-      ClassMaker.StaticMethod(JavaClasses.Thread, "startVirtualThread", mkDescriptor(JavaClasses.Runnable.toTpe)(JavaClasses.Thread.toTpe))
+      ClassMaker.StaticMethod(JavaClasses.Thread, "startVirtualThread", mkDescriptor(JavaClasses.Runnable)(JavaClasses.Thread))
 
   }
 
   object ThreadBuilderOfVirtual {
     val UnstartedMethod: InterfaceMethod =
-      InterfaceMethod(JavaClasses.Thread$Builder$OfVirtual, "unstarted", mkDescriptor(JavaClasses.Runnable.toTpe)(JavaClasses.Thread.toTpe))
+      InterfaceMethod(JavaClasses.Thread$Builder$OfVirtual, "unstarted", mkDescriptor(JavaClasses.Runnable)(JavaClasses.Thread))
   }
 
   object ThreadUncaughtExceptionHandler {
     val UncaughtExceptionMethod: InstanceMethod =
-      InstanceMethod(JavaClasses.Thread$UncaughtExceptionHandler, "uncaughtException", mkVoidDescriptor(JavaClasses.Thread.toTpe, JavaClasses.Throwable.toTpe))
+      InstanceMethod(JavaClasses.Thread$UncaughtExceptionHandler, "uncaughtException", mkVoidDescriptor(JavaClasses.Thread, JavaClasses.Throwable))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{BytecodeAst, SimpleType, SourceLocation}
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugNoOp
+import ca.uwaterloo.flix.language.phase.jvm.classes.GenGlobal
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 import ca.uwaterloo.flix.util.collection.MapOps
 
@@ -89,7 +90,7 @@ object CodeGen {
     val castErrorClass = List(JvmClass(BackendObjType.CastError.desc, BackendObjType.CastError.genByteCode()))
     val unhandledEffectErrorClass = List(JvmClass(BackendObjType.UnhandledEffectError.desc, BackendObjType.UnhandledEffectError.genByteCode()))
 
-    val globalClass = List(JvmClass(BackendObjType.Global.desc, BackendObjType.Global.genByteCode()))
+    val globalClass = List(JvmClass(GenGlobal.desc, GenGlobal.genByteCode()))
 
     val regionClass = List(JvmClass(BackendObjType.Region.desc, BackendObjType.Region.genByteCode()))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -70,9 +70,9 @@ object GenEffectClasses {
       val opFunction = BackendObjType.Arrow(erasedParams :+ BackendType.Object, BackendType.Object)
       val opField = ClassMaker.InstanceField(effectName, name, opFunction.desc)
       cm.mkField(opField, IsPublic, NotFinal, NotVolatile)
-      val methodArgs = erasedParams ++ List(BackendObjType.Handler.toTpe, BackendObjType.Resumption.toTpe)
+      val methodArgs = erasedParams.map(_.toClassDesc) ++ List(BackendObjType.Handler.desc, BackendObjType.Resumption.desc)
       val returnType = BackendType.toBackendType(op.tpe)
-      cm.mkStaticMethod(ClassMaker.StaticMethod(effectName, name, MethodTypeDescs.mkDescriptor(methodArgs *)(BackendObjType.Result.toTpe)), IsPublic, NotFinal, methodIns(effectName, opFunction, opField, erasedParams, returnType)(_))
+      cm.mkStaticMethod(ClassMaker.StaticMethod(effectName, name, MethodTypeDescs.mkDescriptor(methodArgs *)(BackendObjType.Result.desc)), IsPublic, NotFinal, methodIns(effectName, opFunction, opField, erasedParams, returnType)(_))
     }
 
     cm.closeClassMaker()
@@ -124,8 +124,8 @@ object GenEffectClasses {
     val effect = root.effects(sym.eff)
     val op = effect.ops.find(op => op.sym == sym).getOrElse(throw InternalCompilerException(s"Could not find op '$sym' in effect '$effect'.", sym.loc))
     val erasedParams = op.fparams.map(_.tpe).map(BackendType.toErasedBackendType)
-    val methodArgs = erasedParams ++ List(BackendObjType.Handler.toTpe, BackendObjType.Resumption.toTpe)
-    MethodTypeDescs.mkDescriptor(methodArgs *)(BackendObjType.Result.toTpe)
+    val methodArgs = erasedParams.map(_.toClassDesc) ++ List(BackendObjType.Handler.desc, BackendObjType.Resumption.desc)
+    MethodTypeDescs.mkDescriptor(methodArgs *)(BackendObjType.Result.desc)
   }
 
   /** Returns the JVM field/method name of the effect operation `sym`. */

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -276,14 +276,14 @@ object GenExpression {
             compileExpr(exp2)
             mv.visitInsn(Opcodes.F2D) // Convert to double since "pow" is only defined for doubles
             mv.visitMethodInsn(Opcodes.INVOKESTATIC, internalNameOf(JavaClasses.Math), "pow",
-              mkDescriptor(BackendType.Float64, BackendType.Float64)(BackendType.Float64).descriptorString(), false)
+              mkDescriptor(CD_double, CD_double)(CD_double).descriptorString(), false)
             mv.visitInsn(Opcodes.D2F) // Convert double to float
 
           case Float64Op.Exp =>
             compileExpr(exp1)
             compileExpr(exp2)
             mv.visitMethodInsn(Opcodes.INVOKESTATIC, internalNameOf(JavaClasses.Math), "pow",
-              mkDescriptor(BackendType.Float64, BackendType.Float64)(BackendType.Float64).descriptorString(), false)
+              mkDescriptor(CD_double, CD_double)(CD_double).descriptorString(), false)
 
           case Int8Op.Exp =>
             compileExpr(exp1)
@@ -291,7 +291,7 @@ object GenExpression {
             compileExpr(exp2)
             mv.visitInsn(Opcodes.I2D) // Convert to double since "pow" is only defined for doubles
             mv.visitMethodInsn(Opcodes.INVOKESTATIC, internalNameOf(JavaClasses.Math), "pow",
-              mkDescriptor(BackendType.Float64, BackendType.Float64)(BackendType.Float64).descriptorString(), false)
+              mkDescriptor(CD_double, CD_double)(CD_double).descriptorString(), false)
             mv.visitInsn(Opcodes.D2I) // Convert to int
             mv.visitInsn(Opcodes.I2B) // Convert int to byte
 
@@ -301,7 +301,7 @@ object GenExpression {
             compileExpr(exp2)
             mv.visitInsn(Opcodes.I2D) // Convert to double since "pow" is only defined for doubles
             mv.visitMethodInsn(Opcodes.INVOKESTATIC, internalNameOf(JavaClasses.Math), "pow",
-              mkDescriptor(BackendType.Float64, BackendType.Float64)(BackendType.Float64).descriptorString(), false)
+              mkDescriptor(CD_double, CD_double)(CD_double).descriptorString(), false)
             mv.visitInsn(Opcodes.D2I) // Convert to int
             mv.visitInsn(Opcodes.I2S) // Convert int to short
 
@@ -311,7 +311,7 @@ object GenExpression {
             compileExpr(exp2)
             mv.visitInsn(Opcodes.I2D) // Convert to double since "pow" is only defined for doubles
             mv.visitMethodInsn(Opcodes.INVOKESTATIC, internalNameOf(JavaClasses.Math), "pow",
-              mkDescriptor(BackendType.Float64, BackendType.Float64)(BackendType.Float64).descriptorString(), false)
+              mkDescriptor(CD_double, CD_double)(CD_double).descriptorString(), false)
             mv.visitInsn(Opcodes.D2I) // Convert to int
 
           case Int64Op.Exp =>
@@ -320,7 +320,7 @@ object GenExpression {
             compileExpr(exp2)
             mv.visitInsn(Opcodes.L2D) // Convert to double since "pow" is only defined for doubles
             mv.visitMethodInsn(Opcodes.INVOKESTATIC, internalNameOf(JavaClasses.Math), "pow",
-              mkDescriptor(BackendType.Float64, BackendType.Float64)(BackendType.Float64).descriptorString(), false)
+              mkDescriptor(CD_double, CD_double)(CD_double).descriptorString(), false)
             mv.visitInsn(Opcodes.D2L) // Convert to long
 
           case Int8Op.And | Int16Op.And | Int32Op.And =>
@@ -1067,7 +1067,7 @@ object GenExpression {
           // Casting to JvmType of closure abstract class
           mv.visitTypeInsn(Opcodes.CHECKCAST, internalNameOf(closureAbstractClass.desc))
           // retrieving the unique thread object
-          mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, internalNameOf(closureAbstractClass.desc), closureAbstractClass.GetUniqueThreadClosureMethod.name, mkDescriptor()(closureAbstractClass.toTpe).descriptorString(), false)
+          mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, internalNameOf(closureAbstractClass.desc), closureAbstractClass.GetUniqueThreadClosureMethod.name, mkDescriptor()(closureAbstractClass.desc).descriptorString(), false)
           // Putting arg on the Fn class
           // Duplicate the FunctionInterface
           mv.visitInsn(Opcodes.DUP)
@@ -1082,7 +1082,7 @@ object GenExpression {
           // Casting to JvmType of closure abstract class
           mv.visitTypeInsn(Opcodes.CHECKCAST, internalNameOf(closureAbstractClass.desc))
           // retrieving the unique thread object
-          mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, internalNameOf(closureAbstractClass.desc), closureAbstractClass.GetUniqueThreadClosureMethod.name, mkDescriptor()(closureAbstractClass.toTpe).descriptorString(), false)
+          mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, internalNameOf(closureAbstractClass.desc), closureAbstractClass.GetUniqueThreadClosureMethod.name, mkDescriptor()(closureAbstractClass.desc).descriptorString(), false)
           // Putting arg on the Fn class
           // Duplicate the FunctionInterface
           mv.visitInsn(Opcodes.DUP)
@@ -1142,14 +1142,13 @@ object GenExpression {
         val targetIsFunction = defn.cparams.isEmpty
         val canCallStaticMethod = Purity.isControlPure(defn.expr.purity) && targetIsFunction
         if (canCallStaticMethod) {
-          val paramTpes = defn.fparams.map(fp => BackendType.toBackendType(fp.tpe))
+          val paramTpes = defn.fparams.map(fp => BackendType.toClassDesc(fp.tpe))
           // Call the static method, using exact types
           for ((arg, tpe) <- ListOps.zip(exps, paramTpes)) {
             compileExpr(arg)
-            castIfNotPrim(tpe.toClassDesc)
+            castIfNotPrim(tpe)
           }
-          val resultTpe = BackendObjType.Result.toTpe
-          val desc = mkDescriptor(paramTpes *)(resultTpe)
+          val desc = mkDescriptor(paramTpes *)(BackendObjType.Result.desc)
           val className = internalNameOf(BackendObjType.Defn(sym).desc)
           mv.visitMethodInsn(Opcodes.INVOKESTATIC, className, ClassMaker.StaticApplyMethodName, desc.descriptorString(), false)
           BackendObjType.Result.unwindSuspensionFreeThunk("in pure function call", loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -19,7 +19,6 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.api.{CompilerConstants, Flix, FlixEvent}
 import ca.uwaterloo.flix.language.ast.JvmAst.{Def, Root}
 import ca.uwaterloo.flix.language.ast.{Purity, SimpleType, Symbol}
-import ca.uwaterloo.flix.language.phase.jvm.BackendType.RichClassDesc
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.StaticMethod
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
 import ca.uwaterloo.flix.util.{ClassDescs, ParOps}
@@ -282,7 +281,7 @@ object GenFunAndClosureClasses {
   }
 
   private def staticApplyMethod(className: ClassDesc, defn: Def)(implicit root: Root): StaticMethod =
-    StaticMethod(className, ClassMaker.StaticApplyMethodName, MethodTypeDescs.mkDescriptor(defn.fparams.map(fp => BackendType.toBackendType(fp.tpe)) *)(BackendObjType.Result.toTpe))
+    StaticMethod(className, ClassMaker.StaticApplyMethodName, MethodTypeDescs.mkDescriptor(defn.fparams.map(fp => BackendType.toClassDesc(fp.tpe)) *)(BackendObjType.Result.desc))
 
   private def compileStaticApplyMethod(visitor: ClassWriter, className: ClassDesc, defn: Def)(implicit root: Root, flix: Flix): Unit = {
     // Method header
@@ -311,7 +310,7 @@ object GenFunAndClosureClasses {
 
   private def compileStaticInvokeMethod(visitor: ClassWriter, className: ClassDesc, defn: Def)(implicit root: Root): Unit = {
     implicit val m: MethodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, BackendObjType.Thunk.InvokeMethod.name,
-      MethodTypeDescs.mkDescriptor()(BackendObjType.Result.toTpe).descriptorString(), null, null)
+      MethodTypeDescs.mkDescriptor()(BackendObjType.Result.desc).descriptorString(), null, null)
     m.visitCode()
 
     val functionInterface = BackendObjType.Arrow.fromArrowType(defn.arrowType).desc
@@ -337,7 +336,7 @@ object GenFunAndClosureClasses {
 
   private def compileInvokeMethod(visitor: ClassWriter, className: ClassDesc): Unit = {
     implicit val m: MethodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, BackendObjType.Thunk.InvokeMethod.name,
-      MethodTypeDescs.mkDescriptor()(BackendObjType.Result.toTpe).descriptorString(), null, null)
+      MethodTypeDescs.mkDescriptor()(BackendObjType.Result.desc).descriptorString(), null, null)
     m.visitCode()
 
     val applyMethod = BackendObjType.Frame.ApplyMethod
@@ -501,7 +500,7 @@ object GenFunAndClosureClasses {
 
   private def compileGetUniqueThreadClosureMethod(visitor: ClassWriter, className: ClassDesc, defn: Def)(implicit root: Root): Unit = {
     val closureAbstractClass = BackendObjType.AbstractArrow.fromArrowType(defn.arrowType)
-    implicit val m: MethodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC, closureAbstractClass.GetUniqueThreadClosureMethod.name, MethodTypeDescs.mkDescriptor()(closureAbstractClass.toTpe).descriptorString(), null, null)
+    implicit val m: MethodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC, closureAbstractClass.GetUniqueThreadClosureMethod.name, MethodTypeDescs.mkDescriptor()(closureAbstractClass.desc).descriptorString(), null, null)
     m.visitCode()
 
     mkCopy(className, defn)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
@@ -406,6 +406,13 @@ object Instructions {
   def nop(): Unit =
     ()
 
+  /** `[] --> return`, the body of a constructor that only calls the nullary `superClass` constructor. */
+  def nullarySuperConstructor(superClass: ConstructorMethod)(implicit mv: MethodVisitor): Unit = {
+    thisLoad()
+    INVOKESPECIAL(superClass)
+    RETURN()
+  }
+
   def pushBool(b: Boolean)(implicit mv: MethodVisitor): Unit =
     if (b) ICONST_1() else ICONST_0()
 
@@ -437,6 +444,15 @@ object Instructions {
     pushInt(loc.endLine)
     pushInt(loc.endCol)
     INVOKESPECIAL(BackendObjType.ReifiedSourceLocation.Constructor)
+  }
+
+  /** `[] --> return`, the body of a static constructor that stores a fresh instance in `singleton`. */
+  def singletonStaticConstructor(thisConstructor: ConstructorMethod, singleton: StaticField)(implicit mv: MethodVisitor): Unit = {
+    NEW(thisConstructor.clazz)
+    DUP()
+    INVOKESPECIAL(thisConstructor)
+    PUTSTATIC(singleton)
+    RETURN()
   }
 
   /** Emits an `xStore` of `tpe` at `index` and runs `body` with the corresponding [[Variable]]. */

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
@@ -19,6 +19,8 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 
+import java.lang.constant.ClassDesc
+
 /**
   * Name mangling and construction of class names for generated classes.
   */
@@ -29,6 +31,12 @@ object Mangle {
 
   /** The `dev.flix.runtime` package of the Flix runtime classes. */
   val DevFlixRuntime: List[String] = List("dev", "flix", "runtime")
+
+  /** Returns the [[ClassDesc]] of the class `name` in the package `pkg`. */
+  def mkDesc(pkg: List[String], name: String): ClassDesc = {
+    val prefix = if (pkg.isEmpty) "" else pkg.mkString("", "/", "/")
+    ClassDesc.ofInternalName(prefix + name)
+  }
 
   /**
     * Constructs a concatenated string using `Flix.Delimiter`. The call

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/MethodTypeDescs.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/MethodTypeDescs.scala
@@ -16,10 +16,10 @@
 
 package ca.uwaterloo.flix.language.phase.jvm
 
-import java.lang.constant.{ConstantDescs, MethodTypeDesc}
+import java.lang.constant.{ClassDesc, ConstantDescs, MethodTypeDesc}
 
 /**
-  * Helpers for constructing [[MethodTypeDesc]] from [[BackendType]].
+  * Helpers for constructing [[MethodTypeDesc]] from [[ClassDesc]].
   */
 object MethodTypeDescs {
 
@@ -27,11 +27,11 @@ object MethodTypeDescs {
   val NothingToVoid: MethodTypeDesc = MethodTypeDesc.of(ConstantDescs.CD_void)
 
   /** Returns the [[MethodTypeDesc]] of a method that takes `argument`s and returns `result`. */
-  def mkDescriptor(argument: BackendType*)(result: BackendType): MethodTypeDesc =
-    MethodTypeDesc.of(result.toClassDesc, argument.map(_.toClassDesc) *)
+  def mkDescriptor(argument: ClassDesc*)(result: ClassDesc): MethodTypeDesc =
+    MethodTypeDesc.of(result, argument *)
 
   /** Returns the [[MethodTypeDesc]] of a method that takes `argument`s and returns void. */
-  def mkVoidDescriptor(argument: BackendType*): MethodTypeDesc =
-    MethodTypeDesc.of(ConstantDescs.CD_void, argument.map(_.toClassDesc) *)
+  def mkVoidDescriptor(argument: ClassDesc*): MethodTypeDesc =
+    MethodTypeDesc.of(ConstantDescs.CD_void, argument *)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenGlobal.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenGlobal.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, StaticConstructorMethod, StaticField, StaticMethod}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoidDescriptor}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, ClassMaker, JavaClasses, MethodTypeDescs}
+import org.objectweb.asm.{MethodVisitor, Opcodes}
+
+import java.lang.constant.ConstantDescs.{CD_int, CD_long, CD_void}
+import java.lang.constant.{ClassDesc, MethodTypeDesc}
+
+/**
+  * The `dev.flix.runtime.Global` class, which holds the global id counter and the command line arguments.
+  */
+object GenGlobal {
+
+  /** "Global" is fixed in source code, so it should not be mangled and `$` suffixed. */
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, "Global")
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(this.desc, IsFinal)
+
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkStaticConstructor(StaticConstructorMethod(this.desc), staticConstructorIns(_))
+
+    cm.mkField(CounterField, IsPrivate, IsFinal, NotVolatile)
+    cm.mkStaticMethod(NewIdMethod, IsPublic, IsFinal, newIdIns(_))
+
+    cm.mkField(ArgsField, IsPrivate, NotFinal, NotVolatile)
+    cm.mkStaticMethod(GetArgsMethod, IsPublic, IsFinal, getArgsIns(_))
+    cm.mkStaticMethod(SetArgsMethod, IsPublic, IsFinal, setArgsIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
+
+  private def staticConstructorIns(implicit mv: MethodVisitor): Unit = {
+    NEW(JavaClasses.AtomicLong)
+    DUP()
+    invokeConstructor(JavaClasses.AtomicLong, MethodTypeDescs.NothingToVoid)
+    PUTSTATIC(CounterField)
+    ICONST_0()
+    ANEWARRAY(JavaClasses.String)
+    PUTSTATIC(ArgsField)
+    RETURN()
+  }
+
+  private def NewIdMethod: StaticMethod = StaticMethod(this.desc, "newId", mkDescriptor()(CD_long))
+
+  private def newIdIns(implicit mv: MethodVisitor): Unit = {
+    GETSTATIC(CounterField)
+    INVOKEVIRTUAL(JavaClasses.AtomicLong, "getAndIncrement",
+      mkDescriptor()(CD_long))
+    LRETURN()
+  }
+
+  private def GetArgsMethod: StaticMethod = StaticMethod(this.desc, "getArgs", mkDescriptor()(JavaClasses.String.arrayType()))
+
+  private def getArgsIns(implicit mv: MethodVisitor): Unit = {
+    GETSTATIC(ArgsField)
+    ARRAYLENGTH()
+    ANEWARRAY(JavaClasses.String)
+    ASTORE(0)
+    // the new array is now created, now to copy the args
+    GETSTATIC(ArgsField)
+    ICONST_0()
+    ALOAD(0)
+    ICONST_0()
+    GETSTATIC(ArgsField)
+    ARRAYLENGTH()
+    arrayCopy()
+    ALOAD(0)
+    ARETURN()
+  }
+
+  def SetArgsMethod: StaticMethod =
+    StaticMethod(this.desc, "setArgs", MethodTypeDesc.of(CD_void, JavaClasses.String.arrayType()))
+
+  private def setArgsIns(implicit mv: MethodVisitor): Unit = {
+    ALOAD(0)
+    ARRAYLENGTH()
+    ANEWARRAY(JavaClasses.String)
+    ASTORE(1)
+    ALOAD(0)
+    ICONST_0()
+    ALOAD(1)
+    ICONST_0()
+    ALOAD(0)
+    ARRAYLENGTH()
+    arrayCopy()
+    ALOAD(1)
+    PUTSTATIC(ArgsField)
+    RETURN()
+  }
+
+  private def CounterField: StaticField = StaticField(this.desc, "counter", JavaClasses.AtomicLong)
+
+  private def ArgsField: StaticField = StaticField(this.desc, "args", JavaClasses.String.arrayType())
+
+  private def arrayCopy()(implicit mv: MethodVisitor): Unit = {
+    mv.visitMethodInstruction(Opcodes.INVOKESTATIC, JavaClasses.System, "arraycopy",
+      mkVoidDescriptor(JavaClasses.Object, CD_int, JavaClasses.Object, CD_int, CD_int), isInterface = false)
+  }
+
+}


### PR DESCRIPTION
First step of breaking `BackendObjType.scala` into one file per generated JVM class under `phase.jvm.classes`, and of retiring `BackendType`.

### Nominal `MethodTypeDescs`

Every `toTpe` use in the backend was an argument to `MethodTypeDescs.mkDescriptor` or `mkVoidDescriptor` — the last two functions that still took `BackendType`. `ClassMaker`'s fields and methods are already `ClassDesc`/`MethodTypeDesc`, so changing these two to take `ClassDesc` removes all of those uses at once:

- `BackendType.Float64` → `CD_double`, `BackendType.String` → `JavaClasses.String`, and so on
- `JavaClasses.Thread.toTpe` → `JavaClasses.Thread`
- `Result.toTpe` → `Result.desc`
- `toBackendType(fp.tpe)` → `toClassDesc(fp.tpe)`, `toErasedBackendType` → `toErasedClassDesc`

`toTpe` now survives only inside `BackendType.toBackendType` itself, which Wave 3 will delete along with `BackendType.scala`.

### The `jvm.classes` package

Adds `phase.jvm.classes`, which will hold one `Gen*` object per generated JVM class — each owning its own name, fields, methods, and bytecode generation, instead of sharing a sealed trait and a central `desc` match. `Global` moves there as `GenGlobal` to establish the pattern. Supporting moves:

- `mkDesc` goes from a private helper in `BackendObjType` to `Mangle`, so classes outside the sealed hierarchy can compute their own descriptor. `ClassConstants.FlixError` was open-coding it and now reuses it.
- `nullarySuperConstructor` and `singletonStaticConstructor` go from the `BackendObjType` trait to `Instructions`, where the other instruction fragments live. Neither needs the trait: `singletonStaticConstructor` takes the class descriptor from `thisConstructor.clazz`, which is the enclosing class at all three call sites.

No behavior change — the generated bytecode is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)