### PR TITLE
refactor: move the error and entry classes to jvm.classes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.{JvmAst, SimpleType, SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.ast.{JvmAst, SimpleType, SourceLocation}
 import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.mkClassName
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.Branch.*
@@ -25,14 +25,14 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.{IsVolatile, NotVolatile}
-import ca.uwaterloo.flix.language.phase.jvm.classes.GenGlobal
+import ca.uwaterloo.flix.language.phase.jvm.classes.{GenReifiedSourceLocation, GenUncaughtExceptionHandler, GenUnhandledEffectError}
 import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, RootPackage, mkDesc}
 import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoidDescriptor}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 
-import java.lang.constant.{ClassDesc, MethodTypeDesc}
-import java.lang.constant.ConstantDescs.{CD_Object, CD_boolean, CD_byte, CD_char, CD_double, CD_float, CD_int, CD_long, CD_short, CD_void}
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.{CD_Object, CD_boolean, CD_byte, CD_char, CD_double, CD_float, CD_int, CD_long, CD_short}
 
 /**
   * Represents all Flix types that are objects on the JVM (array is an exception).
@@ -53,21 +53,10 @@ sealed trait BackendObjType {
     case BackendObjType.ExtTag(tpes) => mkDesc(RootPackage, mkClassName("ExtTag", tpes))
     case BackendObjType.AbstractArrow(args, result) => mkDesc(RootPackage, mkClassName(s"Clo${args.length}", args :+ result))
     case BackendObjType.Arrow(args, result) => mkDesc(RootPackage, mkClassName(s"Fn${args.length}", args :+ result))
-    case BackendObjType.Defn(sym) => mkDesc(sym.namespace, Mangle.mkClassName("Def", sym.name))
-    case BackendObjType.Closure(sym) => mkDesc(sym.namespace, Mangle.mkClassName("Clo", sym.name))
-    case BackendObjType.Effect(sym) => mkDesc(sym.namespace, Mangle.mkClassName("Eff", sym.name))
     case BackendObjType.RecordEmpty => mkDesc(RootPackage, mkClassName(s"RecordEmpty"))
     case BackendObjType.RecordExtend(value) => mkDesc(RootPackage, mkClassName("RecordExtend", value))
     case BackendObjType.Record => mkDesc(RootPackage, mkClassName("Record"))
-    case BackendObjType.ReifiedSourceLocation => mkDesc(DevFlixRuntime, mkClassName("ReifiedSourceLocation"))
-    case BackendObjType.HoleError => mkDesc(DevFlixRuntime, mkClassName("HoleError"))
-    case BackendObjType.MatchError => mkDesc(DevFlixRuntime, mkClassName("MatchError"))
-    case BackendObjType.CastError => mkDesc(DevFlixRuntime, mkClassName("CastError"))
-    case BackendObjType.UnhandledEffectError => mkDesc(DevFlixRuntime, mkClassName("UnhandledEffectError"))
     case BackendObjType.Region => mkDesc(DevFlixRuntime, mkClassName("Region"))
-    case BackendObjType.UncaughtExceptionHandler => mkDesc(DevFlixRuntime, mkClassName("UncaughtExceptionHandler"))
-    case BackendObjType.Main => mkDesc(RootPackage, "Main")
-    case BackendObjType.Namespace(ns) => mkDesc(ns.dropRight(1), ns.lastOption.getOrElse(s"Root${Flix.Delimiter}"))
     // Java classes
     case BackendObjType.Native(clazz) => clazz
     // Effects Runtime
@@ -715,25 +704,6 @@ object BackendObjType {
     def ArgField(index: Int): InstanceField = InstanceField(this.desc, s"arg$index", args(index).toClassDesc)
   }
 
-  case class Defn(sym: Symbol.DefnSym) extends BackendObjType
-
-  /**
-    * The closure class `Clo$Name` for the given closure.
-    *
-    * String.charAt     =>    String/Clo$charAt
-    * List.length       =>    List/Clo$length
-    * List.map          =>    List/Clo$map
-    */
-  case class Closure(sym: Symbol.DefnSym) extends BackendObjType
-
-  /**
-    * The effect definition class for the given effect symbol.
-    *
-    * Print       =>  Eff$Print
-    * List.Crash  =>  List.Eff$Crash
-    */
-  case class Effect(sym: Symbol.EffSym) extends BackendObjType
-
   case object RecordEmpty extends BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
       val cm = ClassMaker.mkClass(this.desc, IsFinal, interfaces = List(this.interface.desc))
@@ -865,264 +835,6 @@ object BackendObjType {
     */
   case class Native(clazz: ClassDesc) extends BackendObjType
 
-  case object ReifiedSourceLocation extends BackendObjType {
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.desc, IsFinal)
-
-      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
-
-      cm.mkField(SourceField, IsPublic, IsFinal, NotVolatile)
-      cm.mkField(BeginLineField, IsPublic, IsFinal, NotVolatile)
-      cm.mkField(BeginColField, IsPublic, IsFinal, NotVolatile)
-      cm.mkField(EndLineField, IsPublic, IsFinal, NotVolatile)
-      cm.mkField(EndColField, IsPublic, IsFinal, NotVolatile)
-
-      cm.mkMethod(Nil, ToStringMethod, IsPublic, NotFinal, toStringIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(
-      this.desc, List(JavaClasses.String, CD_int, CD_int, CD_int, CD_int)
-    )
-
-    private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      thisLoad()
-      INVOKESPECIAL(ClassConstants.Object.Constructor)
-      thisLoad()
-      ALOAD(1)
-      PUTFIELD(SourceField)
-      thisLoad()
-      ILOAD(2)
-      PUTFIELD(BeginLineField)
-      thisLoad()
-      ILOAD(3)
-      PUTFIELD(BeginColField)
-      thisLoad()
-      ILOAD(4)
-      PUTFIELD(EndLineField)
-      thisLoad()
-      ILOAD(5)
-      PUTFIELD(EndColField)
-      RETURN()
-    }
-
-    private def SourceField: InstanceField =
-      InstanceField(this.desc, "source", JavaClasses.String)
-
-    private def BeginLineField: InstanceField =
-      InstanceField(this.desc, "beginLine", CD_int)
-
-    private def BeginColField: InstanceField =
-      InstanceField(this.desc, "beginCol", CD_int)
-
-    private def EndLineField: InstanceField =
-      InstanceField(this.desc, "endLine", CD_int)
-
-    private def EndColField: InstanceField =
-      InstanceField(this.desc, "endCol", CD_int)
-
-    private def ToStringMethod: InstanceMethod = ClassConstants.Object.ToStringMethod.implementation(this.desc)
-
-    private def toStringIns(implicit mv: MethodVisitor): Unit = {
-      // create string builder
-      NEW(JavaClasses.StringBuilder)
-      DUP()
-      INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
-      // build string
-      thisLoad()
-      GETFIELD(SourceField)
-      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-      pushString(":")
-      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-      thisLoad()
-      GETFIELD(BeginLineField)
-      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendInt32Method)
-      pushString(":")
-      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-      thisLoad()
-      GETFIELD(BeginColField)
-      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendInt32Method)
-      // create the string
-      INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-      ARETURN()
-    }
-  }
-
-  case object HoleError extends BackendObjType {
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.desc, IsFinal, ClassConstants.FlixError.Desc)
-
-      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
-      // These fields allow external equality checking.
-      cm.mkField(HoleField, IsPublic, IsFinal, NotVolatile)
-      cm.mkField(LocationField, IsPublic, IsFinal, NotVolatile)
-
-      cm.closeClassMaker()
-    }
-
-    private def HoleField: InstanceField = InstanceField(this.desc, "hole", JavaClasses.String)
-
-    private def LocationField: InstanceField = InstanceField(this.desc, "location", ReifiedSourceLocation.desc)
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(JavaClasses.String, ReifiedSourceLocation.desc))
-
-    private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, JavaClasses.String) { hole =>
-        withName(2, ReifiedSourceLocation.desc) { loc =>
-          thisLoad()
-          // create an error msg
-          NEW(JavaClasses.StringBuilder)
-          DUP()
-          INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
-          pushString("Hole '")
-          INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-          hole.load()
-          INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-          pushString("' at ")
-          INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-          loc.load()
-          INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-          INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-          INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-          INVOKESPECIAL(ClassConstants.FlixError.Constructor)
-          // save the arguments locally
-          thisLoad()
-          hole.load()
-          PUTFIELD(HoleField)
-          thisLoad()
-          loc.load()
-          PUTFIELD(LocationField)
-          RETURN()
-        }
-      }
-    }
-  }
-
-  case object MatchError extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(MatchError.desc, IsFinal, superClass = ClassConstants.FlixError.Desc)
-
-      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
-      // This field allows external equality checking.
-      cm.mkField(LocationField, IsPublic, IsFinal, NotVolatile)
-
-      cm.closeClassMaker()
-    }
-
-    private def LocationField: InstanceField = InstanceField(this.desc, "location", ReifiedSourceLocation.desc)
-
-    def Constructor: ConstructorMethod = ConstructorMethod(MatchError.desc, List(ReifiedSourceLocation.desc))
-
-    private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      thisLoad()
-      NEW(JavaClasses.StringBuilder)
-      DUP()
-      INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
-      pushString("Non-exhaustive match at ")
-      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-      ALOAD(1)
-      INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-      INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-      INVOKESPECIAL(ClassConstants.FlixError.Constructor)
-      // save argument locally
-      thisLoad()
-      ALOAD(1)
-      PUTFIELD(this.LocationField)
-      RETURN()
-    }
-  }
-
-  case object CastError extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = ClassConstants.FlixError.Desc)
-
-      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(ReifiedSourceLocation.desc, JavaClasses.String))
-
-    private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, ReifiedSourceLocation.desc)(loc => withName(2, JavaClasses.String)(msg => {
-        thisLoad()
-        NEW(JavaClasses.StringBuilder)
-        DUP()
-        INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
-        msg.load()
-        INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-        pushString(" at ")
-        INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-        loc.load()
-        INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-        INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-        INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-        INVOKESPECIAL(ClassConstants.FlixError.Constructor)
-        RETURN()
-      }))
-    }
-  }
-
-  case object UnhandledEffectError extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = ClassConstants.FlixError.Desc)
-
-      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
-      // This field allows external equality checking.
-      cm.mkField(EffectNameField, IsPublic, IsFinal, NotVolatile)
-      cm.mkField(LocationField, IsPublic, IsFinal, NotVolatile)
-
-      cm.closeClassMaker()
-    }
-
-    private def EffectNameField: InstanceField = InstanceField(this.desc, "effectName", JavaClasses.String)
-
-    private def LocationField: InstanceField = InstanceField(this.desc, "location", ReifiedSourceLocation.desc)
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(Suspension.desc, JavaClasses.String, ReifiedSourceLocation.desc))
-
-    private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Suspension.desc)(suspension => withName(2, JavaClasses.String)(info => withName(3, ReifiedSourceLocation.desc)(loc => {
-        def appendString(): Unit = INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
-
-        thisLoad()
-        NEW(JavaClasses.StringBuilder)
-        DUP()
-        INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
-        pushString("Unhandled effect '")
-        appendString()
-        suspension.load()
-        GETFIELD(Suspension.EffSymField)
-        appendString()
-        pushString("' (")
-        appendString()
-        info.load()
-        appendString()
-        pushString(") at ")
-        appendString()
-        loc.load()
-        INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-        appendString()
-        INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-        INVOKESPECIAL(ClassConstants.FlixError.Constructor)
-        // save arguments locally
-        thisLoad()
-        suspension.load()
-        GETFIELD(Suspension.EffSymField)
-        PUTFIELD(EffectNameField)
-        thisLoad()
-        loc.load()
-        PUTFIELD(LocationField)
-        RETURN()
-      })))
-    }
-  }
-
 
   case object Region extends BackendObjType {
 
@@ -1195,10 +907,10 @@ object BackendObjType {
       INVOKEINTERFACE(ClassConstants.ThreadBuilderOfVirtual.UnstartedMethod)
       storeWithName(2, JavaClasses.Thread) { thread =>
         thread.load()
-        NEW(BackendObjType.UncaughtExceptionHandler.desc)
+        NEW(GenUncaughtExceptionHandler.desc)
         DUP()
         thisLoad()
-        invokeConstructor(BackendObjType.UncaughtExceptionHandler.desc, mkVoidDescriptor(BackendObjType.Region.desc))
+        invokeConstructor(GenUncaughtExceptionHandler.desc, mkVoidDescriptor(BackendObjType.Region.desc))
         INVOKEVIRTUAL(ClassConstants.Thread.SetUncaughtExceptionHandlerMethod)
         thread.load()
         INVOKEVIRTUAL(ClassConstants.Thread.StartMethod)
@@ -1298,124 +1010,6 @@ object BackendObjType {
       RETURN()
     }
   }
-
-  case object UncaughtExceptionHandler extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.desc, IsFinal, interfaces = List(JavaClasses.Thread$UncaughtExceptionHandler))
-
-      cm.mkField(RegionField, IsPrivate, IsFinal, NotVolatile)
-      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
-      cm.mkMethod(Nil, UncaughtExceptionMethod, IsPublic, IsFinal, uncaughtExceptionsIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    // private final Region r;
-    private def RegionField: InstanceField = InstanceField(this.desc, "r", BackendObjType.Region.desc)
-
-    // UncaughtExceptionHandler(Region r) { this.r = r; }
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, BackendObjType.Region.desc :: Nil)
-
-    private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      thisLoad()
-      INVOKESPECIAL(ClassConstants.Object.Constructor)
-      thisLoad()
-      ALOAD(1)
-      PUTFIELD(RegionField)
-      RETURN()
-    }
-
-    // public void uncaughtException(Thread t, Throwable e) { r.reportChildException(e); }
-    private def UncaughtExceptionMethod: InstanceMethod =
-      InstanceMethod(this.desc, "uncaughtException", ClassConstants.ThreadUncaughtExceptionHandler.UncaughtExceptionMethod.d)
-
-    private def uncaughtExceptionsIns(implicit mv: MethodVisitor): Unit = {
-      thisLoad()
-      GETFIELD(RegionField)
-      ALOAD(2)
-      INVOKEVIRTUAL(Region.ReportChildExceptionMethod)
-      RETURN()
-    }
-  }
-
-  case object Main extends BackendObjType {
-
-    def genByteCode(sym: Symbol.DefnSym)(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.desc, IsFinal)
-
-      cm.mkStaticMethod(MainMethod, IsPublic, NotFinal, mainIns(sym)(_))
-
-      cm.closeClassMaker()
-    }
-
-    def MainMethod: StaticMethod = StaticMethod(this.desc, "main", mkVoidDescriptor(JavaClasses.String.arrayType()))
-
-    private def mainIns(sym: Symbol.DefnSym)(implicit mv: MethodVisitor): Unit = {
-      val defName = BackendObjType.Defn(sym).desc
-      withName(0, JavaClasses.String.arrayType())(args => {
-        args.load()
-        INVOKESTATIC(GenGlobal.SetArgsMethod)
-        NEW(defName)
-        DUP()
-        INVOKESPECIAL(defName, ConstructorMethodName, MethodTypeDescs.NothingToVoid)
-        DUP()
-        GETSTATIC(Unit.SingletonField)
-        PUTFIELD(InstanceField(defName, "arg0", CD_Object))
-        Result.unwindSuspensionFreeThunk(s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
-        POP()
-        RETURN()
-      })
-    }
-  }
-
-  case class Namespace(ns: List[String]) extends BackendObjType {
-
-    def genByteCode(defs: List[JvmAst.Def])(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkClass(this.desc, IsFinal)
-
-      cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-
-      for (defn <- defs) {
-        cm.mkStaticMethod(ShimMethod(defn), IsPublic, IsFinal, shimIns(defn)(_))
-      }
-
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
-
-    def ShimMethod(defn: JvmAst.Def): StaticMethod = {
-      val erasedArgs = defn.fparams.map(_.tpe).map(BackendType.toErasedClassDesc)
-      val erasedResult = BackendType.toErasedClassDesc(defn.unboxedType.tpe)
-      // Exported names are checked in Safety, so no mangling is needed.
-      val name = if (defn.ann.isExport) defn.sym.name else "m_" + Mangle.mangle(defn.sym.name)
-      StaticMethod(this.desc, name, mkDescriptor(erasedArgs *)(erasedResult))
-    }
-
-    private def shimIns(defn: JvmAst.Def)(implicit mv: MethodVisitor): Unit = {
-      val defnT = Defn(defn.sym)
-      val paramTypes = defn.fparams.map(fp => BackendType.toErasedClassDesc(fp.tpe))
-      withNames(0, paramTypes) {
-        case (_, args) =>
-          val erasedResult = BackendType.toErasedBackendType(defn.unboxedType.tpe)
-          NEW(defnT.desc)
-          DUP()
-          INVOKESPECIAL(ConstructorMethod(defnT.desc, Nil))
-          for ((arg, index) <- args.zipWithIndex) {
-            DUP()
-            arg.load()
-            PUTFIELD(InstanceField(defnT.desc, s"arg$index", paramTypes(index)))
-          }
-          Result.unwindSuspensionFreeThunkToType(erasedResult, s"in shim method of ${defn.sym}", defn.loc)
-          xReturn(erasedResult.toClassDesc)
-      }
-    }
-  }
-
-  //
-  // Java Types
-  //
 
   case object Result extends BackendObjType {
 
@@ -1520,21 +1114,21 @@ object BackendObjType {
 
     /**
       * [..., Result] -> [..., Value|Thunk]
-      * side effect: if the result is a suspension, a [[UnhandledEffectError]] is thrown.
+      * side effect: if the result is a suspension, a [[GenUnhandledEffectError]] is thrown.
       */
     def crashIfSuspension(errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
       DUP()
       INSTANCEOF(Suspension.desc)
       ifCondition(Condition.NE) {
         CHECKCAST(Suspension.desc)
-        NEW(UnhandledEffectError.desc)
+        NEW(GenUnhandledEffectError.desc)
         // [.., suspension, UEE] -> [.., suspension, UEE, UEE, suspension]
         DUP2()
         SWAP()
         pushString(errorHint)
         pushLoc(loc)
         // [.., suspension, UEE, UEE, suspension, info, rsl] -> [.., suspension, UEE]
-        INVOKESPECIAL(UnhandledEffectError.Constructor)
+        INVOKESPECIAL(GenUnhandledEffectError.Constructor)
         ATHROW()
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{BytecodeAst, SimpleType, SourceLocation}
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugNoOp
-import ca.uwaterloo.flix.language.phase.jvm.classes.GenGlobal
+import ca.uwaterloo.flix.language.phase.jvm.classes.{GenCastError, GenGlobal, GenHoleError, GenMain, GenMatchError, GenNamespace, GenReifiedSourceLocation, GenUncaughtExceptionHandler, GenUnhandledEffectError}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 import ca.uwaterloo.flix.util.collection.MapOps
 
@@ -47,14 +47,13 @@ object CodeGen {
     val allTypes = root.types ++ requiredTypes
 
     val mainClass = root.getMain.map(
-      main => JvmClass(BackendObjType.Main.desc, BackendObjType.Main.genByteCode(main.sym))
+      main => JvmClass(GenMain.desc, GenMain.genByteCode(main.sym))
     ).toList
 
     val namespaceClasses = namespacesOf(root).map(
       ns => {
-        val nsClass = BackendObjType.Namespace(ns.ns)
         val entrypointDefs = ns.defs.values.toList.filter(defn => root.entryPoints.contains(defn.sym))
-        JvmClass(nsClass.desc, nsClass.genByteCode(entrypointDefs))
+        JvmClass(GenNamespace.desc(ns.ns), GenNamespace.genByteCode(ns.ns, entrypointDefs))
       }).toList
 
     // Generate function classes.
@@ -84,17 +83,17 @@ object CodeGen {
     val unitClass = List(JvmClass(BackendObjType.Unit.desc, BackendObjType.Unit.genByteCode()))
 
     val flixErrorClass = List(JvmClass(ClassConstants.FlixError.Desc, ClassConstants.FlixError.genByteCode()))
-    val rslClass = List(JvmClass(BackendObjType.ReifiedSourceLocation.desc, BackendObjType.ReifiedSourceLocation.genByteCode()))
-    val holeErrorClass = List(JvmClass(BackendObjType.HoleError.desc, BackendObjType.HoleError.genByteCode()))
-    val matchErrorClass = List(JvmClass(BackendObjType.MatchError.desc, BackendObjType.MatchError.genByteCode()))
-    val castErrorClass = List(JvmClass(BackendObjType.CastError.desc, BackendObjType.CastError.genByteCode()))
-    val unhandledEffectErrorClass = List(JvmClass(BackendObjType.UnhandledEffectError.desc, BackendObjType.UnhandledEffectError.genByteCode()))
+    val rslClass = List(JvmClass(GenReifiedSourceLocation.desc, GenReifiedSourceLocation.genByteCode()))
+    val holeErrorClass = List(JvmClass(GenHoleError.desc, GenHoleError.genByteCode()))
+    val matchErrorClass = List(JvmClass(GenMatchError.desc, GenMatchError.genByteCode()))
+    val castErrorClass = List(JvmClass(GenCastError.desc, GenCastError.genByteCode()))
+    val unhandledEffectErrorClass = List(JvmClass(GenUnhandledEffectError.desc, GenUnhandledEffectError.genByteCode()))
 
     val globalClass = List(JvmClass(GenGlobal.desc, GenGlobal.genByteCode()))
 
     val regionClass = List(JvmClass(BackendObjType.Region.desc, BackendObjType.Region.genByteCode()))
 
-    val uncaughtExceptionHandlerClass = List(JvmClass(BackendObjType.UncaughtExceptionHandler.desc, BackendObjType.UncaughtExceptionHandler.genByteCode()))
+    val uncaughtExceptionHandlerClass = List(JvmClass(GenUncaughtExceptionHandler.desc, GenUncaughtExceptionHandler.genByteCode()))
 
     // Effect runtime classes.
     val resultInterface = List(JvmClass(BackendObjType.Result.desc, BackendObjType.Result.genByteCode()))
@@ -168,13 +167,12 @@ object CodeGen {
 
     val tests = MapOps.mapValues(root.defs.filter(_._2.ann.isTest)) {
       case defn =>
-        val nsType = BackendObjType.Namespace(defn.sym.namespace)
-        BytecodeAst.Test(nsType.desc, nsType.ShimMethod(defn).name, defn.ann.isSkip)
+        val ns = defn.sym.namespace
+        BytecodeAst.Test(GenNamespace.desc(ns), GenNamespace.ShimMethod(ns, defn).name, defn.ann.isSkip)
     }
     val main = root.mainEntryPoint.map{
       case _ =>
-        val mainType = BackendObjType.Main
-        BytecodeAst.Def(mainType.desc, mainType.MainMethod.name)
+        BytecodeAst.Def(GenMain.desc, GenMain.MainMethod.name)
     }
     BytecodeAst.Root(classMap, tests, main, root.sources)
   }(DebugNoOp())

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -52,9 +52,18 @@ import java.lang.constant.{ClassDesc, MethodTypeDesc}
   */
 object GenEffectClasses {
 
+  /**
+    * Returns the descriptor of the effect definition class of `sym`.
+    *
+    * Print       =>  Eff$Print
+    * List.Crash  =>  List.Eff$Crash
+    */
+  def effectDesc(sym: Symbol.EffSym): ClassDesc =
+    Mangle.mkDesc(sym.namespace, Mangle.mkClassName("Eff", sym.name))
+
   def gen(effects: Iterable[Effect])(implicit root: Root, flix: Flix): List[JvmClass] = {
     for (effect <- effects.toList) yield {
-      val className = BackendObjType.Effect(effect.sym).desc
+      val className = effectDesc(effect.sym)
       JvmClass(className, genByteCode(className, effect))
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -23,6 +23,7 @@ import ca.uwaterloo.flix.language.ast.SemanticOp.*
 import ca.uwaterloo.flix.language.ast.shared.{Constant, ExpPosition, Mutability}
 import ca.uwaterloo.flix.language.ast.{SimpleType, *}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.classes.{GenCastError, GenHoleError, GenMatchError}
 import ca.uwaterloo.flix.util.ClassDescs.internalNameOf
 import java.lang.constant.MethodTypeDesc
 import java.lang.constant.ConstantDescs.{CD_double, CD_long, CD_void}
@@ -192,7 +193,7 @@ object GenExpression {
 
       case AtomicOp.Closure(sym) =>
         // JvmType of the closure
-        val closureName = internalNameOf(BackendObjType.Closure(sym).desc)
+        val closureName = internalNameOf(GenFunAndClosureClasses.closureDesc(sym))
         // new closure instance
         mv.visitTypeInsn(Opcodes.NEW, closureName)
         // Duplicate
@@ -1024,30 +1025,30 @@ object GenExpression {
       case AtomicOp.HoleError(sym) =>
         // Add source line number for debugging (failable by design).
         addLoc(loc)
-        NEW(BackendObjType.HoleError.desc) // HoleError
+        NEW(GenHoleError.desc) // HoleError
         DUP() // HoleError, HoleError
         pushString(sym.toString) // HoleError, HoleError, Sym
         pushLoc(loc) // HoleError, HoleError, Sym, Loc
-        INVOKESPECIAL(BackendObjType.HoleError.Constructor) // HoleError
+        INVOKESPECIAL(GenHoleError.Constructor) // HoleError
         ATHROW()
 
       case AtomicOp.MatchError =>
         // Add source line number for debugging (failable by design)
         addLoc(loc)
-        NEW(BackendObjType.MatchError.desc) // MatchError
+        NEW(GenMatchError.desc) // MatchError
         DUP() // MatchError, MatchError
         pushLoc(loc) // MatchError, MatchError, Loc
-        INVOKESPECIAL(BackendObjType.MatchError.Constructor) // MatchError
+        INVOKESPECIAL(GenMatchError.Constructor) // MatchError
         ATHROW()
 
       case AtomicOp.CastError(from, to) =>
         // Add source line number for debugging (failable by design)
         addLoc(loc)
-        NEW(BackendObjType.CastError.desc) // CastError
+        NEW(GenCastError.desc) // CastError
         DUP() // CastError, CastError
         pushLoc(loc) // CastError, CastError, Loc
         pushString(s"Cannot cast from type '$from' to '$to'") // CastError, CastError, Loc, String
-        INVOKESPECIAL(BackendObjType.CastError.Constructor) // CastError
+        INVOKESPECIAL(GenCastError.Constructor) // CastError
         ATHROW()
 
       // Vector operations are simplified to array operations in the Simplifier.
@@ -1118,7 +1119,7 @@ object GenExpression {
 
     case Expr.ApplyDef(sym, exps, ct, _, _, loc) => ct match {
       case ExpPosition.Tail =>
-        val defInternalName = internalNameOf(BackendObjType.Defn(sym).desc)
+        val defInternalName = internalNameOf(GenFunAndClosureClasses.defnDesc(sym))
         // Type of the function abstract class
         val functionInterface = BackendObjType.Arrow.fromArrowType(root.defs(sym).arrowType)
 
@@ -1149,12 +1150,12 @@ object GenExpression {
             castIfNotPrim(tpe)
           }
           val desc = mkDescriptor(paramTpes *)(BackendObjType.Result.desc)
-          val className = internalNameOf(BackendObjType.Defn(sym).desc)
+          val className = internalNameOf(GenFunAndClosureClasses.defnDesc(sym))
           mv.visitMethodInsn(Opcodes.INVOKESTATIC, className, ClassMaker.StaticApplyMethodName, desc.descriptorString(), false)
           BackendObjType.Result.unwindSuspensionFreeThunk("in pure function call", loc)
         } else {
           // JvmType of Def
-          val defInternalName = internalNameOf(BackendObjType.Defn(sym).desc)
+          val defInternalName = internalNameOf(GenFunAndClosureClasses.defnDesc(sym))
 
           // Put the def on the stack
           mv.visitTypeInsn(Opcodes.NEW, defInternalName)
@@ -1209,7 +1210,7 @@ object GenExpression {
         val erasedResult = BackendType.toErasedBackendType(tpe)
         pcCounter(0) += 1
 
-        val effectName = BackendObjType.Effect(sym.eff).desc
+        val effectName = GenEffectClasses.effectDesc(sym.eff)
         val effectStaticMethod = ClassMaker.StaticMethod(
           effectName,
           GenEffectClasses.opName(sym),
@@ -1514,7 +1515,7 @@ object GenExpression {
 
     case Expr.RunWith(exp, effUse, rules, ct, _, _, loc) =>
       // exp is a Unit -> exp.tpe closure
-      val effectName = BackendObjType.Effect(effUse.sym).desc
+      val effectName = GenEffectClasses.effectDesc(effUse.sym)
       val effectInternalName = internalNameOf(effectName)
       // eff name
       pushString(effUse.sym.toString)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -33,6 +33,24 @@ import java.lang.constant.ConstantDescs.CD_int
 object GenFunAndClosureClasses {
 
   /**
+    * Returns the descriptor of the function class `Def$Name` of `sym`.
+    *
+    * String.charAt     =>    String/Def$charAt
+    * List.length       =>    List/Def$length
+    */
+  def defnDesc(sym: Symbol.DefnSym): ClassDesc =
+    Mangle.mkDesc(sym.namespace, Mangle.mkClassName("Def", sym.name))
+
+  /**
+    * Returns the descriptor of the closure class `Clo$Name` of `sym`.
+    *
+    * String.charAt     =>    String/Clo$charAt
+    * List.map          =>    List/Clo$map
+    */
+  def closureDesc(sym: Symbol.DefnSym): ClassDesc =
+    Mangle.mkDesc(sym.namespace, Mangle.mkClassName("Clo", sym.name))
+
+  /**
     * Returns a map of function- and closure-classes for the given set `defs`.
     */
   def gen(defs: Map[Symbol.DefnSym, Def])(implicit root: Root, flix: Flix): Map[ClassDesc, JvmClass] = {
@@ -40,7 +58,7 @@ object GenFunAndClosureClasses {
 
       case (macc, closure) if isClosure(closure) =>
         flix.profile(closure.sym, closure.loc) {
-          val closureName = BackendObjType.Closure(closure.sym).desc
+          val closureName = closureDesc(closure.sym)
           val code = genClosure(closureName, closure)
           flix.emitEvent(FlixEvent.EmittedClass(closure.sym, code.length))
           macc + (closureName -> JvmClass(closureName, code))
@@ -48,7 +66,7 @@ object GenFunAndClosureClasses {
 
       case (macc, defn) if isFunction(defn) && isControlPure(defn) =>
         flix.profile(defn.sym, defn.loc) {
-          val functionName = BackendObjType.Defn(defn.sym).desc
+          val functionName = defnDesc(defn.sym)
           val code = genControlPureFunction(functionName, defn)
           flix.emitEvent(FlixEvent.EmittedClass(defn.sym, code.length))
           macc + (functionName -> JvmClass(functionName, code))
@@ -56,7 +74,7 @@ object GenFunAndClosureClasses {
 
       case (macc, defn) if isFunction(defn) =>
         flix.profile(defn.sym, defn.loc) {
-          val functionName = BackendObjType.Defn(defn.sym).desc
+          val functionName = defnDesc(defn.sym)
           val code = genControlImpureFunction(functionName, defn)
           flix.emitEvent(FlixEvent.EmittedClass(defn.sym, code.length))
           macc + (functionName -> JvmClass(functionName, code))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
@@ -20,6 +20,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.*
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.Branch.{FalseBranch, TrueBranch}
+import ca.uwaterloo.flix.language.phase.jvm.classes.GenReifiedSourceLocation
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 import org.objectweb.asm
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
@@ -436,14 +437,14 @@ object Instructions {
   }
 
   def pushLoc(loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
-    NEW(BackendObjType.ReifiedSourceLocation.desc)
+    NEW(GenReifiedSourceLocation.desc)
     DUP()
     pushString(loc.source.name)
     pushInt(loc.startLine)
     pushInt(loc.startCol)
     pushInt(loc.endLine)
     pushInt(loc.endCol)
-    INVOKESPECIAL(BackendObjType.ReifiedSourceLocation.Constructor)
+    INVOKESPECIAL(GenReifiedSourceLocation.Constructor)
   }
 
   /** `[] --> return`, the body of a static constructor that stores a fresh instance in `singleton`. */

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenCastError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenCastError.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.ConstructorMethod
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, ClassMaker, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `CastError` class, which is thrown when a checked cast fails.
+  */
+object GenCastError {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("CastError"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = ClassConstants.FlixError.Desc)
+
+    cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(GenReifiedSourceLocation.desc, JavaClasses.String))
+
+  private def constructorIns(implicit mv: MethodVisitor): Unit = {
+    withName(1, GenReifiedSourceLocation.desc)(loc => withName(2, JavaClasses.String)(msg => {
+      thisLoad()
+      NEW(JavaClasses.StringBuilder)
+      DUP()
+      INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
+      msg.load()
+      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+      pushString(" at ")
+      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+      loc.load()
+      INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
+      INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+      INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
+      INVOKESPECIAL(ClassConstants.FlixError.Constructor)
+      RETURN()
+    }))
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenHoleError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenHoleError.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, ClassMaker, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `HoleError` class, which is thrown when a hole expression is evaluated.
+  */
+object GenHoleError {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("HoleError"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(this.desc, IsFinal, ClassConstants.FlixError.Desc)
+
+    cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
+    // These fields allow external equality checking.
+    cm.mkField(HoleField, IsPublic, IsFinal, NotVolatile)
+    cm.mkField(LocationField, IsPublic, IsFinal, NotVolatile)
+
+    cm.closeClassMaker()
+  }
+
+  private def HoleField: InstanceField = InstanceField(this.desc, "hole", JavaClasses.String)
+
+  private def LocationField: InstanceField = InstanceField(this.desc, "location", GenReifiedSourceLocation.desc)
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(JavaClasses.String, GenReifiedSourceLocation.desc))
+
+  private def constructorIns(implicit mv: MethodVisitor): Unit = {
+    withName(1, JavaClasses.String) { hole =>
+      withName(2, GenReifiedSourceLocation.desc) { loc =>
+        thisLoad()
+        // create an error msg
+        NEW(JavaClasses.StringBuilder)
+        DUP()
+        INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
+        pushString("Hole '")
+        INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+        hole.load()
+        INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+        pushString("' at ")
+        INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+        loc.load()
+        INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
+        INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+        INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
+        INVOKESPECIAL(ClassConstants.FlixError.Constructor)
+        // save the arguments locally
+        thisLoad()
+        hole.load()
+        PUTFIELD(HoleField)
+        thisLoad()
+        loc.load()
+        PUTFIELD(LocationField)
+        RETURN()
+      }
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenMain.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenMain.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethodName, InstanceField, StaticMethod}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{RootPackage, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkVoidDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.{BackendObjType, ClassMaker, GenFunAndClosureClasses, JavaClasses, MethodTypeDescs}
+import ca.uwaterloo.flix.util.ClassDescs
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.CD_Object
+
+/**
+  * The `Main` class, whose `main` method is the entry point of a compiled Flix program.
+  */
+object GenMain {
+
+  val desc: ClassDesc = mkDesc(RootPackage, "Main")
+
+  def genByteCode(sym: Symbol.DefnSym)(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(this.desc, IsFinal)
+
+    cm.mkStaticMethod(MainMethod, IsPublic, NotFinal, mainIns(sym)(_))
+
+    cm.closeClassMaker()
+  }
+
+  def MainMethod: StaticMethod = StaticMethod(this.desc, "main", mkVoidDescriptor(JavaClasses.String.arrayType()))
+
+  private def mainIns(sym: Symbol.DefnSym)(implicit mv: MethodVisitor): Unit = {
+    val defName = GenFunAndClosureClasses.defnDesc(sym)
+    withName(0, JavaClasses.String.arrayType())(args => {
+      args.load()
+      INVOKESTATIC(GenGlobal.SetArgsMethod)
+      NEW(defName)
+      DUP()
+      INVOKESPECIAL(defName, ConstructorMethodName, MethodTypeDescs.NothingToVoid)
+      DUP()
+      GETSTATIC(BackendObjType.Unit.SingletonField)
+      PUTFIELD(InstanceField(defName, "arg0", CD_Object))
+      BackendObjType.Result.unwindSuspensionFreeThunk(s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+      POP()
+      RETURN()
+    })
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenMatchError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenMatchError.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, ClassMaker, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `MatchError` class, which is thrown when a pattern match is non-exhaustive.
+  */
+object GenMatchError {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("MatchError"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = ClassConstants.FlixError.Desc)
+
+    cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
+    // This field allows external equality checking.
+    cm.mkField(LocationField, IsPublic, IsFinal, NotVolatile)
+
+    cm.closeClassMaker()
+  }
+
+  private def LocationField: InstanceField = InstanceField(this.desc, "location", GenReifiedSourceLocation.desc)
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(GenReifiedSourceLocation.desc))
+
+  private def constructorIns(implicit mv: MethodVisitor): Unit = {
+    thisLoad()
+    NEW(JavaClasses.StringBuilder)
+    DUP()
+    INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
+    pushString("Non-exhaustive match at ")
+    INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+    ALOAD(1)
+    INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
+    INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+    INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
+    INVOKESPECIAL(ClassConstants.FlixError.Constructor)
+    // save argument locally
+    thisLoad()
+    ALOAD(1)
+    PUTFIELD(this.LocationField)
+    RETURN()
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNamespace.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNamespace.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.JvmAst
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField, StaticMethod}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.mkDesc
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.{BackendObjType, BackendType, ClassConstants, ClassMaker, GenFunAndClosureClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The namespace class of a Flix module, which holds the shim methods of the module's
+  * entry points and tests.
+  */
+object GenNamespace {
+
+  def desc(ns: List[String]): ClassDesc =
+    mkDesc(ns.dropRight(1), ns.lastOption.getOrElse(s"Root${Flix.Delimiter}"))
+
+  def genByteCode(ns: List[String], defs: List[JvmAst.Def])(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(desc(ns), IsFinal)
+
+    cm.mkConstructor(Constructor(ns), IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+
+    for (defn <- defs) {
+      cm.mkStaticMethod(ShimMethod(ns, defn), IsPublic, IsFinal, shimIns(defn)(_))
+    }
+
+    cm.closeClassMaker()
+  }
+
+  def Constructor(ns: List[String]): ConstructorMethod = ConstructorMethod(desc(ns), Nil)
+
+  def ShimMethod(ns: List[String], defn: JvmAst.Def): StaticMethod = {
+    val erasedArgs = defn.fparams.map(_.tpe).map(BackendType.toErasedClassDesc)
+    val erasedResult = BackendType.toErasedClassDesc(defn.unboxedType.tpe)
+    // Exported names are checked in Safety, so no mangling is needed.
+    val name = if (defn.ann.isExport) defn.sym.name else "m_" + Mangle.mangle(defn.sym.name)
+    StaticMethod(desc(ns), name, mkDescriptor(erasedArgs *)(erasedResult))
+  }
+
+  private def shimIns(defn: JvmAst.Def)(implicit mv: MethodVisitor): Unit = {
+    val defnDesc = GenFunAndClosureClasses.defnDesc(defn.sym)
+    val paramTypes = defn.fparams.map(fp => BackendType.toErasedClassDesc(fp.tpe))
+    withNames(0, paramTypes) {
+      case (_, args) =>
+        val erasedResult = BackendType.toErasedBackendType(defn.unboxedType.tpe)
+        NEW(defnDesc)
+        DUP()
+        INVOKESPECIAL(ConstructorMethod(defnDesc, Nil))
+        for ((arg, index) <- args.zipWithIndex) {
+          DUP()
+          arg.load()
+          PUTFIELD(InstanceField(defnDesc, s"arg$index", paramTypes(index)))
+        }
+        BackendObjType.Result.unwindSuspensionFreeThunkToType(erasedResult, s"in shim method of ${defn.sym}", defn.loc)
+        xReturn(erasedResult.toClassDesc)
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenReifiedSourceLocation.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenReifiedSourceLocation.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField, InstanceMethod}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, ClassMaker, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.CD_int
+
+/**
+  * The `ReifiedSourceLocation` class, which is a runtime representation of a source location.
+  */
+object GenReifiedSourceLocation {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("ReifiedSourceLocation"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(this.desc, IsFinal)
+
+    cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
+
+    cm.mkField(SourceField, IsPublic, IsFinal, NotVolatile)
+    cm.mkField(BeginLineField, IsPublic, IsFinal, NotVolatile)
+    cm.mkField(BeginColField, IsPublic, IsFinal, NotVolatile)
+    cm.mkField(EndLineField, IsPublic, IsFinal, NotVolatile)
+    cm.mkField(EndColField, IsPublic, IsFinal, NotVolatile)
+
+    cm.mkMethod(Nil, ToStringMethod, IsPublic, NotFinal, toStringIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  def Constructor: ConstructorMethod = ConstructorMethod(
+    this.desc, List(JavaClasses.String, CD_int, CD_int, CD_int, CD_int)
+  )
+
+  private def constructorIns(implicit mv: MethodVisitor): Unit = {
+    thisLoad()
+    INVOKESPECIAL(ClassConstants.Object.Constructor)
+    thisLoad()
+    ALOAD(1)
+    PUTFIELD(SourceField)
+    thisLoad()
+    ILOAD(2)
+    PUTFIELD(BeginLineField)
+    thisLoad()
+    ILOAD(3)
+    PUTFIELD(BeginColField)
+    thisLoad()
+    ILOAD(4)
+    PUTFIELD(EndLineField)
+    thisLoad()
+    ILOAD(5)
+    PUTFIELD(EndColField)
+    RETURN()
+  }
+
+  private def SourceField: InstanceField =
+    InstanceField(this.desc, "source", JavaClasses.String)
+
+  private def BeginLineField: InstanceField =
+    InstanceField(this.desc, "beginLine", CD_int)
+
+  private def BeginColField: InstanceField =
+    InstanceField(this.desc, "beginCol", CD_int)
+
+  private def EndLineField: InstanceField =
+    InstanceField(this.desc, "endLine", CD_int)
+
+  private def EndColField: InstanceField =
+    InstanceField(this.desc, "endCol", CD_int)
+
+  private def ToStringMethod: InstanceMethod = ClassConstants.Object.ToStringMethod.implementation(this.desc)
+
+  private def toStringIns(implicit mv: MethodVisitor): Unit = {
+    // create string builder
+    NEW(JavaClasses.StringBuilder)
+    DUP()
+    INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
+    // build string
+    thisLoad()
+    GETFIELD(SourceField)
+    INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+    pushString(":")
+    INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+    thisLoad()
+    GETFIELD(BeginLineField)
+    INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendInt32Method)
+    pushString(":")
+    INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+    thisLoad()
+    GETFIELD(BeginColField)
+    INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendInt32Method)
+    // create the string
+    INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
+    ARETURN()
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUncaughtExceptionHandler.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUncaughtExceptionHandler.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField, InstanceMethod, mkClass}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{BackendObjType, ClassConstants, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `UncaughtExceptionHandler` class, which reports exceptions of a region's child threads
+  * back to that region.
+  */
+object GenUncaughtExceptionHandler {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("UncaughtExceptionHandler"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkClass(this.desc, IsFinal, interfaces = List(JavaClasses.Thread$UncaughtExceptionHandler))
+
+    cm.mkField(RegionField, IsPrivate, IsFinal, NotVolatile)
+    cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
+    cm.mkMethod(Nil, UncaughtExceptionMethod, IsPublic, IsFinal, uncaughtExceptionsIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  // private final Region r;
+  private def RegionField: InstanceField = InstanceField(this.desc, "r", BackendObjType.Region.desc)
+
+  // UncaughtExceptionHandler(Region r) { this.r = r; }
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, BackendObjType.Region.desc :: Nil)
+
+  private def constructorIns(implicit mv: MethodVisitor): Unit = {
+    thisLoad()
+    INVOKESPECIAL(ClassConstants.Object.Constructor)
+    thisLoad()
+    ALOAD(1)
+    PUTFIELD(RegionField)
+    RETURN()
+  }
+
+  // public void uncaughtException(Thread t, Throwable e) { r.reportChildException(e); }
+  private def UncaughtExceptionMethod: InstanceMethod =
+    InstanceMethod(this.desc, "uncaughtException", ClassConstants.ThreadUncaughtExceptionHandler.UncaughtExceptionMethod.d)
+
+  private def uncaughtExceptionsIns(implicit mv: MethodVisitor): Unit = {
+    thisLoad()
+    GETFIELD(RegionField)
+    ALOAD(2)
+    INVOKEVIRTUAL(BackendObjType.Region.ReportChildExceptionMethod)
+    RETURN()
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnhandledEffectError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnhandledEffectError.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{BackendObjType, ClassConstants, ClassMaker, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `UnhandledEffectError` class, which is thrown when an effect operation is called
+  * without a corresponding handler.
+  */
+object GenUnhandledEffectError {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("UnhandledEffectError"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(this.desc, IsFinal, superClass = ClassConstants.FlixError.Desc)
+
+    cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
+    // This field allows external equality checking.
+    cm.mkField(EffectNameField, IsPublic, IsFinal, NotVolatile)
+    cm.mkField(LocationField, IsPublic, IsFinal, NotVolatile)
+
+    cm.closeClassMaker()
+  }
+
+  private def EffectNameField: InstanceField = InstanceField(this.desc, "effectName", JavaClasses.String)
+
+  private def LocationField: InstanceField = InstanceField(this.desc, "location", GenReifiedSourceLocation.desc)
+
+  def Constructor: ConstructorMethod =
+    ConstructorMethod(this.desc, List(BackendObjType.Suspension.desc, JavaClasses.String, GenReifiedSourceLocation.desc))
+
+  private def constructorIns(implicit mv: MethodVisitor): Unit = {
+    withName(1, BackendObjType.Suspension.desc)(suspension => withName(2, JavaClasses.String)(info => withName(3, GenReifiedSourceLocation.desc)(loc => {
+      def appendString(): Unit = INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
+
+      thisLoad()
+      NEW(JavaClasses.StringBuilder)
+      DUP()
+      INVOKESPECIAL(ClassConstants.StringBuilder.Constructor)
+      pushString("Unhandled effect '")
+      appendString()
+      suspension.load()
+      GETFIELD(BackendObjType.Suspension.EffSymField)
+      appendString()
+      pushString("' (")
+      appendString()
+      info.load()
+      appendString()
+      pushString(") at ")
+      appendString()
+      loc.load()
+      INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
+      appendString()
+      INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
+      INVOKESPECIAL(ClassConstants.FlixError.Constructor)
+      // save arguments locally
+      thisLoad()
+      suspension.load()
+      GETFIELD(BackendObjType.Suspension.EffSymField)
+      PUTFIELD(EffectNameField)
+      thisLoad()
+      loc.load()
+      PUTFIELD(LocationField)
+      RETURN()
+    })))
+  }
+
+}

--- a/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language
 
 import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
-import ca.uwaterloo.flix.language.phase.jvm.BackendObjType
+import ca.uwaterloo.flix.language.phase.jvm.classes.GenHoleError
 import ca.uwaterloo.flix.runtime.{CompilationResult, JvmLoader}
 import ca.uwaterloo.flix.util.{Options, Result}
 import org.scalatest.funsuite.AnyFunSuite
@@ -33,7 +33,7 @@ class TestFlixErrors extends AnyFunSuite {
       .setOptions(Options.TestWithLibMin)
       .addVirtualPath(CompilerConstants.VirtualTestFile, input)
       .compile()
-    expectRuntimeError(result, BackendObjType.HoleError.desc.displayName())
+    expectRuntimeError(result, GenHoleError.desc.displayName())
   }
 
   test("HoleError.02") {
@@ -42,7 +42,7 @@ class TestFlixErrors extends AnyFunSuite {
       .setOptions(Options.TestWithLibMin)
       .addVirtualPath(CompilerConstants.VirtualTestFile, input)
       .compile()
-    expectRuntimeError(result, BackendObjType.HoleError.desc.displayName())
+    expectRuntimeError(result, GenHoleError.desc.displayName())
   }
 
   def expectRuntimeError(v: Result[CompilationResult, List[CompilationMessage]], name: String): Unit = {


### PR DESCRIPTION
Second step of breaking `BackendObjType.scala` into one file per generated JVM class. Follows #13130, which created the `phase.jvm.classes` package.

This one is pure code motion — no descriptor or type changes. Eleven classes leave the sealed `BackendObjType` hierarchy, each becoming an object that owns its own descriptor instead of a case in the central `desc` match. `BackendObjType.scala` drops from 2154 to 1704 lines and from 40 to 29 members.

### New files

`GenReifiedSourceLocation`, `GenHoleError`, `GenMatchError`, `GenCastError`, `GenUnhandledEffectError`, `GenUncaughtExceptionHandler`, `GenMain`, `GenNamespace`.

### `Defn`, `Closure`, and `Effect` don't get their own files

These three carry no fields, methods, or bytecode — only a name. The classes they name are emitted by `GenFunAndClosureClasses` and `GenEffectClasses`, so their descriptors move onto those generators as `defnDesc`, `closureDesc`, and `effectDesc`. Giving them empty `Gen*` files would have put the name in one place and the bytecode generation in another, which is what this refactor is trying to undo.

### Signature changes

`Namespace(ns)` and `Main` were used as values, so their members now take what they need explicitly: `GenNamespace.desc(ns)`, `GenNamespace.genByteCode(ns, defs)`, `GenNamespace.ShimMethod(ns, defn)`.

Three references stay pointing back into `BackendObjType`, and are resolved by later PRs in this sequence: `GenUnhandledEffectError` → `Suspension`, `GenMain`/`GenNamespace` → `Result` and `Unit`, and the `GenUncaughtExceptionHandler` ↔ `Region` cycle.

No behavior change — the generated bytecode is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)