### PR TITLE
refactor: move the effects runtime to jvm.classes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.*
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.{IsVolatile, NotVolatile}
-import ca.uwaterloo.flix.language.phase.jvm.classes.{GenReifiedSourceLocation, GenUncaughtExceptionHandler, GenUnhandledEffectError}
+import ca.uwaterloo.flix.language.phase.jvm.classes.{GenReifiedSourceLocation, GenResult, GenThunk, GenUncaughtExceptionHandler, GenValue}
 import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, RootPackage, mkDesc}
 import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoidDescriptor}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
@@ -55,20 +55,6 @@ sealed trait BackendObjType {
     // Java classes
     case BackendObjType.Native(clazz) => clazz
     // Effects Runtime
-    case BackendObjType.Result => mkDesc(DevFlixRuntime, mkClassName("Result"))
-    case BackendObjType.Value => mkDesc(DevFlixRuntime, mkClassName("Value"))
-    case BackendObjType.Frame => mkDesc(DevFlixRuntime, mkClassName("Frame"))
-    case BackendObjType.Thunk => mkDesc(DevFlixRuntime, mkClassName("Thunk"))
-    case BackendObjType.Suspension => mkDesc(DevFlixRuntime, mkClassName("Suspension"))
-    case BackendObjType.Frames => mkDesc(DevFlixRuntime, mkClassName("Frames"))
-    case BackendObjType.FramesCons => mkDesc(DevFlixRuntime, mkClassName("FramesCons"))
-    case BackendObjType.FramesNil => mkDesc(DevFlixRuntime, mkClassName("FramesNil"))
-    case BackendObjType.Resumption => mkDesc(DevFlixRuntime, mkClassName("Resumption"))
-    case BackendObjType.ResumptionCons => mkDesc(DevFlixRuntime, mkClassName("ResumptionCons"))
-    case BackendObjType.ResumptionNil => mkDesc(DevFlixRuntime, mkClassName("ResumptionNil"))
-    case BackendObjType.Handler => mkDesc(DevFlixRuntime, mkClassName("Handler"))
-    case BackendObjType.EffectCall => mkDesc(DevFlixRuntime, mkClassName("EffectCall"))
-    case BackendObjType.ResumptionWrapper(t) => mkDesc(DevFlixRuntime, mkClassName("ResumptionWrapper", t))
   }
 
   /**
@@ -177,9 +163,9 @@ object BackendObjType {
           // get expression as thunk
           DUP()
           GETFIELD(ExpField)
-          CHECKCAST(Thunk.desc)
+          CHECKCAST(GenThunk.desc)
           // this.value = thunk.unwind()
-          Result.unwindSuspensionFreeThunkToType(tpe, "during call to Lazy.force", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(tpe.toClassDesc, "during call to Lazy.force", SourceLocation.Unknown)
           PUTFIELD(ValueField)
           // this.exp = null
           thisLoad()
@@ -450,105 +436,105 @@ object BackendObjType {
           DUP()
           ALOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           ARETURN()
         case ObjConsumer =>
           thisLoad()
           DUP()
           ALOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           RETURN()
         case ObjPredicate =>
           thisLoad()
           DUP()
           ALOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Bool, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_boolean, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           IRETURN()
         case IntFunction =>
           thisLoad()
           DUP()
           ILOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           ARETURN()
         case IntConsumer =>
           thisLoad()
           DUP()
           ILOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           RETURN()
         case IntPredicate =>
           thisLoad()
           DUP()
           ILOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Bool, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_boolean, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           IRETURN()
         case IntUnaryOperator =>
           thisLoad()
           DUP()
           ILOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Int32, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_int, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           IRETURN()
         case LongFunction =>
           thisLoad()
           DUP()
           LLOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           ARETURN()
         case LongConsumer =>
           thisLoad()
           DUP()
           LLOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           RETURN()
         case LongPredicate =>
           thisLoad()
           DUP()
           LLOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Bool, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_boolean, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           IRETURN()
         case LongUnaryOperator =>
           thisLoad()
           DUP()
           LLOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Int64, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_long, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           LRETURN()
         case DoubleFunction =>
           thisLoad()
           DUP()
           DLOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           ARETURN()
         case DoubleConsumer =>
           thisLoad()
           DUP()
           DLOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_Object, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           RETURN()
         case DoublePredicate =>
           thisLoad()
           DUP()
           DLOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Bool, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_boolean, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           IRETURN()
         case DoubleUnaryOperator =>
           thisLoad()
           DUP()
           DLOAD(1)
           PUTFIELD(ArgField(0))
-          Result.unwindSuspensionFreeThunkToType(BackendType.Float64, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(CD_double, s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
           DRETURN()
       }
     }
@@ -617,7 +603,7 @@ object BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
       val specializedInterface = specialization()
-      val interfaces = Thunk.desc :: specializedInterface.map(_.desc)
+      val interfaces = GenThunk.desc :: specializedInterface.map(_.desc)
 
       val cm = ClassMaker.mkAbstractClass(this.desc, superClass = CD_Object, interfaces)
 
@@ -859,697 +845,6 @@ object BackendObjType {
       ALOAD(1)
       INVOKEVIRTUAL(ClassConstants.LinkedList.AddFirstMethod)
       RETURN()
-    }
-  }
-
-  case object Result extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.desc)
-      cm.closeClassMaker()
-    }
-
-    /**
-      * Expects a Result on the stack and leaves a non-Thunk Result.
-      * [..., Result] --> [..., Suspension|Value]
-      */
-    def unwindThunk()(implicit mv: MethodVisitor): Unit = {
-      whileLoop(Condition.NE) {
-        DUP()
-        INSTANCEOF(Thunk.desc)
-      } {
-        CHECKCAST(Thunk.desc)
-        INVOKEINTERFACE(Thunk.InvokeMethod)
-      }
-    }
-
-    /**
-      * Expects a Result on the stack.
-      * If the result is a Suspension, this will return a modified Suspension.
-      * If the result in NOT a Suspension, this will leave it on the stack.
-      * [..., Result] --> [..., Thunk|Value]
-      * side effect: Will return a modified suspension if a suspension occurs
-      */
-    private def handleSuspension(pc: Int, newFrame: MethodVisitor => Unit, setPc: MethodVisitor => Unit)(implicit mv: MethodVisitor): Unit = {
-      DUP()
-      INSTANCEOF(Suspension.desc)
-      ifCondition(Condition.NE) {
-        DUP()
-        CHECKCAST(Suspension.desc) // [..., s]
-        // Add our new frame
-        NEW(Suspension.desc)
-        DUP()
-        INVOKESPECIAL(Suspension.Constructor) // [..., s, s']
-        SWAP() // [..., s', s]
-        DUP2() // [..., s', s, s', s]
-        GETFIELD(Suspension.EffSymField)
-        PUTFIELD(Suspension.EffSymField) // [..., s', s]
-        DUP2()
-        GETFIELD(Suspension.EffOpField)
-        PUTFIELD(Suspension.EffOpField) // [..., s', s]
-        DUP2()
-        GETFIELD(Suspension.ResumptionField)
-        PUTFIELD(Suspension.ResumptionField) // [..., s', s]
-        DUP2()
-        GETFIELD(Suspension.PrefixField) // [..., s', s, s', s.prefix]
-        // Make the new frame and push it
-        newFrame(mv)
-        DUP()
-        pushInt(pc)
-        setPc(mv)
-        INVOKEINTERFACE(Frames.PushMethod) // [..., s', s, s', prefix']
-        PUTFIELD(Suspension.PrefixField) // [..., s', s]
-        POP() // [..., s']
-        // Return the suspension up the stack
-        xReturn(Suspension.desc)
-      }
-    }
-
-    /**
-      * Expects a Result on the stack and leaves a Value.
-      * This might return if a Suspension is encountered.
-      * [..., Result] --> [..., Value.value: tpe]
-      * side effect: Will return any Suspension found
-      */
-    def unwindThunkToValue(pc: Int, newFrame: MethodVisitor => Unit, setPc: MethodVisitor => Unit)(implicit mv: MethodVisitor): Unit = {
-      unwindThunk()
-      handleSuspension(pc, newFrame, setPc)
-      CHECKCAST(Value.desc) // Cannot fail
-    }
-
-    /**
-      * Expects a Result on the stack and leaves something of the given tpe but erased.
-      * Assumes that the result is control-pure, i.e. it is not a suspension and will never return a suspension through a thunk.
-      * [..., Result] --> [..., Value.value: tpe]
-      * side effect: crashes on suspensions
-      */
-    def unwindSuspensionFreeThunkToType(tpe: BackendType, errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
-      unwindThunk()
-      crashIfSuspension(errorHint, loc)
-      CHECKCAST(Value.desc) // Cannot fail
-      GETFIELD(Value.fieldFromType(tpe))
-      castIfNotPrim(tpe.toClassDesc)
-    }
-
-    /**
-      * Expects a Result on the stack and leaves a Value.
-      * Assumes that the result is control-pure, i.e. it is not a suspension and will never return a suspension through a thunk.
-      * [..., Result] --> [..., Value]
-      * side effect: crashes on suspensions
-      */
-    def unwindSuspensionFreeThunk(errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
-      unwindThunk()
-      crashIfSuspension(errorHint, loc)
-      CHECKCAST(Value.desc)
-    }
-
-    /**
-      * [..., Result] -> [..., Value|Thunk]
-      * side effect: if the result is a suspension, a [[GenUnhandledEffectError]] is thrown.
-      */
-    def crashIfSuspension(errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
-      DUP()
-      INSTANCEOF(Suspension.desc)
-      ifCondition(Condition.NE) {
-        CHECKCAST(Suspension.desc)
-        NEW(GenUnhandledEffectError.desc)
-        // [.., suspension, UEE] -> [.., suspension, UEE, UEE, suspension]
-        DUP2()
-        SWAP()
-        pushString(errorHint)
-        pushLoc(loc)
-        // [.., suspension, UEE, UEE, suspension, info, rsl] -> [.., suspension, UEE]
-        INVOKESPECIAL(GenUnhandledEffectError.Constructor)
-        ATHROW()
-      }
-    }
-  }
-
-  case object Value extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.desc, IsFinal, interfaces = List(Result.desc))
-
-      // The fields of all erased types, only one will be relevant
-      cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-      cm.mkField(BoolField, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(CharField, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(Int8Field, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(Int16Field, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(Int32Field, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(Int64Field, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(Float32Field, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(Float64Field, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(ObjectField, IsPublic, NotFinal, NotVolatile)
-
-      // Cached singleton Value instances for Unit, true, and false
-      cm.mkField(UnitField, IsPublic, IsFinal, NotVolatile)
-      cm.mkField(TrueField, IsPublic, IsFinal, NotVolatile)
-      cm.mkField(FalseField, IsPublic, IsFinal, NotVolatile)
-      cm.mkStaticConstructor(StaticConstructorMethod(this.desc), staticConstructorIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    private def staticConstructorIns(implicit mv: MethodVisitor): Unit = {
-      // Value.UNIT = new Value(); Value.UNIT.o = Unit.INSTANCE
-      NEW(this.desc)
-      DUP()
-      INVOKESPECIAL(Constructor)
-      DUP()
-      GETSTATIC(BackendObjType.Unit.SingletonField)
-      PUTFIELD(ObjectField)
-      PUTSTATIC(UnitField)
-      // Value.TRUE = new Value(); Value.TRUE.b = true
-      NEW(this.desc)
-      DUP()
-      INVOKESPECIAL(Constructor)
-      DUP()
-      ICONST_1()
-      PUTFIELD(BoolField)
-      PUTSTATIC(TrueField)
-      // Value.FALSE = new Value(); Value.FALSE.b = false (default, but explicit)
-      NEW(this.desc)
-      DUP()
-      INVOKESPECIAL(Constructor)
-      PUTSTATIC(FalseField)
-      RETURN()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
-
-    private def BoolField: InstanceField = InstanceField(this.desc, "b", CD_boolean)
-
-    private def CharField: InstanceField = InstanceField(this.desc, "c", CD_char)
-
-    private def Int8Field: InstanceField = InstanceField(this.desc, "i8", CD_byte)
-
-    private def Int16Field: InstanceField = InstanceField(this.desc, "i16", CD_short)
-
-    private def Int32Field: InstanceField = InstanceField(this.desc, "i32", CD_int)
-
-    private def Int64Field: InstanceField = InstanceField(this.desc, "i64", CD_long)
-
-    private def Float32Field: InstanceField = InstanceField(this.desc, "f32", CD_float)
-
-    private def Float64Field: InstanceField = InstanceField(this.desc, "f64", CD_double)
-
-    private def ObjectField: InstanceField = InstanceField(this.desc, "o", CD_Object)
-
-    def UnitField: StaticField = StaticField(this.desc, "UNIT", this.desc)
-
-    def TrueField: StaticField = StaticField(this.desc, "TRUE", this.desc)
-
-    def FalseField: StaticField = StaticField(this.desc, "FALSE", this.desc)
-
-    /**
-      * Returns the field of Value corresponding to the given type
-      */
-    def fieldFromType(tpe: BackendType): InstanceField = {
-      import BackendType.*
-      tpe match {
-        case Bool => BoolField
-        case Char => CharField
-        case Int8 => Int8Field
-        case Int16 => Int16Field
-        case Int32 => Int32Field
-        case Int64 => Int64Field
-        case Float32 => Float32Field
-        case Float64 => Float64Field
-        case Array(_) | BackendType.Reference(_) => ObjectField
-      }
-    }
-  }
-
-  /** Frame is really just java.util.Function<Value, Result> * */
-  case object Frame extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.desc)
-
-      cm.mkInterfaceMethod(ApplyMethod)
-      cm.mkStaticInterfaceMethod(StaticApplyMethod, IsPublic, NotFinal, staticApplyIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "applyFrame", mkDescriptor(Value.desc)(Result.desc))
-
-    def StaticApplyMethod: StaticInterfaceMethod = StaticInterfaceMethod(
-      this.desc,
-      "applyFrameStatic",
-      mkDescriptor(Frame.desc, Value.desc)(Result.desc)
-    )
-
-    private def staticApplyIns(implicit mv: MethodVisitor): Unit = {
-      withName(0, Frame.desc) { fun =>
-        withName(1, Value.desc) { resumeArg =>
-          fun.load()
-          resumeArg.load()
-          INVOKEINTERFACE(Frame.ApplyMethod)
-          ARETURN()
-        }
-      }
-    }
-  }
-
-  case object Thunk extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.desc, interfaces = List(Result.desc, JavaClasses.Runnable))
-
-      cm.mkInterfaceMethod(InvokeMethod)
-      cm.mkDefaultMethod(RunMethod, IsPublic, NotFinal, runIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def InvokeMethod: InterfaceMethod = InterfaceMethod(this.desc, "invoke", mkDescriptor()(Result.desc))
-
-    private def RunMethod: DefaultMethod = DefaultMethod(this.desc, "run", mkVoidDescriptor())
-
-    private def runIns(implicit mv: MethodVisitor): Unit = {
-      thisLoad()
-      Result.unwindSuspensionFreeThunk(s"in ${ClassDescs.binaryNameOf(JavaClasses.Runnable)}", SourceLocation.Unknown)
-      POP()
-      RETURN()
-    }
-  }
-
-  case object Suspension extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.desc, IsFinal, interfaces = List(Result.desc))
-
-      cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-      cm.mkField(EffSymField, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(EffOpField, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(PrefixField, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(ResumptionField, IsPublic, NotFinal, NotVolatile)
-
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
-
-    def EffSymField: InstanceField = InstanceField(this.desc, "effSym", JavaClasses.String)
-
-    def EffOpField: InstanceField = InstanceField(this.desc, "effOp", EffectCall.desc)
-
-    def PrefixField: InstanceField = InstanceField(this.desc, "prefix", Frames.desc)
-
-    def ResumptionField: InstanceField = InstanceField(this.desc, "resumption", Resumption.desc)
-
-  }
-
-  case object Frames extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.desc)
-
-      cm.mkInterfaceMethod(PushMethod)
-      cm.mkInterfaceMethod(ReverseOntoMethod)
-
-      cm.closeClassMaker()
-    }
-
-    def PushMethod: InterfaceMethod = InterfaceMethod(this.desc, "push", mkDescriptor(Frame.desc)(Frames.desc))
-
-    def ReverseOntoMethod: InterfaceMethod = InterfaceMethod(this.desc, "reverseOnto", mkDescriptor(Frames.desc)(Frames.desc))
-
-    def pushImplementation(implicit mv: MethodVisitor): Unit = {
-      withName(1, Frame.desc) { frame =>
-        NEW(FramesCons.desc)
-        DUP()
-        INVOKESPECIAL(FramesCons.Constructor)
-        DUP()
-        frame.load()
-        PUTFIELD(FramesCons.HeadField)
-        DUP()
-        thisLoad()
-        PUTFIELD(FramesCons.TailField)
-        xReturn(FramesCons.desc)
-      }
-    }
-  }
-
-  case object FramesCons extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.desc, IsFinal, interfaces = List(Frames.desc))
-
-      cm.mkField(HeadField, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(TailField, IsPublic, NotFinal, NotVolatile)
-      cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-      cm.mkMethod(Nil, PushMethod, IsPublic, IsFinal, Frames.pushImplementation(_))
-      cm.mkMethod(Nil, Frames.ReverseOntoMethod.implementation(this.desc), IsPublic, IsFinal, reverseOntoIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def HeadField: InstanceField = InstanceField(this.desc, "head", Frame.desc)
-
-    def TailField: InstanceField = InstanceField(this.desc, "tail", Frames.desc)
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
-
-    def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.desc)
-
-    private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Frames.desc) { rest =>
-        thisLoad()
-        GETFIELD(TailField)
-        NEW(FramesCons.desc)
-        DUP()
-        INVOKESPECIAL(FramesCons.Constructor)
-        DUP()
-        thisLoad()
-        GETFIELD(HeadField)
-        PUTFIELD(HeadField)
-        DUP()
-        rest.load()
-        PUTFIELD(TailField)
-        INVOKEINTERFACE(Frames.ReverseOntoMethod)
-        xReturn(Frames.desc)
-      }
-    }
-  }
-
-  case object FramesNil extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.desc, IsFinal, interfaces = List(Frames.desc))
-
-      cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-      cm.mkMethod(Nil, PushMethod, IsPublic, IsFinal, Frames.pushImplementation(_))
-      cm.mkMethod(Nil, Frames.ReverseOntoMethod.implementation(this.desc), IsPublic, IsFinal, reverseOntoIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
-
-    def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.desc)
-
-    private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Frames.desc) { rest =>
-        rest.load()
-        xReturn(rest.tpe)
-      }
-    }
-  }
-
-  case object Resumption extends BackendObjType {
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.desc)
-      cm.mkInterfaceMethod(RewindMethod)
-      cm.mkStaticInterfaceMethod(StaticRewindMethod, IsPublic, NotFinal, staticRewindIns(_))
-      cm.closeClassMaker()
-    }
-
-    def RewindMethod: InterfaceMethod = InterfaceMethod(this.desc, "rewind", mkDescriptor(Value.desc)(Result.desc))
-
-    def StaticRewindMethod: StaticInterfaceMethod = StaticInterfaceMethod(this.desc, "staticRewind", mkDescriptor(Resumption.desc, Value.desc)(Result.desc))
-
-    private def staticRewindIns(implicit mv: MethodVisitor): Unit = {
-      withName(0, Resumption.desc) { resumption =>
-        withName(1, Value.desc) { v =>
-          resumption.load()
-          v.load()
-          INVOKEINTERFACE(Resumption.RewindMethod)
-          ARETURN()
-        }
-      }
-    }
-  }
-
-  case object ResumptionCons extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.desc, IsFinal, interfaces = List(Resumption.desc))
-
-      cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-
-      cm.mkField(SymField, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(HandlerField, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(FramesField, IsPublic, NotFinal, NotVolatile)
-      cm.mkField(TailField, IsPublic, NotFinal, NotVolatile)
-
-      cm.mkMethod(Nil, Resumption.RewindMethod.implementation(this.desc), IsPublic, IsFinal, rewindIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
-
-    def SymField: InstanceField = InstanceField(this.desc, "sym", JavaClasses.String)
-
-    def HandlerField: InstanceField = InstanceField(this.desc, "handler", Handler.desc)
-
-    def FramesField: InstanceField = InstanceField(this.desc, "frames", Frames.desc)
-
-    def TailField: InstanceField = InstanceField(this.desc, "tail", Resumption.desc)
-
-    private def rewindIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Value.desc) { v =>
-        thisLoad()
-        GETFIELD(SymField)
-        thisLoad()
-        GETFIELD(HandlerField)
-        thisLoad()
-        GETFIELD(FramesField)
-        // () -> tail.rewind(v)
-        thisLoad()
-        GETFIELD(TailField)
-        v.load()
-        mkStaticLambda(Thunk.InvokeMethod, Resumption.StaticRewindMethod, drop = 0)
-        mkStaticLambda(Thunk.InvokeMethod, Handler.InstallHandlerMethod, drop = 0)
-        xReturn(Thunk.desc)
-      }
-    }
-  }
-
-  case object ResumptionNil extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.desc, IsFinal, interfaces = List(Resumption.desc))
-
-      cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
-      cm.mkMethod(Nil, Resumption.RewindMethod.implementation(this.desc), IsPublic, IsFinal, rewindIns(_))
-
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
-
-    private def rewindIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Value.desc) { v =>
-        v.load()
-        xReturn(v.tpe)
-      }
-    }
-  }
-
-  case object Handler extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.desc)
-      cm.mkStaticInterfaceMethod(InstallHandlerMethod, IsPublic, NotFinal, installHandlerIns(_))
-      cm.closeClassMaker()
-    }
-
-    def InstallHandlerMethod: StaticInterfaceMethod = StaticInterfaceMethod(
-      this.desc,
-      "installHandler",
-      mkDescriptor(JavaClasses.String, Handler.desc, Frames.desc, Thunk.desc)(Result.desc)
-    )
-
-    private def installHandlerIns(implicit mv: MethodVisitor): Unit = {
-      withName(0, JavaClasses.String) { effSym =>
-        withName(1, Handler.desc) { handler =>
-          withName(2, Frames.desc) { frames =>
-            withName(3, Thunk.desc) { thunk =>
-              thunk.load()
-              // Thunk|Value|Suspension
-              Result.unwindThunk()
-              // Value|Suspension
-              // handle suspension
-              DUP()
-              INSTANCEOF(Suspension.desc)
-              ifCondition(Condition.NE) {
-                DUP()
-                CHECKCAST(Suspension.desc)
-                storeWithName(4, Suspension.desc) { s =>
-                  NEW(ResumptionCons.desc)
-                  DUP()
-                  INVOKESPECIAL(ResumptionCons.Constructor)
-                  DUP()
-                  effSym.load()
-                  PUTFIELD(ResumptionCons.SymField)
-                  DUP()
-                  handler.load()
-                  PUTFIELD(ResumptionCons.HandlerField)
-                  DUP()
-                  s.load()
-                  GETFIELD(Suspension.PrefixField)
-                  frames.load()
-                  INVOKEINTERFACE(Frames.ReverseOntoMethod)
-                  PUTFIELD(ResumptionCons.FramesField)
-                  DUP()
-                  s.load()
-                  GETFIELD(Suspension.ResumptionField)
-                  PUTFIELD(ResumptionCons.TailField)
-                  storeWithName(5, ResumptionCons.desc) { r =>
-                    s.load()
-                    GETFIELD(Suspension.EffSymField)
-                    effSym.load()
-                    INVOKEVIRTUAL(ClassConstants.Object.EqualsMethod)
-                    ifCondition(Condition.NE) {
-                      s.load()
-                      GETFIELD(Suspension.EffOpField)
-                      handler.load()
-                      r.load()
-                      INVOKEINTERFACE(EffectCall.ApplyMethod)
-                      xReturn(Result.desc)
-                    }
-                    NEW(Suspension.desc)
-                    DUP()
-                    INVOKESPECIAL(Suspension.Constructor)
-                    DUP()
-                    s.load()
-                    GETFIELD(Suspension.EffSymField)
-                    PUTFIELD(Suspension.EffSymField)
-                    DUP()
-                    s.load()
-                    GETFIELD(Suspension.EffOpField)
-                    PUTFIELD(Suspension.EffOpField)
-                    DUP()
-                    NEW(FramesNil.desc)
-                    DUP()
-                    INVOKESPECIAL(FramesNil.Constructor)
-                    PUTFIELD(Suspension.PrefixField)
-                    DUP()
-                    r.load()
-                    PUTFIELD(Suspension.ResumptionField)
-                    xReturn(Suspension.desc)
-                  }
-                }
-              }
-
-              // Value
-              CHECKCAST(Value.desc)
-              storeWithName(6, Value.desc) { res =>
-                //
-                // Case on frames
-                // FramesNil
-                frames.load()
-                INSTANCEOF(FramesNil.desc)
-                ifCondition(Condition.NE) {
-                  res.load()
-                  xReturn(Value.desc)
-                }
-                // FramesCons
-                frames.load()
-                CHECKCAST(FramesCons.desc)
-                storeWithName(7, FramesCons.desc) { cons => {
-                  effSym.load()
-                  handler.load()
-                  cons.load()
-                  GETFIELD(FramesCons.TailField)
-                  // thunk
-                  cons.load()
-                  GETFIELD(FramesCons.HeadField)
-                  res.load()
-                  mkStaticLambda(Thunk.InvokeMethod, Frame.StaticApplyMethod, drop = 0)
-                  INVOKESTATIC(InstallHandlerMethod)
-                  xReturn(Result.desc)
-                }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  case object EffectCall extends BackendObjType {
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkInterface(this.desc)
-      cm.mkInterfaceMethod(ApplyMethod)
-      cm.closeClassMaker()
-    }
-
-    def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "apply", mkDescriptor(Handler.desc, Resumption.desc)(Result.desc))
-
-  }
-
-  case class ResumptionWrapper(tpe: BackendType) extends BackendObjType {
-
-    // tpe -> Result
-    private val superClass: AbstractArrow = AbstractArrow(List(tpe.toErased), BackendType.Object)
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = mkClass(this.desc, IsFinal, superClass.desc)
-      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
-      cm.mkField(ResumptionField, IsPrivate, IsFinal, NotVolatile)
-      cm.mkMethod(Nil, InvokeMethod, IsPublic, NotFinal, invokeIns(_))
-      cm.mkMethod(Nil, UniqueMethod, IsPublic, NotFinal, uniqueIns(_))
-      cm.closeClassMaker()
-    }
-
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, List(Resumption.desc))
-
-    private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withName(1, Resumption.desc) { resumption =>
-        thisLoad()
-        INVOKESPECIAL(superClass.desc, ConstructorMethodName, MethodTypeDescs.NothingToVoid)
-        thisLoad()
-        resumption.load()
-        PUTFIELD(ResumptionField)
-        RETURN()
-      }
-    }
-
-    def ResumptionField: InstanceField = InstanceField(this.desc, "resumption", Resumption.desc)
-
-    def InvokeMethod: InstanceMethod = Thunk.InvokeMethod.implementation(this.desc)
-
-    private def invokeIns(implicit mv: MethodVisitor): Unit = {
-      thisLoad()
-      GETFIELD(ResumptionField)
-      tpe.toErased match {
-        case BackendType.Bool =>
-          // Use cached Value.TRUE / Value.FALSE singletons
-          thisLoad()
-          mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc), "arg0", tpe.toErased.toDescriptor)
-          val falseLabel = new Label()
-          val doneLabel = new Label()
-          mv.visitJumpInsn(Opcodes.IFEQ, falseLabel)
-          GETSTATIC(Value.TrueField)
-          mv.visitJumpInsn(Opcodes.GOTO, doneLabel)
-          mv.visitLabel(falseLabel)
-          GETSTATIC(Value.FalseField)
-          mv.visitLabel(doneLabel)
-        case _ =>
-          NEW(Value.desc)
-          DUP()
-          INVOKESPECIAL(Value.Constructor)
-          DUP()
-          thisLoad()
-          mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc), "arg0", tpe.toErased.toDescriptor)
-          PUTFIELD(Value.fieldFromType(tpe.toErased))
-      }
-      INVOKEINTERFACE(Resumption.RewindMethod)
-      xReturn(Result.desc)
-    }
-
-    private def UniqueMethod: InstanceMethod = InstanceMethod(this.desc, "getUniqueThreadClosure", mkDescriptor()(this.superClass.desc))
-
-    private def uniqueIns(implicit mv: MethodVisitor): Unit = {
-      thisLoad()
-      ARETURN()
     }
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{BytecodeAst, SimpleType, SourceLocation}
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugNoOp
-import ca.uwaterloo.flix.language.phase.jvm.classes.{GenCastError, GenExtTag, GenGlobal, GenHoleError, GenMain, GenMatchError, GenNamespace, GenNullaryTag, GenRecordExtend, GenReifiedSourceLocation, GenTag, GenUncaughtExceptionHandler, GenUnhandledEffectError}
+import ca.uwaterloo.flix.language.phase.jvm.classes.{GenCastError, GenEffectCall, GenExtTag, GenFrame, GenFrames, GenFramesCons, GenFramesNil, GenGlobal, GenHandler, GenHoleError, GenMain, GenMatchError, GenNamespace, GenNullaryTag, GenRecordExtend, GenReifiedSourceLocation, GenResult, GenResumption, GenResumptionCons, GenResumptionNil, GenResumptionWrapper, GenSuspension, GenTag, GenThunk, GenUncaughtExceptionHandler, GenUnhandledEffectError, GenValue}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 
 import java.lang.constant.ClassDesc
@@ -102,21 +102,21 @@ object CodeGen {
     val uncaughtExceptionHandlerClass = List(JvmClass(GenUncaughtExceptionHandler.desc, GenUncaughtExceptionHandler.genByteCode()))
 
     // Effect runtime classes.
-    val resultInterface = List(JvmClass(BackendObjType.Result.desc, BackendObjType.Result.genByteCode()))
-    val valueClass = List(JvmClass(BackendObjType.Value.desc, BackendObjType.Value.genByteCode()))
-    val frameInterface = List(JvmClass(BackendObjType.Frame.desc, BackendObjType.Frame.genByteCode()))
-    val thunkAbstractClass = List(JvmClass(BackendObjType.Thunk.desc, BackendObjType.Thunk.genByteCode()))
-    val suspensionClass = List(JvmClass(BackendObjType.Suspension.desc, BackendObjType.Suspension.genByteCode()))
-    val framesInterface = List(JvmClass(BackendObjType.Frames.desc, BackendObjType.Frames.genByteCode()))
-    val framesConsClass = List(JvmClass(BackendObjType.FramesCons.desc, BackendObjType.FramesCons.genByteCode()))
-    val framesNilClass = List(JvmClass(BackendObjType.FramesNil.desc, BackendObjType.FramesNil.genByteCode()))
-    val resumptionInterface = List(JvmClass(BackendObjType.Resumption.desc, BackendObjType.Resumption.genByteCode()))
-    val resumptionConsClass = List(JvmClass(BackendObjType.ResumptionCons.desc, BackendObjType.ResumptionCons.genByteCode()))
-    val resumptionNilClass = List(JvmClass(BackendObjType.ResumptionNil.desc, BackendObjType.ResumptionNil.genByteCode()))
-    val handlerInterface = List(JvmClass(BackendObjType.Handler.desc, BackendObjType.Handler.genByteCode()))
-    val effectCallClass = List(JvmClass(BackendObjType.EffectCall.desc, BackendObjType.EffectCall.genByteCode()))
+    val resultInterface = List(JvmClass(GenResult.desc, GenResult.genByteCode()))
+    val valueClass = List(JvmClass(GenValue.desc, GenValue.genByteCode()))
+    val frameInterface = List(JvmClass(GenFrame.desc, GenFrame.genByteCode()))
+    val thunkAbstractClass = List(JvmClass(GenThunk.desc, GenThunk.genByteCode()))
+    val suspensionClass = List(JvmClass(GenSuspension.desc, GenSuspension.genByteCode()))
+    val framesInterface = List(JvmClass(GenFrames.desc, GenFrames.genByteCode()))
+    val framesConsClass = List(JvmClass(GenFramesCons.desc, GenFramesCons.genByteCode()))
+    val framesNilClass = List(JvmClass(GenFramesNil.desc, GenFramesNil.genByteCode()))
+    val resumptionInterface = List(JvmClass(GenResumption.desc, GenResumption.genByteCode()))
+    val resumptionConsClass = List(JvmClass(GenResumptionCons.desc, GenResumptionCons.genByteCode()))
+    val resumptionNilClass = List(JvmClass(GenResumptionNil.desc, GenResumptionNil.genByteCode()))
+    val handlerInterface = List(JvmClass(GenHandler.desc, GenHandler.genByteCode()))
+    val effectCallClass = List(JvmClass(GenEffectCall.desc, GenEffectCall.genByteCode()))
     val effectClasses = GenEffectClasses.gen(root.effects.values)
-    val resumptionWrappers = BackendType.erasedTypes.map(BackendObjType.ResumptionWrapper.apply).map(bt => JvmClass(bt.desc, bt.genByteCode()))
+    val resumptionWrappers = BackendType.erasedTypes.map(tpe => JvmClass(GenResumptionWrapper.desc(tpe), GenResumptionWrapper.genByteCode(tpe)))
 
     val allClasses = List(
       mainClass,

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.language.ast.shared.{JConstructor, JMethod}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, SimpleType}
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.classes.GenResult
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
@@ -163,7 +164,7 @@ object GenAnonymousClasses {
   /** Creates code to read the arguments, load it into the `cloField` closure, call that function, and returns. */
   private def methodIns(abstractClass: BackendObjType.AbstractArrow, cloField: ClassMaker.InstanceField, actualRes: ClassDesc, m: JvmMethod)(implicit mv: MethodVisitor, root: Root): Unit = {
     val functionAbstractClass = abstractClass.superClass
-    val returnType = BackendType.toBackendType(m.tpe)
+    val returnType = BackendType.toClassDesc(m.tpe)
 
     thisLoad()
     GETFIELD(cloField)
@@ -178,7 +179,7 @@ object GenAnonymousClasses {
         }
     }
     // Invoke the closure, leaving its result on the stack in the representation of `m.tpe`.
-    BackendObjType.Result.unwindSuspensionFreeThunkToType(returnType, s"in anonymous class method ${m.ident.name}", m.loc)
+    GenResult.unwindSuspensionFreeThunkToType(returnType, s"in anonymous class method ${m.ident.name}", m.loc)
 
     // Return the value using the method's erased JVM return type (`actualRes`). Any boxing
     // needed to feed a primitive result into a reference (e.g. `Object`) return has already

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -4,6 +4,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.JvmAst.{Effect, Root}
 import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.classes.{GenHandler, GenResult, GenResumption, GenResumptionWrapper, GenThunk}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.InstanceField
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
@@ -69,7 +70,7 @@ object GenEffectClasses {
   }
 
   private def genByteCode(effectName: ClassDesc, effect: Effect)(implicit root: Root, flix: Flix): Array[Byte] = {
-    val cm = ClassMaker.mkClass(effectName, IsFinal, interfaces = List(BackendObjType.Handler.desc))
+    val cm = ClassMaker.mkClass(effectName, IsFinal, interfaces = List(GenHandler.desc))
 
     cm.mkConstructor(ClassMaker.ConstructorMethod(effectName, Nil), IsPublic, constructorIns(_))
 
@@ -79,9 +80,9 @@ object GenEffectClasses {
       val opFunction = BackendObjType.Arrow(erasedParams :+ BackendType.Object, BackendType.Object)
       val opField = ClassMaker.InstanceField(effectName, name, opFunction.desc)
       cm.mkField(opField, IsPublic, NotFinal, NotVolatile)
-      val methodArgs = erasedParams.map(_.toClassDesc) ++ List(BackendObjType.Handler.desc, BackendObjType.Resumption.desc)
+      val methodArgs = erasedParams.map(_.toClassDesc) ++ List(GenHandler.desc, GenResumption.desc)
       val returnType = BackendType.toBackendType(op.tpe)
-      cm.mkStaticMethod(ClassMaker.StaticMethod(effectName, name, MethodTypeDescs.mkDescriptor(methodArgs *)(BackendObjType.Result.desc)), IsPublic, NotFinal, methodIns(effectName, opFunction, opField, erasedParams, returnType)(_))
+      cm.mkStaticMethod(ClassMaker.StaticMethod(effectName, name, MethodTypeDescs.mkDescriptor(methodArgs *)(GenResult.desc)), IsPublic, NotFinal, methodIns(effectName, opFunction, opField, erasedParams, returnType)(_))
     }
 
     cm.closeClassMaker()
@@ -94,11 +95,10 @@ object GenEffectClasses {
   }
 
   private def methodIns(effectName: ClassDesc, opFunction: BackendObjType.Arrow, opField: InstanceField, erasedParams: List[BackendType], returnType: BackendType)(implicit mv: MethodVisitor): Unit = {
-    val wrapperType = BackendObjType.ResumptionWrapper(returnType)
 
     withNames(0, erasedParams.map(_.toClassDesc)) { case (paramsOffset, params) =>
-      withName(paramsOffset, BackendObjType.Handler.desc) { handler =>
-        withName(paramsOffset + 1, BackendObjType.Resumption.desc) { resumption =>
+      withName(paramsOffset, GenHandler.desc) { handler =>
+        withName(paramsOffset + 1, GenResumption.desc) { resumption =>
           // Cast the given generic handler to the current effect.
           handler.load()
           CHECKCAST(effectName)
@@ -116,13 +116,13 @@ object GenEffectClasses {
           }
           // Convert the resumption to a function.
           DUP()
-          NEW(wrapperType.desc)
+          NEW(GenResumptionWrapper.desc(returnType))
           DUP()
           resumption.load()
-          INVOKESPECIAL(wrapperType.Constructor)
+          INVOKESPECIAL(GenResumptionWrapper.Constructor(returnType))
           PUTFIELD(ClassMaker.InstanceField(opFunction.desc, s"arg${params.size}", JavaClasses.Object))
           // Call invoke.
-          INVOKEINTERFACE(BackendObjType.Thunk.InvokeMethod)
+          INVOKEINTERFACE(GenThunk.InvokeMethod)
           ARETURN()
         }
       }
@@ -133,8 +133,8 @@ object GenEffectClasses {
     val effect = root.effects(sym.eff)
     val op = effect.ops.find(op => op.sym == sym).getOrElse(throw InternalCompilerException(s"Could not find op '$sym' in effect '$effect'.", sym.loc))
     val erasedParams = op.fparams.map(_.tpe).map(BackendType.toErasedBackendType)
-    val methodArgs = erasedParams.map(_.toClassDesc) ++ List(BackendObjType.Handler.desc, BackendObjType.Resumption.desc)
-    MethodTypeDescs.mkDescriptor(methodArgs *)(BackendObjType.Result.desc)
+    val methodArgs = erasedParams.map(_.toClassDesc) ++ List(GenHandler.desc, GenResumption.desc)
+    MethodTypeDescs.mkDescriptor(methodArgs *)(GenResult.desc)
   }
 
   /** Returns the JVM field/method name of the effect operation `sym`. */

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.SemanticOp.*
 import ca.uwaterloo.flix.language.ast.shared.{Constant, ExpPosition, Mutability}
 import ca.uwaterloo.flix.language.ast.{SimpleType, *}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
-import ca.uwaterloo.flix.language.phase.jvm.classes.{GenCastError, GenExtTag, GenHoleError, GenMatchError, GenNullaryTag, GenRecordExtend, GenTag}
+import ca.uwaterloo.flix.language.phase.jvm.classes.{GenCastError, GenEffectCall, GenExtTag, GenFrames, GenFramesNil, GenHandler, GenHoleError, GenMatchError, GenNullaryTag, GenRecordExtend, GenResult, GenResumption, GenResumptionNil, GenSuspension, GenTag, GenThunk, GenValue}
 import ca.uwaterloo.flix.util.ClassDescs.internalNameOf
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
 import java.lang.constant.ConstantDescs.{CD_double, CD_long, CD_void}
@@ -801,11 +801,11 @@ object GenExpression {
 
       case AtomicOp.Unbox =>
         val List(exp) = exps
-        val bType = BackendType.toBackendType(tpe)
+        val bType = BackendType.toClassDesc(tpe)
         compileExpr(exp)
-        CHECKCAST(BackendObjType.Value.desc)
-        GETFIELD(BackendObjType.Value.fieldFromType(bType))
-        castIfNotPrim(bType.toClassDesc)
+        CHECKCAST(GenValue.desc)
+        GETFIELD(GenValue.fieldFromType(bType))
+        castIfNotPrim(bType)
 
       case AtomicOp.Box =>
         val List(exp) = exps
@@ -813,26 +813,26 @@ object GenExpression {
           case SimpleType.Unit =>
             compileExpr(exp)
             POP()
-            GETSTATIC(BackendObjType.Value.UnitField)
+            GETSTATIC(GenValue.UnitField)
           case SimpleType.Bool =>
             compileExpr(exp)
             val falseLabel = new Label()
             val doneLabel = new Label()
             mv.visitJumpInsn(Opcodes.IFEQ, falseLabel)
-            GETSTATIC(BackendObjType.Value.TrueField)
+            GETSTATIC(GenValue.TrueField)
             mv.visitJumpInsn(Opcodes.GOTO, doneLabel)
             mv.visitLabel(falseLabel)
-            GETSTATIC(BackendObjType.Value.FalseField)
+            GETSTATIC(GenValue.FalseField)
             mv.visitLabel(doneLabel)
           case _ =>
-            val erasedExpTpe = BackendType.toErasedBackendType(exp.tpe)
-            val valueField = BackendObjType.Value.fieldFromType(erasedExpTpe)
+            val erasedExpTpe = BackendType.toErasedClassDesc(exp.tpe)
+            val valueField = GenValue.fieldFromType(erasedExpTpe)
             compileExpr(exp)
-            NEW(BackendObjType.Value.desc)
+            NEW(GenValue.desc)
             DUP()
-            INVOKESPECIAL(BackendObjType.Value.Constructor)
+            INVOKESPECIAL(GenValue.Constructor)
             DUP()
-            xSwap(lowerLarge = erasedExpTpe.is64BitWidth, higherLarge = true) // two objects on top of the stack
+            xSwap(lowerLarge = isCategory2(erasedExpTpe), higherLarge = true) // two objects on top of the stack
             PUTFIELD(valueField)
         }
 
@@ -1091,7 +1091,7 @@ object GenExpression {
 
           // Calling unwind and unboxing
           if (Purity.isControlPure(purity)) {
-            BackendObjType.Result.unwindSuspensionFreeThunk("in pure closure call", loc)
+            GenResult.unwindSuspensionFreeThunk("in pure closure call", loc)
           } else {
             ctx match {
               case EffectContext(_, _, newFrame, setPc, narrowLocals, _, pcLabels, pcCounter) =>
@@ -1099,7 +1099,7 @@ object GenExpression {
                 val pcPointLabel = pcLabels(pcPoint)
                 val afterUnboxing = new Label()
                 pcCounter(0) += 1
-                BackendObjType.Result.unwindThunkToValue(pcPoint, newFrame, setPc)
+                GenResult.unwindThunkToValue(pcPoint, newFrame, setPc)
                 mv.visitJumpInsn(Opcodes.GOTO, afterUnboxing)
 
                 mv.visitLabel(pcPointLabel)
@@ -1147,10 +1147,10 @@ object GenExpression {
             compileExpr(arg)
             castIfNotPrim(tpe)
           }
-          val desc = mkDescriptor(paramTpes *)(BackendObjType.Result.desc)
+          val desc = mkDescriptor(paramTpes *)(GenResult.desc)
           val className = internalNameOf(GenFunAndClosureClasses.defnDesc(sym))
           mv.visitMethodInsn(Opcodes.INVOKESTATIC, className, ClassMaker.StaticApplyMethodName, desc.descriptorString(), false)
-          BackendObjType.Result.unwindSuspensionFreeThunk("in pure function call", loc)
+          GenResult.unwindSuspensionFreeThunk("in pure function call", loc)
         } else {
           // JvmType of Def
           val defInternalName = internalNameOf(GenFunAndClosureClasses.defnDesc(sym))
@@ -1174,13 +1174,13 @@ object GenExpression {
             case EffectContext(_, _, newFrame, setPc, narrowLocals, _, pcLabels, pcCounter) =>
               val defn = root.defs(sym)
               if (Purity.isControlPure(defn.expr.purity)) {
-                BackendObjType.Result.unwindSuspensionFreeThunk("in pure function call", loc)
+                GenResult.unwindSuspensionFreeThunk("in pure function call", loc)
               } else {
                 val pcPoint = pcCounter(0) + 1
                 val pcPointLabel = pcLabels(pcPoint)
                 val afterUnboxing = new Label()
                 pcCounter(0) += 1
-                BackendObjType.Result.unwindThunkToValue(pcPoint, newFrame, setPc)
+                GenResult.unwindThunkToValue(pcPoint, newFrame, setPc)
                 mv.visitJumpInsn(Opcodes.GOTO, afterUnboxing)
 
                 mv.visitLabel(pcPointLabel)
@@ -1190,22 +1190,20 @@ object GenExpression {
                 mv.visitLabel(afterUnboxing)
               }
             case DirectInstanceContext(_, _, _) | DirectStaticContext(_, _, _) =>
-              BackendObjType.Result.unwindSuspensionFreeThunk("in pure function call", loc)
+              GenResult.unwindSuspensionFreeThunk("in pure function call", loc)
           }
         }
     }
 
     case Expr.ApplyOp(sym, exps, tpe, _, loc) => ctx match {
       case DirectInstanceContext(_, _, _) | DirectStaticContext(_, _, _) =>
-        BackendObjType.Result.crashIfSuspension("Unexpected do-expression in direct method context", loc)
+        GenResult.crashIfSuspension("Unexpected do-expression in direct method context", loc)
 
       case EffectContext(_, _, newFrame, setPc, narrowLocals, _, pcLabels, pcCounter) =>
-        import BackendObjType.Suspension
-
         val pcPoint = pcCounter(0) + 1
         val pcPointLabel = pcLabels(pcPoint)
         val afterUnboxing = new Label()
-        val erasedResult = BackendType.toErasedBackendType(tpe)
+        val erasedResult = BackendType.toErasedClassDesc(tpe)
         pcCounter(0) += 1
 
         val effectName = GenEffectClasses.effectDesc(sym.eff)
@@ -1214,41 +1212,41 @@ object GenExpression {
           GenEffectClasses.opName(sym),
           GenEffectClasses.opStaticFunctionDescriptor(sym)
         )
-        NEW(Suspension.desc)
+        NEW(GenSuspension.desc)
         DUP()
-        INVOKESPECIAL(Suspension.Constructor)
+        INVOKESPECIAL(GenSuspension.Constructor)
         DUP()
         pushString(sym.eff.toString)
-        PUTFIELD(Suspension.EffSymField)
+        PUTFIELD(GenSuspension.EffSymField)
         DUP()
         // --- eff op ---
         exps.foreach(compileExpr)
-        mkStaticLambda(BackendObjType.EffectCall.ApplyMethod, effectStaticMethod, 2)
+        mkStaticLambda(GenEffectCall.ApplyMethod, effectStaticMethod, 2)
         // --------------
-        PUTFIELD(Suspension.EffOpField)
+        PUTFIELD(GenSuspension.EffOpField)
         DUP()
         // create continuation
-        NEW(BackendObjType.FramesNil.desc)
+        NEW(GenFramesNil.desc)
         DUP()
-        INVOKESPECIAL(BackendObjType.FramesNil.Constructor)
+        INVOKESPECIAL(GenFramesNil.Constructor)
         newFrame(mv)
         DUP()
         pushInt(pcPoint)
         setPc(mv)
-        INVOKEVIRTUAL(BackendObjType.FramesNil.PushMethod)
+        INVOKEVIRTUAL(GenFramesNil.PushMethod)
         // store continuation
-        PUTFIELD(Suspension.PrefixField)
+        PUTFIELD(GenSuspension.PrefixField)
         DUP()
-        NEW(BackendObjType.ResumptionNil.desc)
+        NEW(GenResumptionNil.desc)
         DUP()
-        INVOKESPECIAL(BackendObjType.ResumptionNil.Constructor)
-        PUTFIELD(Suspension.ResumptionField)
-        xReturn(Suspension.desc)
+        INVOKESPECIAL(GenResumptionNil.Constructor)
+        PUTFIELD(GenSuspension.ResumptionField)
+        xReturn(GenSuspension.desc)
 
         mv.visitLabel(pcPointLabel)
         narrowLocals(mv)
         ALOAD(1)
-        GETFIELD(BackendObjType.Value.fieldFromType(erasedResult))
+        GETFIELD(GenValue.fieldFromType(erasedResult))
 
         mv.visitLabel(afterUnboxing)
         castIfNotPrim(BackendType.toClassDesc(tpe))
@@ -1528,27 +1526,27 @@ object GenExpression {
         mv.visitFieldInsn(Opcodes.PUTFIELD, effectInternalName, GenEffectClasses.opName(op.sym), GenEffectClasses.opFieldType(op.sym).toDescriptor)
       }
       // frames
-      NEW(BackendObjType.FramesNil.desc)
+      NEW(GenFramesNil.desc)
       DUP()
-      INVOKESPECIAL(BackendObjType.FramesNil.Constructor)
+      INVOKESPECIAL(GenFramesNil.Constructor)
       // continuation
       compileExpr(exp)
       // exp.arg0 should be set to unit here but from lifting we know that it is unused so the
       // implicit null is fine.
       // call installHandler
-      INVOKESTATIC(BackendObjType.Handler.InstallHandlerMethod)
+      INVOKESTATIC(GenHandler.InstallHandlerMethod)
       // handle value/suspend/thunk if in non-tail position
       if (ct == ExpPosition.NonTail) {
         ctx match {
           case DirectInstanceContext(_, _, _) | DirectStaticContext(_, _, _) =>
-            BackendObjType.Result.unwindSuspensionFreeThunk("in pure run-with call", loc)
+            GenResult.unwindSuspensionFreeThunk("in pure run-with call", loc)
 
           case EffectContext(_, _, newFrame, setPc, narrowLocals, _, pcLabels, pcCounter) =>
             val pcPoint = pcCounter(0) + 1
             val pcPointLabel = pcLabels(pcPoint)
             val afterUnboxing = new Label()
             pcCounter(0) += 1
-            BackendObjType.Result.unwindThunkToValue(pcPoint, newFrame, setPc)
+            GenResult.unwindThunkToValue(pcPoint, newFrame, setPc)
             mv.visitJumpInsn(Opcodes.GOTO, afterUnboxing)
 
             mv.visitLabel(pcPointLabel)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.language.ast.JvmAst.{Def, Root}
 import ca.uwaterloo.flix.language.ast.{Purity, SimpleType, Symbol}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.StaticMethod
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.classes.{GenFrame, GenResult, GenThunk, GenValue}
 import ca.uwaterloo.flix.util.{ClassDescs, ParOps}
 import org.objectweb.asm.{ClassWriter, Label, MethodVisitor, Opcodes}
 
@@ -175,7 +176,7 @@ object GenFunAndClosureClasses {
 
     // Header
     val functionInterface = BackendObjType.Arrow.fromArrowType(defn.arrowType).desc
-    val frameInterface = BackendObjType.Frame
+    val frameInterface = GenFrame
     visitor.visit(CompilerConstants.JvmTargetVersion, Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, ClassDescs.internalNameOf(className), null,
       ClassDescs.internalNameOf(functionInterface), Array(ClassDescs.internalNameOf(frameInterface.desc)))
     visitor.visitSource(defn.loc.source.name, null)
@@ -257,7 +258,7 @@ object GenFunAndClosureClasses {
 
     // Header
     val functionInterface = BackendObjType.AbstractArrow.fromArrowType(defn.arrowType).desc
-    val frameInterface = BackendObjType.Frame
+    val frameInterface = GenFrame
     visitor.visit(CompilerConstants.JvmTargetVersion, Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, ClassDescs.internalNameOf(className), null,
       ClassDescs.internalNameOf(functionInterface), Array(ClassDescs.internalNameOf(frameInterface.desc)))
     visitor.visitSource(defn.loc.source.name, null)
@@ -299,7 +300,7 @@ object GenFunAndClosureClasses {
   }
 
   private def staticApplyMethod(className: ClassDesc, defn: Def)(implicit root: Root): StaticMethod =
-    StaticMethod(className, ClassMaker.StaticApplyMethodName, MethodTypeDescs.mkDescriptor(defn.fparams.map(fp => BackendType.toClassDesc(fp.tpe)) *)(BackendObjType.Result.desc))
+    StaticMethod(className, ClassMaker.StaticApplyMethodName, MethodTypeDescs.mkDescriptor(defn.fparams.map(fp => BackendType.toClassDesc(fp.tpe)) *)(GenResult.desc))
 
   private def compileStaticApplyMethod(visitor: ClassWriter, className: ClassDesc, defn: Def)(implicit root: Root, flix: Flix): Unit = {
     // Method header
@@ -319,7 +320,7 @@ object GenFunAndClosureClasses {
     val ctx = GenExpression.DirectStaticContext(enterLabel, labelEnv, localOffset)
     GenExpression.compileExpr(defn.expr)(m, ctx, root, flix)
 
-    xReturn(BackendObjType.Result.desc)
+    xReturn(GenResult.desc)
 
 
     m.visitMaxs(999, 999)
@@ -327,8 +328,8 @@ object GenFunAndClosureClasses {
   }
 
   private def compileStaticInvokeMethod(visitor: ClassWriter, className: ClassDesc, defn: Def)(implicit root: Root): Unit = {
-    implicit val m: MethodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, BackendObjType.Thunk.InvokeMethod.name,
-      MethodTypeDescs.mkDescriptor()(BackendObjType.Result.desc).descriptorString(), null, null)
+    implicit val m: MethodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, GenThunk.InvokeMethod.name,
+      MethodTypeDescs.mkDescriptor()(GenResult.desc).descriptorString(), null, null)
     m.visitCode()
 
     val functionInterface = BackendObjType.Arrow.fromArrowType(defn.arrowType).desc
@@ -346,23 +347,23 @@ object GenFunAndClosureClasses {
     val method = staticApplyMethod(className, defn)
     m.visitMethodInsn(Opcodes.INVOKESTATIC, ClassDescs.internalNameOf(className), method.name, method.d.descriptorString(), false)
 
-    xReturn(BackendObjType.Result.desc)
+    xReturn(GenResult.desc)
 
     m.visitMaxs(999, 999)
     m.visitEnd()
   }
 
   private def compileInvokeMethod(visitor: ClassWriter, className: ClassDesc): Unit = {
-    implicit val m: MethodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, BackendObjType.Thunk.InvokeMethod.name,
-      MethodTypeDescs.mkDescriptor()(BackendObjType.Result.desc).descriptorString(), null, null)
+    implicit val m: MethodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, GenThunk.InvokeMethod.name,
+      MethodTypeDescs.mkDescriptor()(GenResult.desc).descriptorString(), null, null)
     m.visitCode()
 
-    val applyMethod = BackendObjType.Frame.ApplyMethod
+    val applyMethod = GenFrame.ApplyMethod
     m.visitVarInsn(Opcodes.ALOAD, 0)
     m.visitInsn(Opcodes.ACONST_NULL)
     m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, ClassDescs.internalNameOf(className), applyMethod.name, applyMethod.d.descriptorString(), false)
 
-    xReturn(BackendObjType.Result.desc)
+    xReturn(GenResult.desc)
 
     m.visitMaxs(999, 999)
     m.visitEnd()
@@ -373,7 +374,7 @@ object GenFunAndClosureClasses {
                                  defn: Def)(implicit root: Root, flix: Flix): Unit = {
     // Method header
     val classInternalName = ClassDescs.internalNameOf(className)
-    val applyMethod = BackendObjType.Frame.ApplyMethod
+    val applyMethod = GenFrame.ApplyMethod
     implicit val m: MethodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, applyMethod.name, applyMethod.d.descriptorString(), null, null)
     val localOffset = 2 // [this: Obj, value: Obj, ...]
 
@@ -455,7 +456,7 @@ object GenFunAndClosureClasses {
       assert(ctx.pcCounter(0) == pcLabels.size, s"${(className, ctx.pcCounter(0), pcLabels.size)}")
     }
 
-    xReturn(BackendObjType.Result.desc)
+    xReturn(GenResult.desc)
 
     m.visitMaxs(999, 999)
     m.visitEnd()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
@@ -404,6 +404,10 @@ object Instructions {
   def invokeConstructor(className: ClassDesc, descriptor: MethodTypeDesc)(implicit mv: MethodVisitor): Unit =
     INVOKESPECIAL(className, ConstructorMethodName, descriptor)
 
+  /** Returns `true` if `tpe` takes two slots on the stack, i.e. it is `long` or `double`. */
+  def isCategory2(tpe: ClassDesc): Boolean =
+    tpe == ConstantDescs.CD_long || tpe == ConstantDescs.CD_double
+
   def nop(): Unit =
     ()
 
@@ -535,7 +539,7 @@ object Instructions {
   /** Emits a `POP` or `POP2` instruction that pops a value of type `tpe` off the stack. */
   def xPop(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     import java.lang.constant.ConstantDescs.*
-    if (tpe == CD_long || tpe == CD_double) mv.visitInsn(Opcodes.POP2)
+    if (isCategory2(tpe)) mv.visitInsn(Opcodes.POP2)
     else mv.visitInsn(Opcodes.POP)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenEffectCall.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenEffectCall.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{InterfaceMethod, mkInterface}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.Mangle
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `EffectCall` interface: an effect operation applied to a handler and a resumption.
+  */
+object GenEffectCall {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("EffectCall"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkInterface(this.desc)
+    cm.mkInterfaceMethod(ApplyMethod)
+    cm.closeClassMaker()
+  }
+
+  def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "apply", mkDescriptor(GenHandler.desc, GenResumption.desc)(GenResult.desc))
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFrame.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFrame.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.NotFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{InterfaceMethod, StaticInterfaceMethod, mkInterface}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.Mangle
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/** Frame is really just java.util.Function<Value, Result> * */
+object GenFrame {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("Frame"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkInterface(this.desc)
+
+    cm.mkInterfaceMethod(ApplyMethod)
+    cm.mkStaticInterfaceMethod(StaticApplyMethod, IsPublic, NotFinal, staticApplyIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  def ApplyMethod: InterfaceMethod = InterfaceMethod(this.desc, "applyFrame", mkDescriptor(GenValue.desc)(GenResult.desc))
+
+  def StaticApplyMethod: StaticInterfaceMethod = StaticInterfaceMethod(
+    this.desc,
+    "applyFrameStatic",
+    mkDescriptor(GenFrame.desc, GenValue.desc)(GenResult.desc)
+  )
+
+  private def staticApplyIns(implicit mv: MethodVisitor): Unit = {
+    withName(0, GenFrame.desc) { fun =>
+      withName(1, GenValue.desc) { resumeArg =>
+        fun.load()
+        resumeArg.load()
+        INVOKEINTERFACE(GenFrame.ApplyMethod)
+        ARETURN()
+      }
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFrames.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFrames.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{InterfaceMethod, mkInterface}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.Mangle
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `Frames` interface, a stack of [[GenFrame]]s, implemented by [[GenFramesCons]] and
+  * [[GenFramesNil]].
+  */
+object GenFrames {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("Frames"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkInterface(this.desc)
+
+    cm.mkInterfaceMethod(PushMethod)
+    cm.mkInterfaceMethod(ReverseOntoMethod)
+
+    cm.closeClassMaker()
+  }
+
+  def PushMethod: InterfaceMethod = InterfaceMethod(this.desc, "push", mkDescriptor(GenFrame.desc)(GenFrames.desc))
+
+  def ReverseOntoMethod: InterfaceMethod = InterfaceMethod(this.desc, "reverseOnto", mkDescriptor(GenFrames.desc)(GenFrames.desc))
+
+  def pushImplementation(implicit mv: MethodVisitor): Unit = {
+    withName(1, GenFrame.desc) { frame =>
+      NEW(GenFramesCons.desc)
+      DUP()
+      INVOKESPECIAL(GenFramesCons.Constructor)
+      DUP()
+      frame.load()
+      PUTFIELD(GenFramesCons.HeadField)
+      DUP()
+      thisLoad()
+      PUTFIELD(GenFramesCons.TailField)
+      xReturn(GenFramesCons.desc)
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFramesCons.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFramesCons.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField, InstanceMethod, mkClass}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/** A non-empty [[GenFrames]] stack: a head [[GenFrame]] and the rest of the stack. */
+object GenFramesCons {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("FramesCons"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkClass(this.desc, IsFinal, interfaces = List(GenFrames.desc))
+
+    cm.mkField(HeadField, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(TailField, IsPublic, NotFinal, NotVolatile)
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkMethod(Nil, PushMethod, IsPublic, IsFinal, GenFrames.pushImplementation(_))
+    cm.mkMethod(Nil, GenFrames.ReverseOntoMethod.implementation(this.desc), IsPublic, IsFinal, reverseOntoIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  def HeadField: InstanceField = InstanceField(this.desc, "head", GenFrame.desc)
+
+  def TailField: InstanceField = InstanceField(this.desc, "tail", GenFrames.desc)
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
+
+  def PushMethod: InstanceMethod = GenFrames.PushMethod.implementation(this.desc)
+
+  private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
+    withName(1, GenFrames.desc) { rest =>
+      thisLoad()
+      GETFIELD(TailField)
+      NEW(GenFramesCons.desc)
+      DUP()
+      INVOKESPECIAL(GenFramesCons.Constructor)
+      DUP()
+      thisLoad()
+      GETFIELD(HeadField)
+      PUTFIELD(HeadField)
+      DUP()
+      rest.load()
+      PUTFIELD(TailField)
+      INVOKEINTERFACE(GenFrames.ReverseOntoMethod)
+      xReturn(GenFrames.desc)
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFramesNil.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFramesNil.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceMethod, mkClass}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/** The empty [[GenFrames]] stack. */
+object GenFramesNil {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("FramesNil"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkClass(this.desc, IsFinal, interfaces = List(GenFrames.desc))
+
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkMethod(Nil, PushMethod, IsPublic, IsFinal, GenFrames.pushImplementation(_))
+    cm.mkMethod(Nil, GenFrames.ReverseOntoMethod.implementation(this.desc), IsPublic, IsFinal, reverseOntoIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
+
+  def PushMethod: InstanceMethod = GenFrames.PushMethod.implementation(this.desc)
+
+  private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
+    withName(1, GenFrames.desc) { rest =>
+      rest.load()
+      xReturn(rest.tpe)
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenHandler.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenHandler.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.NotFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{StaticInterfaceMethod, mkInterface}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `Handler` interface, implemented by every generated effect class.
+  *
+  * [[InstallHandlerMethod]] runs a thunk under a handler: if the thunk suspends on this
+  * handler's effect it applies the operation, and otherwise it passes the suspension
+  * further up with this handler recorded in the resumption.
+  */
+object GenHandler {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("Handler"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkInterface(this.desc)
+    cm.mkStaticInterfaceMethod(InstallHandlerMethod, IsPublic, NotFinal, installHandlerIns(_))
+    cm.closeClassMaker()
+  }
+
+  def InstallHandlerMethod: StaticInterfaceMethod = StaticInterfaceMethod(
+    this.desc,
+    "installHandler",
+    mkDescriptor(JavaClasses.String, GenHandler.desc, GenFrames.desc, GenThunk.desc)(GenResult.desc)
+  )
+
+  private def installHandlerIns(implicit mv: MethodVisitor): Unit = {
+    withName(0, JavaClasses.String) { effSym =>
+      withName(1, GenHandler.desc) { handler =>
+        withName(2, GenFrames.desc) { frames =>
+          withName(3, GenThunk.desc) { thunk =>
+            thunk.load()
+            // Thunk|Value|Suspension
+            GenResult.unwindThunk()
+            // Value|Suspension
+            // handle suspension
+            DUP()
+            INSTANCEOF(GenSuspension.desc)
+            ifCondition(Condition.NE) {
+              DUP()
+              CHECKCAST(GenSuspension.desc)
+              storeWithName(4, GenSuspension.desc) { s =>
+                NEW(GenResumptionCons.desc)
+                DUP()
+                INVOKESPECIAL(GenResumptionCons.Constructor)
+                DUP()
+                effSym.load()
+                PUTFIELD(GenResumptionCons.SymField)
+                DUP()
+                handler.load()
+                PUTFIELD(GenResumptionCons.HandlerField)
+                DUP()
+                s.load()
+                GETFIELD(GenSuspension.PrefixField)
+                frames.load()
+                INVOKEINTERFACE(GenFrames.ReverseOntoMethod)
+                PUTFIELD(GenResumptionCons.FramesField)
+                DUP()
+                s.load()
+                GETFIELD(GenSuspension.ResumptionField)
+                PUTFIELD(GenResumptionCons.TailField)
+                storeWithName(5, GenResumptionCons.desc) { r =>
+                  s.load()
+                  GETFIELD(GenSuspension.EffSymField)
+                  effSym.load()
+                  INVOKEVIRTUAL(ClassConstants.Object.EqualsMethod)
+                  ifCondition(Condition.NE) {
+                    s.load()
+                    GETFIELD(GenSuspension.EffOpField)
+                    handler.load()
+                    r.load()
+                    INVOKEINTERFACE(GenEffectCall.ApplyMethod)
+                    xReturn(GenResult.desc)
+                  }
+                  NEW(GenSuspension.desc)
+                  DUP()
+                  INVOKESPECIAL(GenSuspension.Constructor)
+                  DUP()
+                  s.load()
+                  GETFIELD(GenSuspension.EffSymField)
+                  PUTFIELD(GenSuspension.EffSymField)
+                  DUP()
+                  s.load()
+                  GETFIELD(GenSuspension.EffOpField)
+                  PUTFIELD(GenSuspension.EffOpField)
+                  DUP()
+                  NEW(GenFramesNil.desc)
+                  DUP()
+                  INVOKESPECIAL(GenFramesNil.Constructor)
+                  PUTFIELD(GenSuspension.PrefixField)
+                  DUP()
+                  r.load()
+                  PUTFIELD(GenSuspension.ResumptionField)
+                  xReturn(GenSuspension.desc)
+                }
+              }
+            }
+
+            // Value
+            CHECKCAST(GenValue.desc)
+            storeWithName(6, GenValue.desc) { res =>
+              //
+              // Case on frames
+              // FramesNil
+              frames.load()
+              INSTANCEOF(GenFramesNil.desc)
+              ifCondition(Condition.NE) {
+                res.load()
+                xReturn(GenValue.desc)
+              }
+              // FramesCons
+              frames.load()
+              CHECKCAST(GenFramesCons.desc)
+              storeWithName(7, GenFramesCons.desc) { cons => {
+                effSym.load()
+                handler.load()
+                cons.load()
+                GETFIELD(GenFramesCons.TailField)
+                // thunk
+                cons.load()
+                GETFIELD(GenFramesCons.HeadField)
+                res.load()
+                mkStaticLambda(GenThunk.InvokeMethod, GenFrame.StaticApplyMethod, drop = 0)
+                INVOKESTATIC(InstallHandlerMethod)
+                xReturn(GenResult.desc)
+              }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenMain.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenMain.scala
@@ -59,7 +59,7 @@ object GenMain {
       DUP()
       GETSTATIC(BackendObjType.Unit.SingletonField)
       PUTFIELD(InstanceField(defName, "arg0", CD_Object))
-      BackendObjType.Result.unwindSuspensionFreeThunk(s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
+      GenResult.unwindSuspensionFreeThunk(s"in ${ClassDescs.binaryNameOf(desc)}", SourceLocation.Unknown)
       POP()
       RETURN()
     })

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNamespace.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNamespace.scala
@@ -65,7 +65,7 @@ object GenNamespace {
     val paramTypes = defn.fparams.map(fp => BackendType.toErasedClassDesc(fp.tpe))
     withNames(0, paramTypes) {
       case (_, args) =>
-        val erasedResult = BackendType.toErasedBackendType(defn.unboxedType.tpe)
+        val erasedResult = BackendType.toErasedClassDesc(defn.unboxedType.tpe)
         NEW(defnDesc)
         DUP()
         INVOKESPECIAL(ConstructorMethod(defnDesc, Nil))
@@ -74,8 +74,8 @@ object GenNamespace {
           arg.load()
           PUTFIELD(InstanceField(defnDesc, s"arg$index", paramTypes(index)))
         }
-        BackendObjType.Result.unwindSuspensionFreeThunkToType(erasedResult, s"in shim method of ${defn.sym}", defn.loc)
-        xReturn(erasedResult.toClassDesc)
+        GenResult.unwindSuspensionFreeThunkToType(erasedResult, s"in shim method of ${defn.sym}", defn.loc)
+        xReturn(erasedResult)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResult.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResult.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.SourceLocation
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.mkInterface
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.Mangle
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `Result` interface, the return type of every compiled Flix function.
+  *
+  * A `Result` is one of [[GenValue]] (a finished computation), [[GenThunk]] (a computation
+  * still to run), or [[GenSuspension]] (a computation stopped by an effect operation).
+  */
+object GenResult {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("Result"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkInterface(this.desc)
+    cm.closeClassMaker()
+  }
+
+  /**
+    * Expects a Result on the stack and leaves a non-Thunk Result.
+    * [..., Result] --> [..., Suspension|Value]
+    */
+  def unwindThunk()(implicit mv: MethodVisitor): Unit = {
+    whileLoop(Condition.NE) {
+      DUP()
+      INSTANCEOF(GenThunk.desc)
+    } {
+      CHECKCAST(GenThunk.desc)
+      INVOKEINTERFACE(GenThunk.InvokeMethod)
+    }
+  }
+
+  /**
+    * Expects a Result on the stack.
+    * If the result is a Suspension, this will return a modified Suspension.
+    * If the result in NOT a Suspension, this will leave it on the stack.
+    * [..., Result] --> [..., Thunk|Value]
+    * side effect: Will return a modified suspension if a suspension occurs
+    */
+  private def handleSuspension(pc: Int, newFrame: MethodVisitor => Unit, setPc: MethodVisitor => Unit)(implicit mv: MethodVisitor): Unit = {
+    DUP()
+    INSTANCEOF(GenSuspension.desc)
+    ifCondition(Condition.NE) {
+      DUP()
+      CHECKCAST(GenSuspension.desc) // [..., s]
+      // Add our new frame
+      NEW(GenSuspension.desc)
+      DUP()
+      INVOKESPECIAL(GenSuspension.Constructor) // [..., s, s']
+      SWAP() // [..., s', s]
+      DUP2() // [..., s', s, s', s]
+      GETFIELD(GenSuspension.EffSymField)
+      PUTFIELD(GenSuspension.EffSymField) // [..., s', s]
+      DUP2()
+      GETFIELD(GenSuspension.EffOpField)
+      PUTFIELD(GenSuspension.EffOpField) // [..., s', s]
+      DUP2()
+      GETFIELD(GenSuspension.ResumptionField)
+      PUTFIELD(GenSuspension.ResumptionField) // [..., s', s]
+      DUP2()
+      GETFIELD(GenSuspension.PrefixField) // [..., s', s, s', s.prefix]
+      // Make the new frame and push it
+      newFrame(mv)
+      DUP()
+      pushInt(pc)
+      setPc(mv)
+      INVOKEINTERFACE(GenFrames.PushMethod) // [..., s', s, s', prefix']
+      PUTFIELD(GenSuspension.PrefixField) // [..., s', s]
+      POP() // [..., s']
+      // Return the suspension up the stack
+      xReturn(GenSuspension.desc)
+    }
+  }
+
+  /**
+    * Expects a Result on the stack and leaves a Value.
+    * This might return if a Suspension is encountered.
+    * [..., Result] --> [..., Value.value: tpe]
+    * side effect: Will return any Suspension found
+    */
+  def unwindThunkToValue(pc: Int, newFrame: MethodVisitor => Unit, setPc: MethodVisitor => Unit)(implicit mv: MethodVisitor): Unit = {
+    unwindThunk()
+    handleSuspension(pc, newFrame, setPc)
+    CHECKCAST(GenValue.desc) // Cannot fail
+  }
+
+  /**
+    * Expects a Result on the stack and leaves something of the given tpe but erased.
+    * Assumes that the result is control-pure, i.e. it is not a suspension and will never return a suspension through a thunk.
+    * [..., Result] --> [..., Value.value: tpe]
+    * side effect: crashes on suspensions
+    */
+  def unwindSuspensionFreeThunkToType(tpe: ClassDesc, errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
+    unwindThunk()
+    crashIfSuspension(errorHint, loc)
+    CHECKCAST(GenValue.desc) // Cannot fail
+    GETFIELD(GenValue.fieldFromType(tpe))
+    castIfNotPrim(tpe)
+  }
+
+  /**
+    * Expects a Result on the stack and leaves a Value.
+    * Assumes that the result is control-pure, i.e. it is not a suspension and will never return a suspension through a thunk.
+    * [..., Result] --> [..., Value]
+    * side effect: crashes on suspensions
+    */
+  def unwindSuspensionFreeThunk(errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
+    unwindThunk()
+    crashIfSuspension(errorHint, loc)
+    CHECKCAST(GenValue.desc)
+  }
+
+  /**
+    * [..., Result] -> [..., Value|Thunk]
+    * side effect: if the result is a suspension, a [[GenUnhandledEffectError]] is thrown.
+    */
+  def crashIfSuspension(errorHint: String, loc: SourceLocation)(implicit mv: MethodVisitor): Unit = {
+    DUP()
+    INSTANCEOF(GenSuspension.desc)
+    ifCondition(Condition.NE) {
+      CHECKCAST(GenSuspension.desc)
+      NEW(GenUnhandledEffectError.desc)
+      // [.., suspension, UEE] -> [.., suspension, UEE, UEE, suspension]
+      DUP2()
+      SWAP()
+      pushString(errorHint)
+      pushLoc(loc)
+      // [.., suspension, UEE, UEE, suspension, info, rsl] -> [.., suspension, UEE]
+      INVOKESPECIAL(GenUnhandledEffectError.Constructor)
+      ATHROW()
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumption.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumption.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.NotFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{InterfaceMethod, StaticInterfaceMethod, mkInterface}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.Mangle
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `Resumption` interface, the continuation of a suspended computation, implemented by
+  * [[GenResumptionCons]] and [[GenResumptionNil]].
+  */
+object GenResumption {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("Resumption"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkInterface(this.desc)
+    cm.mkInterfaceMethod(RewindMethod)
+    cm.mkStaticInterfaceMethod(StaticRewindMethod, IsPublic, NotFinal, staticRewindIns(_))
+    cm.closeClassMaker()
+  }
+
+  def RewindMethod: InterfaceMethod = InterfaceMethod(this.desc, "rewind", mkDescriptor(GenValue.desc)(GenResult.desc))
+
+  def StaticRewindMethod: StaticInterfaceMethod = StaticInterfaceMethod(this.desc, "staticRewind", mkDescriptor(GenResumption.desc, GenValue.desc)(GenResult.desc))
+
+  private def staticRewindIns(implicit mv: MethodVisitor): Unit = {
+    withName(0, GenResumption.desc) { resumption =>
+      withName(1, GenValue.desc) { v =>
+        resumption.load()
+        v.load()
+        INVOKEINTERFACE(GenResumption.RewindMethod)
+        ARETURN()
+      }
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionCons.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionCons.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField, mkClass}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * A non-empty [[GenResumption]]: one handler's worth of the continuation, and the
+  * resumption to continue with once it is done.
+  */
+object GenResumptionCons {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("ResumptionCons"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkClass(this.desc, IsFinal, interfaces = List(GenResumption.desc))
+
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+
+    cm.mkField(SymField, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(HandlerField, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(FramesField, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(TailField, IsPublic, NotFinal, NotVolatile)
+
+    cm.mkMethod(Nil, GenResumption.RewindMethod.implementation(this.desc), IsPublic, IsFinal, rewindIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
+
+  def SymField: InstanceField = InstanceField(this.desc, "sym", JavaClasses.String)
+
+  def HandlerField: InstanceField = InstanceField(this.desc, "handler", GenHandler.desc)
+
+  def FramesField: InstanceField = InstanceField(this.desc, "frames", GenFrames.desc)
+
+  def TailField: InstanceField = InstanceField(this.desc, "tail", GenResumption.desc)
+
+  private def rewindIns(implicit mv: MethodVisitor): Unit = {
+    withName(1, GenValue.desc) { v =>
+      thisLoad()
+      GETFIELD(SymField)
+      thisLoad()
+      GETFIELD(HandlerField)
+      thisLoad()
+      GETFIELD(FramesField)
+      // () -> tail.rewind(v)
+      thisLoad()
+      GETFIELD(TailField)
+      v.load()
+      mkStaticLambda(GenThunk.InvokeMethod, GenResumption.StaticRewindMethod, drop = 0)
+      mkStaticLambda(GenThunk.InvokeMethod, GenHandler.InstallHandlerMethod, drop = 0)
+      xReturn(GenThunk.desc)
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionNil.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionNil.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, mkClass}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/** The empty [[GenResumption]]: rewinding it just yields the value it is given. */
+object GenResumptionNil {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("ResumptionNil"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkClass(this.desc, IsFinal, interfaces = List(GenResumption.desc))
+
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkMethod(Nil, GenResumption.RewindMethod.implementation(this.desc), IsPublic, IsFinal, rewindIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
+
+  private def rewindIns(implicit mv: MethodVisitor): Unit = {
+    withName(1, GenValue.desc) { v =>
+      v.load()
+      xReturn(v.tpe)
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionWrapper.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionWrapper.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, ConstructorMethodName, InstanceField, InstanceMethod, mkClass}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.{BackendObjType, BackendType, Mangle, MethodTypeDescs}
+import ca.uwaterloo.flix.util.ClassDescs
+import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The class that presents a [[GenResumption]] as a one-argument Flix function, so that a
+  * handler can call the continuation like any other closure.
+  *
+  * NB: `tpe` is still a [[BackendType]] because the superclass is a
+  * `BackendObjType.AbstractArrow`, which Wave 2 de-parametrizes. Only its erasure is ever
+  * used.
+  */
+object GenResumptionWrapper {
+
+  def desc(tpe: BackendType): ClassDesc =
+    mkDesc(DevFlixRuntime, Mangle.mkClassName("ResumptionWrapper", tpe.toErasedString))
+
+  // tpe -> Result
+  private def superClass(tpe: BackendType): BackendObjType.AbstractArrow =
+    BackendObjType.AbstractArrow(List(tpe.toErased), BackendType.Object)
+
+  def genByteCode(tpe: BackendType)(implicit flix: Flix): Array[Byte] = {
+    val cm = mkClass(desc(tpe), IsFinal, superClass(tpe).desc)
+    cm.mkConstructor(Constructor(tpe), IsPublic, constructorIns(tpe)(_))
+    cm.mkField(ResumptionField(tpe), IsPrivate, IsFinal, NotVolatile)
+    cm.mkMethod(Nil, InvokeMethod(tpe), IsPublic, NotFinal, invokeIns(tpe)(_))
+    cm.mkMethod(Nil, UniqueMethod(tpe), IsPublic, NotFinal, uniqueIns(_))
+    cm.closeClassMaker()
+  }
+
+  def Constructor(tpe: BackendType): ConstructorMethod = ConstructorMethod(desc(tpe), List(GenResumption.desc))
+
+  private def constructorIns(tpe: BackendType)(implicit mv: MethodVisitor): Unit = {
+    withName(1, GenResumption.desc) { resumption =>
+      thisLoad()
+      INVOKESPECIAL(superClass(tpe).desc, ConstructorMethodName, MethodTypeDescs.NothingToVoid)
+      thisLoad()
+      resumption.load()
+      PUTFIELD(ResumptionField(tpe))
+      RETURN()
+    }
+  }
+
+  def ResumptionField(tpe: BackendType): InstanceField = InstanceField(desc(tpe), "resumption", GenResumption.desc)
+
+  def InvokeMethod(tpe: BackendType): InstanceMethod = GenThunk.InvokeMethod.implementation(desc(tpe))
+
+  private def invokeIns(tpe: BackendType)(implicit mv: MethodVisitor): Unit = {
+    thisLoad()
+    GETFIELD(ResumptionField(tpe))
+    tpe.toErased match {
+      case BackendType.Bool =>
+        // Use cached Value.TRUE / Value.FALSE singletons
+        thisLoad()
+        mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc(tpe)), "arg0", tpe.toErased.toDescriptor)
+        val falseLabel = new Label()
+        val doneLabel = new Label()
+        mv.visitJumpInsn(Opcodes.IFEQ, falseLabel)
+        GETSTATIC(GenValue.TrueField)
+        mv.visitJumpInsn(Opcodes.GOTO, doneLabel)
+        mv.visitLabel(falseLabel)
+        GETSTATIC(GenValue.FalseField)
+        mv.visitLabel(doneLabel)
+      case _ =>
+        NEW(GenValue.desc)
+        DUP()
+        INVOKESPECIAL(GenValue.Constructor)
+        DUP()
+        thisLoad()
+        mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc(tpe)), "arg0", tpe.toErased.toDescriptor)
+        PUTFIELD(GenValue.fieldFromType(tpe.toErased.toClassDesc))
+    }
+    INVOKEINTERFACE(GenResumption.RewindMethod)
+    xReturn(GenResult.desc)
+  }
+
+  private def UniqueMethod(tpe: BackendType): InstanceMethod =
+    InstanceMethod(desc(tpe), "getUniqueThreadClosure", mkDescriptor()(superClass(tpe).desc))
+
+  private def uniqueIns(implicit mv: MethodVisitor): Unit = {
+    thisLoad()
+    ARETURN()
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenSuspension.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenSuspension.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField, mkClass}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `Suspension` class, a [[GenResult]] holding a computation stopped by an effect
+  * operation, together with the frames to resume once the operation is handled.
+  */
+object GenSuspension {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("Suspension"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkClass(this.desc, IsFinal, interfaces = List(GenResult.desc))
+
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkField(EffSymField, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(EffOpField, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(PrefixField, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(ResumptionField, IsPublic, NotFinal, NotVolatile)
+
+    cm.closeClassMaker()
+  }
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
+
+  def EffSymField: InstanceField = InstanceField(this.desc, "effSym", JavaClasses.String)
+
+  def EffOpField: InstanceField = InstanceField(this.desc, "effOp", GenEffectCall.desc)
+
+  def PrefixField: InstanceField = InstanceField(this.desc, "prefix", GenFrames.desc)
+
+  def ResumptionField: InstanceField = InstanceField(this.desc, "resumption", GenResumption.desc)
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenThunk.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenThunk.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.SourceLocation
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.NotFinal
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{DefaultMethod, InterfaceMethod, mkInterface}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoidDescriptor}
+import ca.uwaterloo.flix.language.phase.jvm.{JavaClasses, Mangle}
+import ca.uwaterloo.flix.util.ClassDescs
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The `Thunk` interface, a [[GenResult]] holding a computation that has not run yet.
+  */
+object GenThunk {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("Thunk"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkInterface(this.desc, interfaces = List(GenResult.desc, JavaClasses.Runnable))
+
+    cm.mkInterfaceMethod(InvokeMethod)
+    cm.mkDefaultMethod(RunMethod, IsPublic, NotFinal, runIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  def InvokeMethod: InterfaceMethod = InterfaceMethod(this.desc, "invoke", mkDescriptor()(GenResult.desc))
+
+  private def RunMethod: DefaultMethod = DefaultMethod(this.desc, "run", mkVoidDescriptor())
+
+  private def runIns(implicit mv: MethodVisitor): Unit = {
+    thisLoad()
+    GenResult.unwindSuspensionFreeThunk(s"in ${ClassDescs.binaryNameOf(JavaClasses.Runnable)}", SourceLocation.Unknown)
+    POP()
+    RETURN()
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnhandledEffectError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnhandledEffectError.scala
@@ -52,10 +52,10 @@ object GenUnhandledEffectError {
   private def LocationField: InstanceField = InstanceField(this.desc, "location", GenReifiedSourceLocation.desc)
 
   def Constructor: ConstructorMethod =
-    ConstructorMethod(this.desc, List(BackendObjType.Suspension.desc, JavaClasses.String, GenReifiedSourceLocation.desc))
+    ConstructorMethod(this.desc, List(GenSuspension.desc, JavaClasses.String, GenReifiedSourceLocation.desc))
 
   private def constructorIns(implicit mv: MethodVisitor): Unit = {
-    withName(1, BackendObjType.Suspension.desc)(suspension => withName(2, JavaClasses.String)(info => withName(3, GenReifiedSourceLocation.desc)(loc => {
+    withName(1, GenSuspension.desc)(suspension => withName(2, JavaClasses.String)(info => withName(3, GenReifiedSourceLocation.desc)(loc => {
       def appendString(): Unit = INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
 
       thisLoad()
@@ -65,7 +65,7 @@ object GenUnhandledEffectError {
       pushString("Unhandled effect '")
       appendString()
       suspension.load()
-      GETFIELD(BackendObjType.Suspension.EffSymField)
+      GETFIELD(GenSuspension.EffSymField)
       appendString()
       pushString("' (")
       appendString()
@@ -81,7 +81,7 @@ object GenUnhandledEffectError {
       // save arguments locally
       thisLoad()
       suspension.load()
-      GETFIELD(BackendObjType.Suspension.EffSymField)
+      GETFIELD(GenSuspension.EffSymField)
       PUTFIELD(EffectNameField)
       thisLoad()
       loc.load()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenValue.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenValue.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField, StaticConstructorMethod, StaticField, mkClass}
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.{BackendObjType, ClassConstants, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.{CD_Object, CD_boolean, CD_byte, CD_char, CD_double, CD_float, CD_int, CD_long, CD_short}
+
+/**
+  * The `Value` class, a [[GenResult]] holding a finished computation's value.
+  *
+  * It has one field per erased type, of which only the one matching the value's type is
+  * used, plus cached singletons for `Unit`, `true`, and `false`.
+  */
+object GenValue {
+
+  val desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("Value"))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = mkClass(this.desc, IsFinal, interfaces = List(GenResult.desc))
+
+    // The fields of all erased types, only one will be relevant
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkField(BoolField, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(CharField, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(Int8Field, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(Int16Field, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(Int32Field, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(Int64Field, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(Float32Field, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(Float64Field, IsPublic, NotFinal, NotVolatile)
+    cm.mkField(ObjectField, IsPublic, NotFinal, NotVolatile)
+
+    // Cached singleton Value instances for Unit, true, and false
+    cm.mkField(UnitField, IsPublic, IsFinal, NotVolatile)
+    cm.mkField(TrueField, IsPublic, IsFinal, NotVolatile)
+    cm.mkField(FalseField, IsPublic, IsFinal, NotVolatile)
+    cm.mkStaticConstructor(StaticConstructorMethod(this.desc), staticConstructorIns(_))
+
+    cm.closeClassMaker()
+  }
+
+  private def staticConstructorIns(implicit mv: MethodVisitor): Unit = {
+    // Value.UNIT = new Value(); Value.UNIT.o = Unit.INSTANCE
+    NEW(this.desc)
+    DUP()
+    INVOKESPECIAL(Constructor)
+    DUP()
+    GETSTATIC(BackendObjType.Unit.SingletonField)
+    PUTFIELD(ObjectField)
+    PUTSTATIC(UnitField)
+    // Value.TRUE = new Value(); Value.TRUE.b = true
+    NEW(this.desc)
+    DUP()
+    INVOKESPECIAL(Constructor)
+    DUP()
+    ICONST_1()
+    PUTFIELD(BoolField)
+    PUTSTATIC(TrueField)
+    // Value.FALSE = new Value(); Value.FALSE.b = false (default, but explicit)
+    NEW(this.desc)
+    DUP()
+    INVOKESPECIAL(Constructor)
+    PUTSTATIC(FalseField)
+    RETURN()
+  }
+
+  def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
+
+  private def BoolField: InstanceField = InstanceField(this.desc, "b", CD_boolean)
+
+  private def CharField: InstanceField = InstanceField(this.desc, "c", CD_char)
+
+  private def Int8Field: InstanceField = InstanceField(this.desc, "i8", CD_byte)
+
+  private def Int16Field: InstanceField = InstanceField(this.desc, "i16", CD_short)
+
+  private def Int32Field: InstanceField = InstanceField(this.desc, "i32", CD_int)
+
+  private def Int64Field: InstanceField = InstanceField(this.desc, "i64", CD_long)
+
+  private def Float32Field: InstanceField = InstanceField(this.desc, "f32", CD_float)
+
+  private def Float64Field: InstanceField = InstanceField(this.desc, "f64", CD_double)
+
+  private def ObjectField: InstanceField = InstanceField(this.desc, "o", CD_Object)
+
+  def UnitField: StaticField = StaticField(this.desc, "UNIT", this.desc)
+
+  def TrueField: StaticField = StaticField(this.desc, "TRUE", this.desc)
+
+  def FalseField: StaticField = StaticField(this.desc, "FALSE", this.desc)
+
+  /**
+    * Returns the field of Value that holds a value of type `tpe`.
+    *
+    * `tpe` need not be erased: every reference type is held in [[ObjectField]].
+    */
+  def fieldFromType(tpe: ClassDesc): InstanceField = tpe match {
+    case CD_boolean => BoolField
+    case CD_char => CharField
+    case CD_byte => Int8Field
+    case CD_short => Int16Field
+    case CD_int => Int32Field
+    case CD_long => Int64Field
+    case CD_float => Float32Field
+    case CD_double => Float64Field
+    case _ => ObjectField
+  }
+
+}


### PR DESCRIPTION
Fourth and final step of Wave 1. Follows #13130, #13131, and #13132.

Moves the fourteen classes of the effects runtime out of `BackendObjType`: `Result`, `Value`, `Frame`, `Thunk`, `Suspension`, `Frames`, `FramesCons`, `FramesNil`, `Resumption`, `ResumptionCons`, `ResumptionNil`, `Handler`, `EffectCall`, and `ResumptionWrapper`.

They move as one PR because they are one strongly-connected component — `Result` ↔ `Value` ↔ `Frame`, `Suspension` → `Frames`/`Resumption`/`EffectCall`, `ResumptionCons` → `Handler` ↔ `EffectCall`. Splitting them would leave each PR rewriting the previous one's half-moved back-references.

`BackendObjType.scala` is now 850 lines with 12 members, down from 2222 lines and 40 members before this sequence started. What remains is exactly Wave 2's and Wave 4's input: the ten classes pinned by `BackendType.Reference`/`toBackendType`, plus `Record`, `RecordEmpty`, and `AbstractArrow`.

### `Value.fieldFromType` is re-keyed on `ClassDesc`

It maps every reference type to the object field, so it accepts an unerased descriptor — which lets callers use one value for both the field lookup and the `castIfNotPrim` that follows, instead of converting twice. `Result.unwindSuspensionFreeThunkToType` takes a `ClassDesc` for the same reason.

### `ResumptionWrapper` keeps its `BackendType` parameter

The plan had this de-parametrized here, but its superclass is a `BackendObjType.AbstractArrow`, still parametrized by `List[BackendType]` until Wave 2. Erasing only this class would mean inventing a `ClassDesc` to `BackendType` conversion — a new function pointing the wrong way, which Wave 3 would then delete. Every use of the parameter inside the class is already erased, so this costs nothing; it is de-parametrized in Wave 2 alongside `Arrow` and `AbstractArrow`, where it belongs.

### `Instructions.isCategory2`

Replaces the last use of `BackendType.is64BitWidth`. `xPop` was doing the same `CD_long || CD_double` check inline and now shares it.

No behavior change — the generated bytecode is identical, including all nine `ResumptionWrapper$*` variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)