### PR TITLE
refactor: de-parametrize Tuple and Struct

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -43,8 +43,8 @@ sealed trait BackendObjType {
   val desc: ClassDesc = this match {
     case BackendObjType.Unit => mkDesc(DevFlixRuntime, mkClassName("Unit"))
     case BackendObjType.Lazy(tpe) => mkDesc(RootPackage, mkClassName("Lazy", tpe))
-    case BackendObjType.Tuple(elms) => mkDesc(RootPackage, mkClassName("Tuple", elms))
-    case BackendObjType.Struct(elms) => mkDesc(RootPackage, mkClassName("Struct", elms))
+    case BackendObjType.Tuple(elms) => mkDesc(RootPackage, Mangle.mkClassName("Tuple", elms.map(Mangle.erasedName)))
+    case BackendObjType.Struct(elms) => mkDesc(RootPackage, Mangle.mkClassName("Struct", elms.map(Mangle.erasedName)))
     case BackendObjType.Tagged => mkDesc(RootPackage, mkClassName("Tagged"))
     case BackendObjType.ExtTagged => mkDesc(RootPackage, mkClassName("ExtTagged"))
     case BackendObjType.AbstractArrow(args, result) => mkDesc(RootPackage, mkClassName(s"Clo${args.length}", args :+ result))
@@ -184,7 +184,7 @@ object BackendObjType {
     }
   }
 
-  case class Tuple(elms: List[BackendType]) extends BackendObjType {
+  case class Tuple(elms: List[ClassDesc]) extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
       val cm = ClassMaker.mkClass(this.desc, IsFinal)
@@ -195,13 +195,13 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def IndexField(i: Int): InstanceField = InstanceField(this.desc, s"field$i", elms(i).toClassDesc)
+    def IndexField(i: Int): InstanceField = InstanceField(this.desc, s"field$i", elms(i))
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, elms.map(_.toClassDesc))
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, elms)
 
     /** `[] --> return` */
     private def constructorIns(implicit mv: MethodVisitor): Unit =
-      withNames(1, elms.map(_.toClassDesc)) { case (_, variables) =>
+      withNames(1, elms) { case (_, variables) =>
         thisLoad()
         // super()
         DUP()
@@ -220,10 +220,10 @@ object BackendObjType {
   object Struct {
     /** Returns the struct type of `struct`. */
     def fromStruct(struct: JvmAst.Struct)(implicit root: JvmAst.Root): Struct =
-      Struct(struct.fields.map(field => BackendType.toBackendType(field.tpe)))
+      Struct(struct.fields.map(field => BackendType.toErasedClassDesc(field.tpe)))
   }
 
-  case class Struct(elms: List[BackendType]) extends BackendObjType {
+  case class Struct(elms: List[ClassDesc]) extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
       val cm = ClassMaker.mkClass(this.desc, IsFinal)
@@ -234,12 +234,12 @@ object BackendObjType {
       cm.closeClassMaker()
     }
 
-    def IndexField(i: Int): InstanceField = InstanceField(this.desc, s"field$i", elms(i).toClassDesc)
+    def IndexField(i: Int): InstanceField = InstanceField(this.desc, s"field$i", elms(i))
 
-    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, elms.map(_.toClassDesc))
+    def Constructor: ConstructorMethod = ConstructorMethod(this.desc, elms)
 
     private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      withNames(1, elms.map(_.toClassDesc)) { case (_, variables) =>
+      withNames(1, elms) { case (_, variables) =>
         thisLoad()
         // super()
         DUP()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -157,7 +157,7 @@ object BackendType {
       case SimpleType.Null => BackendType.Object
       case SimpleType.Array(tpe) => Array(toBackendType(tpe))
       case SimpleType.Lazy(tpe) => BackendObjType.Lazy(toBackendType(tpe)).toTpe
-      case SimpleType.Tuple(elms) => BackendObjType.Tuple(elms.map(toBackendType)).toTpe
+      case SimpleType.Tuple(elms) => BackendObjType.Tuple(elms.map(toErasedClassDesc)).toTpe
       case SimpleType.Enum(_, Nil) => BackendObjType.Tagged.toTpe
       case SimpleType.Struct(sym, Nil) => BackendObjType.Struct.fromStruct(root.structs(sym)).toTpe
       case SimpleType.Arrow(args, result) => BackendObjType.Arrow(args.map(toBackendType), toBackendType(result)).toTpe

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -223,7 +223,7 @@ object CodeGen {
   private def getTupleTypesOf(types: Iterable[SimpleType])(implicit root: Root): Set[BackendObjType.Tuple] =
     types.foldLeft(Set.empty[BackendObjType.Tuple]) {
       case (acc, SimpleType.Tuple(elms)) =>
-        acc + BackendObjType.Tuple(elms.map(BackendType.toBackendType))
+        acc + BackendObjType.Tuple(elms.map(BackendType.toErasedClassDesc))
       case (acc, _) => acc
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -625,7 +625,7 @@ object GenExpression {
       case AtomicOp.Index(idx) =>
         val List(exp) = exps
         val SimpleType.Tuple(elmTypes) = exp.tpe
-        val tupleType = BackendObjType.Tuple(elmTypes.map(BackendType.toBackendType))
+        val tupleType = BackendObjType.Tuple(elmTypes.map(BackendType.toErasedClassDesc))
 
         compileExpr(exp)
         GETFIELD(tupleType.IndexField(idx))
@@ -633,7 +633,7 @@ object GenExpression {
 
       case AtomicOp.Tuple =>
         val SimpleType.Tuple(elmTypes) = tpe
-        val tupleType = BackendObjType.Tuple(elmTypes.map(BackendType.toBackendType))
+        val tupleType = BackendObjType.Tuple(elmTypes.map(BackendType.toErasedClassDesc))
         NEW(tupleType.desc)
         DUP()
         exps.foreach(compileExpr)
@@ -1590,7 +1590,7 @@ object GenExpression {
   }
 
   private def getStructType(struct: Struct)(implicit root: Root): BackendObjType.Struct = {
-    BackendObjType.Struct(struct.fields.map(field => BackendType.toBackendType(field.tpe)))
+    BackendObjType.Struct(struct.fields.map(field => BackendType.toErasedClassDesc(field.tpe)))
   }
 
   private def compileIsTag(ordinal: Int, exp: Expr)(implicit mv: MethodVisitor, ctx: MethodContext, root: Root, flix: Flix): Unit = {


### PR DESCRIPTION
First step of Wave 2, which converts the remaining `BackendObjType` parametrization from `List[BackendType]` to erased `List[ClassDesc]` in place. These classes cannot leave the sealed hierarchy yet — `toBackendType` still produces `BackendType.Reference`s of them — so this PR only changes how they are parametrized.

`Tuple(elms)` and `Struct(elms)` now carry `List[ClassDesc]`. Both used `elms(i).toClassDesc` for their fields and `elms.map(_.toClassDesc)` for their constructor, so the bodies simply drop the conversions, and naming moves to the `Mangle.erasedName` helper added in #13132.

As with the tag classes, erasing here is not a behavior change: `Eraser` erases tuple element types in `visitType`, and struct field types in `specializeStructField`, so the construction sites were passing already-erased types into `toBackendType`.

No behavior change — the generated bytecode is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)