### PR TITLE
refactor: de-parametrize Lazy

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -42,7 +42,7 @@ sealed trait BackendObjType {
     */
   val desc: ClassDesc = this match {
     case BackendObjType.Unit => mkDesc(DevFlixRuntime, mkClassName("Unit"))
-    case BackendObjType.Lazy(tpe) => mkDesc(RootPackage, mkClassName("Lazy", tpe))
+    case BackendObjType.Lazy(tpe) => mkDesc(RootPackage, Mangle.mkClassName("Lazy", Mangle.erasedName(tpe)))
     case BackendObjType.Tuple(elms) => mkDesc(RootPackage, Mangle.mkClassName("Tuple", elms.map(Mangle.erasedName)))
     case BackendObjType.Struct(elms) => mkDesc(RootPackage, Mangle.mkClassName("Struct", elms.map(Mangle.erasedName)))
     case BackendObjType.Tagged => mkDesc(RootPackage, mkClassName("Tagged"))
@@ -99,7 +99,7 @@ object BackendObjType {
 
   }
 
-  case class Lazy(tpe: BackendType) extends BackendObjType {
+  case class Lazy(tpe: ClassDesc) extends BackendObjType {
 
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
       val cm = ClassMaker.mkClass(this.desc, IsFinal)
@@ -115,7 +115,7 @@ object BackendObjType {
 
     def ExpField: InstanceField = InstanceField(this.desc, "expression", CD_Object)
 
-    def ValueField: InstanceField = InstanceField(this.desc, "value", tpe.toClassDesc)
+    def ValueField: InstanceField = InstanceField(this.desc, "value", tpe)
 
     private def LockField: InstanceField = InstanceField(this.desc, "lock", JavaClasses.ReentrantLock)
 
@@ -141,7 +141,7 @@ object BackendObjType {
         RETURN()
       })
 
-    def ForceMethod: InstanceMethod = InstanceMethod(this.desc, "force", mkDescriptor()(tpe.toClassDesc))
+    def ForceMethod: InstanceMethod = InstanceMethod(this.desc, "force", mkDescriptor()(tpe))
 
     /** `[] --> return tpe` */
     private def forceIns(implicit mv: MethodVisitor): Unit = {
@@ -165,7 +165,7 @@ object BackendObjType {
           GETFIELD(ExpField)
           CHECKCAST(GenThunk.desc)
           // this.value = thunk.unwind()
-          GenResult.unwindSuspensionFreeThunkToType(tpe.toClassDesc, "during call to Lazy.force", SourceLocation.Unknown)
+          GenResult.unwindSuspensionFreeThunkToType(tpe, "during call to Lazy.force", SourceLocation.Unknown)
           PUTFIELD(ValueField)
           // this.exp = null
           thisLoad()
@@ -180,7 +180,7 @@ object BackendObjType {
         ATHROW()
       }
       unlockLock()
-      xReturn(tpe.toClassDesc)
+      xReturn(tpe)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -156,7 +156,7 @@ object BackendType {
       case SimpleType.Region => BackendObjType.Region.toTpe
       case SimpleType.Null => BackendType.Object
       case SimpleType.Array(tpe) => Array(toBackendType(tpe))
-      case SimpleType.Lazy(tpe) => BackendObjType.Lazy(toBackendType(tpe)).toTpe
+      case SimpleType.Lazy(tpe) => BackendObjType.Lazy(toErasedClassDesc(tpe)).toTpe
       case SimpleType.Tuple(elms) => BackendObjType.Tuple(elms.map(toErasedClassDesc)).toTpe
       case SimpleType.Enum(_, Nil) => BackendObjType.Tagged.toTpe
       case SimpleType.Struct(sym, Nil) => BackendObjType.Struct.fromStruct(root.structs(sym)).toTpe

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -238,7 +238,7 @@ object CodeGen {
   /** Returns the set of lazy types in `types` without searching recursively. */
   private def getLazyTypesOf(types: Iterable[SimpleType])(implicit root: Root): Set[BackendObjType.Lazy] =
     types.foldLeft(Set.empty[BackendObjType.Lazy]) {
-      case (acc, SimpleType.Lazy(tpe)) => acc + BackendObjType.Lazy(BackendType.toBackendType(tpe))
+      case (acc, SimpleType.Lazy(tpe)) => acc + BackendObjType.Lazy(BackendType.toErasedClassDesc(tpe))
       case (acc, _) => acc
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -994,7 +994,7 @@ object GenExpression {
 
         // Find the Lazy class name (Lazy$tpe).
         val SimpleType.Lazy(elmType) = tpe
-        val lazyType = BackendObjType.Lazy(BackendType.toBackendType(elmType))
+        val lazyType = BackendObjType.Lazy(BackendType.toErasedClassDesc(elmType))
 
         NEW(lazyType.desc)
         DUP()
@@ -1006,7 +1006,7 @@ object GenExpression {
 
         // Find the Lazy class type (Lazy$tpe) and the inner value type.
         val SimpleType.Lazy(elmType) = exp.tpe
-        val erasedElmType = BackendType.toBackendType(elmType)
+        val erasedElmType = BackendType.toErasedClassDesc(elmType)
         val lazyType = BackendObjType.Lazy(erasedElmType)
 
         // Emit code for the lazy expression.


### PR DESCRIPTION
Second step of Wave 2, following #13134. `Lazy(tpe)` now carries an erased `ClassDesc` instead of a `BackendType`.

Every use of the parameter inside the class was already `tpe.toClassDesc` — the value field, the `force` descriptor, the unwind, and the return — so the body simply drops the conversions. Naming moves to the `Mangle.erasedName` helper from #13132.

As with the previous de-parametrizations, this is not a behavior change: `Eraser.visitType` erases the element type of a lazy, so the construction sites were passing an already-erased type into `toBackendType`.

Verified against both parametrizations that matter: `out/example.flix` gained a lazy over a reference type alongside the existing one over a primitive, so the comparison covers `Lazy$Int32` (whose value field is `int`) and `Lazy$Obj`. Both are byte-identical, as are `Tuple$Int32$Obj` and `Struct$Obj$Int32$Bool` from #13134 and all 32 runtime classes.

No behavior change — the generated bytecode is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)