### PR TITLE
refactor: de-parametrize Arrow, AbstractArrow, and ResumptionWrapper

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -47,8 +47,8 @@ sealed trait BackendObjType {
     case BackendObjType.Struct(elms) => mkDesc(RootPackage, Mangle.mkClassName("Struct", elms.map(Mangle.erasedName)))
     case BackendObjType.Tagged => mkDesc(RootPackage, mkClassName("Tagged"))
     case BackendObjType.ExtTagged => mkDesc(RootPackage, mkClassName("ExtTagged"))
-    case BackendObjType.AbstractArrow(args, result) => mkDesc(RootPackage, mkClassName(s"Clo${args.length}", args :+ result))
-    case BackendObjType.Arrow(args, result) => mkDesc(RootPackage, mkClassName(s"Fn${args.length}", args :+ result))
+    case BackendObjType.AbstractArrow(args, result) => mkDesc(RootPackage, Mangle.mkClassName(s"Clo${args.length}", (args :+ result).map(Mangle.erasedName)))
+    case BackendObjType.Arrow(args, result) => mkDesc(RootPackage, Mangle.mkClassName(s"Fn${args.length}", (args :+ result).map(Mangle.erasedName)))
     case BackendObjType.RecordEmpty => mkDesc(RootPackage, mkClassName(s"RecordEmpty"))
     case BackendObjType.Record => mkDesc(RootPackage, mkClassName("Record"))
     case BackendObjType.Region => mkDesc(DevFlixRuntime, mkClassName("Region"))
@@ -69,14 +69,6 @@ sealed trait BackendObjType {
 }
 
 object BackendObjType {
-
-  private def mkClassName(prefix: String, tpe: BackendType): String = {
-    Mangle.mkClassName(prefix, tpe.toErasedString)
-  }
-
-  private def mkClassName(prefix: String, tpes: List[BackendType]): String = {
-    Mangle.mkClassName(prefix, tpes.map(_.toErasedString))
-  }
 
   private def mkClassName(prefix: String): String = {
     Mangle.mkClassName(prefix)
@@ -312,7 +304,7 @@ object BackendObjType {
       */
     def fromArrowType(tpe: SimpleType): AbstractArrow = tpe match {
       case SimpleType.Arrow(targs, tresult) =>
-        AbstractArrow(targs.map(BackendType.toErasedBackendType), BackendType.toErasedBackendType(tresult))
+        AbstractArrow(targs.map(BackendType.toErasedClassDesc), BackendType.toErasedClassDesc(tresult))
       case _ => throw InternalCompilerException(s"Unexpected type: '$tpe'.", SourceLocation.Unknown)
     }
   }
@@ -324,7 +316,7 @@ object BackendObjType {
     * public abstract Clo2$Int$Obj$Bool getUniqueThreadClosure();
     * }
     */
-  case class AbstractArrow(args: List[BackendType], result: BackendType) extends BackendObjType {
+  case class AbstractArrow(args: List[ClassDesc], result: ClassDesc) extends BackendObjType {
 
     def superClass: BackendObjType.Arrow = Arrow(args, result)
 
@@ -354,15 +346,15 @@ object BackendObjType {
       *
       * NB: The given type `tpe` must be an arrow type.
       */
-    def fromArrowType(tpe: SimpleType)(implicit root: JvmAst.Root): Arrow = tpe match {
+    def fromArrowType(tpe: SimpleType): Arrow = tpe match {
       case SimpleType.Arrow(targs, tresult) =>
-        Arrow(targs.map(BackendType.toErasedBackendType), BackendType.toBackendType(tresult))
+        Arrow(targs.map(BackendType.toErasedClassDesc), BackendType.toErasedClassDesc(tresult))
       case _ =>
         throw InternalCompilerException(s"Unexpected type: '$tpe'.", SourceLocation.Unknown)
     }
   }
 
-  case class Arrow(args: List[BackendType], result: BackendType) extends BackendObjType {
+  case class Arrow(args: List[ClassDesc], result: ClassDesc) extends BackendObjType {
 
     /**
       * Represents a function interface from `java.util.function`.
@@ -589,13 +581,13 @@ object BackendObjType {
       */
     private def specialization(): List[FunctionInterface] = {
       (args, result) match {
-        case (BackendType.Reference(BackendObjType.Native(CD_Object)) :: Nil, _) =>
+        case (CD_Object :: Nil, _) =>
           ObjFunction :: ObjConsumer :: ObjPredicate :: Nil
-        case (BackendType.Int32 :: Nil, _) =>
+        case (CD_int :: Nil, _) =>
           IntFunction :: IntConsumer :: IntPredicate :: IntUnaryOperator :: Nil
-        case (BackendType.Int64 :: Nil, _) =>
+        case (CD_long :: Nil, _) =>
           LongFunction :: LongConsumer :: LongPredicate :: LongUnaryOperator :: Nil
-        case (BackendType.Float64 :: Nil, _) =>
+        case (CD_double :: Nil, _) =>
           DoubleFunction :: DoubleConsumer :: DoublePredicate :: DoubleUnaryOperator :: Nil
         case _ => Nil
       }
@@ -616,7 +608,7 @@ object BackendObjType {
 
     def Constructor: ConstructorMethod = ConstructorMethod(this.desc, Nil)
 
-    def ArgField(index: Int): InstanceField = InstanceField(this.desc, s"arg$index", args(index).toClassDesc)
+    def ArgField(index: Int): InstanceField = InstanceField(this.desc, s"arg$index", args(index))
   }
 
   case object RecordEmpty extends BackendObjType {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -160,7 +160,7 @@ object BackendType {
       case SimpleType.Tuple(elms) => BackendObjType.Tuple(elms.map(toErasedClassDesc)).toTpe
       case SimpleType.Enum(_, Nil) => BackendObjType.Tagged.toTpe
       case SimpleType.Struct(sym, Nil) => BackendObjType.Struct.fromStruct(root.structs(sym)).toTpe
-      case SimpleType.Arrow(args, result) => BackendObjType.Arrow(args.map(toBackendType), toBackendType(result)).toTpe
+      case SimpleType.Arrow(args, result) => BackendObjType.Arrow(args.map(toErasedClassDesc), toErasedClassDesc(result)).toTpe
       case SimpleType.RecordEmpty => BackendObjType.Record.toTpe
       case SimpleType.RecordExtend(_, _, _) => BackendObjType.Record.toTpe
       case SimpleType.ExtensibleEmpty => BackendObjType.ExtTagged.toTpe

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -116,7 +116,7 @@ object CodeGen {
     val handlerInterface = List(JvmClass(GenHandler.desc, GenHandler.genByteCode()))
     val effectCallClass = List(JvmClass(GenEffectCall.desc, GenEffectCall.genByteCode()))
     val effectClasses = GenEffectClasses.gen(root.effects.values)
-    val resumptionWrappers = BackendType.erasedTypes.map(tpe => JvmClass(GenResumptionWrapper.desc(tpe), GenResumptionWrapper.genByteCode(tpe)))
+    val resumptionWrappers = BackendType.erasedTypes.map(_.toClassDesc).map(tpe => JvmClass(GenResumptionWrapper.desc(tpe), GenResumptionWrapper.genByteCode(tpe)))
 
     val allClasses = List(
       mainClass,
@@ -197,7 +197,7 @@ object CodeGen {
   private def getErasedArrowsOf(types: Iterable[SimpleType]): Set[BackendObjType.Arrow] =
     types.foldLeft(Set.empty[BackendObjType.Arrow]) {
       case (acc, SimpleType.Arrow(args, result)) =>
-        acc + BackendObjType.Arrow(args.map(BackendType.toErasedBackendType), BackendType.toErasedBackendType(result))
+        acc + BackendObjType.Arrow(args.map(BackendType.toErasedClassDesc), BackendType.toErasedClassDesc(result))
       case (acc, _) => acc
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -29,7 +29,7 @@ import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.{MethodVisitor, Opcodes}
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
-import java.lang.constant.ConstantDescs.CD_void
+import java.lang.constant.ConstantDescs.{CD_Object, CD_void}
 import scala.jdk.CollectionConverters.*
 
 /** Generates bytecode for anonymous classes (created through NewObject). */
@@ -119,8 +119,8 @@ object GenAnonymousClasses {
 
   /** Returns the erased abstract arrow class for the given parameter types and return type. */
   private def erasedArrowType(paramTypes: List[SimpleType], retTpe: SimpleType): BackendObjType.AbstractArrow = {
-    val boxedResult = BackendType.Object
-    BackendObjType.AbstractArrow(paramTypes.map(BackendType.toErasedBackendType), boxedResult)
+    val boxedResult = CD_Object
+    BackendObjType.AbstractArrow(paramTypes.map(BackendType.toErasedClassDesc), boxedResult)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -13,6 +13,7 @@ import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.MethodVisitor
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
+import java.lang.constant.ConstantDescs.CD_Object
 
 /** An effect class like this:
   * {{{
@@ -76,12 +77,12 @@ object GenEffectClasses {
 
     for (op <- effect.ops) {
       val name = opName(op.sym)
-      val erasedParams = op.fparams.map(_.tpe).map(BackendType.toErasedBackendType)
-      val opFunction = BackendObjType.Arrow(erasedParams :+ BackendType.Object, BackendType.Object)
+      val erasedParams = op.fparams.map(_.tpe).map(BackendType.toErasedClassDesc)
+      val opFunction = BackendObjType.Arrow(erasedParams :+ CD_Object, CD_Object)
       val opField = ClassMaker.InstanceField(effectName, name, opFunction.desc)
       cm.mkField(opField, IsPublic, NotFinal, NotVolatile)
-      val methodArgs = erasedParams.map(_.toClassDesc) ++ List(GenHandler.desc, GenResumption.desc)
-      val returnType = BackendType.toBackendType(op.tpe)
+      val methodArgs = erasedParams ++ List(GenHandler.desc, GenResumption.desc)
+      val returnType = BackendType.toErasedClassDesc(op.tpe)
       cm.mkStaticMethod(ClassMaker.StaticMethod(effectName, name, MethodTypeDescs.mkDescriptor(methodArgs *)(GenResult.desc)), IsPublic, NotFinal, methodIns(effectName, opFunction, opField, erasedParams, returnType)(_))
     }
 
@@ -94,9 +95,9 @@ object GenEffectClasses {
     RETURN()
   }
 
-  private def methodIns(effectName: ClassDesc, opFunction: BackendObjType.Arrow, opField: InstanceField, erasedParams: List[BackendType], returnType: BackendType)(implicit mv: MethodVisitor): Unit = {
+  private def methodIns(effectName: ClassDesc, opFunction: BackendObjType.Arrow, opField: InstanceField, erasedParams: List[ClassDesc], returnType: ClassDesc)(implicit mv: MethodVisitor): Unit = {
 
-    withNames(0, erasedParams.map(_.toClassDesc)) { case (paramsOffset, params) =>
+    withNames(0, erasedParams) { case (paramsOffset, params) =>
       withName(paramsOffset, GenHandler.desc) { handler =>
         withName(paramsOffset + 1, GenResumption.desc) { resumption =>
           // Cast the given generic handler to the current effect.
@@ -132,8 +133,8 @@ object GenEffectClasses {
   def opStaticFunctionDescriptor(sym: Symbol.OpSym)(implicit root: Root): MethodTypeDesc = {
     val effect = root.effects(sym.eff)
     val op = effect.ops.find(op => op.sym == sym).getOrElse(throw InternalCompilerException(s"Could not find op '$sym' in effect '$effect'.", sym.loc))
-    val erasedParams = op.fparams.map(_.tpe).map(BackendType.toErasedBackendType)
-    val methodArgs = erasedParams.map(_.toClassDesc) ++ List(GenHandler.desc, GenResumption.desc)
+    val erasedParams = op.fparams.map(_.tpe).map(BackendType.toErasedClassDesc)
+    val methodArgs = erasedParams ++ List(GenHandler.desc, GenResumption.desc)
     MethodTypeDescs.mkDescriptor(methodArgs *)(GenResult.desc)
   }
 
@@ -144,8 +145,8 @@ object GenEffectClasses {
   def opFieldType(sym: Symbol.OpSym)(implicit root: Root): BackendObjType.Arrow = {
     val effect = root.effects(sym.eff)
     val op = effect.ops.find(op => op.sym == sym).getOrElse(throw InternalCompilerException(s"Could not find op '$sym' in effect '$effect'.", sym.loc))
-    val erasedParams = op.fparams.map(_.tpe).map(BackendType.toErasedBackendType)
-    BackendObjType.Arrow(erasedParams :+ BackendType.Object, BackendType.Object)
+    val erasedParams = op.fparams.map(_.tpe).map(BackendType.toErasedClassDesc)
+    BackendObjType.Arrow(erasedParams :+ CD_Object, CD_Object)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1167,7 +1167,7 @@ object GenExpression {
             // Evaluating the expression
             compileExpr(arg)
             mv.visitFieldInsn(Opcodes.PUTFIELD, defInternalName,
-              s"arg$i", BackendType.toErasedBackendType(arg.tpe).toDescriptor)
+              s"arg$i", BackendType.toErasedClassDesc(arg.tpe).descriptorString())
           }
           // Calling unwind and unboxing
           ctx match {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionWrapper.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionWrapper.scala
@@ -24,30 +24,29 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, Const
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
 import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
 import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkDescriptor
-import ca.uwaterloo.flix.language.phase.jvm.{BackendObjType, BackendType, Mangle, MethodTypeDescs}
+import ca.uwaterloo.flix.language.phase.jvm.{BackendObjType, Mangle, MethodTypeDescs}
 import ca.uwaterloo.flix.util.ClassDescs
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 
 import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.{CD_Object, CD_boolean}
 
 /**
   * The class that presents a [[GenResumption]] as a one-argument Flix function, so that a
   * handler can call the continuation like any other closure.
   *
-  * NB: `tpe` is still a [[BackendType]] because the superclass is a
-  * `BackendObjType.AbstractArrow`, which Wave 2 de-parametrizes. Only its erasure is ever
-  * used.
+  * `tpe` is the erased type the resumption is resumed with.
   */
 object GenResumptionWrapper {
 
-  def desc(tpe: BackendType): ClassDesc =
-    mkDesc(DevFlixRuntime, Mangle.mkClassName("ResumptionWrapper", tpe.toErasedString))
+  def desc(tpe: ClassDesc): ClassDesc =
+    mkDesc(DevFlixRuntime, Mangle.mkClassName("ResumptionWrapper", Mangle.erasedName(tpe)))
 
   // tpe -> Result
-  private def superClass(tpe: BackendType): BackendObjType.AbstractArrow =
-    BackendObjType.AbstractArrow(List(tpe.toErased), BackendType.Object)
+  private def superClass(tpe: ClassDesc): BackendObjType.AbstractArrow =
+    BackendObjType.AbstractArrow(List(tpe), CD_Object)
 
-  def genByteCode(tpe: BackendType)(implicit flix: Flix): Array[Byte] = {
+  def genByteCode(tpe: ClassDesc)(implicit flix: Flix): Array[Byte] = {
     val cm = mkClass(desc(tpe), IsFinal, superClass(tpe).desc)
     cm.mkConstructor(Constructor(tpe), IsPublic, constructorIns(tpe)(_))
     cm.mkField(ResumptionField(tpe), IsPrivate, IsFinal, NotVolatile)
@@ -56,9 +55,9 @@ object GenResumptionWrapper {
     cm.closeClassMaker()
   }
 
-  def Constructor(tpe: BackendType): ConstructorMethod = ConstructorMethod(desc(tpe), List(GenResumption.desc))
+  def Constructor(tpe: ClassDesc): ConstructorMethod = ConstructorMethod(desc(tpe), List(GenResumption.desc))
 
-  private def constructorIns(tpe: BackendType)(implicit mv: MethodVisitor): Unit = {
+  private def constructorIns(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     withName(1, GenResumption.desc) { resumption =>
       thisLoad()
       INVOKESPECIAL(superClass(tpe).desc, ConstructorMethodName, MethodTypeDescs.NothingToVoid)
@@ -69,18 +68,18 @@ object GenResumptionWrapper {
     }
   }
 
-  def ResumptionField(tpe: BackendType): InstanceField = InstanceField(desc(tpe), "resumption", GenResumption.desc)
+  def ResumptionField(tpe: ClassDesc): InstanceField = InstanceField(desc(tpe), "resumption", GenResumption.desc)
 
-  def InvokeMethod(tpe: BackendType): InstanceMethod = GenThunk.InvokeMethod.implementation(desc(tpe))
+  def InvokeMethod(tpe: ClassDesc): InstanceMethod = GenThunk.InvokeMethod.implementation(desc(tpe))
 
-  private def invokeIns(tpe: BackendType)(implicit mv: MethodVisitor): Unit = {
+  private def invokeIns(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     thisLoad()
     GETFIELD(ResumptionField(tpe))
-    tpe.toErased match {
-      case BackendType.Bool =>
+    tpe match {
+      case CD_boolean =>
         // Use cached Value.TRUE / Value.FALSE singletons
         thisLoad()
-        mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc(tpe)), "arg0", tpe.toErased.toDescriptor)
+        mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc(tpe)), "arg0", tpe.descriptorString())
         val falseLabel = new Label()
         val doneLabel = new Label()
         mv.visitJumpInsn(Opcodes.IFEQ, falseLabel)
@@ -95,14 +94,14 @@ object GenResumptionWrapper {
         INVOKESPECIAL(GenValue.Constructor)
         DUP()
         thisLoad()
-        mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc(tpe)), "arg0", tpe.toErased.toDescriptor)
-        PUTFIELD(GenValue.fieldFromType(tpe.toErased.toClassDesc))
+        mv.visitFieldInsn(Opcodes.GETFIELD, ClassDescs.internalNameOf(desc(tpe)), "arg0", tpe.descriptorString())
+        PUTFIELD(GenValue.fieldFromType(tpe))
     }
     INVOKEINTERFACE(GenResumption.RewindMethod)
     xReturn(GenResult.desc)
   }
 
-  private def UniqueMethod(tpe: BackendType): InstanceMethod =
+  private def UniqueMethod(tpe: ClassDesc): InstanceMethod =
     InstanceMethod(desc(tpe), "getUniqueThreadClosure", mkDescriptor()(superClass(tpe).desc))
 
   private def uniqueIns(implicit mv: MethodVisitor): Unit = {


### PR DESCRIPTION
Final step of Wave 2, following #13134 and #13135. `Arrow(args, result)` and `AbstractArrow(args, result)` now carry erased `List[ClassDesc]`, and `GenResumptionWrapper` comes with them — its de-parametrization was deferred from #13133 precisely because its superclass is an `AbstractArrow`.

**No `BackendObjType` member is parametrized by `BackendType` any more.** What remains of `BackendType` in the backend is the `toBackendType`/`Reference` conversion itself, which Wave 3 deletes.

### Why erasing `args` and `result` changes nothing

`args` were already erased at every construction site, and every `ArgField` caller — `GenExpression`, `GenAnonymousClasses`, `GenEffectClasses`, and `Arrow`'s own `functionIns` — passed an arrow built from erased args, so field types are unchanged.

`result` only ever fed the class name, which erases. Erasing it also makes the two construction paths agree: `Arrow.fromArrowType` erased `args` but not `result`, while `toBackendType` erased neither, and both produced the same descriptor. That inconsistency is now gone.

### Other changes

- `Arrow.specialization` matches on `ClassDesc` instead of `BackendType`.
- `Arrow.fromArrowType` no longer takes an implicit `Root`; it no longer calls `toBackendType`.
- The last `toErasedBackendType` caller, in closure-field generation, now uses `toErasedClassDesc`. That function is now referenced only by its own definition.

### Verification

The `specialization()` rewrite is the risky part of this change, so I checked it is actually exercised rather than assuming: the comparison emits `Fn1$Obj$Obj`, `Fn1$Int32$Obj`, `Fn1$Int64$Obj`, and `Fn1$Float64$Obj` — one per specialization branch, carrying the expected `java.util.function` interfaces — plus `Fn1$Bool$Obj` for the fall-through case that gets none. All 26 `Fn*`, 26 `Clo*`, and 9 `ResumptionWrapper*` classes are byte-identical, as are all 32 runtime classes.

No behavior change — the generated bytecode is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)