### PR TITLE
refactor: compute toClassDesc directly from SimpleType

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -172,8 +172,38 @@ object BackendType {
   }
 
   /** Converts the given [[SimpleType]] into the [[ClassDesc]] of its JVM representation. */
-  def toClassDesc(tpe0: SimpleType)(implicit root: JvmAst.Root): ClassDesc =
-    ClassDesc.ofDescriptor(toBackendType(tpe0).toDescriptor)
+  def toClassDesc(tpe0: SimpleType)(implicit root: JvmAst.Root): ClassDesc = tpe0 match {
+    case SimpleType.Void => CD_Object
+    case SimpleType.AnyType => CD_Object
+    case SimpleType.Unit => BackendObjType.Unit.desc
+    case SimpleType.Bool => CD_boolean
+    case SimpleType.Char => CD_char
+    case SimpleType.Float32 => CD_float
+    case SimpleType.Float64 => CD_double
+    case SimpleType.BigDecimal => JavaClasses.BigDecimal
+    case SimpleType.Int8 => CD_byte
+    case SimpleType.Int16 => CD_short
+    case SimpleType.Int32 => CD_int
+    case SimpleType.Int64 => CD_long
+    case SimpleType.BigInt => JavaClasses.BigInteger
+    case SimpleType.String => CD_String
+    case SimpleType.Regex => JavaClasses.Regex
+    case SimpleType.Region => BackendObjType.Region.desc
+    case SimpleType.Null => CD_Object
+    case SimpleType.Array(tpe) => toClassDesc(tpe).arrayType()
+    case SimpleType.Lazy(tpe) => BackendObjType.Lazy(toErasedClassDesc(tpe)).desc
+    case SimpleType.Tuple(elms) => BackendObjType.Tuple(elms.map(toErasedClassDesc)).desc
+    case SimpleType.Enum(_, Nil) => BackendObjType.Tagged.desc
+    case SimpleType.Struct(sym, Nil) => BackendObjType.Struct.fromStruct(root.structs(sym)).desc
+    case SimpleType.Arrow(args, result) => BackendObjType.Arrow(args.map(toErasedClassDesc), toErasedClassDesc(result)).desc
+    case SimpleType.RecordEmpty => BackendObjType.Record.desc
+    case SimpleType.RecordExtend(_, _, _) => BackendObjType.Record.desc
+    case SimpleType.ExtensibleEmpty => BackendObjType.ExtTagged.desc
+    case SimpleType.ExtensibleExtend(_, _, _) => BackendObjType.ExtTagged.desc
+    case SimpleType.Native(clazz) => clazz
+    case SimpleType.Enum(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe0'", SourceLocation.Unknown)
+    case SimpleType.Struct(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe0'", SourceLocation.Unknown)
+  }
 
   /**
     * Contains all the primitive types and `Reference(Native(CD_Object))`.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -266,7 +266,7 @@ object GenFunAndClosureClasses {
     // Fields
     val closureArgTypes = defn.cparams.map(_.tpe)
     for ((argType, index) <- closureArgTypes.zipWithIndex) {
-      val field = visitor.visitField(Opcodes.ACC_PUBLIC, s"clo$index", BackendType.toBackendType(argType).toDescriptor, null, null)
+      val field = visitor.visitField(Opcodes.ACC_PUBLIC, s"clo$index", BackendType.toClassDesc(argType).descriptorString(), null, null)
       field.visitEnd()
     }
     // lparams use erased types (like fparams) so setPc can store without casting


### PR DESCRIPTION
First step of Wave 3, which ends with `BackendType.scala` deleted. Follows #13136.

`toClassDesc` built a `BackendType` tree, rendered it to a descriptor string, and re-parsed that string with `ClassDesc.ofDescriptor`. It now matches on `SimpleType` and returns the descriptor directly.

This also converts the last `toBackendType` caller, in closure-field generation, so `toBackendType` is reachable only from its own `Array` case. The next PR deletes it along with `Reference`, `RichClassDesc.toTpe`, and `BackendType.scala` itself.

### Checking the two implementations agree

Thirty match arms had to keep producing the same descriptor, and the `Array` case is not a transcription: the old code computed the nesting depth and concatenated `[` prefixes onto the base descriptor, while the new one recurses through `ClassDesc.arrayType()`. Rather than reason arm by arm, I compared the implementations mechanically while both still existed — a throwaway test asserting

- `toClassDesc(t) == ClassDesc.ofDescriptor(toBackendType(t).toDescriptor)`, and
- `toErasedClassDesc(t) == toErasedBackendType(t).toClassDesc`

over 1254 generated `SimpleType` shapes: every leaf, two levels of array/lazy/tuple/arrow/record nesting, and `Native` wrapping array and primitive descriptors. No mismatches. The test is not committed, since `toBackendType` is about to disappear and it would go stale immediately.

### Performance

This touches the hot conversion path, so it got the `Xperf` full-pipeline benchmark rather than only the bytecode check. Four matched adjacent pairs at `--par --n 50`, medians in lines/sec:

| Pair | Before | After | Δ |
|---|---|---|---|
| 1 | 66,270 | 65,746 | −0.8% |
| 2 | 64,444 | 67,005 | +4.0% |
| 3 | 59,895 | 68,555 | +14.5% |
| 4 | 59,891 | 55,333 | −7.6% |

**These measurements do not resolve a difference.** The swings run both directions and are far larger than the change could plausibly cause: pair 3's *before* run and pair 4's *after* run are both visibly degraded relative to their neighbours, so those two pairs are measuring machine load. The only pairs that look clean, 1 and 2, straddle zero within the ±2% noise floor.

Taking the conservative reading: no measurable performance change. That is the expected outcome — the change strictly removes work (a tree construction and a string round-trip), so a regression is not a plausible mechanism, but this path evidently is not hot enough for the saving to show above the noise on this machine.

The generated bytecode is identical, and all 16,583 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)