### PR TITLE
refactor: monomorph2 cleanup

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
@@ -62,14 +62,14 @@ object ConstraintGen {
     ParOps.parMap(root.defs.values) { defn =>
       flix.profile(defn.sym, defn.loc) {
         val mvar = MonoVar.Def(defn.sym)
-        implicit val tparamEnv: TparamEnv = mkTparamEnv(mvar, defn.spec.tparams)
+        implicit val tparamEnv: TypeParamEnv = mkTypeParamEnv(mvar, defn.spec.tparams)
         visitDef(defn)
       }
     }
 
     ParOps.parMap(root.enums.values) { enm =>
       val mvar = MonoVar.Enum(enm.sym)
-      implicit val tparamEnv: TparamEnv = mkTparamEnv(mvar, enm.tparams)
+      implicit val tparamEnv: TypeParamEnv = mkTypeParamEnv(mvar, enm.tparams)
       visitEnum(enm)
     }
 
@@ -77,7 +77,7 @@ object ConstraintGen {
       for (instDef <- inst.defs) {
         val mvar = MonoVar.Def(instDef.sym)
         val allTparams = inst.tparams ++ instDef.spec.tparams
-        implicit val tparamEnv: TparamEnv = mkTparamEnv(mvar, allTparams)
+        implicit val tparamEnv: TypeParamEnv = mkTypeParamEnv(mvar, allTparams)
         flix.profile(instDef.sym, instDef.loc) {
           visitDef(instDef)
         }
@@ -86,13 +86,13 @@ object ConstraintGen {
 
     ParOps.parMap(root.restrictableEnums.values) { enm =>
       val mvar = MonoVar.RestrictableEnum(enm.sym)
-      implicit val tparamEnv: TparamEnv = mkTparamEnv(mvar, enm.index :: enm.tparams)
+      implicit val tparamEnv: TypeParamEnv = mkTypeParamEnv(mvar, enm.index :: enm.tparams)
       visitRestrictableEnum(enm)
     }
 
     ParOps.parMap(root.structs.values) { struct =>
       val mvar = MonoVar.Struct(struct.sym)
-      implicit val tparamEnv: TparamEnv = mkTparamEnv(mvar, struct.tparams)
+      implicit val tparamEnv: TypeParamEnv = mkTypeParamEnv(mvar, struct.tparams)
       visitStruct(struct)
     }
 
@@ -105,7 +105,7 @@ object ConstraintGen {
       // We synthesize a DefnSym so their own tparams classify as Param, not  wrongly-ground Const. (As for fromEffects)
       val defnSym = MonomorphHelpers.defaultSigImplSym(sig)
       val mvar = MonoVar.Def(defnSym)
-      implicit val tparamEnv: TparamEnv = mkTparamEnv(mvar, allTparams)
+      implicit val tparamEnv: TypeParamEnv = mkTypeParamEnv(mvar, allTparams)
       flix.profile(defnSym, sig.sym.loc) {
         for (exp <- sig.exp) {
           visitExp(exp)
@@ -117,7 +117,7 @@ object ConstraintGen {
       // We need a Synthetic DefnSym to tie the tparams to
       val defnSym = new Symbol.DefnSym(None, op.sym.namespace, op.sym.name, op.sym.loc)
       val mvar = MonoVar.Def(defnSym)
-      implicit val tparamEnv: TparamEnv = mkTparamEnv(mvar, op.spec.tparams)
+      implicit val tparamEnv: TypeParamEnv = mkTypeParamEnv(mvar, op.spec.tparams)
       visitOp(op)
     }
 
@@ -125,18 +125,18 @@ object ConstraintGen {
   }
 
   /** Maps the current declaration's own type parameters to their `MonoArg.Param` binding. */
-  private case class TparamEnv(m: Map[Symbol.KindedTypeVarSym, MonoArg]) {
+  private case class TypeParamEnv(m: Map[Symbol.KindedTypeVarSym, MonoArg]) {
     def get(sym: Symbol.KindedTypeVarSym): Option[MonoArg] = m.get(sym)
   }
 
   /** Returns the `MonoArg.Param` bindings for `mvar`'s type parameters, in declared order. */
-  private def mkTparamEnv(mvar: MonoVar, tparams: List[TypeParam]): TparamEnv =
-    TparamEnv(tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap)
+  private def mkTypeParamEnv(mvar: MonoVar, tparams: List[TypeParam]): TypeParamEnv =
+    TypeParamEnv(tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap)
 
   /**
     * Emits flow constraints for enum type applications occurring in `tpe`.
     */
-  private def visitType(tpe0: Type)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def visitType(tpe0: Type)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     def dealiasedVisitType(tpe: Type): Unit = tpe match {
       case at @ Type.AssocType(_, arg, _, _) =>
         if (at.typeVars.isEmpty)
@@ -173,7 +173,7 @@ object ConstraintGen {
   /**
     * Emits flow constraints for all case field types in `enumDecl`.
     */
-  private def visitEnum(enumDecl: TypedAst.Enum)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def visitEnum(enumDecl: TypedAst.Enum)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     for (cas <- enumDecl.cases.values) {
       for (tpe <- cas.tpes) {
         visitType(tpe)
@@ -184,7 +184,7 @@ object ConstraintGen {
   /**
     * Emits flow constraints for all case field types in `restrictableEnumDecl`.
     */
-  private def visitRestrictableEnum(restrictableEnumDecl: TypedAst.RestrictableEnum)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def visitRestrictableEnum(restrictableEnumDecl: TypedAst.RestrictableEnum)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     for (cas <- restrictableEnumDecl.cases.values) {
       for (tpe <- cas.tpes) {
         visitType(tpe)
@@ -195,7 +195,7 @@ object ConstraintGen {
   /**
     * Emits flow constraints for all field types in `structDecl`.
     */
-  private def visitStruct(structDecl: TypedAst.Struct)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def visitStruct(structDecl: TypedAst.Struct)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     for (field <- structDecl.fields.values) {
       visitType(field.tpe)
     }
@@ -204,7 +204,7 @@ object ConstraintGen {
   /**
     * Emits flow constraints for the formal parameter and return types of `op`.
     */
-  private def visitOp(op: TypedAst.Op)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def visitOp(op: TypedAst.Op)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     for (case FormalParam(_, tpe, _, _, _) <- op.spec.fparams) {
       visitType(tpe)
     }
@@ -214,7 +214,7 @@ object ConstraintGen {
   /**
     * Emits flow constraints for the formal parameter types, return type, and body of `defn`.
     */
- private def visitDef(defn: TypedAst.Def)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+ private def visitDef(defn: TypedAst.Def)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     for (case FormalParam(_, tpe, _, _, _) <- defn.spec.fparams) {
       visitType(tpe)
     }
@@ -227,7 +227,7 @@ object ConstraintGen {
     * Emits flow constraints for the default-handler calls that
     * [[SpecializeAndLower.wrapDefWithDefaultHandlers]] synthesizes around entry points.
     */
-  private def entryPointHandlerConstraints(defn: TypedAst.Def)(implicit tparamEnv: TparamEnv, sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit =
+  private def entryPointHandlerConstraints(defn: TypedAst.Def)(implicit tparamEnv: TypeParamEnv, sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit =
     if (TypedAstOps.isEntryPoint(defn)(root)) {
       val loc = defn.spec.eff.loc
       val defEffects = Canonicalization.evalEff(defn.spec.eff)
@@ -277,7 +277,7 @@ object ConstraintGen {
     * Datalog and channel nodes additionally emit constraints for the stdlib calls
     * [[SpecializeAndLower]] will synthesize for them.
     */
-  private def visitExp(exp0: Expr)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = exp0 match {
+  private def visitExp(exp0: Expr)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = exp0 match {
     case Expr.Cst(_, _, _)        => ()
     case Expr.Var(_, _, _)        => ()
     case Expr.Hole(_, _, _, _, _) => ()
@@ -633,7 +633,7 @@ object ConstraintGen {
     * `AnyType` reach `Fixpoint.Boxable`'s box/unbox, whose unchecked casts would turn it into a
     * silently wrong runtime value instead.
     */
-  private def visitPat(pat0: TypedAst.Pattern)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = pat0 match {
+  private def visitPat(pat0: TypedAst.Pattern)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = pat0 match {
     case TypedAst.Pattern.Tag(_, pats, tpe, _) =>
       val (mvar, tpArgs) = getMonoVarAndTypeArgs(tpe)
       for (pat <- pats) {
@@ -656,7 +656,7 @@ object ConstraintGen {
   }
 
   /** Generates: Fixpoint3.Boxable.box(x: a): Boxed with Order[a] — mirrors [[SpecializeAndLower.box]]. */
-  private def boxConstraint(tpe: Type)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit =
+  private def boxConstraint(tpe: Type)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit =
     sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(tpe))), MonoVar.Def(Defs.Fixpoint.Boxable.Box)))
 
   /**
@@ -666,7 +666,7 @@ object ConstraintGen {
     *   Fixpoint3.Boxable.liftN(f: t1 -> ... -> tN -> t): Boxed -> ... -> Boxed
     *     with Order[t1], ..., Order[tN], Order[t]
     */
-  private def headTermConstraints(cparams0: List[TypedAst.ConstraintParam], exp0: TypedAst.Expr)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = exp0 match {
+  private def headTermConstraints(cparams0: List[TypedAst.ConstraintParam], exp0: TypedAst.Expr)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = exp0 match {
     case Expr.Var(sym, tpe, _) =>
       if (!MonomorphHelpers.isQuantifiedVar(sym, cparams0)) {
         boxConstraint(tpe)
@@ -683,7 +683,7 @@ object ConstraintGen {
   }
 
   /** Flows for a body atom's terms — mirrors [[SpecializeAndLower.lowerBodyTerm]]. */
-  private def bodyAtomTermConstraints(cparams0: List[TypedAst.ConstraintParam], terms: List[TypedAst.Pattern])(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def bodyAtomTermConstraints(cparams0: List[TypedAst.ConstraintParam], terms: List[TypedAst.Pattern])(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     for (term <- terms) {
       term match {
         case TypedAst.Pattern.Wild(_, _)           => ()
@@ -707,7 +707,7 @@ object ConstraintGen {
     *   with Order[t1], ..., Order[tN]
     * Mirrors [[SpecializeAndLower.mkGuard]]. Arity 0 emits nothing: there is no `lift0b`.
     */
-  private def guardLiftConstraint(cparams0: List[TypedAst.ConstraintParam], exp0: TypedAst.Expr)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def guardLiftConstraint(cparams0: List[TypedAst.ConstraintParam], exp0: TypedAst.Expr)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     val fvs = MonomorphHelpers.quantifiedVars(cparams0, exp0)
     if (fvs.nonEmpty) {
       val argTypes = fvs.map(_._2) // t1, ..., tN
@@ -721,7 +721,7 @@ object ConstraintGen {
     *   Vector[Boxed] -> Vector[Vector[Boxed]]
     * Mirrors [[SpecializeAndLower.mkFunctional]].
     */
-  private def functionalLiftConstraint(cparams0: List[TypedAst.ConstraintParam], outArity: Int, exp0: TypedAst.Expr)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def functionalLiftConstraint(cparams0: List[TypedAst.ConstraintParam], outArity: Int, exp0: TypedAst.Expr)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     val inVars = MonomorphHelpers.quantifiedVars(cparams0, exp0)
     val inner = Type.eraseAliases(exp0.tpe) match {
       case Type.Apply(Type.Cst(TypeConstructor.Vector, _), t, _) => t
@@ -740,7 +740,7 @@ object ConstraintGen {
     *   Fixpoint3.Ast.Shared.box(d: Denotation[v]): Denotation[Boxed] with Order[v]
     * Mirrors [[SpecializeAndLower.mkDenotation]].
     */
-  private def latticeConstraints(den: Denotation, lastTermType: Option[Type], loc: SourceLocation)(implicit tparamEnv: TparamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = den match {
+  private def latticeConstraints(den: Denotation, lastTermType: Option[Type], loc: SourceLocation)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = den match {
     case Denotation.Relational =>
       sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(Types.Fixpoint.Boxed))), MonoVar.Enum(Enums.Fixpoint.Ast.Shared.Denotation)))
     case Denotation.Latticenal =>
@@ -785,11 +785,11 @@ object ConstraintGen {
   }
 
   /** Converts `tpe0` to a `MonoArg` relative to the current declaration context. */
-  private def typeToMonoArg(tpe0: Type)(implicit tparamEnv: TparamEnv, root: TypedAst.Root, flix: Flix): MonoArg =
+  private def typeToMonoArg(tpe0: Type)(implicit tparamEnv: TypeParamEnv, root: TypedAst.Root, flix: Flix): MonoArg =
     dealiasedTypeToMonoArg(Type.eraseAliases(tpe0))
 
   /** Like [[typeToMonoArg]], but `tpe` must already have its aliases erased (deeply). */
-  private def dealiasedTypeToMonoArg(tpe: Type)(implicit tparamEnv: TparamEnv, root: TypedAst.Root, flix: Flix): MonoArg =
+  private def dealiasedTypeToMonoArg(tpe: Type)(implicit tparamEnv: TypeParamEnv, root: TypedAst.Root, flix: Flix): MonoArg =
     tpe match {
       case Type.Var(sym, _) =>
         // A type variable that is not a tparam of the current decl (absent from tparamEnv) — e.g.

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
@@ -785,6 +785,13 @@ object ConstraintGen {
     flattenApply(rel).reverse
   }
 
+  /** Extracts T from NewChannel's `(Sender[T], Receiver[T])` type — see ConstraintGen's NewChannel rule. */
+  private def extractChannelElm(tpe: Type): Type = tpe.typeArguments match {
+    case List(Type.Apply(Type.Cst(TypeConstructor.Sender, _), elm, _), _) => elm
+    case List(Type.Apply(Type.Cst(TypeConstructor.Receiver, _), elm, _), _) => elm
+    case _ => throw InternalCompilerException(s"Expected (Sender[_], Receiver[_]), but got $tpe", tpe.loc)
+  }
+
   /** Converts `tpe0` to a `MonoArg` relative to the current declaration context. */
   private def typeToMonoArg(tpe0: Type)(implicit tparamEnv: TypeParamEnv, root: TypedAst.Root, flix: Flix): MonoArg =
     dealiasedTypeToMonoArg(Type.eraseAliases(tpe0))
@@ -826,12 +833,5 @@ object ConstraintGen {
     val mvar = declMonoVar(tpe.baseType).getOrElse(
       throw InternalCompilerException(s"Expected an Enum, RestrictableEnum, or Struct type, but got $tpe", tpe0.loc))
     (mvar, tpe.typeArguments)
-  }
-
-  /** Extracts T from NewChannel's `(Sender[T], Receiver[T])` type — see ConstraintGen's NewChannel rule. */
-  private def extractChannelElm(tpe: Type): Type = tpe.typeArguments match {
-    case List(Type.Apply(Type.Cst(TypeConstructor.Sender, _), elm, _), _) => elm
-    case List(Type.Apply(Type.Cst(TypeConstructor.Receiver, _), elm, _), _) => elm
-    case _ => throw InternalCompilerException(s"Expected (Sender[_], Receiver[_]), but got $tpe", tpe.loc)
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
@@ -114,7 +114,6 @@ object ConstraintGen {
     }
 
     ParOps.parMap(root.effects.values.flatMap(_.ops)) { op =>
-      // We need a Synthetic DefnSym to tie the tparams to
       val defnSym = new Symbol.DefnSym(None, op.sym.namespace, op.sym.name, op.sym.loc)
       val mvar = MonoVar.Def(defnSym)
       implicit val tparamEnv: TypeParamEnv = mkTypeParamEnv(mvar, op.spec.tparams)
@@ -139,10 +138,11 @@ object ConstraintGen {
   private def visitType(tpe0: Type)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     def dealiasedVisitType(tpe: Type): Unit = tpe match {
       case at @ Type.AssocType(_, arg, _, _) =>
-        if (at.typeVars.isEmpty)
+        if (at.typeVars.isEmpty) {
           visitType(Canonicalization.reduceAssocType(at)(root, flix))
-        else
+        } else {
           dealiasedVisitType(arg)
+        }
       case app @ Type.Apply(_, _, _)    =>
         val args = app.typeArguments
         for (arg <- args) {
@@ -214,7 +214,7 @@ object ConstraintGen {
   /**
     * Emits flow constraints for the formal parameter types, return type, and body of `defn`.
     */
- private def visitDef(defn: TypedAst.Def)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
+  private def visitDef(defn: TypedAst.Def)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = {
     for (case FormalParam(_, tpe, _, _, _) <- defn.spec.fparams) {
       visitType(tpe)
     }
@@ -227,47 +227,48 @@ object ConstraintGen {
     * Emits flow constraints for the default-handler calls that
     * [[SpecializeAndLower.wrapDefWithDefaultHandlers]] synthesizes around entry points.
     */
-  private def entryPointHandlerConstraints(defn: TypedAst.Def)(implicit tparamEnv: TypeParamEnv, sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit =
+  private def entryPointHandlerConstraints(defn: TypedAst.Def)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit =
     if (TypedAstOps.isEntryPoint(defn)(root)) {
       val loc = defn.spec.eff.loc
       val defEffects = Canonicalization.evalEff(defn.spec.eff)
       val requiredHandlers = root.defaultHandlers.filter(h => defEffects.contains(h.handledSym))
-      requiredHandlers.foldLeft(defn.spec.eff) { case (eff, handler) =>
-        val handlerDef = root.defs(handler.handlerSym)
-        val handlerTparams = handlerDef.spec.tparams
-        // E.g. imagine we have this effect declaration:
-        // {{{
-        //   eff Ask {
-        //       def ask(): Int32
-        //   }
-        // }}}
-        // with this default handler declaration:
-        // {{{
-        //   mod Ask {
-        //       @DefaultHandler
-        //       def handle(f: Unit -> a \ ef): a \ (ef - Ask) + IO = ...
-        //   }
-        // }}}
-        // which will then be (implicitly) used at this entry point:
-        // {{{
-        //   def main(): Unit \ Ask + IO = println(Ask.ask())
-        // }}}
-        // `SpecializeAndLower` will synthesize a call `Ask.handle(() -> <main's body>)` around
-        // `main`, so we must create the flow:
-        // {{{
-        //   [Unit, Ask + IO] ~> Ask.handle
-        // }}}
-        //
-        // N.B. We use full unification rather than reading `a`/`ef` off fixed positions because
-        // a default handler's parameter type only has to be *equal* to `Unit -> a \ ef`, not
-        // written that way syntactically — e.g. `f: Unit -> a \ (ef + Pure)` is a valid handler
-        // parameter type too.
-        val concreteParamTpe = Type.mkArrowWithEffect(Type.Unit, eff, defn.spec.retTpe, loc)
-        val subst = ConstraintSolver2.fullyUnify(handlerDef.spec.fparams.head.tpe, concreteParamTpe, RegionScope.Top, RigidityEnv.empty)(root.eqEnv, flix)
-          .getOrElse(throw InternalCompilerException(s"Could not unify default handler '${handler.handlerSym}' against its call site.", loc))
-        val args = handlerTparams.map(tp => typeToMonoArg(subst(Type.Var(tp.sym, loc))))
-        sctx.addFlowConstraint(FlowConstraint(Instantiation(args), MonoVar.Def(handler.handlerSym)))
-        Canonicalization.canonicalEffect(Type.mkUnion(Type.mkDifference(eff, handler.handledEff, loc), Type.IO, loc))
+      requiredHandlers.foldLeft(defn.spec.eff) {
+        case (eff, handler) =>
+          val handlerDef = root.defs(handler.handlerSym)
+          val handlerTparams = handlerDef.spec.tparams
+          // E.g. imagine we have this effect declaration:
+          // {{{
+          //   eff Ask {
+          //       def ask(): Int32
+          //   }
+          // }}}
+          // with this default handler declaration:
+          // {{{
+          //   mod Ask {
+          //       @DefaultHandler
+          //       def handle(f: Unit -> a \ ef): a \ (ef - Ask) + IO = ...
+          //   }
+          // }}}
+          // which will then be (implicitly) used at this entry point:
+          // {{{
+          //   def main(): Unit \ Ask + IO = println(Ask.ask())
+          // }}}
+          // `SpecializeAndLower` will synthesize a call `Ask.handle(() -> <main's body>)` around
+          // `main`, so we must create the flow:
+          // {{{
+          //   [Unit, Ask + IO] ~> Ask.handle
+          // }}}
+          //
+          // N.B. We use full unification rather than reading `a`/`ef` off fixed positions because
+          // a default handler's parameter type only has to be *equal* to `Unit -> a \ ef`, not
+          // written that way syntactically — e.g. `f: Unit -> a \ (ef + Pure)` is a valid handler
+          // parameter type too.
+          val concreteParamTpe = Type.mkArrowWithEffect(Type.Unit, eff, defn.spec.retTpe, loc)
+          val subst = ConstraintSolver2.fullyUnify(handlerDef.spec.fparams.head.tpe, concreteParamTpe, RegionScope.Top, RigidityEnv.empty)(root.eqEnv, flix)
+            .getOrElse(throw InternalCompilerException(s"Could not unify default handler '${handler.handlerSym}' against its call site.", loc))
+          val args = handlerTparams.map(tp => typeToMonoArg(subst(Type.Var(tp.sym, loc))))
+          sctx.addFlowConstraint(FlowConstraint(Instantiation(args), MonoVar.Def(handler.handlerSym)))
+          Canonicalization.canonicalEffect(Type.mkUnion(Type.mkDifference(eff, handler.handledEff, loc), Type.IO, loc))
       }
       ()
     }
@@ -789,35 +790,35 @@ object ConstraintGen {
     dealiasedTypeToMonoArg(Type.eraseAliases(tpe0))
 
   /** Like [[typeToMonoArg]], but `tpe` must already have its aliases erased (deeply). */
-  private def dealiasedTypeToMonoArg(tpe: Type)(implicit tparamEnv: TypeParamEnv, root: TypedAst.Root, flix: Flix): MonoArg =
-    tpe match {
-      case Type.Var(sym, _) =>
-        // A type variable that is not a tparam of the current decl (absent from tparamEnv) — e.g.
-        // a region var introduced by `region r { ... }`. We record it as an opaque constant so the
-        // flow is still emitted but the solver does not propagate it.
-        tparamEnv.get(sym).getOrElse(MonoArg.Const(tpe))
-      case at @ Type.AssocType(symUse, arg, kind, assocLoc) =>
-        if (tpe.typeVars.isEmpty)
-          MonoArg.Const(Canonicalization.reduceAssocType(at)(root, flix))
-        else
-          MonoArg.Assoc(symUse.sym, dealiasedTypeToMonoArg(arg), kind, assocLoc)
-      case Type.Cst(_, _) =>
-        MonoArg.Const(tpe)
-      case Type.Apply(_, _, _) =>
-        if (tpe.kind == Kind.Eff && tpe.typeVars.isEmpty)
-          MonoArg.Const(Canonicalization.simplify(tpe, isGround = true)(root, flix))
-        else {
-          MonoArg.App(dealiasedTypeToMonoArg(tpe.baseType), tpe.typeArguments.map(arg => dealiasedTypeToMonoArg(arg)))
-        }
-      case Type.Alias(_, _, _, _) =>
-        throw InternalCompilerException(s"Unexpected type alias (should have been erased): $tpe", tpe.loc)
-      case Type.JvmToType(_, loc) =>
-        throw InternalCompilerException("Unexpected JVM type", loc)
-      case Type.JvmToEff(_, loc) =>
-        throw InternalCompilerException("Unexpected JVM eff", loc)
-      case Type.UnresolvedJvmType(_, loc) =>
-        throw InternalCompilerException("Unexpected JVM type", loc)
-    }
+  private def dealiasedTypeToMonoArg(tpe: Type)(implicit tparamEnv: TypeParamEnv, root: TypedAst.Root, flix: Flix): MonoArg = tpe match {
+    case Type.Var(sym, _) =>
+      // A type variable that is not a tparam of the current decl (absent from tparamEnv) — e.g.
+      // a region var introduced by `region r { ... }`. We record it as an opaque constant so the
+      // flow is still emitted but the solver does not propagate it.
+      tparamEnv.get(sym).getOrElse(MonoArg.Const(tpe))
+    case at @ Type.AssocType(symUse, arg, kind, assocLoc) =>
+      if (tpe.typeVars.isEmpty) {
+        MonoArg.Const(Canonicalization.reduceAssocType(at)(root, flix))
+      } else {
+        MonoArg.Assoc(symUse.sym, dealiasedTypeToMonoArg(arg), kind, assocLoc)
+      }
+    case Type.Cst(_, _) =>
+      MonoArg.Const(tpe)
+    case Type.Apply(_, _, _) =>
+      if (tpe.kind == Kind.Eff && tpe.typeVars.isEmpty) {
+        MonoArg.Const(Canonicalization.simplify(tpe, isGround = true)(root, flix))
+      } else {
+        MonoArg.App(dealiasedTypeToMonoArg(tpe.baseType), tpe.typeArguments.map(arg => dealiasedTypeToMonoArg(arg)))
+      }
+    case Type.Alias(_, _, _, _) =>
+      throw InternalCompilerException(s"Unexpected type alias (should have been erased): $tpe", tpe.loc)
+    case Type.JvmToType(_, loc) =>
+      throw InternalCompilerException("Unexpected JVM type", loc)
+    case Type.JvmToEff(_, loc) =>
+      throw InternalCompilerException("Unexpected JVM eff", loc)
+    case Type.UnresolvedJvmType(_, loc) =>
+      throw InternalCompilerException("Unexpected JVM type", loc)
+  }
 
   /** Returns the enum/restrictable-enum/struct `MonoVar` and type arguments of `tpe0`. */
   private def getMonoVarAndTypeArgs(tpe0: Type): (MonoVar, List[Type]) = {

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
@@ -189,8 +189,8 @@ object ConstraintSolver {
       instance <- instanceMap.get((sigSym.trt, tyCon))
       result   <- instance.defs.find(_.sym.text == sigSym.name) match {
         case Some(implDef) =>
-          val sigOwnArgs = instantiation.args.tail // type args beyond the trait type param
-          Some((implDef.sym, GroundInstantiation(instanceArgsFor(instance, traitType, root) ++ sigOwnArgs)))
+          val implOwnArgs = dropEconstrArgs(sigSym, instantiation, root)
+          Some((implDef.sym, GroundInstantiation(instanceArgsFor(instance, traitType, root) ++ implOwnArgs)))
 
         case None =>
           // No impl def: sig has a default impl. Synthesize a trait-level sym and forward the
@@ -202,6 +202,15 @@ object ConstraintSolver {
           }
       }
     } yield result
+  }
+
+  /** Drops `sigSym`'s own args that equality constraints introduced, leaving the impl def's. */
+  private def dropEconstrArgs(sigSym: Symbol.SigSym, instantiation: GroundInstantiation, root: TypedAst.Root): List[Type] = {
+    val sigSpec = root.sigs(sigSym).spec
+    val econstrVars = sigSpec.econstrs.flatMap(ec => ec.tpe1.typeVars ++ ec.tpe2.typeVars).map(_.sym).toSet
+    ListOps.zip(sigSpec.tparams.map(_.sym), instantiation.args.tail).collect {
+      case (sym, arg) if !econstrVars.contains(sym) => arg
+    }
   }
 
   /** Unifies `instance`'s type against `traitType`, returning its tparams' values in order. */

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -263,31 +263,35 @@ object Specialize {
 
   /** Returns every def reachable from `root`. */
   private def mkAllDefs(root: TypedAst.Root): AllDefs = {
-    val allInstanceDefs: Map[Symbol.DefnSym, TypedAst.Def] = (for {
+    val instanceDefPairs = for {
       inst <- root.instances.values
       d    <- inst.defs
-    } yield d.sym -> d).toMap
+    } yield d.sym -> d
+    val allInstanceDefs = instanceDefPairs.toMap
 
-    val defToInst: Map[Symbol.DefnSym, TypedAst.Instance] = (for {
+    val defToInstPairs = for {
       inst <- root.instances.values
       d    <- inst.defs
-    } yield d.sym -> inst).toMap
+    } yield d.sym -> inst
+    val defToInst = defToInstPairs.toMap
 
-    val defaultSigDefs: Map[Symbol.DefnSym, TypedAst.Def] = (for {
-      sig    <- root.sigs.values
-      exp    <- sig.exp
+    val defaultSigDefPairs = for {
+      sig <- root.sigs.values
+      exp <- sig.exp
     } yield {
       val defnSym = MonomorphHelpers.defaultSigImplSym(sig)
       defnSym -> TypedAst.Def(defnSym, sig.spec, exp, sig.sym.loc)
-    }).toMap
+    }
+    val defaultSigDefs = defaultSigDefPairs.toMap
 
-    val defaultSigTraitTparams: Map[Symbol.DefnSym, List[TypedAst.TypeParam]] = (for {
-      sig    <- root.sigs.values
-      _      <- sig.exp // Filters out sigs without a default impl.
+    val defaultSigTraitTparamPairs = for {
+      sig <- root.sigs.values
+      _   <- sig.exp // Filters out sigs without a default impl.
     } yield {
       val defnSym = MonomorphHelpers.defaultSigImplSym(sig)
       defnSym -> List(root.traits(sig.sym.trt).tparam)
-    }).toMap
+    }
+    val defaultSigTraitTparams = defaultSigTraitTparamPairs.toMap
 
     val prefixTparams: Map[Symbol.DefnSym, List[TypedAst.TypeParam]] =
       MapOps.mapValues(defToInst)(_.tparams) ++ defaultSigTraitTparams

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -180,8 +180,6 @@ object Specialize {
                             (implicit tables: SpecializationTables, root: TypedAst.Root, flix: Flix): Symbol.DefnSym = {
     val sig = root.sigs(sym)
     val trt = root.traits(sym.trt)
-    // groundArrowTpe comes from an already-solved, reachable call site, so it must unify with
-    // the sig's own declared scheme.
     val subst = ConstraintSolver2.fullyUnify(sig.spec.declaredScheme.base, groundArrowTpe, RegionScope.Top, RigidityEnv.empty)(root.eqEnv, flix).get
     val traitType = subst.m(trt.tparam.sym)
     // traitType is ground (groundArrowTpe has no free vars), so it always has a type constructor.
@@ -230,9 +228,12 @@ object Specialize {
     case Type.Apply(_, _, loc)             =>
       val args = tpe.typeArguments
       tpe.baseType match {
-        case Type.Cst(TypeConstructor.Enum(sym, _), _) => Type.mkEnum(tables.enumTable((sym, args)), Nil, loc)
-        case Type.Cst(TypeConstructor.RestrictableEnum(sym, _), _) => Type.mkEnum(tables.restrictableEnumTable((sym, args)), Nil, loc)
-        case Type.Cst(TypeConstructor.Struct(sym, _), _) => Type.mkStruct(tables.structTable((sym, args)), Nil, loc)
+        case Type.Cst(TypeConstructor.Enum(sym, _), _) =>
+          Type.mkEnum(tables.enumTable((sym, args)), Nil, loc)
+        case Type.Cst(TypeConstructor.RestrictableEnum(sym, _), _) =>
+          Type.mkEnum(tables.restrictableEnumTable((sym, args)), Nil, loc)
+        case Type.Cst(TypeConstructor.Struct(sym, _), _) =>
+          Type.mkStruct(tables.structTable((sym, args)), Nil, loc)
         case _ => Type.mkApply(rewriteEnumStructType(tpe.baseType), args.map(rewriteEnumStructType), loc)
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -398,19 +398,19 @@ object Specialize {
     val AllDefs(allDefs, defToInst, defaultSigDefs, prefixTparams) = mkAllDefs(root)
 
     val entries = mkDefEntries(solution, allDefs, prefixTparams)
-    val defTableMap: Map[(Symbol.DefnSym, Type), Symbol.DefnSym] =
+    val defTableMap =
       entries.map { case (freshSym, defn, _, it) => (defn.sym, it) -> freshSym }.toMap
 
     val enumEntries = mkEnumEntries(solution)
-    val enumTableMap: Map[(Symbol.EnumSym, List[Type]), Symbol.EnumSym] =
+    val enumTableMap =
       enumEntries.map { case (sym, args, freshSym, _) => (sym, args) -> freshSym }.toMap
 
     val structEntries = mkStructEntries(solution)
-    val structTableMap: Map[(Symbol.StructSym, List[Type]), Symbol.StructSym] =
+    val structTableMap =
       structEntries.map { case (sym, args, freshSym, _) => (sym, args) -> freshSym }.toMap
 
     val restrictableEnumEntries = mkRestrictableEnumEntries(solution)
-    val restrictableEnumTableMap: Map[(Symbol.RestrictableEnumSym, List[Type]), Symbol.EnumSym] =
+    val restrictableEnumTableMap =
       restrictableEnumEntries.map { case (sym, args, freshSym, _) => (sym, args) -> freshSym }.toMap
 
     val is: Map[(Symbol.TraitSym, TypeConstructor), Instance] = MonomorphHelpers.mkInstanceMap(root.instances)
@@ -420,23 +420,23 @@ object Specialize {
     // Create specialized and lowered versions of the different families of declarations
 
     // Biggest-first scheduling to preload long-tailed jobs
-    def sortByLineSpan(defn: TypedAst.Def): Int = defn.loc.startLine - defn.loc.endLine
+    def negativeLineCount(defn: TypedAst.Def): Int = defn.loc.startLine - defn.loc.endLine
 
+    val nonParametricDefEntries = allDefs.filter {
+      case (sym, defn) =>
+        defn.spec.tparams.isEmpty &&
+          defToInst.get(sym).forall(_.tparams.isEmpty) &&
+          !defaultSigDefs.contains(sym)
+    }
     val nonParametricDefs: Map[Symbol.DefnSym, MonoAst.Def] =
-      ParOps.parMapWithPriority(allDefs.filter {
-        case (sym, defn) =>
-          defn.spec.tparams.isEmpty &&
-            defToInst.get(sym).forall(_.tparams.isEmpty) &&
-            !defaultSigDefs.contains(sym)
-        },
-        sortBy = ({ case (_, defn) => sortByLineSpan(defn) }: ((Symbol.DefnSym, TypedAst.Def)) => Int)) {
+      ParOps.parMapWithPriority(nonParametricDefEntries, sortBy = ({ case (_, defn) => negativeLineCount(defn) }: ((Symbol.DefnSym, TypedAst.Def)) => Int)) {
         case (sym, defn) => sym -> flix.profile(defn.sym, defn.loc) {
           SpecializeAndLower.visitDef(sym, defn, StrictSubstitution.empty)
         }
       }.toMap
 
     val specializedDefs: Map[Symbol.DefnSym, MonoAst.Def] =
-      ParOps.parMapWithPriority(entries, sortBy = ({ case (_, defn, _, _) => sortByLineSpan(defn) }: ((Symbol.DefnSym, TypedAst.Def, StrictSubstitution, Type)) => Int)) {
+      ParOps.parMapWithPriority(entries, sortBy = ({ case (_, defn, _, _) => negativeLineCount(defn) }: ((Symbol.DefnSym, TypedAst.Def, StrictSubstitution, Type)) => Int)) {
         case (freshSym, defn, subst, _) => freshSym -> flix.profile(defn.sym, defn.loc) {
           SpecializeAndLower.visitDef(freshSym, defn, subst)
         }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -336,9 +336,10 @@ object Specialize {
       val substMap = ListOps.zip(enm.tparams, args).map { case (tp, ty) => tp.sym -> ty }.toMap
       val freshSym = Symbol.freshEnumSym(enm.sym)
       val subst = StrictSubstitution.mk(Substitution(substMap))
-      val newCases = enm.cases.map { case (caseSym, TypedAst.Case(_, tpes, sc, cloc)) =>
-        val newCaseSym = new Symbol.CaseSym(freshSym, caseSym.name, caseSym.ordinal, caseSym.loc)
-        newCaseSym -> TypedAst.Case(newCaseSym, tpes.map(subst.apply), sc, cloc)
+      val newCases = enm.cases.map {
+        case (caseSym, TypedAst.Case(_, tpes, sc, cloc)) =>
+          val newCaseSym = new Symbol.CaseSym(freshSym, caseSym.name, caseSym.ordinal, caseSym.loc)
+          newCaseSym -> TypedAst.Case(newCaseSym, tpes.map(subst.apply), sc, cloc)
       }
       val newEnum = TypedAst.Enum(enm.doc, enm.ann, enm.mod, freshSym, Nil, enm.derives, newCases, enm.loc)
       (sym, args, freshSym, newEnum)
@@ -358,9 +359,10 @@ object Specialize {
       val substMap = ListOps.zip(enm.index :: enm.tparams, args).map { case (tp, ty) => tp.sym -> ty }.toMap
       val freshSym = Symbol.freshEnumSym(SpecializeAndLower.lowerRestrictableEnumSym(sym))
       val subst = StrictSubstitution.mk(Substitution(substMap))
-      val newCases = enm.cases.map { case (caseSym, TypedAst.RestrictableCase(_, tpes, sc, cloc)) =>
-        val newCaseSym = new Symbol.CaseSym(freshSym, caseSym.name, Symbol.CaseSym.NoOrdinal, caseSym.loc)
-        newCaseSym -> TypedAst.Case(newCaseSym, tpes.map(subst.apply), sc, cloc)
+      val newCases = enm.cases.map {
+        case (caseSym, TypedAst.RestrictableCase(_, tpes, sc, cloc)) =>
+          val newCaseSym = new Symbol.CaseSym(freshSym, caseSym.name, Symbol.CaseSym.NoOrdinal, caseSym.loc)
+          newCaseSym -> TypedAst.Case(newCaseSym, tpes.map(subst.apply), sc, cloc)
       }
       val newEnum = TypedAst.Enum(enm.doc, enm.ann, enm.mod, freshSym, Nil, enm.derives, newCases, enm.loc)
       (sym, args, freshSym, newEnum)
@@ -380,9 +382,10 @@ object Specialize {
       val substMap = ListOps.zip(struct.tparams, args).map { case (tp, ty) => tp.sym -> ty }.toMap
       val freshSym = Symbol.freshStructSym(struct.sym)
       val subst = StrictSubstitution.mk(Substitution(substMap))
-      val newFields = struct.fields.map { case (fieldSym, TypedAst.StructField(_, tpe, floc)) =>
-        val newFieldSym = new Symbol.StructFieldSym(freshSym, fieldSym.name, fieldSym.loc)
-        newFieldSym -> TypedAst.StructField(newFieldSym, subst(tpe), floc)
+      val newFields = struct.fields.map {
+        case (fieldSym, TypedAst.StructField(_, tpe, floc)) =>
+          val newFieldSym = new Symbol.StructFieldSym(freshSym, fieldSym.name, fieldSym.loc)
+          newFieldSym -> TypedAst.StructField(newFieldSym, subst(tpe), floc)
       }
       val newStruct = TypedAst.Struct(struct.doc, struct.ann, struct.mod, freshSym, Nil, struct.sc, newFields, struct.loc)
       (sym, args, freshSym, newStruct)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.{Kind, MonoAst, RigidityEnv, Symbol, Type,
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.phase.typer.ConstraintSolver2
 import ca.uwaterloo.flix.language.phase.unification.Substitution
-import ca.uwaterloo.flix.util.collection.{MapOps, Nel}
+import ca.uwaterloo.flix.util.collection.{ListOps, MapOps, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 /**
@@ -311,7 +311,7 @@ object Specialize {
       prefixTparams           = prefixTparamsMap.getOrElse(sym, Nil)
       if defn.spec.tparams.nonEmpty || prefixTparams.nonEmpty
     } yield {
-      val substMap = (prefixTparams.zip(args) ++ defn.spec.tparams.zip(args.drop(prefixTparams.length)))
+      val substMap = (ListOps.zip(prefixTparams, args.take(prefixTparams.length)) ++ ListOps.zip(defn.spec.tparams, args.drop(prefixTparams.length)))
         .map { case (tp, ty) => tp.sym -> ty }.toMap
       val freshSym = Symbol.freshDefnSym(defn.sym)
       val subst = StrictSubstitution.mk(Substitution(substMap))
@@ -329,7 +329,7 @@ object Specialize {
       if enm.tparams.nonEmpty
       args                  <- instantiations.map(_.args)
     } yield {
-      val substMap = enm.tparams.zip(args).map { case (tp, ty) => tp.sym -> ty }.toMap
+      val substMap = ListOps.zip(enm.tparams, args).map { case (tp, ty) => tp.sym -> ty }.toMap
       val freshSym = Symbol.freshEnumSym(enm.sym)
       val subst = StrictSubstitution.mk(Substitution(substMap))
       val newCases = enm.cases.map { case (caseSym, TypedAst.Case(_, tpes, sc, cloc)) =>
@@ -351,7 +351,7 @@ object Specialize {
       enm                   <- root.restrictableEnums.get(sym).toList
       args                  <- instantiations.map(_.args)
     } yield {
-      val substMap = (enm.index :: enm.tparams).zip(args).map { case (tp, ty) => tp.sym -> ty }.toMap
+      val substMap = ListOps.zip(enm.index :: enm.tparams, args).map { case (tp, ty) => tp.sym -> ty }.toMap
       val freshSym = Symbol.freshEnumSym(SpecializeAndLower.lowerRestrictableEnumSym(sym))
       val subst = StrictSubstitution.mk(Substitution(substMap))
       val newCases = enm.cases.map { case (caseSym, TypedAst.RestrictableCase(_, tpes, sc, cloc)) =>
@@ -373,7 +373,7 @@ object Specialize {
       if struct.tparams.nonEmpty
       args                  <- instantiations.map(_.args)
     } yield {
-      val substMap = struct.tparams.zip(args).map { case (tp, ty) => tp.sym -> ty }.toMap
+      val substMap = ListOps.zip(struct.tparams, args).map { case (tp, ty) => tp.sym -> ty }.toMap
       val freshSym = Symbol.freshStructSym(struct.sym)
       val subst = StrictSubstitution.mk(Substitution(substMap))
       val newFields = struct.fields.map { case (fieldSym, TypedAst.StructField(_, tpe, floc)) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -1058,7 +1058,7 @@ object SpecializeAndLower {
       case (Type.Float64, Type.Float64) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
       case (x, y) if !isPrimType(x) && !isPrimType(y) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
       case (x, y) =>
-        val crash = MonoAst.Expr.ApplyAtomic(AtomicOp.CastError(erasedString(x), erasedString(y)), Nil, tpe, eff, loc)
+        val crash = MonoAst.Expr.ApplyAtomic(AtomicOp.CastError(prettyPrintErasedType(x), prettyPrintErasedType(y)), Nil, tpe, eff, loc)
         MonoAst.Expr.Stm(List(exp), crash, tpe, eff, loc)
     }
   }
@@ -1088,11 +1088,12 @@ object SpecializeAndLower {
   }
 
   /**
-    * Returns the erased string representation of `tpe`
+    * Returns a human-readable name for the erased runtime type of `tpe`, for use in a
+    * `CastError` message.
     *
     * N.B.: `tpe` must be normalized.
     */
-  private def erasedString(tpe: Type): String = tpe match {
+  private def prettyPrintErasedType(tpe: Type): String = tpe match {
     case Type.Char => "Char"
     case Type.Bool => "Bool"
     case Type.Int8 => "Int8"

--- a/main/test/flix/Test.Dec.Enum.flix
+++ b/main/test/flix/Test.Dec.Enum.flix
@@ -59,9 +59,4 @@ mod Test.Dec.Enum {
         case Base(a)
         case Recurse(PolyRecursive[a])
     }
-
-    pub enum PolyRecursiveNonRegular[a] {
-        case Simple(a)
-        case Recurse(PolyRecursiveNonRegular[Poly[a]])
-    }
 }

--- a/main/test/flix/Test.Dec.Struct.flix
+++ b/main/test/flix/Test.Dec.Struct.flix
@@ -33,11 +33,6 @@ mod Test.Dec.Struct {
         poly_recurse: PolyRecursive[a, r]
     }
 
-    pub struct PolyRecursiveNonRegular[a, r] {
-        poly_nonregular_simple: a,
-        poly_nonregular_recurse: PolyRecursiveNonRegular[Poly[a, r], r]
-    }
-
     pub struct BinaryTree[t, r] {
         l: Option[BinaryTree[t, r]],
         r: Option[BinaryTree[t, r]],


### PR DESCRIPTION
This includes an assortment of small refactorings that were asked for in the following PRs (after they had been merged):
- https://github.com/flix/flix/pull/12995#discussion_r3734375890
- https://github.com/flix/flix/pull/13014
- https://github.com/flix/flix/pull/13066
- https://github.com/flix/flix/pull/13078#discussion_r3838014552
And removing two polymorphically recursive definitions from flix tests, since we could in principle run the test suite with the new pipeline.
