### PR TITLE
feat: make `--version` respect the `--json` flag

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -28,12 +28,19 @@ import ca.uwaterloo.flix.runtime.shell.Shell
 import ca.uwaterloo.flix.tools.*
 import ca.uwaterloo.flix.tools.pkg.PackageModules
 import ca.uwaterloo.flix.util.*
+import org.json4s.JsonDSL.*
+import org.json4s.native.JsonMethods
 
 import java.io.{File, PrintStream}
 import java.net.BindException
 import java.nio.file.Paths
 
 object Main {
+
+  /**
+    * The header printed by `--help` and `--version`.
+    */
+  private val Header: String = s"The Flix Programming Language ${Version.CurrentVersion}"
 
   def main(argv: Array[String]): Unit = {
 
@@ -45,6 +52,12 @@ object Main {
       Console.err.println("Unable to parse command line arguments. Will now exit.")
       System.exit(1)
       null
+    }
+
+    // check if the --version flag was passed.
+    if (cmdOpts.version) {
+      printVersion(cmdOpts.json)
+      System.exit(0)
     }
 
     // get GitHub token
@@ -487,6 +500,7 @@ object Main {
     listen: Option[Int] = None,
     threads: Option[Int] = None,
     top: Boolean = false,
+    version: Boolean = false,
     assumeYes: Boolean = false,
     xbenchmarkCodeSize: Boolean = false,
     xbenchmarkIncremental: Boolean = false,
@@ -591,7 +605,7 @@ object Main {
     val parser = new scopt.OptionParser[CmdOpts]("flix") {
 
       // Head
-      head("The Flix Programming Language", Version.CurrentVersion.toString)
+      head(Header)
 
       // Command
       cmd("init").action((_, c) => c.copy(command = Command.Init)).text("  creates a new project in the current directory.")
@@ -691,7 +705,8 @@ object Main {
       opt[Unit]("yes").action((_, c) => c.copy(assumeYes = true)).
         text("automatically answer yes to all prompts.")
 
-      version("version").text("prints the version number.")
+      opt[Unit]("version").action((_, c) => c.copy(version = true)).
+        text("prints the version number.")
 
       // Experimental options:
       note("")
@@ -752,6 +767,22 @@ object Main {
     }
 
     parser.parse(flixArgs, CmdOpts()).map(_.copy(args = progArgs.toList))
+  }
+
+  /**
+    * Prints the version number as JSON or plain text.
+    */
+  private def printVersion(json: Boolean): Unit = {
+    if (json) {
+      val v = Version.CurrentVersion
+      val result =
+        ("major" -> v.major) ~
+          ("minor" -> v.minor) ~
+          ("revision" -> v.revision)
+      println(JsonMethods.pretty(JsonMethods.render(result)))
+    } else {
+      println(Header)
+    }
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/TestMain.scala
+++ b/main/test/ca/uwaterloo/flix/TestMain.scala
@@ -157,6 +157,27 @@ class TestMain extends AnyFunSuite {
     assert(opts.assumeYes)
   }
 
+  test("--version") {
+    val args = Array("--version")
+    val opts = Main.parseCmdOpts(args).get
+    assert(opts.version)
+    assert(!opts.json)
+  }
+
+  test("--version --json") {
+    val args = Array("--version", "--json")
+    val opts = Main.parseCmdOpts(args).get
+    assert(opts.version)
+    assert(opts.json)
+  }
+
+  test("--json --version") {
+    val args = Array("--json", "--version")
+    val opts = Main.parseCmdOpts(args).get
+    assert(opts.version)
+    assert(opts.json)
+  }
+
   test("--Xbenchmark-code-size") {
     val args = Array("--Xbenchmark-code-size", "p.flix")
     val opts = Main.parseCmdOpts(args).get


### PR DESCRIPTION
`--version` was defined with scopt's built-in `version` option, which prints the header and terminates *during* parsing. As a result `--json` was never seen, and `flix --version --json` printed plain text.

This replaces it with a regular flag recorded in `CmdOpts` and handled after parsing, so flag order does not matter.

Plain output is unchanged:

```
$ flix --version
The Flix Programming Language 0.75.3
```

With `--json`:

```
$ flix --version --json
{
  "major":0,
  "minor":75,
  "revision":3
}
```

The header string is now a single `Header` val shared by `head(...)` (used by `--help`) and the plain `--version` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)