### PR TITLE
refactor: tighten JVM class member visibility

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenAbstractArrow.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenAbstractArrow.scala
@@ -68,7 +68,7 @@ object GenAbstractArrow {
     cm.closeClassMaker()
   }
 
-  def Constructor(args: List[ClassDesc], result: ClassDesc): ConstructorMethod =
+  private def Constructor(args: List[ClassDesc], result: ClassDesc): ConstructorMethod =
     ConstructorMethod(desc(args, result), Nil)
 
   def GetUniqueThreadClosureMethod(args: List[ClassDesc], result: ClassDesc): AbstractMethod =

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenArrow.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenArrow.scala
@@ -68,7 +68,7 @@ object GenArrow {
   /**
     * Represents a function interface from `java.util.function`.
     */
-  sealed trait FunctionInterface {
+  private sealed trait FunctionInterface {
     /**
       * The [[ClassDesc]] of the interface.
       */
@@ -241,49 +241,49 @@ object GenArrow {
   }
 
   // ClassMaker.Object -> ClassMaker.Object
-  case object ObjFunction extends FunctionInterface
+  private case object ObjFunction extends FunctionInterface
 
   // ClassMaker.Object -> Unit
-  case object ObjConsumer extends FunctionInterface
+  private case object ObjConsumer extends FunctionInterface
 
   // ClassMaker.Object -> Bool
-  case object ObjPredicate extends FunctionInterface
+  private case object ObjPredicate extends FunctionInterface
 
   // Int32 -> ClassMaker.Object
-  case object IntFunction extends FunctionInterface
+  private case object IntFunction extends FunctionInterface
 
   // Int32 -> Unit
-  case object IntConsumer extends FunctionInterface
+  private case object IntConsumer extends FunctionInterface
 
   // Int32 -> Bool
-  case object IntPredicate extends FunctionInterface
+  private case object IntPredicate extends FunctionInterface
 
   // Int32 -> Int32
-  case object IntUnaryOperator extends FunctionInterface
+  private case object IntUnaryOperator extends FunctionInterface
 
   // Int64 -> ClassMaker.Object
-  case object LongFunction extends FunctionInterface
+  private case object LongFunction extends FunctionInterface
 
   // Int64 -> Unit
-  case object LongConsumer extends FunctionInterface
+  private case object LongConsumer extends FunctionInterface
 
   // Int64 -> Bool
-  case object LongPredicate extends FunctionInterface
+  private case object LongPredicate extends FunctionInterface
 
   // Int64 -> Int64
-  case object LongUnaryOperator extends FunctionInterface
+  private case object LongUnaryOperator extends FunctionInterface
 
   // Float64 -> ClassMaker.Object
-  case object DoubleFunction extends FunctionInterface
+  private case object DoubleFunction extends FunctionInterface
 
   // Float64 -> Unit
-  case object DoubleConsumer extends FunctionInterface
+  private case object DoubleConsumer extends FunctionInterface
 
   // Float64 -> Bool
-  case object DoublePredicate extends FunctionInterface
+  private case object DoublePredicate extends FunctionInterface
 
   // Float64 -> Float64
-  case object DoubleUnaryOperator extends FunctionInterface
+  private case object DoubleUnaryOperator extends FunctionInterface
 
   /**
     * Returns the specialized java function interfaces of the function type.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFramesCons.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFramesCons.scala
@@ -52,7 +52,7 @@ object GenFramesCons {
 
   def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, Nil)
 
-  def PushMethod: InstanceMethod = GenFrames.PushMethod.implementation(this.Desc)
+  private def PushMethod: InstanceMethod = GenFrames.PushMethod.implementation(this.Desc)
 
   private def reverseOntoIns(implicit mv: MethodVisitor): Unit = {
     withName(1, GenFrames.Desc) { rest =>

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenGlobal.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenGlobal.scala
@@ -42,7 +42,7 @@ object GenGlobal {
   def genByteCode()(implicit flix: Flix): Array[Byte] = {
     val cm = ClassMaker.mkClass(this.Desc, IsFinal)
 
-    cm.mkConstructor(Constructor, IsPrivate, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
     cm.mkStaticConstructor(StaticConstructorMethod(this.Desc), staticConstructorIns(_))
 
     cm.mkField(CounterField, IsPrivate, IsFinal, NotVolatile)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenGlobal.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenGlobal.scala
@@ -42,7 +42,7 @@ object GenGlobal {
   def genByteCode()(implicit flix: Flix): Array[Byte] = {
     val cm = ClassMaker.mkClass(this.Desc, IsFinal)
 
-    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkConstructor(Constructor, IsPrivate, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
     cm.mkStaticConstructor(StaticConstructorMethod(this.Desc), staticConstructorIns(_))
 
     cm.mkField(CounterField, IsPrivate, IsFinal, NotVolatile)
@@ -55,7 +55,7 @@ object GenGlobal {
     cm.closeClassMaker()
   }
 
-  def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, Nil)
+  private def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, Nil)
 
   private def staticConstructorIns(implicit mv: MethodVisitor): Unit = {
     NEW(JavaClasses.AtomicLong)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNamespace.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNamespace.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase.jvm.classes
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.JvmAst
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField, StaticMethod}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
 import ca.uwaterloo.flix.language.phase.jvm.Mangle.mkDesc
@@ -41,7 +41,7 @@ object GenNamespace {
   def genByteCode(ns: List[String], defs: List[JvmAst.Def])(implicit flix: Flix): Array[Byte] = {
     val cm = ClassMaker.mkClass(desc(ns), IsFinal)
 
-    cm.mkConstructor(Constructor(ns), IsPrivate, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkConstructor(Constructor(ns), IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
 
     for (defn <- defs) {
       cm.mkStaticMethod(ShimMethod(ns, defn), IsPublic, IsFinal, shimIns(defn)(_))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNamespace.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNamespace.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase.jvm.classes
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.JvmAst
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceField, StaticMethod}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
 import ca.uwaterloo.flix.language.phase.jvm.Mangle.mkDesc
@@ -41,7 +41,7 @@ object GenNamespace {
   def genByteCode(ns: List[String], defs: List[JvmAst.Def])(implicit flix: Flix): Array[Byte] = {
     val cm = ClassMaker.mkClass(desc(ns), IsFinal)
 
-    cm.mkConstructor(Constructor(ns), IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkConstructor(Constructor(ns), IsPrivate, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
 
     for (defn <- defs) {
       cm.mkStaticMethod(ShimMethod(ns, defn), IsPublic, IsFinal, shimIns(defn)(_))
@@ -50,7 +50,7 @@ object GenNamespace {
     cm.closeClassMaker()
   }
 
-  def Constructor(ns: List[String]): ConstructorMethod = ConstructorMethod(desc(ns), Nil)
+  private def Constructor(ns: List[String]): ConstructorMethod = ConstructorMethod(desc(ns), Nil)
 
   def ShimMethod(ns: List[String], defn: JvmAst.Def): StaticMethod = {
     val erasedArgs = defn.fparams.map(_.tpe).map(TypeDescs.toErasedClassDesc)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNullaryTag.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNullaryTag.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm.classes
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, StaticConstructorMethod, StaticField}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
@@ -45,7 +45,7 @@ object GenNullaryTag {
 
     cm.mkStaticConstructor(StaticConstructorMethod(d), singletonStaticConstructor(Constructor(enumName, name), SingletonField(enumName, name))(_))
     cm.mkField(SingletonField(enumName, name), IsPublic, IsFinal, NotVolatile)
-    cm.mkConstructor(Constructor(enumName, name), IsPublic, constructorIns(ordinal)(_))
+    cm.mkConstructor(Constructor(enumName, name), IsPrivate, constructorIns(ordinal)(_))
 
     cm.closeClassMaker()
   }
@@ -55,7 +55,7 @@ object GenNullaryTag {
     StaticField(d, "singleton", d)
   }
 
-  def Constructor(enumName: String, name: String): ConstructorMethod =
+  private def Constructor(enumName: String, name: String): ConstructorMethod =
     ConstructorMethod(desc(enumName, name), Nil)
 
   /** `[] --> return` */

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNullaryTag.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNullaryTag.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm.classes
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, StaticConstructorMethod, StaticField}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
@@ -45,7 +45,7 @@ object GenNullaryTag {
 
     cm.mkStaticConstructor(StaticConstructorMethod(d), singletonStaticConstructor(Constructor(enumName, name), SingletonField(enumName, name))(_))
     cm.mkField(SingletonField(enumName, name), IsPublic, IsFinal, NotVolatile)
-    cm.mkConstructor(Constructor(enumName, name), IsPrivate, constructorIns(ordinal)(_))
+    cm.mkConstructor(Constructor(enumName, name), IsPublic, constructorIns(ordinal)(_))
 
     cm.closeClassMaker()
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRecordEmpty.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRecordEmpty.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm.classes
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceMethod, StaticConstructorMethod, StaticField}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
@@ -38,7 +38,7 @@ object GenRecordEmpty {
     val cm = ClassMaker.mkClass(this.Desc, IsFinal, interfaces = List(GenRecord.Desc))
 
     cm.mkStaticConstructor(StaticConstructorMethod(this.Desc), singletonStaticConstructor(Constructor, SingletonField)(_))
-    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkConstructor(Constructor, IsPrivate, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
     cm.mkField(SingletonField, IsPublic, IsFinal, NotVolatile)
     cm.mkMethod(Nil, LookupFieldMethod, IsPublic, IsFinal, throwUnsupportedExc(_))
     cm.mkMethod(Nil, RestrictFieldMethod, IsPublic, IsFinal, throwUnsupportedExc(_))
@@ -46,7 +46,7 @@ object GenRecordEmpty {
     cm.closeClassMaker()
   }
 
-  def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, Nil)
+  private def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, Nil)
 
   def SingletonField: StaticField = StaticField(this.Desc, "INSTANCE", this.Desc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRecordEmpty.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRecordEmpty.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm.classes
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceMethod, StaticConstructorMethod, StaticField}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
@@ -38,7 +38,7 @@ object GenRecordEmpty {
     val cm = ClassMaker.mkClass(this.Desc, IsFinal, interfaces = List(GenRecord.Desc))
 
     cm.mkStaticConstructor(StaticConstructorMethod(this.Desc), singletonStaticConstructor(Constructor, SingletonField)(_))
-    cm.mkConstructor(Constructor, IsPrivate, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
     cm.mkField(SingletonField, IsPublic, IsFinal, NotVolatile)
     cm.mkMethod(Nil, LookupFieldMethod, IsPublic, IsFinal, throwUnsupportedExc(_))
     cm.mkMethod(Nil, RestrictFieldMethod, IsPublic, IsFinal, throwUnsupportedExc(_))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRecordExtend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRecordExtend.scala
@@ -76,7 +76,7 @@ object GenRecordExtend {
     }
   }
 
-  def RestrictFieldMethod(value: ClassDesc): InstanceMethod =
+  private def RestrictFieldMethod(value: ClassDesc): InstanceMethod =
     GenRecord.RestrictFieldMethod.implementation(desc(value))
 
   private def restrictFieldIns(value: ClassDesc)(implicit mv: MethodVisitor): Unit = {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRegion.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRegion.scala
@@ -53,7 +53,7 @@ object GenRegion {
     cm.mkMethod(Nil, ExitMethod, IsPublic, IsFinal, exitIns(_))
     cm.mkMethod(Nil, ReportChildExceptionMethod, IsPublic, IsFinal, reportChildExceptionIns(_))
     cm.mkMethod(Nil, ReThrowChildExceptionMethod, IsPublic, IsFinal, reThrowChildExceptionIns(_))
-    cm.mkMethod(Nil, RunOnExitMethod, IsPrivate, IsFinal, runOnExitIns(_))
+    cm.mkMethod(Nil, RunOnExitMethod, IsPublic, IsFinal, runOnExitIns(_))
 
     cm.closeClassMaker()
   }
@@ -198,7 +198,7 @@ object GenRegion {
     RETURN()
   }
 
-  // private final void runOnExit(Runnable r) {
+  // final public void runOnExit(Runnable r) {
   //   onExit.addFirst(r);
   // }
   private def RunOnExitMethod: InstanceMethod = InstanceMethod(this.Desc, "runOnExit", mkVoidDescriptor(JavaClasses.Runnable))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRegion.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenRegion.scala
@@ -53,7 +53,7 @@ object GenRegion {
     cm.mkMethod(Nil, ExitMethod, IsPublic, IsFinal, exitIns(_))
     cm.mkMethod(Nil, ReportChildExceptionMethod, IsPublic, IsFinal, reportChildExceptionIns(_))
     cm.mkMethod(Nil, ReThrowChildExceptionMethod, IsPublic, IsFinal, reThrowChildExceptionIns(_))
-    cm.mkMethod(Nil, RunOnExitMethod, IsPublic, IsFinal, runOnExitIns(_))
+    cm.mkMethod(Nil, RunOnExitMethod, IsPrivate, IsFinal, runOnExitIns(_))
 
     cm.closeClassMaker()
   }
@@ -70,7 +70,7 @@ object GenRegion {
   // private volatile Throwable childException = null;
   private def ChildExceptionField: InstanceField = InstanceField(this.Desc, "childException", JavaClasses.Throwable)
 
-  def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, Nil)
+  private def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, Nil)
 
   private def constructorIns(implicit mv: MethodVisitor): Unit = {
     thisLoad()
@@ -198,7 +198,7 @@ object GenRegion {
     RETURN()
   }
 
-  // final public void runOnExit(Runnable r) {
+  // private final void runOnExit(Runnable r) {
   //   onExit.addFirst(r);
   // }
   private def RunOnExitMethod: InstanceMethod = InstanceMethod(this.Desc, "runOnExit", mkVoidDescriptor(JavaClasses.Runnable))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionWrapper.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenResumptionWrapper.scala
@@ -68,9 +68,9 @@ object GenResumptionWrapper {
     }
   }
 
-  def ResumptionField(tpe: ClassDesc): InstanceField = InstanceField(desc(tpe), "resumption", GenResumption.Desc)
+  private def ResumptionField(tpe: ClassDesc): InstanceField = InstanceField(desc(tpe), "resumption", GenResumption.Desc)
 
-  def InvokeMethod(tpe: ClassDesc): InstanceMethod = GenThunk.InvokeMethod.implementation(desc(tpe))
+  private def InvokeMethod(tpe: ClassDesc): InstanceMethod = GenThunk.InvokeMethod.implementation(desc(tpe))
 
   private def invokeIns(tpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     thisLoad()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUncaughtExceptionHandler.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUncaughtExceptionHandler.scala
@@ -51,7 +51,7 @@ object GenUncaughtExceptionHandler {
   private def RegionField: InstanceField = InstanceField(this.Desc, "r", GenRegion.Desc)
 
   // UncaughtExceptionHandler(Region r) { this.r = r; }
-  def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, GenRegion.Desc :: Nil)
+  private def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, GenRegion.Desc :: Nil)
 
   private def constructorIns(implicit mv: MethodVisitor): Unit = {
     thisLoad()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnit.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnit.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm.classes
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, StaticConstructorMethod, StaticField, mkClass}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
@@ -37,13 +37,13 @@ object GenUnit {
     val cm = mkClass(this.Desc, IsFinal)
 
     cm.mkStaticConstructor(StaticConstructorMethod(this.Desc), singletonStaticConstructor(Constructor, SingletonField)(_))
-    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkConstructor(Constructor, IsPrivate, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
     cm.mkField(SingletonField, IsPublic, IsFinal, NotVolatile)
 
     cm.closeClassMaker()
   }
 
-  def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, Nil)
+  private def Constructor: ConstructorMethod = ConstructorMethod(this.Desc, Nil)
 
   def SingletonField: StaticField = StaticField(this.Desc, "INSTANCE", this.Desc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnit.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnit.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm.classes
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.IsFinal
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, StaticConstructorMethod, StaticField, mkClass}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
@@ -37,7 +37,7 @@ object GenUnit {
     val cm = mkClass(this.Desc, IsFinal)
 
     cm.mkStaticConstructor(StaticConstructorMethod(this.Desc), singletonStaticConstructor(Constructor, SingletonField)(_))
-    cm.mkConstructor(Constructor, IsPrivate, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
+    cm.mkConstructor(Constructor, IsPublic, nullarySuperConstructor(ClassConstants.Object.Constructor)(_))
     cm.mkField(SingletonField, IsPublic, IsFinal, NotVolatile)
 
     cm.closeClassMaker()

--- a/main/src/dev/flix/runtime/Global.java
+++ b/main/src/dev/flix/runtime/Global.java
@@ -8,6 +8,8 @@ package dev.flix.runtime;
  */
 public final class Global {
 
+    private Global() {}
+
     public static final long newId() {
         throw new RuntimeException("Global.newId should not be called on the mock class");
     }

--- a/main/src/dev/flix/runtime/Global.java
+++ b/main/src/dev/flix/runtime/Global.java
@@ -8,8 +8,6 @@ package dev.flix.runtime;
  */
 public final class Global {
 
-    private Global() {}
-
     public static final long newId() {
         throw new RuntimeException("Global.newId should not be called on the mock class");
     }


### PR DESCRIPTION
## Summary
- restrict unused Scala helper descriptors and internal generator types to private visibility
- keep emitted JVM member visibility unchanged

## Testing
- ./mill --no-server flix.compile
- ./mill --no-server flix.test.testOnly ca.uwaterloo.flix.language.TestFlixErrors
- ./mill --no-server flix.test.testOnly ca.uwaterloo.flix.language.TestProgramArgs
- ./mill --no-server flix.test.testOnly flix.CompilerSuite -- -z Test.Dec.Enum.Singleton -z Test.Exp.Record.Literal -z Test.Exp.Regions
- git diff --check