### PR TITLE
refactor: remove blank lines between consecutive single-line match cases

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
@@ -94,29 +94,19 @@ private[monomorph2] object Canonicalization {
     // and the applied kind is computed from nt1.kind alone, so this avoids a throwaway Type.Apply.
     (nt1, nt2) match {
       case _ if isGround && (nt1.kind match { case Kind.Arrow(_, k) => k == Kind.Eff; case _ => false }) => canonicalEffect(Type.Apply(nt1, nt2, loc))
-
       case (Type.Cst(TypeConstructor.Complement, _), y) => Type.mkComplement(y, loc)
-
       case (Type.Apply(Type.Cst(TypeConstructor.Union, _), x, _), y) => Type.mkUnion(x, y, loc)
-
       case (Type.Apply(Type.Cst(TypeConstructor.Intersection, _), x, _), y) => Type.mkIntersection(x, y, loc)
-
       case (Type.Apply(Type.Cst(TypeConstructor.Difference, _), x, _), y) => Type.mkDifference(x, y, loc)
-
       case (Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y) => Type.mkSymmetricDiff(x, y, loc)
 
       // Bool equations don't need separate canonicalization: unlike effects, these smart
       // constructors fully reduce a ground formula to a single True/False constant.
       case (Type.Cst(TypeConstructor.Not, _), y) => Type.mkNot(y, loc)
-
       case (Type.Apply(Type.Cst(TypeConstructor.And, _), x, _), y) => Type.mkAnd(x, y, loc)
-
       case (Type.Apply(Type.Cst(TypeConstructor.Or, _), x, _), y) => Type.mkOr(x, y, loc)
-
       case (Type.Cst(TypeConstructor.CaseComplement(sym), _), y) => Type.mkCaseComplement(y, sym, loc)
-
       case (Type.Apply(Type.Cst(TypeConstructor.CaseIntersection(sym), _), x, _), y) => Type.mkCaseIntersection(x, y, sym, loc)
-
       case (Type.Apply(Type.Cst(TypeConstructor.CaseUnion(sym), _), x, _), y) => Type.mkCaseUnion(x, y, sym, loc)
 
       case (Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(label), _), tpe, _), rest) =>
@@ -140,11 +130,8 @@ private[monomorph2] object Canonicalization {
     */
   private[monomorph2] def simplify(tpe: Type, isGround: Boolean)(implicit root: TypedAst.Root, flix: Flix): Type = tpe match {
     case Type.Var(_, _)            => tpe
-
     case Type.Cst(_, _)            => tpe
-
     case app@Type.Apply(_, _, _)   => normalizeApply(simplify(_, isGround), app, isGround)
-
     case Type.Alias(_, _, t, _)    => simplify(t, isGround)
 
     case Type.AssocType(symUse, arg0, kind, loc) =>
@@ -152,9 +139,7 @@ private[monomorph2] object Canonicalization {
       simplify(reduceAssocType(Type.AssocType(symUse, arg, kind, loc)), isGround)
 
     case Type.JvmToType(_, loc)         => throw InternalCompilerException("unexpected JVM type", loc)
-
     case Type.JvmToEff(_, loc)          => throw InternalCompilerException("unexpected JVM eff", loc)
-
     case Type.UnresolvedJvmType(_, loc) => throw InternalCompilerException("unexpected JVM type", loc)
   }
 
@@ -199,19 +184,12 @@ private[monomorph2] object Canonicalization {
       Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(l), loc1), t, loc2), newRest, loc3)
 
     case Type.Cst(_, _)                => Type.mkRecordRowExtend(label, tpe, rest, loc)
-
     case Type.Apply(_, _, _)           => Type.mkRecordRowExtend(label, tpe, rest, loc)
-
     case Type.Var(_, _)                => Type.mkRecordRowExtend(label, tpe, rest, loc)
-
     case Type.Alias(_, _, _, _)        => throw InternalCompilerException(s"Unexpected alias '$rest'", rest.loc)
-
     case Type.AssocType(_, _, _, _)    => throw InternalCompilerException(s"Unexpected associated type '$rest'", rest.loc)
-
     case Type.JvmToType(_, _)          => throw InternalCompilerException(s"Unexpected JVM type '$rest'", rest.loc)
-
     case Type.JvmToEff(_, _)           => throw InternalCompilerException(s"Unexpected JVM eff '$rest'", rest.loc)
-
     case Type.UnresolvedJvmType(_, _)  => throw InternalCompilerException(s"Unexpected JVM type '$rest'", rest.loc)
   }
 
@@ -228,19 +206,12 @@ private[monomorph2] object Canonicalization {
       Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(l), loc1), t, loc2), newRest, loc3)
 
     case Type.Cst(_, _)                => Type.mkSchemaRowExtend(label, tpe, rest, loc)
-
     case Type.Apply(_, _, _)           => Type.mkSchemaRowExtend(label, tpe, rest, loc)
-
     case Type.Var(_, _)                => Type.mkSchemaRowExtend(label, tpe, rest, loc)
-
     case Type.Alias(_, _, _, _)        => throw InternalCompilerException(s"Unexpected alias '$rest'", rest.loc)
-
     case Type.AssocType(_, _, _, _)    => throw InternalCompilerException(s"Unexpected associated type '$rest'", rest.loc)
-
     case Type.JvmToType(_, _)          => throw InternalCompilerException(s"Unexpected JVM type '$rest'", rest.loc)
-
     case Type.JvmToEff(_, _)           => throw InternalCompilerException(s"Unexpected JVM eff '$rest'", rest.loc)
-
     case Type.UnresolvedJvmType(_, _)  => throw InternalCompilerException(s"Unexpected JVM type '$rest'", rest.loc)
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
@@ -154,13 +154,9 @@ private[monomorph2] object ConstraintGen {
         }
 
       case Type.Var(_, _)               => ()
-
       case Type.Cst(_, _)               => ()
-
       case Type.JvmToEff(_, _)          => ()
-
       case Type.JvmToType(_, _)         => ()
-
       case Type.UnresolvedJvmType(_, _) => ()
 
       case Type.Alias(_, _, _, _)       =>
@@ -287,9 +283,7 @@ private[monomorph2] object ConstraintGen {
     */
   private def visitExp(exp0: Expr)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = exp0 match {
     case Expr.Cst(_, _, _)        => ()
-
     case Expr.Var(_, _, _)        => ()
-
     case Expr.Hole(_, _, _, _, _) => ()
 
     case Expr.ApplyDef(symUse, exps, targs, _, _, _, _, _) =>
@@ -337,9 +331,7 @@ private[monomorph2] object ConstraintGen {
       visitExp(exp)
 
     case Expr.Discard(exp, _, _) => visitExp(exp)
-
     case Expr.Region(_, _, exp, _, _, _) => visitExp(exp)
-
     case Expr.Use(_, _, exp, _) => visitExp(exp)
 
     case Expr.Match(exp, rules, _, _, _) =>
@@ -401,7 +393,6 @@ private[monomorph2] object ConstraintGen {
       }
 
     case Expr.HoleWithExp(exp, _, _, _, _) => visitExp(exp)
-
     case Expr.RecordSelect(exp, _, _, _, _) => visitExp(exp)
 
     case Expr.RecordExtend(_, exp1, exp2, _, _, _) =>
@@ -460,17 +451,11 @@ private[monomorph2] object ConstraintGen {
       visitExp(exp2)
 
     case Expr.Lazy(exp, _, _) => visitExp(exp)
-
     case Expr.Force(exp, _, _, _) => visitExp(exp)
-
     case Expr.Ascribe(exp, _, _, _, _, _) => visitExp(exp)
-
     case Expr.InstanceOf(exp, _, _) => visitExp(exp)
-
     case Expr.CheckedCast(_, exp, _, _, _) => visitExp(exp)
-
     case Expr.UncheckedCast(exp, _, _, _, _, _) => visitExp(exp)
-
     case Expr.Unsafe(exp, _, _, _, _, _) => visitExp(exp)
 
     case Expr.TryCatch(exp, rules, _, _, _) =>
@@ -545,7 +530,6 @@ private[monomorph2] object ConstraintGen {
       visitExp(exp2)
 
     case Expr.GetStaticField(_, _, _, _) => ()
-
     case Expr.PutStaticField(_, exp, _, _, _) => visitExp(exp)
 
     case Expr.NewObject(_, _, _, _, constructors, methods, _) =>
@@ -727,11 +711,8 @@ private[monomorph2] object ConstraintGen {
       visitPat(pat)
 
     case TypedAst.Pattern.Wild(_, _)   => ()
-
     case TypedAst.Pattern.Var(_, _, _) => ()
-
     case TypedAst.Pattern.Cst(_, _, _) => ()
-
     case TypedAst.Pattern.Error(_, _)  => ()
   }
 
@@ -777,13 +758,9 @@ private[monomorph2] object ConstraintGen {
           }
 
         case TypedAst.Pattern.Cst(_, tpe, _)       => boxConstraint(tpe)
-
         case TypedAst.Pattern.Tag(_, _, _, loc)    => throw InternalCompilerException(s"Unexpected pattern: '$term'.", loc)
-
         case TypedAst.Pattern.Tuple(_, _, loc)     => throw InternalCompilerException(s"Unexpected pattern: '$term'.", loc)
-
         case TypedAst.Pattern.Error(_, loc)        => throw InternalCompilerException(s"Unexpected pattern: '$term'.", loc)
-
         case TypedAst.Pattern.Record(_, _, _, loc) => throw InternalCompilerException(s"Unexpected pattern: '$term'.", loc)
       }
     }
@@ -855,9 +832,7 @@ private[monomorph2] object ConstraintGen {
       (pred, termTypesOfRelation(rel)) :: predicatesOfSchemaRow(tpe2)
 
     case Type.Var(_, _) => Nil
-
     case Type.SchemaRowEmpty => Nil
-
     case t => throw InternalCompilerException(s"Got unexpected $t", t.loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
@@ -63,11 +63,8 @@ private[monomorph2] object ConstraintSolver {
           }
 
         case MonoVar.Enum(_)              => inst0
-
         case MonoVar.Sig(_)               => inst0
-
         case MonoVar.RestrictableEnum(_)  => inst0
-
         case MonoVar.Struct(_)            => inst0
       }
       // Only add genuinely new instantiations, i.e. ones not already in the solution nor in the worklist.
@@ -97,11 +94,8 @@ private[monomorph2] object ConstraintSolver {
           }
 
         case MonoVar.Def(_)              => ()
-
         case MonoVar.Enum(_)             => ()
-
         case MonoVar.RestrictableEnum(_) => ()
-
         case MonoVar.Struct(_)           => ()
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
@@ -111,9 +111,7 @@ private[monomorph2] object NonMonomorphizableCheck {
       }
 
     case MonoArg.App(_, _)                  => true
-
     case MonoArg.Const(_)                   => true
-
     case MonoArg.Assoc(_, _, _, _)          => true
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -145,11 +145,8 @@ private[monomorph2] object Specialize {
       }
 
       case Type.Cst(TypeConstructor.Region(_), loc) => throw InternalCompilerException("unexpected Region: should have been rewritten to IO already", loc)
-
       case Type.Cst(_, _)                           => tpe0
-
       case app@Type.Apply(_, _, _)                  => Canonicalization.normalizeApply(applySubst, app, isGround = true)
-
       case Type.Alias(_, _, t, _)                   => applySubst(t)
 
       case Type.AssocType(symUse, arg0, kind, loc)  =>
@@ -159,9 +156,7 @@ private[monomorph2] object Specialize {
         Canonicalization.simplify(reducedType, isGround = true)
 
       case Type.JvmToType(_, loc)                   => throw InternalCompilerException("unexpected JVM type", loc)
-
       case Type.JvmToEff(_, loc)                    => throw InternalCompilerException("unexpected JVM eff", loc)
-
       case Type.UnresolvedJvmType(_, loc)           => throw InternalCompilerException("unexpected JVM type", loc)
     }
   }
@@ -253,13 +248,9 @@ private[monomorph2] object Specialize {
       Type.Alias(sym, args.map(rewriteEnumStructType), rewriteEnumStructType(inner), loc)
 
     case Type.Var(_, loc)                  => throw InternalCompilerException("Unexpected type variable", loc)
-
     case Type.AssocType(_, _, _, loc)      => throw InternalCompilerException("Unexpected associated type", loc)
-
     case Type.JvmToType(_, loc)            => throw InternalCompilerException("Unexpected JVM type", loc)
-
     case Type.JvmToEff(_, loc)             => throw InternalCompilerException("Unexpected JVM eff", loc)
-
     case Type.UnresolvedJvmType(_, loc)    => throw InternalCompilerException("Unexpected JVM type", loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -58,7 +58,6 @@ private[monomorph2] object SpecializeAndLower {
 
   private def lowerTypeNonSchema(tpe0: Type): Type = tpe0 match {
     case Type.Cst(_, _) => tpe0 // Reuse tpe0.
-
     case Type.Var(_, _) => tpe0
 
     // Sender[t] -> Concurrent.Channel.Mpmc[t, IO]
@@ -82,13 +81,9 @@ private[monomorph2] object SpecializeAndLower {
       }
 
     case Type.Alias(_, _, _, loc) => throw InternalCompilerException("unexpected type alias", loc)
-
     case Type.AssocType(_, _, _, loc) => throw InternalCompilerException("unexpected associated type", loc)
-
     case Type.JvmToType(_, loc) => throw InternalCompilerException("unexpected JVM type", loc)
-
     case Type.JvmToEff(_, loc) => throw InternalCompilerException("unexpected JVM eff", loc)
-
     case Type.UnresolvedJvmType(_, loc) => throw InternalCompilerException("unexpected JVM type", loc)
 
   }
@@ -784,7 +779,6 @@ private[monomorph2] object SpecializeAndLower {
               env1 + (bnd.sym -> Symbol.freshVarSym(bnd.sym))
 
             case (env1, TypedAst.RestrictableChoosePattern.Wild(_, _)) => env1
-
             case (_, TypedAst.RestrictableChoosePattern.Error(_, errLoc)) => throw InternalCompilerException("unexpected restrictable choose variable", errLoc)
           }
           val termPatterns = pat0.map {
@@ -1055,25 +1049,15 @@ private[monomorph2] object SpecializeAndLower {
   private def mkCast(exp: MonoAst.Expr, tpe: Type, eff: Type, loc: SourceLocation): MonoAst.Expr = {
     (exp.tpe, tpe) match {
       case (Type.Char, Type.Char) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (Type.Char, Type.Int16) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (Type.Int16, Type.Char) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (Type.Bool, Type.Bool) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (Type.Int8, Type.Int8) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (Type.Int16, Type.Int16) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (Type.Int32, Type.Int32) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (Type.Int64, Type.Int64) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (Type.Float32, Type.Float32) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (Type.Float64, Type.Float64) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-
       case (x, y) if !isPrimType(x) && !isPrimType(y) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
 
       case (x, y) =>
@@ -2270,7 +2254,6 @@ private[monomorph2] object SpecializeAndLower {
     */
   private def unwrapVectorType(tpe: Type, loc: SourceLocation): Type = tpe match {
     case Type.Apply(Type.Cst(TypeConstructor.Vector, _), extType, _) => extType
-
     case t => throw InternalCompilerException(
       s"Expected Type.Apply(Type.Cst(TypeConstructor.Vector, _), _, _), but got $t",
       loc
@@ -2299,9 +2282,7 @@ private[monomorph2] object SpecializeAndLower {
       (pred, termTypesOfRelation(rel, loc2)) :: predicatesOfSchemaRow(tpe2, loc1)
 
     case Type.Var(_, _) => Nil
-
     case Type.SchemaRowEmpty => Nil
-
     case t => throw InternalCompilerException(s"Got unexpected $t", loc)
   }
 
@@ -2311,9 +2292,7 @@ private[monomorph2] object SpecializeAndLower {
   private def termTypesOfRelation(rel: Type, loc: SourceLocation): List[Type] = {
     def flattenApply(rel0: Type, loc0: SourceLocation): List[Type] = rel0 match {
       case Type.Cst(TypeConstructor.Relation(_), _) => Nil
-
       case Type.Apply(rest, t, loc1) => t :: flattenApply(rest, loc1)
-
       case _ if rel0.typeConstructor.contains(TypeConstructor.AnyType) => Nil
 
       // The type of the relation is undetermined, i.e. it is a free type variable that has been replaced by AnyType.
@@ -2585,11 +2564,8 @@ private[monomorph2] object SpecializeAndLower {
       mkBodyTermLit(box(MonoAst.Expr.Cst(cst, visitTypeSubstituted(rawTpe), loc), rawTpe))
 
     case TypedAst.Pattern.Tag(_, _, _, loc) => throw InternalCompilerException(s"Unexpected pattern: '$pat0'.", loc)
-
     case TypedAst.Pattern.Tuple(_, _, loc) => throw InternalCompilerException(s"Unexpected pattern: '$pat0'.", loc)
-
     case TypedAst.Pattern.Record(_, _, _, loc) => throw InternalCompilerException(s"Unexpected pattern: '$pat0'.", loc)
-
     case TypedAst.Pattern.Error(_, loc) => throw InternalCompilerException(s"Unexpected pattern: '$pat0'.", loc)
 
   }


### PR DESCRIPTION
This should address the formatting misunderstanding pointed out in https://github.com/flix/flix/pull/13151.