### PR TITLE
refactor: reuse a constant for the toml file extension

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -189,8 +189,11 @@ object Bootstrap {
   /** The jar file extension. Does not contain leading '.' */
   private val EXT_JAR: String = "jar"
 
+  /** The toml file extension. Does not contain leading '.' */
+  val EXT_TOML: String = "toml"
+
   /** The manifest / flix toml file name. */
-  val FLIX_TOML: String = "flix.toml"
+  val FLIX_TOML: String = s"flix.$EXT_TOML"
 
   /** The license file name. */
   private val LICENSE: String = "LICENSE.md"

--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -224,7 +224,7 @@ object FlixPackageManager {
       // download toml files
       tomlPaths <- traverse(flixDeps) { dep =>
         val depName = s"${dep.username}/${dep.projectName}"
-        install(depName, dep.version, "toml", path, apiKey).map(p => (p, dep))
+        install(depName, dep.version, Bootstrap.EXT_TOML, path, apiKey).map(p => (p, dep))
       }
 
       // parse manifests


### PR DESCRIPTION
_I split this constant out of #13067 because making it visible is an API decision of its own, and that PR should not carry it._

## Summary

`Bootstrap` spells out every file extension it knows as a constant -- `EXT_CLASS`,
`EXT_FLIX`, `EXT_FPKG`, `EXT_JAR` -- except the toml one, which was written
literally in `FLIX_TOML` and again at the `FlixPackageManager` call site that
downloads a dependency's manifest.

This adds `EXT_TOML` next to the others, derives `FLIX_TOML` from it, and replaces
the remaining literal. It is the only hardcoded `"toml"` left in `main/src`.

No behavior change.

Split out of #13067, which needs the constant at that same call site and will be
rebased once this lands.
