### PR TITLE
feat: monomorph2 flix phase

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Monomorpher2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Monomorpher2.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase.monomorph2
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{MonoAst, TypedAst}
+import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugMonoAst
 
 /**
   * Entry point for constraint-based monomorphization, following the approach of "The Simple
@@ -43,7 +44,7 @@ import ca.uwaterloo.flix.language.ast.{MonoAst, TypedAst}
 object Monomorpher2 {
 
   /** Performs constraint-based monomorphization of the given AST `root`. */
-  def run(root: TypedAst.Root)(implicit flix: Flix): MonoAst.Root = {
+  def run(root: TypedAst.Root)(implicit flix: Flix): MonoAst.Root = flix.phase("Monomorpher2") {
     val constraints = ConstraintGen.generate(root)
     NonMonomorphizableCheck.checkMonomorphizable(constraints)
     val solution = ConstraintSolver.solve(constraints, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -399,7 +399,7 @@ private[monomorph2] object Specialize {
     }
 
   /** Specializes `root` per [[ConstraintSolver]]'s [[Solution]]. */
-  private[monomorph2] def run(root: TypedAst.Root, solution: Solution)(implicit flix: Flix): MonoAst.Root = flix.phase("Monomorpher") {
+  private[monomorph2] def run(root: TypedAst.Root, solution: Solution)(implicit flix: Flix): MonoAst.Root = {
     implicit val r: TypedAst.Root = root
     // Prepare [[SpecializationTables]]
     val AllDefs(allDefs, defToInst, defaultSigDefs, prefixTparams) = mkAllDefs(root)


### PR DESCRIPTION
In the merging in of code from my own branch (which has several flix.phases for benchmarking reasons) a spurious `flix.phase("Monomorpher") {...` had sneaked its way in. I have now removed that and added a `flix.phase("Monomorpher2")` on the whole of the new monomorphization pipeline.