### PR TITLE
refactor: read Java class metadata without loading classes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.util.{ClassDescs, Result}
 import net.bytebuddy.ClassFileVersion
 import net.bytebuddy.description.TypeVariableSource
 import net.bytebuddy.description.field.FieldDescription
-import net.bytebuddy.description.method.{MethodDescription, ParameterDescription}
+import net.bytebuddy.description.method.MethodDescription
 import net.bytebuddy.description.`type`.{TypeDefinition, TypeDescription}
 import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.pool.TypePool
@@ -40,7 +40,13 @@ object ByteBuddyJavaTypeProvider {
 
   /** Returns a provider that reads resources visible to `loader` without loading classes; `null` denotes the bootstrap loader. */
   def fromClassLoader(loader: ClassLoader): ByteBuddyJavaTypeProvider = {
-    val locator = if (loader == null) ClassFileLocator.ForClassLoader.ofBootLoader() else ClassFileLocator.ForClassLoader.of(loader)
+    val locator = if (loader == null) {
+      // The JVM represents the bootstrap class loader with null.
+      ClassFileLocator.ForClassLoader.ofBootLoader()
+    } else {
+      // A non-null loader exposes application or user-provided class-path resources.
+      ClassFileLocator.ForClassLoader.of(loader)
+    }
     fromLocators(List(locator))
   }
 
@@ -48,16 +54,19 @@ object ByteBuddyJavaTypeProvider {
   def fromClassPath(entries: List[Path], includePlatform: Boolean = true): ByteBuddyJavaTypeProvider = {
     val version = ClassFileVersion.ofThisVm()
     val entryLocators = entries.map { path =>
-      if (Files.isDirectory(path)) ClassFileLocator.ForFolder.of(path.toFile, version)
-      else ClassFileLocator.ForJarFile.of(path.toFile, version)
+      if (Files.isDirectory(path)) {
+        ClassFileLocator.ForFolder.of(path.toFile, version)
+      } else {
+        ClassFileLocator.ForJarFile.of(path.toFile, version)
+      }
     }
-    val locators = if (includePlatform) entryLocators :+ ClassFileLocator.ForClassLoader.ofPlatformLoader() else entryLocators
+    val locators = if (includePlatform) {
+      entryLocators :+ ClassFileLocator.ForClassLoader.ofPlatformLoader()
+    } else {
+      entryLocators
+    }
     fromLocators(locators)
   }
-
-  /** Returns a provider backed by an arbitrary locator for focused tests. */
-  private[jvm] def fromLocator(locator: ClassFileLocator): ByteBuddyJavaTypeProvider =
-    fromLocators(List(locator))
 
   /** Returns a provider backed by the given locators in lookup order. */
   private def fromLocators(locators: List[ClassFileLocator]): ByteBuddyJavaTypeProvider = {
@@ -95,7 +104,6 @@ final case class ByteBuddyJavaTypeProvider(
         case ex: GenericSignatureFormatError => Err(InvalidClass(desc, exceptionMessage(ex)))
         case ex: MalformedParameterizedTypeException => Err(InvalidClass(desc, exceptionMessage(ex)))
         case ex: IllegalArgumentException => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: IndexOutOfBoundsException => Err(InvalidClass(desc, exceptionMessage(ex)))
         case ex: IllegalStateException => Err(InvalidClass(desc, exceptionMessage(ex)))
       }
     }
@@ -143,9 +151,7 @@ final case class ByteBuddyJavaTypeProvider(
       ref = ref,
       modifiers = method.getModifiers,
       typeParameters = method.getTypeVariables.asScala.toList.map(toTypeParameter),
-      parameterTypes = method.getParameters.asScala.toList
-        .map(_.asInstanceOf[ParameterDescription])
-        .map(p => toType(p.getType)),
+      parameterTypes = method.getParameters.asTypeList().asScala.toList.map(toType),
       returnType = toType(method.getReturnType),
       isConstructor = method.isConstructor,
       isVarArgs = method.isVarArgs

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.typer.jvm
+
+import ca.uwaterloo.flix.language.ast.jvm.{JavaClass, JavaField, JavaFieldRef, JavaMethod, JavaMethodRef, JavaType, JavaTypeParameter, JavaTypeVariable, JavaTypeVariableOwner}
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaLookupError.{InvalidClass, MissingClass, UnsupportedDescriptor}
+import ca.uwaterloo.flix.util.Result
+import ca.uwaterloo.flix.util.Result.{Err, Ok}
+import net.bytebuddy.ClassFileVersion
+import net.bytebuddy.description.TypeVariableSource
+import net.bytebuddy.description.field.FieldDescription
+import net.bytebuddy.description.method.{MethodDescription, ParameterDescription}
+import net.bytebuddy.description.`type`.{TypeDefinition, TypeDescription}
+import net.bytebuddy.dynamic.ClassFileLocator
+import net.bytebuddy.pool.TypePool
+
+import java.lang.constant.{ClassDesc, MethodTypeDesc}
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
+
+/**
+  * A [[JavaTypeProvider]] backed by Byte Buddy's lazy class-file type pool.
+  *
+  * Byte Buddy reads bytes through a [[ClassFileLocator]] and parses class-file metadata. It is never given a target
+  * `Class`, and this implementation never calls `Class.forName` or `ClassLoader.loadClass`.
+  */
+final class ByteBuddyJavaTypeProvider private(
+  private val locator: ClassFileLocator,
+  private val pool: TypePool
+) extends JavaTypeProvider {
+
+  override def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError] =
+    resolve(desc).flatMap(tpe => attempt(desc)(toClass(tpe)))
+
+  override def close(): Unit = locator.close()
+
+  private def resolve(desc: ClassDesc): Result[TypeDescription, JavaLookupError] = {
+    binaryName(desc) match {
+      case None => Err(UnsupportedDescriptor(desc))
+      case Some(name) =>
+        attempt(desc)(pool.describe(name)).flatMap { resolution =>
+          if (resolution.isResolved) attempt(desc)(resolution.resolve()) else Err(MissingClass(desc))
+        }
+    }
+  }
+
+  private def toClass(tpe: TypeDescription): JavaClass = {
+    val desc = toClassDesc(tpe)
+    val methods = tpe.getDeclaredMethods.asScala.toList
+
+    JavaClass(
+      desc = desc,
+      modifiers = tpe.getModifiers,
+      typeParameters = tpe.getTypeVariables.asScala.toList.map(toTypeParameter),
+      superClass = Option(tpe.getSuperClass).map(toType),
+      interfaces = tpe.getInterfaces.asScala.toList.map(toType),
+      declaredConstructors = methods.filter(_.isConstructor).map(toMethod),
+      declaredMethods = methods.filter(_.isMethod).map(toMethod),
+      declaredFields = tpe.getDeclaredFields.asScala.toList.map(toField)
+    )
+  }
+
+  private def toMethod(method: MethodDescription): JavaMethod = {
+    val ref = toMethodRef(method)
+    JavaMethod(
+      ref = ref,
+      modifiers = method.getModifiers,
+      typeParameters = method.getTypeVariables.asScala.toList.map(toTypeParameter),
+      parameterTypes = method.getParameters.asScala.toList
+        .map(_.asInstanceOf[ParameterDescription])
+        .map(p => toType(p.getType)),
+      returnType = toType(method.getReturnType),
+      isConstructor = method.isConstructor,
+      isVarArgs = method.isVarArgs
+    )
+  }
+
+  private def toField(field: FieldDescription): JavaField = {
+    val fieldType = toType(field.getType)
+    val ref = JavaFieldRef(
+      owner = toClassDesc(field.getDeclaringType.asErasure()),
+      name = field.getName,
+      descriptor = fieldType.erasure
+    )
+    JavaField(ref, field.getModifiers, fieldType)
+  }
+
+  private def toTypeParameter(tpe: TypeDescription.Generic): JavaTypeParameter =
+    JavaTypeParameter(toTypeVariable(tpe), tpe.getUpperBounds.asScala.toList.map(toType))
+
+  private def toType(tpe: TypeDescription.Generic): JavaType = {
+    tpe.getSort match {
+      case TypeDefinition.Sort.GENERIC_ARRAY =>
+        JavaType.GenericArray(toType(tpe.getComponentType), toClassDesc(tpe.asErasure()))
+      case TypeDefinition.Sort.NON_GENERIC => JavaType.NonGeneric(toClassDesc(tpe.asErasure()))
+      case TypeDefinition.Sort.PARAMETERIZED =>
+        JavaType.Parameterized(toClassDesc(tpe.asErasure()), tpe.getTypeArguments.asScala.toList.map(toType))
+      case TypeDefinition.Sort.VARIABLE | TypeDefinition.Sort.VARIABLE_SYMBOLIC =>
+        JavaType.Variable(toTypeVariable(tpe), toClassDesc(tpe.asErasure()))
+      case TypeDefinition.Sort.WILDCARD =>
+        val upperBounds = tpe.getUpperBounds.asScala.toList.map(toType)
+        val lowerBounds = tpe.getLowerBounds.asScala.toList.map(toType)
+        val erasure = upperBounds.headOption.map(_.erasure).getOrElse(ClassDesc.of("java.lang.Object"))
+        JavaType.Wildcard(upperBounds, lowerBounds, erasure)
+    }
+  }
+
+  private def toTypeVariable(tpe: TypeDescription.Generic): JavaTypeVariable = {
+    val owner = tpe.getTypeVariableSource match {
+      case clazz: TypeDescription => JavaTypeVariableOwner.Class(toClassDesc(clazz))
+      case method: MethodDescription => JavaTypeVariableOwner.Method(toMethodRef(method))
+      case _: TypeVariableSource => JavaTypeVariableOwner.Unknown
+      case null => JavaTypeVariableOwner.Unknown
+    }
+    JavaTypeVariable(owner, tpe.getSymbol)
+  }
+
+  private def toMethodRef(method: MethodDescription): JavaMethodRef = {
+    // Preserve the method's defined class-file descriptor in its nominal identity while retaining generic parameter
+    // and return types in JavaMethod.
+    val defined = method.asDefined()
+    JavaMethodRef(
+      owner = toClassDesc(defined.getDeclaringType.asErasure()),
+      name = defined.getInternalName,
+      descriptor = MethodTypeDesc.ofDescriptor(defined.getDescriptor)
+    )
+  }
+
+  private def toClassDesc(tpe: TypeDefinition): ClassDesc =
+    ClassDesc.ofDescriptor(tpe.asErasure().getDescriptor)
+
+  private def binaryName(desc: ClassDesc): Option[String] = {
+    val descriptor = desc.descriptorString()
+    if (descriptor.startsWith("L") && descriptor.endsWith(";")) {
+      Some(descriptor.substring(1, descriptor.length - 1).replace('/', '.'))
+    } else {
+      None
+    }
+  }
+
+  private def attempt[A](desc: ClassDesc)(f: => A): Result[A, JavaLookupError] =
+    try Ok(f)
+    catch {
+      case NonFatal(ex) => Err(InvalidClass(desc, Option(ex.getMessage).getOrElse(ex.getClass.getName)))
+    }
+
+}
+
+object ByteBuddyJavaTypeProvider {
+
+  /** Returns a provider for the classes visible through the JDK platform class loader. */
+  def platform(): ByteBuddyJavaTypeProvider =
+    fromLocators(List(ClassFileLocator.ForClassLoader.ofPlatformLoader()))
+
+  /**
+    * Returns a provider that reads resources visible to `loader`.
+    *
+    * Resource lookup does not define or initialize the class being described. A `null` loader denotes the bootstrap
+    * class loader.
+    */
+  def fromClassLoader(loader: ClassLoader): ByteBuddyJavaTypeProvider = {
+    val locator = if (loader == null) ClassFileLocator.ForClassLoader.ofBootLoader() else ClassFileLocator.ForClassLoader.of(loader)
+    fromLocators(List(locator))
+  }
+
+  /**
+    * Returns a provider for explicit JARs and class directories.
+    *
+    * Multi-release entries are selected for the running JVM. Platform classes are appended as a fallback when
+    * `includePlatform` is `true`.
+    */
+  def fromClassPath(entries: List[Path], includePlatform: Boolean = true): ByteBuddyJavaTypeProvider = {
+    val version = ClassFileVersion.ofThisVm()
+    val entryLocators = entries.map { path =>
+      if (Files.isDirectory(path)) ClassFileLocator.ForFolder.of(path.toFile, version)
+      else ClassFileLocator.ForJarFile.of(path.toFile, version)
+    }
+    val locators = if (includePlatform) entryLocators :+ ClassFileLocator.ForClassLoader.ofPlatformLoader() else entryLocators
+    fromLocators(locators)
+  }
+
+  /** Constructs a provider from an arbitrary locator. Intended for focused tests. */
+  private[jvm] def fromLocator(locator: ClassFileLocator): ByteBuddyJavaTypeProvider =
+    fromLocators(List(locator))
+
+  private def fromLocators(locators: List[ClassFileLocator]): ByteBuddyJavaTypeProvider = {
+    val locator = new ClassFileLocator.Compound(locators.asJava)
+    val pool = new TypePool.Default.WithLazyResolution(
+      new TypePool.CacheProvider.Simple(),
+      locator,
+      TypePool.Default.ReaderMode.FAST
+    )
+    new ByteBuddyJavaTypeProvider(locator, pool)
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -15,10 +15,10 @@
  */
 package ca.uwaterloo.flix.language.phase.typer.jvm
 
-import ca.uwaterloo.flix.language.ast.jvm.{JavaClass, JavaField, JavaFieldRef, JavaMethod, JavaMethodRef, JavaType, JavaTypeParameter, JavaTypeVariable, JavaTypeVariableOwner}
+import ca.uwaterloo.flix.language.ast.jvm.*
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaLookupError.{InvalidClass, MissingClass, UnsupportedDescriptor}
-import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
+import ca.uwaterloo.flix.util.{ClassDescs, Result}
 import net.bytebuddy.ClassFileVersion
 import net.bytebuddy.description.TypeVariableSource
 import net.bytebuddy.description.field.FieldDescription
@@ -28,9 +28,49 @@ import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.pool.TypePool
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
+import java.lang.reflect.{GenericSignatureFormatError, MalformedParameterizedTypeException}
 import java.nio.file.{Files, Path}
 import scala.jdk.CollectionConverters.*
-import scala.util.control.NonFatal
+
+object ByteBuddyJavaTypeProvider {
+
+  /** Returns a provider for the classes visible through the JDK platform class loader. */
+  def platform(): ByteBuddyJavaTypeProvider =
+    fromLocators(List(ClassFileLocator.ForClassLoader.ofPlatformLoader()))
+
+  /** Returns a provider that reads resources visible to `loader` without loading classes; `null` denotes the bootstrap loader. */
+  def fromClassLoader(loader: ClassLoader): ByteBuddyJavaTypeProvider = {
+    val locator = if (loader == null) ClassFileLocator.ForClassLoader.ofBootLoader() else ClassFileLocator.ForClassLoader.of(loader)
+    fromLocators(List(locator))
+  }
+
+  /** Returns a provider for JARs and class directories, with running-JVM multi-release entries and optional platform fallback. */
+  def fromClassPath(entries: List[Path], includePlatform: Boolean = true): ByteBuddyJavaTypeProvider = {
+    val version = ClassFileVersion.ofThisVm()
+    val entryLocators = entries.map { path =>
+      if (Files.isDirectory(path)) ClassFileLocator.ForFolder.of(path.toFile, version)
+      else ClassFileLocator.ForJarFile.of(path.toFile, version)
+    }
+    val locators = if (includePlatform) entryLocators :+ ClassFileLocator.ForClassLoader.ofPlatformLoader() else entryLocators
+    fromLocators(locators)
+  }
+
+  /** Returns a provider backed by an arbitrary locator for focused tests. */
+  private[jvm] def fromLocator(locator: ClassFileLocator): ByteBuddyJavaTypeProvider =
+    fromLocators(List(locator))
+
+  /** Returns a provider backed by the given locators in lookup order. */
+  private def fromLocators(locators: List[ClassFileLocator]): ByteBuddyJavaTypeProvider = {
+    val locator = new ClassFileLocator.Compound(locators.asJava)
+    val pool = new TypePool.Default.WithLazyResolution(
+      new TypePool.CacheProvider.Simple(),
+      locator,
+      TypePool.Default.ReaderMode.FAST
+    )
+    ByteBuddyJavaTypeProvider(locator, pool)
+  }
+
+}
 
 /**
   * A [[JavaTypeProvider]] backed by Byte Buddy's lazy class-file type pool.
@@ -38,26 +78,33 @@ import scala.util.control.NonFatal
   * Byte Buddy reads bytes through a [[ClassFileLocator]] and parses class-file metadata. It is never given a target
   * `Class`, and this implementation never calls `Class.forName` or `ClassLoader.loadClass`.
   */
-final class ByteBuddyJavaTypeProvider private(
-  private val locator: ClassFileLocator,
-  private val pool: TypePool
+final case class ByteBuddyJavaTypeProvider(
+  locator: ClassFileLocator,
+  pool: TypePool
 ) extends JavaTypeProvider {
 
-  override def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError] =
-    resolve(desc).flatMap(tpe => attempt(desc)(toClass(tpe)))
-
-  override def close(): Unit = locator.close()
-
-  private def resolve(desc: ClassDesc): Result[TypeDescription, JavaLookupError] = {
-    binaryName(desc) match {
-      case None => Err(UnsupportedDescriptor(desc))
-      case Some(name) =>
-        attempt(desc)(pool.describe(name)).flatMap { resolution =>
-          if (resolution.isResolved) attempt(desc)(resolution.resolve()) else Err(MissingClass(desc))
-        }
+  /** Returns `Ok` with metadata for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
+  override def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError] = {
+    if (!desc.isClassOrInterface) {
+      Err(UnsupportedDescriptor(desc))
+    } else {
+      try {
+        val resolution = pool.describe(ClassDescs.binaryNameOf(desc))
+        if (resolution.isResolved) Ok(toClass(resolution.resolve())) else Err(MissingClass(desc))
+      } catch {
+        case ex: GenericSignatureFormatError => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: MalformedParameterizedTypeException => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: IllegalArgumentException => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: IndexOutOfBoundsException => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: IllegalStateException => Err(InvalidClass(desc, exceptionMessage(ex)))
+      }
     }
   }
 
+  /** Closes the underlying class-file locator and its owned resources. */
+  override def close(): Unit = locator.close()
+
+  /** Converts a Byte Buddy type description to Java class-file metadata. */
   private def toClass(tpe: TypeDescription): JavaClass = {
     val desc = toClassDesc(tpe)
     val methods = tpe.getDeclaredMethods.asScala.toList
@@ -74,6 +121,22 @@ final class ByteBuddyJavaTypeProvider private(
     )
   }
 
+  /** Converts a Byte Buddy type definition to its erased class descriptor. */
+  private def toClassDesc(tpe: TypeDefinition): ClassDesc =
+    ClassDesc.ofDescriptor(tpe.asErasure().getDescriptor)
+
+  /** Converts a Byte Buddy field description to Java field metadata. */
+  private def toField(field: FieldDescription): JavaField = {
+    val fieldType = toType(field.getType)
+    val ref = JavaFieldRef(
+      owner = toClassDesc(field.getDeclaringType.asErasure()),
+      name = field.getName,
+      descriptor = fieldType.erasure
+    )
+    JavaField(ref, field.getModifiers, fieldType)
+  }
+
+  /** Converts a Byte Buddy method description to Java method metadata. */
   private def toMethod(method: MethodDescription): JavaMethod = {
     val ref = toMethodRef(method)
     JavaMethod(
@@ -89,19 +152,17 @@ final class ByteBuddyJavaTypeProvider private(
     )
   }
 
-  private def toField(field: FieldDescription): JavaField = {
-    val fieldType = toType(field.getType)
-    val ref = JavaFieldRef(
-      owner = toClassDesc(field.getDeclaringType.asErasure()),
-      name = field.getName,
-      descriptor = fieldType.erasure
+  /** Converts a Byte Buddy method description to its nominal class-file reference. */
+  private def toMethodRef(method: MethodDescription): JavaMethodRef = {
+    val defined = method.asDefined()
+    JavaMethodRef(
+      owner = toClassDesc(defined.getDeclaringType.asErasure()),
+      name = defined.getInternalName,
+      descriptor = MethodTypeDesc.ofDescriptor(defined.getDescriptor)
     )
-    JavaField(ref, field.getModifiers, fieldType)
   }
 
-  private def toTypeParameter(tpe: TypeDescription.Generic): JavaTypeParameter =
-    JavaTypeParameter(toTypeVariable(tpe), tpe.getUpperBounds.asScala.toList.map(toType))
-
+  /** Converts a Byte Buddy generic type description to Java type metadata. */
   private def toType(tpe: TypeDescription.Generic): JavaType = {
     tpe.getSort match {
       case TypeDefinition.Sort.GENERIC_ARRAY =>
@@ -119,6 +180,11 @@ final class ByteBuddyJavaTypeProvider private(
     }
   }
 
+  /** Converts a Byte Buddy type variable declaration to a Java type parameter. */
+  private def toTypeParameter(tpe: TypeDescription.Generic): JavaTypeParameter =
+    JavaTypeParameter(toTypeVariable(tpe), tpe.getUpperBounds.asScala.toList.map(toType))
+
+  /** Converts a Byte Buddy type variable to its owner-qualified Java identity. */
   private def toTypeVariable(tpe: TypeDescription.Generic): JavaTypeVariable = {
     val owner = tpe.getTypeVariableSource match {
       case clazz: TypeDescription => JavaTypeVariableOwner.Class(toClassDesc(clazz))
@@ -129,82 +195,8 @@ final class ByteBuddyJavaTypeProvider private(
     JavaTypeVariable(owner, tpe.getSymbol)
   }
 
-  private def toMethodRef(method: MethodDescription): JavaMethodRef = {
-    // Preserve the method's defined class-file descriptor in its nominal identity while retaining generic parameter
-    // and return types in JavaMethod.
-    val defined = method.asDefined()
-    JavaMethodRef(
-      owner = toClassDesc(defined.getDeclaringType.asErasure()),
-      name = defined.getInternalName,
-      descriptor = MethodTypeDesc.ofDescriptor(defined.getDescriptor)
-    )
-  }
-
-  private def toClassDesc(tpe: TypeDefinition): ClassDesc =
-    ClassDesc.ofDescriptor(tpe.asErasure().getDescriptor)
-
-  private def binaryName(desc: ClassDesc): Option[String] = {
-    val descriptor = desc.descriptorString()
-    if (descriptor.startsWith("L") && descriptor.endsWith(";")) {
-      Some(descriptor.substring(1, descriptor.length - 1).replace('/', '.'))
-    } else {
-      None
-    }
-  }
-
-  private def attempt[A](desc: ClassDesc)(f: => A): Result[A, JavaLookupError] =
-    try Ok(f)
-    catch {
-      case NonFatal(ex) => Err(InvalidClass(desc, Option(ex.getMessage).getOrElse(ex.getClass.getName)))
-    }
-
-}
-
-object ByteBuddyJavaTypeProvider {
-
-  /** Returns a provider for the classes visible through the JDK platform class loader. */
-  def platform(): ByteBuddyJavaTypeProvider =
-    fromLocators(List(ClassFileLocator.ForClassLoader.ofPlatformLoader()))
-
-  /**
-    * Returns a provider that reads resources visible to `loader`.
-    *
-    * Resource lookup does not define or initialize the class being described. A `null` loader denotes the bootstrap
-    * class loader.
-    */
-  def fromClassLoader(loader: ClassLoader): ByteBuddyJavaTypeProvider = {
-    val locator = if (loader == null) ClassFileLocator.ForClassLoader.ofBootLoader() else ClassFileLocator.ForClassLoader.of(loader)
-    fromLocators(List(locator))
-  }
-
-  /**
-    * Returns a provider for explicit JARs and class directories.
-    *
-    * Multi-release entries are selected for the running JVM. Platform classes are appended as a fallback when
-    * `includePlatform` is `true`.
-    */
-  def fromClassPath(entries: List[Path], includePlatform: Boolean = true): ByteBuddyJavaTypeProvider = {
-    val version = ClassFileVersion.ofThisVm()
-    val entryLocators = entries.map { path =>
-      if (Files.isDirectory(path)) ClassFileLocator.ForFolder.of(path.toFile, version)
-      else ClassFileLocator.ForJarFile.of(path.toFile, version)
-    }
-    val locators = if (includePlatform) entryLocators :+ ClassFileLocator.ForClassLoader.ofPlatformLoader() else entryLocators
-    fromLocators(locators)
-  }
-
-  /** Constructs a provider from an arbitrary locator. Intended for focused tests. */
-  private[jvm] def fromLocator(locator: ClassFileLocator): ByteBuddyJavaTypeProvider =
-    fromLocators(List(locator))
-
-  private def fromLocators(locators: List[ClassFileLocator]): ByteBuddyJavaTypeProvider = {
-    val locator = new ClassFileLocator.Compound(locators.asJava)
-    val pool = new TypePool.Default.WithLazyResolution(
-      new TypePool.CacheProvider.Simple(),
-      locator,
-      TypePool.Default.ReaderMode.FAST
-    )
-    new ByteBuddyJavaTypeProvider(locator, pool)
-  }
+  /** Returns the exception message, falling back to the exception class name when absent. */
+  private def exceptionMessage(ex: Throwable): String =
+    Option(ex.getMessage).getOrElse(ex.getClass.getName)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypeProvider.scala
@@ -28,7 +28,7 @@ import java.lang.constant.ClassDesc
   */
 trait JavaTypeProvider extends AutoCloseable {
 
-  /** Looks up the class denoted by `desc`. */
+  /** Returns `Ok` with metadata for `desc`, or `Err` if the descriptor cannot be looked up. */
   def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError]
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -15,10 +15,10 @@
  */
 package ca.uwaterloo.flix.language.phase.typer.jvm
 
+import ca.uwaterloo.flix.language.ast.jvm.*
 import ca.uwaterloo.flix.language.ast.jvm.JavaType.{NonGeneric, Parameterized, Variable}
 import ca.uwaterloo.flix.language.ast.jvm.JavaTypeVariableOwner.Class
-import ca.uwaterloo.flix.language.ast.jvm.{JavaMethodRef, JavaTypeParameter, JavaTypeVariable, JavaTypeVariableOwner}
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaLookupError.{MissingClass, UnsupportedDescriptor}
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaLookupError.{InvalidClass, MissingClass, UnsupportedDescriptor}
 import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import net.bytebuddy.dynamic.ClassFileLocator
@@ -98,6 +98,20 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
     }
   }
 
+  test("lookupClass.ReportsInvalidClass") {
+    val className = "dev.flix.prototype.Invalid"
+    val classDesc = ClassDesc.of(className)
+    val locator = ClassFileLocator.Simple.of(className, Array.emptyByteArray)
+
+    withProvider(ByteBuddyJavaTypeProvider.fromLocator(locator)) { provider =>
+      provider.lookupClass(classDesc) match {
+        case Err(InvalidClass(`classDesc`, _)) => succeed
+        case result => fail(s"Expected InvalidClass, got: $result")
+      }
+    }
+  }
+
+  /** Returns the bytes of a generic interface with class- and method-owned type variables. */
   private def mkGenericInterface(internalName: String): Array[Byte] = {
     val writer = new ClassWriter(0)
     writer.visit(
@@ -126,10 +140,12 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
     writer.toByteArray
   }
 
+  /** Runs `f` with `provider` and closes the provider afterward. */
   private def withProvider[A](provider: ByteBuddyJavaTypeProvider)(f: ByteBuddyJavaTypeProvider => A): A =
     try f(provider)
     finally provider.close()
 
+  /** Returns an `Ok` value or fails the test when `result` is `Err`. */
   private def resolve[A](result: Result[A, JavaLookupError]): A = result match {
     case Ok(value) => value
     case Err(error) => fail(error.toString)

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.typer.jvm
+
+import ca.uwaterloo.flix.language.ast.jvm.JavaType.{NonGeneric, Parameterized, Variable}
+import ca.uwaterloo.flix.language.ast.jvm.JavaTypeVariableOwner.Class
+import ca.uwaterloo.flix.language.ast.jvm.{JavaMethodRef, JavaTypeParameter, JavaTypeVariable, JavaTypeVariableOwner}
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaLookupError.{MissingClass, UnsupportedDescriptor}
+import ca.uwaterloo.flix.util.Result
+import ca.uwaterloo.flix.util.Result.{Err, Ok}
+import net.bytebuddy.dynamic.ClassFileLocator
+import org.objectweb.asm.{ClassWriter, Opcodes}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.lang.constant.{ClassDesc, MethodTypeDesc}
+
+class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
+
+  test("lookupClass.PlatformClass") {
+    withProvider(ByteBuddyJavaTypeProvider.platform()) { provider =>
+      val arrayListDesc = ClassDesc.of("java.util.ArrayList")
+      val arrayList = resolve(provider.lookupClass(arrayListDesc))
+
+      assert(arrayList.desc == arrayListDesc)
+      assert(arrayList.typeParameters.map(_.variable) ==
+        List(JavaTypeVariable(Class(arrayListDesc), "E")))
+
+      val get = arrayList.declaredMethods.find(m =>
+        m.ref.name == "get" && m.ref.descriptor == MethodTypeDesc.ofDescriptor("(I)Ljava/lang/Object;"))
+      assert(get.exists(_.returnType == Variable(
+        JavaTypeVariable(Class(arrayListDesc), "E"),
+        ClassDesc.of("java.lang.Object")
+      )))
+
+      assert(arrayList.interfaces.exists {
+        case Parameterized(desc, List(Variable(variable, _))) =>
+          desc == ClassDesc.of("java.util.List") && variable == JavaTypeVariable(Class(arrayListDesc), "E")
+        case _ => false
+      })
+    }
+  }
+
+  test("lookupClass.InMemoryClassFile") {
+    val className = "dev.flix.prototype.Unloaded"
+    val classDesc = ClassDesc.of(className)
+    val classBytes = mkGenericInterface(className.replace('.', '/'))
+    val locator = new ClassFileLocator.Compound(
+      ClassFileLocator.Simple.of(className, classBytes),
+      ClassFileLocator.ForClassLoader.ofPlatformLoader()
+    )
+
+    withProvider(ByteBuddyJavaTypeProvider.fromLocator(locator)) { provider =>
+      val clazz = resolve(provider.lookupClass(classDesc))
+      val variable = JavaTypeVariable(Class(classDesc), "T")
+
+      assert(clazz.typeParameters == List(JavaTypeParameter(
+        variable,
+        List(NonGeneric(ClassDesc.of("java.lang.Object")))
+      )))
+
+      val id = clazz.declaredMethods.find(_.ref.name == "id").get
+      assert(id.ref == JavaMethodRef(
+        classDesc,
+        "id",
+        MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;)Ljava/lang/Object;")
+      ))
+      assert(id.parameterTypes == List(Variable(variable, ClassDesc.of("java.lang.Object"))))
+      assert(id.returnType == Variable(variable, ClassDesc.of("java.lang.Object")))
+
+      val convert = clazz.declaredMethods.find(_.ref.name == "convert").get
+      val methodVariable = JavaTypeVariable(JavaTypeVariableOwner.Method(convert.ref), "U")
+      assert(convert.typeParameters.map(_.variable) == List(methodVariable))
+      assert(convert.parameterTypes == List(Variable(methodVariable, ClassDesc.of("java.lang.Object"))))
+      assert(convert.returnType == Variable(variable, ClassDesc.of("java.lang.Object")))
+    }
+  }
+
+  test("lookupClass.ReportsMissingAndUnsupportedDescriptors") {
+    withProvider(ByteBuddyJavaTypeProvider.platform()) { provider =>
+      val missing = ClassDesc.of("dev.flix.prototype.DoesNotExist")
+      assert(provider.lookupClass(missing) == Err(MissingClass(missing)))
+
+      val array = ClassDesc.ofDescriptor("[Ljava/lang/String;")
+      assert(provider.lookupClass(array) == Err(UnsupportedDescriptor(array)))
+    }
+  }
+
+  private def mkGenericInterface(internalName: String): Array[Byte] = {
+    val writer = new ClassWriter(0)
+    writer.visit(
+      Opcodes.V21,
+      Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE,
+      internalName,
+      "<T:Ljava/lang/Object;>Ljava/lang/Object;",
+      "java/lang/Object",
+      null
+    )
+    writer.visitMethod(
+      Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT,
+      "id",
+      "(Ljava/lang/Object;)Ljava/lang/Object;",
+      "(TT;)TT;",
+      null
+    ).visitEnd()
+    writer.visitMethod(
+      Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT,
+      "convert",
+      "(Ljava/lang/Object;)Ljava/lang/Object;",
+      "<U:Ljava/lang/Object;>(TU;)TT;",
+      null
+    ).visitEnd()
+    writer.visitEnd()
+    writer.toByteArray
+  }
+
+  private def withProvider[A](provider: ByteBuddyJavaTypeProvider)(f: ByteBuddyJavaTypeProvider => A): A =
+    try f(provider)
+    finally provider.close()
+
+  private def resolve[A](result: Result[A, JavaLookupError]): A = result match {
+    case Ok(value) => value
+    case Err(error) => fail(error.toString)
+  }
+
+}

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -15,140 +15,102 @@
  */
 package ca.uwaterloo.flix.language.phase.typer.jvm
 
-import ca.uwaterloo.flix.language.ast.jvm.*
-import ca.uwaterloo.flix.language.ast.jvm.JavaType.{NonGeneric, Parameterized, Variable}
+import ca.uwaterloo.flix.language.ast.jvm.JavaType.{Parameterized, Variable}
+import ca.uwaterloo.flix.language.ast.jvm.JavaTypeVariable
 import ca.uwaterloo.flix.language.ast.jvm.JavaTypeVariableOwner.Class
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaLookupError.{InvalidClass, MissingClass, UnsupportedDescriptor}
-import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import net.bytebuddy.dynamic.ClassFileLocator
-import org.objectweb.asm.{ClassWriter, Opcodes}
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
 
 class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
 
-  test("lookupClass.PlatformClass") {
-    withProvider(ByteBuddyJavaTypeProvider.platform()) { provider =>
+  test("lookupClass.PlatformClass.Descriptor") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
       val arrayListDesc = ClassDesc.of("java.util.ArrayList")
-      val arrayList = resolve(provider.lookupClass(arrayListDesc))
-
-      assert(arrayList.desc == arrayListDesc)
-      assert(arrayList.typeParameters.map(_.variable) ==
-        List(JavaTypeVariable(Class(arrayListDesc), "E")))
-
-      val get = arrayList.declaredMethods.find(m =>
-        m.ref.name == "get" && m.ref.descriptor == MethodTypeDesc.ofDescriptor("(I)Ljava/lang/Object;"))
-      assert(get.exists(_.returnType == Variable(
-        JavaTypeVariable(Class(arrayListDesc), "E"),
-        ClassDesc.of("java.lang.Object")
-      )))
-
-      assert(arrayList.interfaces.exists {
-        case Parameterized(desc, List(Variable(variable, _))) =>
-          desc == ClassDesc.of("java.util.List") && variable == JavaTypeVariable(Class(arrayListDesc), "E")
-        case _ => false
-      })
-    }
+      provider.lookupClass(arrayListDesc) match {
+        case Ok(arrayList) => assert(arrayList.desc == arrayListDesc)
+        case Err(error) => fail(error.toString)
+      }
+    } finally provider.close()
   }
 
-  test("lookupClass.InMemoryClassFile") {
-    val className = "dev.flix.prototype.Unloaded"
-    val classDesc = ClassDesc.of(className)
-    val classBytes = mkGenericInterface(className.replace('.', '/'))
-    val locator = new ClassFileLocator.Compound(
-      ClassFileLocator.Simple.of(className, classBytes),
-      ClassFileLocator.ForClassLoader.ofPlatformLoader()
-    )
-
-    withProvider(ByteBuddyJavaTypeProvider.fromLocator(locator)) { provider =>
-      val clazz = resolve(provider.lookupClass(classDesc))
-      val variable = JavaTypeVariable(Class(classDesc), "T")
-
-      assert(clazz.typeParameters == List(JavaTypeParameter(
-        variable,
-        List(NonGeneric(ClassDesc.of("java.lang.Object")))
-      )))
-
-      val id = clazz.declaredMethods.find(_.ref.name == "id").get
-      assert(id.ref == JavaMethodRef(
-        classDesc,
-        "id",
-        MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;)Ljava/lang/Object;")
-      ))
-      assert(id.parameterTypes == List(Variable(variable, ClassDesc.of("java.lang.Object"))))
-      assert(id.returnType == Variable(variable, ClassDesc.of("java.lang.Object")))
-
-      val convert = clazz.declaredMethods.find(_.ref.name == "convert").get
-      val methodVariable = JavaTypeVariable(JavaTypeVariableOwner.Method(convert.ref), "U")
-      assert(convert.typeParameters.map(_.variable) == List(methodVariable))
-      assert(convert.parameterTypes == List(Variable(methodVariable, ClassDesc.of("java.lang.Object"))))
-      assert(convert.returnType == Variable(variable, ClassDesc.of("java.lang.Object")))
-    }
+  test("lookupClass.PlatformClass.TypeParameters") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
+      val arrayListDesc = ClassDesc.of("java.util.ArrayList")
+      provider.lookupClass(arrayListDesc) match {
+        case Ok(arrayList) =>
+          assert(arrayList.typeParameters.map(_.variable) == List(JavaTypeVariable(Class(arrayListDesc), "E")))
+        case Err(error) => fail(error.toString)
+      }
+    } finally provider.close()
   }
 
-  test("lookupClass.ReportsMissingAndUnsupportedDescriptors") {
-    withProvider(ByteBuddyJavaTypeProvider.platform()) { provider =>
+  test("lookupClass.PlatformClass.GenericMethod") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
+      val arrayListDesc = ClassDesc.of("java.util.ArrayList")
+      provider.lookupClass(arrayListDesc) match {
+        case Ok(arrayList) =>
+          val get = arrayList.declaredMethods.find(m =>
+            m.ref.name == "get" && m.ref.descriptor == MethodTypeDesc.ofDescriptor("(I)Ljava/lang/Object;"))
+          assert(get.exists(_.returnType == Variable(
+            JavaTypeVariable(Class(arrayListDesc), "E"),
+            ClassDesc.of("java.lang.Object")
+          )))
+        case Err(error) => fail(error.toString)
+      }
+    } finally provider.close()
+  }
+
+  test("lookupClass.PlatformClass.GenericInterface") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
+      val arrayListDesc = ClassDesc.of("java.util.ArrayList")
+      provider.lookupClass(arrayListDesc) match {
+        case Ok(arrayList) =>
+          assert(arrayList.interfaces.exists {
+            case Parameterized(desc, List(Variable(variable, _))) =>
+              desc == ClassDesc.of("java.util.List") && variable == JavaTypeVariable(Class(arrayListDesc), "E")
+            case _ => false
+          })
+        case Err(error) => fail(error.toString)
+      }
+    } finally provider.close()
+  }
+
+  test("lookupClass.ReportsMissingClass") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
       val missing = ClassDesc.of("dev.flix.prototype.DoesNotExist")
       assert(provider.lookupClass(missing) == Err(MissingClass(missing)))
+    } finally provider.close()
+  }
 
+  test("lookupClass.ReportsUnsupportedDescriptor") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
       val array = ClassDesc.ofDescriptor("[Ljava/lang/String;")
       assert(provider.lookupClass(array) == Err(UnsupportedDescriptor(array)))
-    }
+    } finally provider.close()
   }
 
   test("lookupClass.ReportsInvalidClass") {
     val className = "dev.flix.prototype.Invalid"
     val classDesc = ClassDesc.of(className)
     val locator = ClassFileLocator.Simple.of(className, Array.emptyByteArray)
+    val provider = ByteBuddyJavaTypeProvider.fromLocator(locator)
 
-    withProvider(ByteBuddyJavaTypeProvider.fromLocator(locator)) { provider =>
+    try {
       provider.lookupClass(classDesc) match {
         case Err(InvalidClass(`classDesc`, _)) => succeed
         case result => fail(s"Expected InvalidClass, got: $result")
       }
-    }
-  }
-
-  /** Returns the bytes of a generic interface with class- and method-owned type variables. */
-  private def mkGenericInterface(internalName: String): Array[Byte] = {
-    val writer = new ClassWriter(0)
-    writer.visit(
-      Opcodes.V21,
-      Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE,
-      internalName,
-      "<T:Ljava/lang/Object;>Ljava/lang/Object;",
-      "java/lang/Object",
-      null
-    )
-    writer.visitMethod(
-      Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT,
-      "id",
-      "(Ljava/lang/Object;)Ljava/lang/Object;",
-      "(TT;)TT;",
-      null
-    ).visitEnd()
-    writer.visitMethod(
-      Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT,
-      "convert",
-      "(Ljava/lang/Object;)Ljava/lang/Object;",
-      "<U:Ljava/lang/Object;>(TU;)TT;",
-      null
-    ).visitEnd()
-    writer.visitEnd()
-    writer.toByteArray
-  }
-
-  /** Runs `f` with `provider` and closes the provider afterward. */
-  private def withProvider[A](provider: ByteBuddyJavaTypeProvider)(f: ByteBuddyJavaTypeProvider => A): A =
-    try f(provider)
-    finally provider.close()
-
-  /** Returns an `Ok` value or fails the test when `result` is `Err`. */
-  private def resolve[A](result: Result[A, JavaLookupError]): A = result match {
-    case Ok(value) => value
-    case Err(error) => fail(error.toString)
+    } finally provider.close()
   }
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.language.ast.jvm.JavaTypeVariableOwner.Class
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaLookupError.{InvalidClass, MissingClass, UnsupportedDescriptor}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import net.bytebuddy.dynamic.ClassFileLocator
+import net.bytebuddy.pool.TypePool
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
@@ -102,8 +103,18 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
   test("lookupClass.ReportsInvalidClass") {
     val className = "dev.flix.prototype.Invalid"
     val classDesc = ClassDesc.of(className)
-    val locator = ClassFileLocator.Simple.of(className, Array.emptyByteArray)
-    val provider = ByteBuddyJavaTypeProvider.fromLocator(locator)
+    val classBytes = Array[Byte](
+      0xca.toByte, 0xfe.toByte, 0xba.toByte, 0xbe.toByte,
+      0x00.toByte, 0x00.toByte, 0x00.toByte, 0x41.toByte,
+      0x00.toByte, 0x02.toByte, 0x00.toByte
+    )
+    val locator = ClassFileLocator.Simple.of(className, classBytes)
+    val pool = new TypePool.Default.WithLazyResolution(
+      new TypePool.CacheProvider.Simple(),
+      locator,
+      TypePool.Default.ReaderMode.FAST
+    )
+    val provider = ByteBuddyJavaTypeProvider(locator, pool)
 
     try {
       provider.lookupClass(classDesc) match {


### PR DESCRIPTION
## Summary

- add a Byte Buddy-backed implementation of `JavaTypeProvider`
- read platform, class-loader, directory, and JAR class-file metadata without loading target classes
- convert generic class-file signatures into the descriptor-based Java metadata AST
- close owned class-path resources and report structured lookup errors
- cover platform, in-memory, missing, and unsupported class lookup

This PR contains only class-file lookup and metadata conversion. Hierarchy queries, overload matching, member resolution, and typer integration remain in later PRs.

## Review questions

- Can any resource lookup define or initialize a target class?
- Are generic signatures converted correctly?
- Are multi-release JARs handled correctly?
- Are class-path resources owned and closed correctly?

## Validation

- `./mill --no-server flix.test.compile`
- `./mill --no-server flix.test.testOnly ca.uwaterloo.flix.language.phase.typer.jvm.TestByteBuddyJavaTypeProvider`