### PR TITLE
refactor: add Java hierarchy queries to the metadata provider

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -187,11 +187,6 @@ final case class ByteBuddyJavaTypeProvider(
 
   /** Converts a Byte Buddy method description to its nominal class-file reference. */
   private def toMethodRef(method: MethodDescription): JavaMethodRef = {
-    // A method graph specializes inherited generic methods for the queried type. For example, Java's Delayed extends
-    // Comparable<Delayed>, so its graph represents the inherited compareTo method as accepting a Delayed argument.
-    // The method is nevertheless declared on Comparable as compareTo(T). Since T erases to Object, its class-file
-    // descriptor accepts Object, not Delayed. Calling asDefined discards the Delayed substitution, ensuring that
-    // JavaMethodRef identifies the method declared in the class file while JavaMethod retains the specialized type.
     val defined = method.asDefined()
     JavaMethodRef(
       owner = toClassDesc(defined.getDeclaringType.asErasure()),

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -95,34 +95,17 @@ final case class ByteBuddyJavaTypeProvider(
 
   /** Returns `Ok` with metadata for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
   override def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError] =
-    resolve(desc).flatMap { tpe =>
-      try {
-        Ok(toClass(tpe))
-      } catch {
-        case ex: GenericSignatureFormatError => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: MalformedParameterizedTypeException => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: IllegalArgumentException => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: IllegalStateException => Err(InvalidClass(desc, exceptionMessage(ex)))
-      }
-    }
+    resolve(desc).map(toClass)
 
   /** Returns `Ok` with the virtual method graph for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
   override def virtualMethods(desc: ClassDesc): Result[List[JavaMethod], JavaLookupError] =
-    resolve(desc).flatMap { tpe =>
-      try {
-        val methods = MethodGraph.Compiler.Default.forJavaHierarchy().compile(tpe: TypeDefinition).listNodes().asScala
-          .map(_.getRepresentative)
-          .filter(_.isVirtual)
-          .map(toMethod)
-          .toList
-          .sortBy(m => (m.ref.name, m.ref.descriptor.descriptorString()))
-        Ok(methods)
-      } catch {
-        case ex: GenericSignatureFormatError => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: MalformedParameterizedTypeException => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: IllegalArgumentException => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: IllegalStateException => Err(InvalidClass(desc, exceptionMessage(ex)))
-      }
+    resolve(desc).map { tpe =>
+      MethodGraph.Compiler.Default.forJavaHierarchy().compile(tpe: TypeDefinition).listNodes().asScala
+        .map(_.getRepresentative)
+        .filter(_.isVirtual)
+        .map(toMethod)
+        .toList
+        .sortBy(m => (m.ref.name, m.ref.descriptor.descriptorString()))
     }
 
   /** Returns `Ok` with the subtype result, or `Err` if either descriptor is unsupported, missing, or invalid. */
@@ -131,16 +114,7 @@ final case class ByteBuddyJavaTypeProvider(
       Ok(true)
     } else {
       resolve(subtype).flatMap { sub =>
-        resolve(supertype).flatMap { sup =>
-          try {
-            Ok(sub.isAssignableTo(sup))
-          } catch {
-            case ex: GenericSignatureFormatError => Err(InvalidClass(subtype, exceptionMessage(ex)))
-            case ex: MalformedParameterizedTypeException => Err(InvalidClass(subtype, exceptionMessage(ex)))
-            case ex: IllegalArgumentException => Err(InvalidClass(subtype, exceptionMessage(ex)))
-            case ex: IllegalStateException => Err(InvalidClass(subtype, exceptionMessage(ex)))
-          }
-        }
+        resolve(supertype).map(sup => sub.isAssignableTo(sup))
       }
     }
   }
@@ -213,9 +187,11 @@ final case class ByteBuddyJavaTypeProvider(
 
   /** Converts a Byte Buddy method description to its nominal class-file reference. */
   private def toMethodRef(method: MethodDescription): JavaMethodRef = {
-    // A method-graph representative can carry type substitutions from the queried subtype. Its nominal identity,
-    // however, is the descriptor declared in its owning class. Keep contextual types in JavaMethod and use the
-    // defined shape for JavaMethodRef.
+    // A method graph specializes inherited generic methods for the queried type. For example, Java's Delayed extends
+    // Comparable<Delayed>, so its graph represents the inherited compareTo method as accepting a Delayed argument.
+    // The method is nevertheless declared on Comparable as compareTo(T). Since T erases to Object, its class-file
+    // descriptor accepts Object, not Delayed. Calling asDefined discards the Delayed substitution, ensuring that
+    // JavaMethodRef identifies the method declared in the class file while JavaMethod retains the specialized type.
     val defined = method.asDefined()
     JavaMethodRef(
       owner = toClassDesc(defined.getDeclaringType.asErasure()),

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -25,6 +25,7 @@ import net.bytebuddy.description.field.FieldDescription
 import net.bytebuddy.description.method.MethodDescription
 import net.bytebuddy.description.`type`.{TypeDefinition, TypeDescription}
 import net.bytebuddy.dynamic.ClassFileLocator
+import net.bytebuddy.dynamic.scaffold.MethodGraph
 import net.bytebuddy.pool.TypePool
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
@@ -93,13 +94,68 @@ final case class ByteBuddyJavaTypeProvider(
 ) extends JavaTypeProvider {
 
   /** Returns `Ok` with metadata for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
-  override def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError] = {
+  override def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError] =
+    resolve(desc).flatMap { tpe =>
+      try {
+        Ok(toClass(tpe))
+      } catch {
+        case ex: GenericSignatureFormatError => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: MalformedParameterizedTypeException => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: IllegalArgumentException => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: IllegalStateException => Err(InvalidClass(desc, exceptionMessage(ex)))
+      }
+    }
+
+  /** Returns `Ok` with the virtual method graph for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
+  override def virtualMethods(desc: ClassDesc): Result[List[JavaMethod], JavaLookupError] =
+    resolve(desc).flatMap { tpe =>
+      try {
+        val methods = MethodGraph.Compiler.Default.forJavaHierarchy().compile(tpe: TypeDefinition).listNodes().asScala
+          .map(_.getRepresentative)
+          .filter(_.isVirtual)
+          .map(toMethod)
+          .toList
+          .sortBy(m => (m.ref.name, m.ref.descriptor.descriptorString()))
+        Ok(methods)
+      } catch {
+        case ex: GenericSignatureFormatError => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: MalformedParameterizedTypeException => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: IllegalArgumentException => Err(InvalidClass(desc, exceptionMessage(ex)))
+        case ex: IllegalStateException => Err(InvalidClass(desc, exceptionMessage(ex)))
+      }
+    }
+
+  /** Returns `Ok` with the subtype result, or `Err` if either descriptor is unsupported, missing, or invalid. */
+  override def isSubtype(subtype: ClassDesc, supertype: ClassDesc): Result[Boolean, JavaLookupError] = {
+    if (subtype == supertype) {
+      Ok(true)
+    } else {
+      resolve(subtype).flatMap { sub =>
+        resolve(supertype).flatMap { sup =>
+          try {
+            Ok(sub.isAssignableTo(sup))
+          } catch {
+            case ex: GenericSignatureFormatError => Err(InvalidClass(subtype, exceptionMessage(ex)))
+            case ex: MalformedParameterizedTypeException => Err(InvalidClass(subtype, exceptionMessage(ex)))
+            case ex: IllegalArgumentException => Err(InvalidClass(subtype, exceptionMessage(ex)))
+            case ex: IllegalStateException => Err(InvalidClass(subtype, exceptionMessage(ex)))
+          }
+        }
+      }
+    }
+  }
+
+  /** Closes the underlying class-file locator and its owned resources. */
+  override def close(): Unit = locator.close()
+
+  /** Returns `Ok` with the resolved type, or `Err` if `desc` is unsupported, missing, or invalid. */
+  private def resolve(desc: ClassDesc): Result[TypeDescription, JavaLookupError] = {
     if (!desc.isClassOrInterface) {
       Err(UnsupportedDescriptor(desc))
     } else {
       try {
         val resolution = pool.describe(ClassDescs.binaryNameOf(desc))
-        if (resolution.isResolved) Ok(toClass(resolution.resolve())) else Err(MissingClass(desc))
+        if (resolution.isResolved) Ok(resolution.resolve()) else Err(MissingClass(desc))
       } catch {
         case ex: GenericSignatureFormatError => Err(InvalidClass(desc, exceptionMessage(ex)))
         case ex: MalformedParameterizedTypeException => Err(InvalidClass(desc, exceptionMessage(ex)))
@@ -108,9 +164,6 @@ final case class ByteBuddyJavaTypeProvider(
       }
     }
   }
-
-  /** Closes the underlying class-file locator and its owned resources. */
-  override def close(): Unit = locator.close()
 
   /** Converts a Byte Buddy type description to Java class-file metadata. */
   private def toClass(tpe: TypeDescription): JavaClass = {
@@ -160,6 +213,9 @@ final case class ByteBuddyJavaTypeProvider(
 
   /** Converts a Byte Buddy method description to its nominal class-file reference. */
   private def toMethodRef(method: MethodDescription): JavaMethodRef = {
+    // A method-graph representative can carry type substitutions from the queried subtype. Its nominal identity,
+    // however, is the descriptor declared in its owning class. Keep contextual types in JavaMethod and use the
+    // defined shape for JavaMethodRef.
     val defined = method.asDefined()
     JavaMethodRef(
       owner = toClassDesc(defined.getDeclaringType.asErasure()),

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypeProvider.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.language.phase.typer.jvm
 
-import ca.uwaterloo.flix.language.ast.jvm.JavaClass
+import ca.uwaterloo.flix.language.ast.jvm.{JavaClass, JavaMethod}
 import ca.uwaterloo.flix.util.Result
 
 import java.lang.constant.ClassDesc
@@ -30,5 +30,11 @@ trait JavaTypeProvider extends AutoCloseable {
 
   /** Returns `Ok` with metadata for `desc`, or `Err` if the descriptor cannot be looked up. */
   def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError]
+
+  /** Returns `Ok` with the virtual method graph for `desc`, or `Err` if the descriptor cannot be looked up. */
+  def virtualMethods(desc: ClassDesc): Result[List[JavaMethod], JavaLookupError]
+
+  /** Returns `Ok` with the subtype result, or `Err` if either descriptor cannot be looked up. */
+  def isSubtype(subtype: ClassDesc, supertype: ClassDesc): Result[Boolean, JavaLookupError]
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -124,4 +124,49 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
     } finally provider.close()
   }
 
+  test("isSubtype.ClassFileHierarchy") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
+      provider.isSubtype(ClassDesc.of("java.util.ArrayList"), ClassDesc.of("java.util.List")) match {
+        case Ok(arrayListIsList) => assert(arrayListIsList)
+        case Err(error) => fail(error.toString)
+      }
+      provider.isSubtype(ClassDesc.of("java.util.List"), ClassDesc.of("java.util.ArrayList")) match {
+        case Ok(listIsArrayList) => assert(!listIsArrayList)
+        case Err(error) => fail(error.toString)
+      }
+    } finally provider.close()
+  }
+
+  test("virtualMethods.IncludesInheritedMethods") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
+      provider.virtualMethods(ClassDesc.of("java.util.function.UnaryOperator")) match {
+        case Ok(methods) =>
+          val applyDescriptor = MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;)Ljava/lang/Object;")
+          assert(methods.exists(m =>
+            m.ref.owner == ClassDesc.of("java.util.function.Function") &&
+              m.ref.name == "apply" &&
+              m.ref.descriptor == applyDescriptor
+          ))
+        case Err(error) => fail(error.toString)
+      }
+    } finally provider.close()
+  }
+
+  test("virtualMethods.PreservesDeclaredErasureAfterGenericSubstitution") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
+      provider.virtualMethods(ClassDesc.of("java.util.concurrent.Delayed")) match {
+        case Ok(methods) =>
+          assert(methods.exists(m =>
+            m.ref.owner == ClassDesc.of("java.lang.Comparable") &&
+              m.ref.name == "compareTo" &&
+              m.ref.descriptor == MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;)I")
+          ))
+        case Err(error) => fail(error.toString)
+      }
+    } finally provider.close()
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -150,11 +150,12 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
       provider.virtualMethods(ClassDesc.of("java.util.function.UnaryOperator")) match {
         case Ok(methods) =>
           val applyDescriptor = MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;)Ljava/lang/Object;")
-          val hasInheritedApply = methods.exists(m =>
-            m.ref.owner == ClassDesc.of("java.util.function.Function") &&
-              m.ref.name == "apply" &&
-              m.ref.descriptor == applyDescriptor
-          )
+          val hasInheritedApply = methods.exists { m =>
+            val hasExpectedOwner = m.ref.owner == ClassDesc.of("java.util.function.Function")
+            val hasExpectedName = m.ref.name == "apply"
+            val hasExpectedDescriptor = m.ref.descriptor == applyDescriptor
+            hasExpectedOwner && hasExpectedName && hasExpectedDescriptor
+          }
           assert(hasInheritedApply)
         case Err(error) => fail(error.toString)
       }
@@ -166,11 +167,13 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
     try {
       provider.virtualMethods(ClassDesc.of("java.util.concurrent.Delayed")) match {
         case Ok(methods) =>
-          val hasDeclaredCompareTo = methods.exists(m =>
-            m.ref.owner == ClassDesc.of("java.lang.Comparable") &&
-              m.ref.name == "compareTo" &&
-              m.ref.descriptor == MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;)I")
-          )
+          val compareToDescriptor = MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;)I")
+          val hasDeclaredCompareTo = methods.exists { m =>
+            val hasExpectedOwner = m.ref.owner == ClassDesc.of("java.lang.Comparable")
+            val hasExpectedName = m.ref.name == "compareTo"
+            val hasExpectedDescriptor = m.ref.descriptor == compareToDescriptor
+            hasExpectedOwner && hasExpectedName && hasExpectedDescriptor
+          }
           assert(hasDeclaredCompareTo)
         case Err(error) => fail(error.toString)
       }

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -144,11 +144,12 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
       provider.virtualMethods(ClassDesc.of("java.util.function.UnaryOperator")) match {
         case Ok(methods) =>
           val applyDescriptor = MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;)Ljava/lang/Object;")
-          assert(methods.exists(m =>
+          val hasInheritedApply = methods.exists(m =>
             m.ref.owner == ClassDesc.of("java.util.function.Function") &&
               m.ref.name == "apply" &&
               m.ref.descriptor == applyDescriptor
-          ))
+          )
+          assert(hasInheritedApply)
         case Err(error) => fail(error.toString)
       }
     } finally provider.close()
@@ -159,11 +160,12 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
     try {
       provider.virtualMethods(ClassDesc.of("java.util.concurrent.Delayed")) match {
         case Ok(methods) =>
-          assert(methods.exists(m =>
+          val hasDeclaredCompareTo = methods.exists(m =>
             m.ref.owner == ClassDesc.of("java.lang.Comparable") &&
               m.ref.name == "compareTo" &&
               m.ref.descriptor == MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;)I")
-          ))
+          )
+          assert(hasDeclaredCompareTo)
         case Err(error) => fail(error.toString)
       }
     } finally provider.close()

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -124,13 +124,19 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
     } finally provider.close()
   }
 
-  test("isSubtype.ClassFileHierarchy") {
+  test("isSubtype.ClassFileHierarchy.Subtype") {
     val provider = ByteBuddyJavaTypeProvider.platform()
     try {
       provider.isSubtype(ClassDesc.of("java.util.ArrayList"), ClassDesc.of("java.util.List")) match {
         case Ok(arrayListIsList) => assert(arrayListIsList)
         case Err(error) => fail(error.toString)
       }
+    } finally provider.close()
+  }
+
+  test("isSubtype.ClassFileHierarchy.NotSubtype") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
       provider.isSubtype(ClassDesc.of("java.util.List"), ClassDesc.of("java.util.ArrayList")) match {
         case Ok(listIsArrayList) => assert(!listIsArrayList)
         case Err(error) => fail(error.toString)


### PR DESCRIPTION
## Summary

- extend `JavaTypeProvider` with descriptor-based subtype and virtual-method queries
- compile Byte Buddy Java method graphs without loading target classes
- return inherited virtual methods in deterministic order
- preserve declared method descriptors after contextual generic substitution
- add focused subtype, inheritance, and declared-erasure tests

Array subtyping and overload/member resolution remain outside this PR and belong to the descriptor-based member resolver.

## Review questions

- Does the Byte Buddy method graph match the Java inheritance rules needed by Flix?
- Should bridge methods be represented by the provider or restored by the member resolver?
- Are contextual generic types kept separate from declared JVM descriptors?
- Which array-subtyping rules belong in the provider rather than its clients?

## Validation

- `./mill --no-server flix.test.compile`
- `./mill --no-server flix.test.testOnly ca.uwaterloo.flix.language.phase.typer.jvm.TestByteBuddyJavaTypeProvider`