### PR TITLE
fix: report specific predicate arity and denotation mismatch errors across schema types

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -28,6 +28,7 @@ import ca.uwaterloo.flix.language.phase.util.PredefinedTraits
 import ca.uwaterloo.flix.util.Build
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 
 /**
   * Interface to [[ConstraintSolver2]].
@@ -301,15 +302,23 @@ object ConstraintSolverInterface {
     * Returns `None` unless the predicate can be uniquely identified.
     */
   private def findMismatchedPred(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type): Option[Name.Pred] = {
+    val preds1 = getPredicates(fullType1)
     val preds2 = getPredicates(fullType2)
-    val candidates = getPredicates(fullType1).collect {
-      case (pred1, payload1) if payload1.typeConstructor == baseType1.typeConstructor &&
-        preds2.exists { case (pred2, payload2) => pred1 == pred2 && payload2.typeConstructor == baseType2.typeConstructor } => pred1
+
+    // The set of predicates whose payloads match `baseType1` in `fullType1` and `baseType2` in `fullType2`.
+    val candidates = mutable.Set.empty[Name.Pred]
+    for ((pred1, payload1) <- preds1) {
+      if (payload1.typeConstructor == baseType1.typeConstructor) {
+        for ((pred2, payload2) <- preds2) {
+          if (pred1 == pred2 && payload2.typeConstructor == baseType2.typeConstructor) {
+            candidates += pred1
+          }
+        }
+      }
     }
-    candidates.distinct match {
-      case pred :: Nil => Some(pred)
-      case _ => None
-    }
+
+    // The predicate is only identified if there is exactly one candidate.
+    if (candidates.size == 1) Some(candidates.head) else None
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -203,22 +203,29 @@ object ConstraintSolverInterface {
       val fullTpe2 = subst(fullType2)
       val default = List(mkMismatchedTypesOrEffects(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc))
 
-      (fullType1.typeConstructor, fullType2.typeConstructor) match {
-        case (Some(TypeConstructor.SchemaRowExtend(pred1)), Some(TypeConstructor.SchemaRowExtend(pred2))) if pred1 == pred2 =>
-          (baseType1.typeConstructor, baseType2.typeConstructor) match {
-            case (Some(TypeConstructor.Relation(arity1)), Some(TypeConstructor.Relation(arity2))) if arity1 != arity2 =>
-              List(TypeError.MismatchedPredicateArity(pred1, arity1, arity2, baseType1.loc, baseType2.loc, loc))
+      (baseTpe1.typeConstructor, baseTpe2.typeConstructor) match {
+        case (Some(TypeConstructor.Relation(arity1)), Some(TypeConstructor.Relation(arity2))) if arity1 != arity2 =>
+          findMismatchedPred(baseTpe1, baseTpe2, fullTpe1, fullTpe2) match {
+            case Some(pred) => List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, baseTpe1.loc, baseTpe2.loc, loc))
+            case None => default
+          }
 
-            case (Some(TypeConstructor.Lattice(arity1)), Some(TypeConstructor.Lattice(arity2))) if arity1 != arity2 =>
-              List(TypeError.MismatchedPredicateArity(pred1, arity1, arity2, baseType1.loc, baseType2.loc, loc))
+        case (Some(TypeConstructor.Lattice(arity1)), Some(TypeConstructor.Lattice(arity2))) if arity1 != arity2 =>
+          findMismatchedPred(baseTpe1, baseTpe2, fullTpe1, fullTpe2) match {
+            case Some(pred) => List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, baseTpe1.loc, baseTpe2.loc, loc))
+            case None => default
+          }
 
-            case (Some(TypeConstructor.Relation(_)), Some(TypeConstructor.Lattice(_))) =>
-              List(TypeError.MismatchedPredicateDenotation(pred1, Denotation.Relational, Denotation.Latticenal, baseType1.loc, baseType2.loc, loc))
+        case (Some(TypeConstructor.Relation(_)), Some(TypeConstructor.Lattice(_))) =>
+          findMismatchedPred(baseTpe1, baseTpe2, fullTpe1, fullTpe2) match {
+            case Some(pred) => List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Relational, Denotation.Latticenal, baseTpe1.loc, baseTpe2.loc, loc))
+            case None => default
+          }
 
-            case (Some(TypeConstructor.Lattice(_)), Some(TypeConstructor.Relation(_))) =>
-              List(TypeError.MismatchedPredicateDenotation(pred1, Denotation.Latticenal, Denotation.Relational, baseType1.loc, baseType2.loc, loc))
-
-            case _ => default
+        case (Some(TypeConstructor.Lattice(_)), Some(TypeConstructor.Relation(_))) =>
+          findMismatchedPred(baseTpe1, baseTpe2, fullTpe1, fullTpe2) match {
+            case Some(pred) => List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Latticenal, Denotation.Relational, baseTpe1.loc, baseTpe2.loc, loc))
+            case None => default
           }
 
         // A function type and a concrete non-function type can never be unified, regardless of effects.
@@ -282,6 +289,39 @@ object ConstraintSolverInterface {
       case _ =>
         TypeError.MismatchedTypes(baseType1, baseType2, fullType1, fullType2, renv, loc)
     }
+  }
+
+  /**
+    * Attempts to find the predicate in the schema types `fullType1` and `fullType2` whose
+    * payload types are `baseType1` and `baseType2`, respectively.
+    *
+    * The predicate is identified by comparing type constructors, so `baseType1` and `baseType2`
+    * must have different type constructors (e.g. relations of different arity).
+    *
+    * Returns `None` unless the predicate can be uniquely identified.
+    */
+  private def findMismatchedPred(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type): Option[Name.Pred] = {
+    val preds2 = getPredicates(fullType2)
+    val candidates = getPredicates(fullType1).collect {
+      case (pred1, payload1) if payload1.typeConstructor == baseType1.typeConstructor &&
+        preds2.exists { case (pred2, payload2) => pred1 == pred2 && payload2.typeConstructor == baseType2.typeConstructor } => pred1
+    }
+    candidates.distinct match {
+      case pred :: Nil => Some(pred)
+      case _ => None
+    }
+  }
+
+  /**
+    * Returns the predicates of the schema or schema row type `tpe` paired with their payload types.
+    *
+    * Returns the empty list if `tpe` is not a schema or schema row type.
+    */
+  private def getPredicates(tpe: Type): List[(Name.Pred, Type)] = tpe match {
+    case Type.Apply(Type.Cst(TypeConstructor.Schema, _), row, _) => getPredicates(row)
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(pred), _), payload, _), rest, _) =>
+      (pred, payload) :: getPredicates(rest)
+    case _ => Nil
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -2893,6 +2893,34 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.MismatchedPredicateArity](result)
   }
 
+  test("TypeError.MismatchedPredicateArity.04") {
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Foo(1, 2). };
+        |    let p2 = #{ Foo(1, 2, 3). };
+        |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateArity](result)
+  }
+
+  test("TypeError.MismatchedPredicateArity.05") {
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Bar(1). Foo(1, 2). };
+        |    let p2 = #{ Foo(1, 2, 3). Baz("a"). };
+        |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateArity](result)
+  }
+
   test("TypeError.MismatchedPredicateDenotation.01") {
     val input =
       """
@@ -2916,6 +2944,20 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |        Foo(1; 2).
         |        Foo(1, 2).
         |    };
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibAll)
+    expectError[TypeError.MismatchedPredicateDenotation](result)
+  }
+
+  test("TypeError.MismatchedPredicateDenotation.03") {
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Foo(1, 2). };
+        |    let p2 = #{ Foo(1; 2). };
+        |    let _ = p1 <+> p2;
         |    println("Hello World!")
         |
         |""".stripMargin


### PR DESCRIPTION
## Summary

Merging two schemas whose predicates disagree on arity (or denotation) previously reported a generic unification error that lost the predicate name:

```flix
let p1 = #{ Edge(1, 2). };
let p2 = #{ Edge(1, 2, 3). };
p1 <+> p2
```

```
>> Unable to unify the types: 'Relation(Int32, Int32)' and 'Relation(Int32, Int32, Int32)'.
```

The specific `MismatchedPredicateArity` and `MismatchedPredicateDenotation` errors only fired when the failing constraint's provenance types were bare schema rows headed by the mismatched predicate — true for duplicate predicates inside a single `#{ ... }` literal, but not for `<+>`, where the provenance holds the full `Schema`-wrapped types (e.g. `#{ Edge(...) | s0 }`).

This PR inverts the dispatch in `ConstraintSolverInterface.mkTypeError`: it now matches on the failing base types (`Relation`/`Lattice` constructors with differing arity or denotation) and recovers the predicate name by searching both provenance types' schema rows for the unique predicate whose payload constructors match, falling back to the generic error when the predicate cannot be uniquely identified. The above fragment now reports:

```
>> Mismatched predicate arity: 'Edge/2' and 'Edge/3'.

2 |     let p1 = #{ Edge(1, 2). };
                    ^^^^^^^^^^
                    here 'Edge' has arity 2.

3 |     let p2 = #{ Edge(1, 2, 3). };
                    ^^^^^^^^^^^^^
                    here 'Edge' has arity 3.
```

This also covers mismatched predicates that are not at the head of the row and denotation mismatches (relation vs. lattice) across `<+>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)