### PR TITLE
refactor: shadow Java static field resolution

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -22,12 +22,15 @@ import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration
 import ca.uwaterloo.flix.language.ast.ResolvedAst.Pattern.Record
 import ca.uwaterloo.flix.language.ast.UnkindedType.*
+import ca.uwaterloo.flix.language.ast.jvm.JavaFieldRef
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
+import ca.uwaterloo.flix.language.phase.typer.JavaReductionOpsTEMP
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
 
@@ -807,7 +810,19 @@ object Resolver {
           case List(Resolution.JavaClass(clazz)) =>
             // We have a static field access.
             val fieldName = qname.ident
-            JvmUtils.getField(clazz, fieldName.name, static = true) match {
+
+            // Old path (authoritative): resolve the static field with reflection.
+            val oldField = JvmUtils.getField(clazz, fieldName.name, static = true)
+
+            // New path (shadow only): resolve the static field from its owner descriptor.
+            val owner = ClassDescs.of(clazz)
+            val oldResult = oldField.map(field =>
+              JavaFieldRef(ClassDescs.of(field.getDeclaringClass), field.getName, ClassDescs.of(field.getType)))
+            val newResult = JavaMemberResolver.field(owner, fieldName.name, static = true).map(_.map(_.ref))
+            JavaReductionOpsTEMP.compareField(owner, fieldName.name, oldResult, newResult, loc)
+
+            // TODO: Remove the old path once GetStaticField stores JavaField instead of Field.
+            oldField match {
               case Some(field) =>
                 // Returns out of resolveExp
                 return ResolvedAst.Expr.GetStaticField(field, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/JavaReductionOpsTEMP.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/JavaReductionOpsTEMP.scala
@@ -23,8 +23,8 @@ import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
 
 import java.lang.constant.ClassDesc
 
-/** Checks descriptor-based Java field resolution against reflective type reduction. */
-private[typer] object JavaReductionOpsTEMP {
+/** Checks descriptor-based Java member resolution against reflective lookup. */
+private[phase] object JavaReductionOpsTEMP {
 
   /** Compares the old reflective field result with the new descriptor-based field result. */
   def compareField(owner: ClassDesc,


### PR DESCRIPTION
## Summary

- run descriptor-based static-field lookup beside the existing reflective Resolver path
- compare normalized JavaFieldRef results exactly while keeping reflection authoritative
- share JavaReductionOpsTEMP across the Resolver and typer phases
- document the condition for removing the reflective path

## Testing

- TestResolver: 197 passed
- TestTyper: 212 passed
- CompilerSuite: 314 passed