### PR TITLE
feat: make the monomorph2 constraint solver demand-driven

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
@@ -114,7 +114,7 @@ private[monomorph2] object ConstraintGen {
     }
 
     ParOps.parMap(root.effects.values.flatMap(_.ops)) { op =>
-      val defnSym = new Symbol.DefnSym(None, op.sym.namespace, op.sym.name, op.sym.loc)
+      val defnSym = MonomorphHelpers.effectOpImplSym(op.sym)
       val mvar = MonoVar.Def(defnSym)
       implicit val tparamEnv: TypeParamEnv = mkTypeParamEnv(mvar, op.spec.tparams)
       visitOp(op)
@@ -123,14 +123,21 @@ private[monomorph2] object ConstraintGen {
     sctx.result
   }
 
-  /** Maps the current declaration's own type parameters to their `MonoArg.Param` binding. */
-  private case class TypeParamEnv(m: Map[Symbol.KindedTypeVarSym, MonoArg]) {
+  /**
+    * The current declaration (`owner`) and the mapping from its own type parameters to their
+    * `MonoArg.Param` bindings. The `owner` is recorded as the `src` of every emitted flow.
+    */
+  private case class TypeParamEnv(owner: MonoVar, m: Map[Symbol.KindedTypeVarSym, MonoArg]) {
     def get(sym: Symbol.KindedTypeVarSym): Option[MonoArg] = m.get(sym)
   }
 
   /** Returns the `MonoArg.Param` bindings for `mvar`'s type parameters, in declared order. */
   private def mkTypeParamEnv(mvar: MonoVar, tparams: List[TypeParam]): TypeParamEnv =
-    TypeParamEnv(tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap)
+    TypeParamEnv(mvar, tparams.zipWithIndex.map { case (tp, i) => tp.sym -> MonoArg.Param(mvar, i) }.toMap)
+
+  /** Emits the flow `args ~> dst`, recording the current declaration as its origin. */
+  private def emit(args: Instantiation, dst: MonoVar)(implicit tparamEnv: TypeParamEnv, sctx: SharedContext): Unit =
+    sctx.addFlowConstraint(FlowConstraint(args, dst, tparamEnv.owner))
 
   /**
     * Emits flow constraints for enum type applications occurring in `tpe`.
@@ -150,7 +157,7 @@ private[monomorph2] object ConstraintGen {
           dealiasedVisitType(arg)
         }
         for (mvar <- declMonoVar(app.baseType)) {
-          sctx.addFlowConstraint(FlowConstraint(Instantiation(args.map(t => dealiasedTypeToMonoArg(t))), mvar))
+          emit(Instantiation(args.map(t => dealiasedTypeToMonoArg(t))), mvar)
         }
 
       case Type.Var(_, _)               => ()
@@ -270,7 +277,7 @@ private[monomorph2] object ConstraintGen {
           val subst = ConstraintSolver2.fullyUnify(handlerDef.spec.fparams.head.tpe, concreteParamTpe, RegionScope.Top, RigidityEnv.empty)(root.eqEnv, flix)
             .getOrElse(throw InternalCompilerException(s"Could not unify default handler '${handler.handlerSym}' against its call site.", loc))
           val args = handlerTparams.map(tp => typeToMonoArg(subst(Type.Var(tp.sym, loc))))
-          sctx.addFlowConstraint(FlowConstraint(Instantiation(args), MonoVar.Def(handler.handlerSym)))
+          emit(Instantiation(args), MonoVar.Def(handler.handlerSym))
           Canonicalization.canonicalEffect(Type.mkUnion(Type.mkDifference(eff, handler.handledEff, loc), Type.IO, loc))
       }
       ()
@@ -290,13 +297,13 @@ private[monomorph2] object ConstraintGen {
       for (exp <- exps) {
         visitExp(exp)
       }
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(targs.map(typeToMonoArg)), MonoVar.Def(symUse.sym)))
+      emit(Instantiation(targs.map(typeToMonoArg)), MonoVar.Def(symUse.sym))
 
     case Expr.ApplySig(symUse, exps, targ, targs, _, _, _, _, _) =>
       for (exp <- exps) {
         visitExp(exp)
       }
-      sctx.addFlowConstraint(FlowConstraint(Instantiation((targ :: targs).map(typeToMonoArg)), MonoVar.Sig(symUse.sym)))
+      emit(Instantiation((targ :: targs).map(typeToMonoArg)), MonoVar.Sig(symUse.sym))
 
     case Expr.ApplyOp(_, exps, _, _, _, _) =>
       for (exp <- exps) {
@@ -349,14 +356,14 @@ private[monomorph2] object ConstraintGen {
       for (exp <- exps) {
         visitExp(exp)
       }
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(tpArgs.map(typeToMonoArg)), mvar))
+      emit(Instantiation(tpArgs.map(typeToMonoArg)), mvar)
 
     case Expr.RestrictableTag(_, exps, tpe, _, _) =>
       val (mvar, tpArgs) = getMonoVarAndTypeArgs(tpe)
       for (exp <- exps) {
         visitExp(exp)
       }
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(tpArgs.map(typeToMonoArg)), mvar))
+      emit(Instantiation(tpArgs.map(typeToMonoArg)), mvar)
 
     case Expr.RestrictableChoose(_, exp, rules, _, _, _) =>
       visitExp(exp)
@@ -442,7 +449,7 @@ private[monomorph2] object ConstraintGen {
       for (exp <- region) {
         visitExp(exp)
       }
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(tpArgs.map(typeToMonoArg)), mvar))
+      emit(Instantiation(tpArgs.map(typeToMonoArg)), mvar)
 
     case Expr.StructGet(exp, _, _, _, _) => visitExp(exp)
 
@@ -492,9 +499,9 @@ private[monomorph2] object ConstraintGen {
       for (frag <- frags.init) {
         val elmType = frag.exp.tpe
         val elmArg = typeToMonoArg(MonomorphHelpers.lowerChannelType(elmType))
-        sctx.addFlowConstraint(FlowConstraint(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.NewChannel)))
-        sctx.addFlowConstraint(FlowConstraint(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.Put)))
-        sctx.addFlowConstraint(FlowConstraint(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.Get)))
+        emit(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.NewChannel))
+        emit(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.Put))
+        emit(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.Get))
       }
 
     case Expr.InvokeConstructor(_, exps, _, _, _) =>
@@ -543,19 +550,19 @@ private[monomorph2] object ConstraintGen {
     case Expr.GetChannel(exp, tpe, _, _) =>
       // Generates: Concurrent.Channel.get(c: Mpmc[a, Static]): a \ IO
       visitExp(exp)
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(MonomorphHelpers.lowerChannelType(tpe)))), MonoVar.Def(Defs.Concurrent.Channel.Get)))
+      emit(Instantiation(List(typeToMonoArg(MonomorphHelpers.lowerChannelType(tpe)))), MonoVar.Def(Defs.Concurrent.Channel.Get))
 
     case Expr.PutChannel(exp1, exp2, _, _, _) =>
       // Generates: Concurrent.Channel.put(e: a, c: Mpmc[a, Static]): Unit \ IO
       visitExp(exp1)
       visitExp(exp2)
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(MonomorphHelpers.lowerChannelType(exp2.tpe)))), MonoVar.Def(Defs.Concurrent.Channel.Put)))
+      emit(Instantiation(List(typeToMonoArg(MonomorphHelpers.lowerChannelType(exp2.tpe)))), MonoVar.Def(Defs.Concurrent.Channel.Put))
 
     case Expr.NewChannel(exp, tpe, _, _) =>
       // Generates: Concurrent.Channel.newChannelTuple(bufferSize: Int32): (Mpmc[a, Static], Mpmc[a, Static]) \ IO
       val elmType = extractChannelElm(tpe)
       visitExp(exp)
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(MonomorphHelpers.lowerChannelType(elmType)))), MonoVar.Def(Defs.Concurrent.Channel.NewChannelTuple)))
+      emit(Instantiation(List(typeToMonoArg(MonomorphHelpers.lowerChannelType(elmType)))), MonoVar.Def(Defs.Concurrent.Channel.NewChannelTuple))
 
     case Expr.SelectChannel(rules, default, _, _, _) =>
       // Generates, per rule (element type `a`, not a Channel.get call):
@@ -571,13 +578,13 @@ private[monomorph2] object ConstraintGen {
         val elmArg = typeToMonoArg(MonomorphHelpers.lowerChannelType(elmType))
         visitExp(rule.chan)
         visitExp(rule.exp)
-        sctx.addFlowConstraint(FlowConstraint(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.UnsafeGetAndUnlock)))
-        sctx.addFlowConstraint(FlowConstraint(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.MpmcAdmin)))
+        emit(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.UnsafeGetAndUnlock))
+        emit(Instantiation(List(elmArg)), MonoVar.Def(Defs.Concurrent.Channel.MpmcAdmin))
       }
       for (exp <- default) {
         visitExp(exp)
       }
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(Types.Concurrent.Channel.MpmcAdmin))), MonoVar.Enum(Enums.List.List)))
+      emit(Instantiation(List(typeToMonoArg(Types.Concurrent.Channel.MpmcAdmin))), MonoVar.Enum(Enums.List.List))
 
     case Expr.FixpointConstraintSet(cs, _, _) =>
       // Generates the Box/Unbox/liftN/lattice/Facts/ProjectInto/ProvenanceOf calls for Datalog
@@ -615,7 +622,7 @@ private[monomorph2] object ConstraintGen {
       // Generates a `List[PredSym]` value directly via mkTag/mkList (bypassing the ordinary
       // rewrite path), so its instantiation must be predicted here.
       visitExp(exp)
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(Types.Fixpoint.Ast.Shared.PredSym))), MonoVar.Enum(Enums.List.List)))
+      emit(Instantiation(List(typeToMonoArg(Types.Fixpoint.Ast.Shared.PredSym))), MonoVar.Enum(Enums.List.List))
 
     case Expr.FixpointMerge(exp1, exp2, _, _, _) =>
       visitExp(exp1)
@@ -636,7 +643,7 @@ private[monomorph2] object ConstraintGen {
             val argTypes = Type.unmkTuplish(arity, innerTpe)
             val injectIntoArgs = (tc :: argTypes).map(typeToMonoArg)
             visitExp(e)
-            sctx.addFlowConstraint(FlowConstraint(Instantiation(injectIntoArgs), MonoVar.Def(Defs.Fixpoint.Solver.InjectInto(arity))))
+            emit(Instantiation(injectIntoArgs), MonoVar.Def(Defs.Fixpoint.Solver.InjectInto(arity)))
 
           case t => throw InternalCompilerException(s"Unexpected non-foldable type: '$t'.", loc)
         }
@@ -653,7 +660,7 @@ private[monomorph2] object ConstraintGen {
         visitExp(exp)
       }
       visitExp(queryExp)
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(argTypes.map(typeToMonoArg)), MonoVar.Def(Defs.Fixpoint.Solver.Facts(arity))))
+      emit(Instantiation(argTypes.map(typeToMonoArg)), MonoVar.Def(Defs.Fixpoint.Solver.Facts(arity)))
 
     case Expr.FixpointQueryWithProvenance(exps, select, _, tpe0, _, _) =>
       // Generates, per goal term (type `a`): Fixpoint3.Boxable.box(x: a): Boxed with Order[a]
@@ -674,10 +681,10 @@ private[monomorph2] object ConstraintGen {
       }
       val extVarType = unwrapVectorType(tpe0)
       for (t <- predicatesOfExtVar(extVarType).flatMap(_._2)) {
-        sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(t))), MonoVar.Def(Defs.Fixpoint.Boxable.Unbox)))
+        emit(Instantiation(List(typeToMonoArg(t))), MonoVar.Def(Defs.Fixpoint.Boxable.Unbox))
       }
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(Types.Fixpoint.Boxed))), MonoVar.Def(Defs.Vector.Get)))
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(extVarType))), MonoVar.Def(Defs.Fixpoint.Solver.ProvenanceOf)))
+      emit(Instantiation(List(typeToMonoArg(Types.Fixpoint.Boxed))), MonoVar.Def(Defs.Vector.Get))
+      emit(Instantiation(List(typeToMonoArg(extVarType))), MonoVar.Def(Defs.Fixpoint.Solver.ProvenanceOf))
 
     case Expr.Error(_, _, _) => ()
   }
@@ -697,7 +704,7 @@ private[monomorph2] object ConstraintGen {
       for (pat <- pats) {
         visitPat(pat)
       }
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(tpArgs.map(typeToMonoArg)), mvar))
+      emit(Instantiation(tpArgs.map(typeToMonoArg)), mvar)
 
     case TypedAst.Pattern.Tuple(elms, _, _) =>
       for (elm <- elms) {
@@ -718,7 +725,7 @@ private[monomorph2] object ConstraintGen {
 
   /** Generates: Fixpoint3.Boxable.box(x: a): Boxed with Order[a] — mirrors [[SpecializeAndLower.box]]. */
   private def boxConstraint(tpe: Type)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit =
-    sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(tpe))), MonoVar.Def(Defs.Fixpoint.Boxable.Box)))
+    emit(Instantiation(List(typeToMonoArg(tpe))), MonoVar.Def(Defs.Fixpoint.Boxable.Box))
 
   /**
     * Flows for a head term — mirrors [[SpecializeAndLower.lowerHeadTerm]]. A bare quantified var
@@ -740,7 +747,7 @@ private[monomorph2] object ConstraintGen {
       } else {
         val argTypes = fvs.map(_._2) // t1, ..., tN
         val liftArgs = (argTypes :+ exp0.tpe).map(typeToMonoArg)
-        sctx.addFlowConstraint(FlowConstraint(Instantiation(liftArgs), MonoVar.Def(Defs.Fixpoint.Boxable.Lift(fvs.length))))
+        emit(Instantiation(liftArgs), MonoVar.Def(Defs.Fixpoint.Boxable.Lift(fvs.length)))
       }
   }
 
@@ -776,7 +783,7 @@ private[monomorph2] object ConstraintGen {
     if (fvs.nonEmpty) {
       val argTypes = fvs.map(_._2) // t1, ..., tN
       val liftArgs = argTypes.map(typeToMonoArg)
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(liftArgs), MonoVar.Def(Defs.Fixpoint.Boxable.LiftB(fvs.length))))
+      emit(Instantiation(liftArgs), MonoVar.Def(Defs.Fixpoint.Boxable.LiftB(fvs.length)))
     }
   }
 
@@ -794,7 +801,7 @@ private[monomorph2] object ConstraintGen {
     val outTypes = Type.unmkTuplish(outArity, inner)
     val inTypes = inVars.map(_._2) // i1, ..., iM
     val liftArgs = (inTypes ++ outTypes).map(typeToMonoArg)
-    sctx.addFlowConstraint(FlowConstraint(Instantiation(liftArgs), MonoVar.Def(Defs.Fixpoint.Boxable.LiftXM(inTypes.length, outArity))))
+    emit(Instantiation(liftArgs), MonoVar.Def(Defs.Fixpoint.Boxable.LiftXM(inTypes.length, outArity)))
   }
 
   /**
@@ -806,12 +813,12 @@ private[monomorph2] object ConstraintGen {
     */
   private def latticeConstraints(den: Denotation, lastTermType: Option[Type], loc: SourceLocation)(implicit tparamEnv: TypeParamEnv,  sctx: SharedContext, root: TypedAst.Root, flix: Flix): Unit = den match {
     case Denotation.Relational =>
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(Types.Fixpoint.Boxed))), MonoVar.Enum(Enums.Fixpoint.Ast.Shared.Denotation)))
+      emit(Instantiation(List(typeToMonoArg(Types.Fixpoint.Boxed))), MonoVar.Enum(Enums.Fixpoint.Ast.Shared.Denotation))
 
     case Denotation.Latticenal =>
       val tpe = lastTermType.getOrElse(throw InternalCompilerException("Unexpected nullary lattice predicate.", loc))
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(tpe))), MonoVar.Def(Defs.Fixpoint.Ast.Shared.Lattice)))
-      sctx.addFlowConstraint(FlowConstraint(Instantiation(List(typeToMonoArg(tpe))), MonoVar.Def(Defs.Fixpoint.Ast.Shared.Box)))
+      emit(Instantiation(List(typeToMonoArg(tpe))), MonoVar.Def(Defs.Fixpoint.Ast.Shared.Lattice))
+      emit(Instantiation(List(typeToMonoArg(tpe))), MonoVar.Def(Defs.Fixpoint.Ast.Shared.Box))
   }
 
   /** Returns `t` from `Vector[t]` — mirrors [[SpecializeAndLower.unwrapVectorType]]. */

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintSolver.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.monomorph2
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.shared.{RegionScope, SymUse}
-import ca.uwaterloo.flix.language.ast.{RigidityEnv, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.phase.monomorph2.MonomorphHelpers.lowerChannelType
 import ca.uwaterloo.flix.language.phase.monomorph2.Symbols.Defs
 import ca.uwaterloo.flix.language.phase.typer.ConstraintSolver2
@@ -28,14 +28,20 @@ import ca.uwaterloo.flix.util.collection.ListOps
 import scala.collection.mutable
 
 /**
-  * Solves the flow constraints produced by [[ConstraintGen]] to a fixpoint: starting from
-  * the ground (all-constant) flows, each newly solved instantiation is substituted into the
-  * flows that depend on it until no new instantiations appear.
+  * Solves the flow constraints produced by [[ConstraintGen]] to a fixpoint, demand-driven:
+  * solving starts from the entry points (plus a small set of always-live declarations), and a
+  * flow only fires once its origin declaration ([[FlowConstraint]]'s `src`) is live. A
+  * declaration becomes live when it receives its first instantiation; its parameter-free flows
+  * then fire once, and its parameter-bearing flows fire once per instantiation, until no new
+  * instantiations appear. Flows originating in declarations that never become live — e.g.
+  * ground calls inside a never-instantiated polymorphic def, or the defs of an instance that
+  * is never dispatched to — never produce specializations.
   *
   * Sig destinations are additionally dispatched to their implementing (or default) def.
   *
-  * The result is, per polymorphic symbol, the set of ground instantiations it must be
-  * specialized at.
+  * The result is, per live symbol, the set of ground instantiations it must be specialized at.
+  * Live monomorphic defs appear with a single nullary instantiation, which [[Specialize]] uses
+  * as its liveness filter for non-parametric defs.
   */
 private[monomorph2] object ConstraintSolver {
 
@@ -47,11 +53,24 @@ private[monomorph2] object ConstraintSolver {
     */
   private[monomorph2] def solve(flows: List[FlowConstraint], root: TypedAst.Root)(implicit flix: Flix): Solution = {
     val instanceMap = MonomorphHelpers.mkInstanceMap(root.instances)
-    val dependents  = buildDependents(flows)
+
+    // Split each declaration's flows: parameter-free flows fire once, when the declaration
+    // becomes live; parameter-bearing flows fire once per instantiation of the declaration.
+    // Every `Param` inside a flow references the flow's own origin, since [[ConstraintGen]]'s
+    // `TypeParamEnv` only binds the enclosing declaration's type parameters.
+    val (paramBearing0, paramFree0) = flows.partition(fc => paramVars(fc).nonEmpty)
+    for (fc <- paramBearing0) {
+      if (paramVars(fc) != Set(fc.src)) {
+        throw InternalCompilerException(s"Flow into '${fc.dst}' references type parameters of a declaration other than its origin '${fc.src}'.", SourceLocation.Unknown)
+      }
+    }
+    val paramFree    = paramFree0.groupBy(_.src)
+    val paramBearing = paramBearing0.groupBy(_.src)
 
     val solution  = mutable.Map.empty[MonoVar, mutable.ListBuffer[GroundInstantiation]]
     val worklist  = mutable.Queue.empty[(MonoVar, GroundInstantiation)]
     val enqueued  = mutable.HashSet.empty[(MonoVar, GroundInstantiation)]
+    val live      = mutable.HashSet.empty[MonoVar]
 
     def enqueue(dst: MonoVar, inst0: GroundInstantiation): Unit = {
       val inst = dst match {
@@ -73,10 +92,48 @@ private[monomorph2] object ConstraintSolver {
       }
     }
 
-    // Seed: ground flows (all-Const instantiations) become initial worklist entries.
-    for (fc <- flows) {
-      for (t <- groundArgs(fc, Map.empty, root)) {
-        enqueue(fc.dst, t)
+    /** Marks `v` live; the first time around fires its parameter-free flows. */
+    def markLive(v: MonoVar): Unit = {
+      if (live.add(v)) {
+        for (fc <- paramFree.getOrElse(v, Nil)) {
+          for (inst <- groundArgs(fc, Map.empty, root)) {
+            enqueue(fc.dst, inst)
+          }
+        }
+      }
+    }
+
+    // Seed the demand:
+    //  - Entry points: the roots of all liveness. Monomorphic (guaranteed by `EntryPoints`),
+    //    so the nullary instantiation is exact; it also carries them through Specialize's
+    //    liveness filter.
+    //  - Monomorphic channel/Datalog lowering targets: [[SpecializeAndLower]] references them
+    //    by original symbol whenever the corresponding syntax occurs, and [[TreeShaker1]]
+    //    keeps them in `root.defs` exactly when it does. (Parametric lowering targets get
+    //    real instantiations from the explicit per-construct flows instead.)
+    //  - Effect ops: effects are never shaken and all ops are lowered, so their signature
+    //    demands must fire. Mark-live only: nothing ever flows into an op.
+    //  - Non-parametric enums/structs: [[Specialize]] emits all of them, so their case/field
+    //    type demands must fire. Mark-live only, for the same reason.
+    for (sym <- root.entryPoints) {
+      enqueue(MonoVar.Def(sym), GroundInstantiation(Nil))
+    }
+    for (defn <- root.defs.values) {
+      if ((defn.spec.ann.isLoweringTargetChannel || defn.spec.ann.isLoweringTargetDatalog) && defn.spec.tparams.isEmpty) {
+        enqueue(MonoVar.Def(defn.sym), GroundInstantiation(Nil))
+      }
+    }
+    for (eff <- root.effects.values; op <- eff.ops) {
+      markLive(MonoVar.Def(MonomorphHelpers.effectOpImplSym(op.sym)))
+    }
+    for (enm <- root.enums.values) {
+      if (enm.tparams.isEmpty) {
+        markLive(MonoVar.Enum(enm.sym))
+      }
+    }
+    for (struct <- root.structs.values) {
+      if (struct.tparams.isEmpty) {
+        markLive(MonoVar.Struct(struct.sym))
       }
     }
 
@@ -85,6 +142,7 @@ private[monomorph2] object ConstraintSolver {
       val (dst, inst) = worklist.dequeue()
 
       solution.getOrElseUpdate(dst, mutable.ListBuffer.empty) += inst
+      markLive(dst)
 
       // Sig dispatch: resolve to impl def and forward the instantiation.
       dst match {
@@ -99,8 +157,8 @@ private[monomorph2] object ConstraintSolver {
         case MonoVar.Struct(_)           => ()
       }
 
-      // Propagate: substitute this MonoVar's new instantiation into all dependent flows.
-      for (fc <- dependents.getOrElse(dst, Nil)) {
+      // Propagate: substitute this new instantiation into `dst`'s parameter-bearing flows.
+      for (fc <- paramBearing.getOrElse(dst, Nil)) {
         for (groundInstantiation <- groundArgs(fc, Map(dst -> inst), root)) {
           enqueue(fc.dst, groundInstantiation)
         }
@@ -118,16 +176,6 @@ private[monomorph2] object ConstraintSolver {
   /** Returns every distinct MonoVar referenced by a `Param` in `fc`'s args. */
   private def paramVars(fc: FlowConstraint): Set[MonoVar] =
     fc.args.args.flatMap(MonoArg.collectParams).map(_._1).toSet
-
-  /** Return for each MonoVar, the flows whose args contain `Param(mvar, _)`. */
-  private def buildDependents(flows: List[FlowConstraint]): Map[MonoVar, List[FlowConstraint]] = {
-    val edges = for {
-      fc <- flows
-      v  <- paramVars(fc)
-    } yield v -> fc
-
-    edges.groupMap(_._1)(_._2)
-  }
 
   /**
     * Substitutes `bindings` into `arg`'s `Param`s.

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/FlowConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/FlowConstraint.scala
@@ -18,5 +18,9 @@ package ca.uwaterloo.flix.language.phase.monomorph2
 
 /**
   * A component-wise flow constraint: `args` flows into the type-parameter slots of `dst`.
+  *
+  * `src` is the declaration whose visitation emitted the constraint. The solver only fires a
+  * constraint once `src` is live (demanded), so flows originating in dead declarations never
+  * produce specializations.
   */
-private[monomorph2] case class FlowConstraint(args: Instantiation, dst: MonoVar)
+private[monomorph2] case class FlowConstraint(args: Instantiation, dst: MonoVar, src: MonoVar)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonomorphHelpers.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/MonomorphHelpers.scala
@@ -37,6 +37,10 @@ private[monomorph2] object MonomorphHelpers {
     new Symbol.DefnSym(None, ns, sig.sym.name, sig.sym.loc)
   }
 
+  /** Returns the synthesized `DefnSym` under which an effect op's signature flows are tracked. */
+  private[monomorph2] def effectOpImplSym(opSym: Symbol.OpSym): Symbol.DefnSym =
+    new Symbol.DefnSym(None, opSym.namespace, opSym.name, opSym.loc)
+
   /** Returns the free variables of `exp0` that are quantified (bound by `cparams0`). */
   private[monomorph2] def quantifiedVars(cparams0: List[TypedAst.ConstraintParam], exp0: Expr): List[(Symbol.VarSym, Type)] =
     TypedAstOps.freeVars(exp0).toList.filter { case (sym, _) => isQuantifiedVar(sym, cparams0) }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Monomorpher2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Monomorpher2.scala
@@ -33,13 +33,21 @@ import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugMonoAst
   *   - 2. [[NonMonomorphizableCheck]] rejects programs with no finite solution (e.g. polymorphic
   *     recursion) before solving, so the next step cannot loop forever.
   *   - 3. [[ConstraintSolver]] solves the flow constraints to a fixpoint, producing the set of
-  *     concrete instantiations each polymorphic symbol must be specialized at.
-  *   - 4. [[Specialize]] specializes (and lowers) every def/enum/struct/
+  *     concrete instantiations each live symbol must be specialized at. Solving is
+  *     demand-driven: it starts from the entry points (plus effect ops, non-parametric
+  *     enums/structs, and monomorphic channel/Datalog lowering targets), and a flow only fires
+  *     once its origin declaration is live — so declarations that are never demanded produce no
+  *     specializations, even if [[TreeShaker1]]'s coarser reachability kept them around.
+  *   - 4. [[Specialize]] specializes (and lowers) every live def/enum/struct/
   *     restrictable-enum accordingly.
   *
   * Caution: step 4's lowering can synthesize references to specific stdlib defs/enums that step 1
   * would not otherwise have any reason to see. Any such construct needs its own constraints
-  * generated in step 1, or it won't be in the solution by the time step 4 needs to specialize it.
+  * generated in step 1 (or a seed in step 3, for monomorphic targets), or it won't be in the
+  * solution by the time step 4 needs to specialize it. Demand-driven solving makes this stricter:
+  * an eager ground flow from an unrelated declaration can no longer paper over a missing demand —
+  * a miss surfaces as a strict lookup failure in step 4 and must be fixed by adding the missing
+  * constraint in step 1, never by weakening the gating in step 3.
   */
 object Monomorpher2 {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/NonMonomorphizableCheck.scala
@@ -54,7 +54,10 @@ import ca.uwaterloo.flix.util.{Graph, InternalCompilerException}
   *
   * N.B. Because of [[TreeShaker1]], unreachable occurrences of polymorphic recursive function
   * definitions (`def`, `sig`, instance `def`) will not be detected, whereas unreachable
-  * polymorphic recursive enum/struct declarations will still be rejected.
+  * polymorphic recursive enum/struct declarations will still be rejected. The check runs on
+  * every generated flow, ignoring [[FlowConstraint]]'s `src` — it deliberately stays more
+  * conservative than the demand-driven [[ConstraintSolver]], which fires a flow only once its
+  * origin declaration is live.
   */
 private[monomorph2] object NonMonomorphizableCheck {
 
@@ -68,7 +71,7 @@ private[monomorph2] object NonMonomorphizableCheck {
   /** Checks whether `flows` contains a growing cycle and throws [[InternalCompilerException]] if so. */
   private[monomorph2] def checkMonomorphizable(flows: List[FlowConstraint]): Unit = {
     val edges = for {
-      FlowConstraint(Instantiation(args), dst) <- flows
+      FlowConstraint(Instantiation(args), dst, _) <- flows
       (arg, i) <- args.zipWithIndex
       (v, j) <- MonoArg.collectParams(arg).distinct
     } yield Edge(Vertex(v, j), Vertex(dst, i), growing = isGrowingHead(arg))

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -429,11 +429,14 @@ private[monomorph2] object Specialize {
     // Biggest-first scheduling to preload long-tailed jobs
     def negativeLineCount(defn: TypedAst.Def): Int = defn.loc.startLine - defn.loc.endLine
 
+    // Note: only *live* non-parametric defs are kept — the demand-driven [[ConstraintSolver]]
+    // records a nullary instantiation for every monomorphic def that is actually demanded.
     val nonParametricDefEntries = allDefs.filter {
       case (sym, defn) =>
         defn.spec.tparams.isEmpty &&
           defToInst.get(sym).forall(_.tparams.isEmpty) &&
-          !defaultSigDefs.contains(sym)
+          !defaultSigDefs.contains(sym) &&
+          solution.defs.contains(sym)
     }
     val nonParametricDefs =
       ParOps.parMapWithPriority(nonParametricDefEntries, sortBy = ({ case (_, defn) => negativeLineCount(defn) }: ((Symbol.DefnSym, TypedAst.Def)) => Int)) {


### PR DESCRIPTION
_This PR is an experiment. We should consider the code only after discussing the theory. The idea is that we should have constraint be directed, so we only solve flow starting from the entry points. This significantly reduces the amount of work that has to be done._

## Summary

Makes the `monomorph2` constraint solver demand-driven: solving now starts from the entry points instead of eagerly seeding every ground flow in the program, and each flow constraint only fires once its origin declaration is live. Declarations kept by `TreeShaker1`'s coarse syntactic reachability but never actually demanded — ground calls inside never-instantiated polymorphic defs, defs of instances that are never dispatched to, dead monomorphic defs — no longer produce specializations.

## Design

- `FlowConstraint` gains a `src: MonoVar` recording the declaration whose visitation emitted it. `ConstraintGen` threads the enclosing declaration through `TypeParamEnv` and a new `emit` helper; constraint generation still visits every declaration in parallel, unchanged.
- `ConstraintSolver` partitions each declaration's flows: parameter-free flows fire once, when the declaration becomes live (receives its first instantiation); parameter-bearing flows fire once per instantiation. This also replaces the old `buildDependents` reverse index, since every `Param` in a flow references its own origin.
- Seeds: entry points (`root.entryPoints`, i.e. main/`@Test`/`@Export`, as nullary instantiations), monomorphic `@LoweringTargetChannel`/`@LoweringTargetDatalog` defs, effect ops (mark-live only), and non-parametric enums/structs (mark-live only). Default handlers need no seed — the existing entry-point handler constraints originate from the (always live) entry points, so unused handlers now die too.
- `Specialize` keeps a non-parametric def only if the solution contains its nullary liveness entry; live monomorphic defs keep their original symbols, so `root.entryPoints`/`root.mainEntryPoint` remain valid.

Enum/struct shaking is deliberately out of scope: all non-parametric enums/structs are still emitted (their case/field-type demands are kept firing via the mark-live seeds).

## Impact

Defs right after monomorphization for a small program (`def main(): Unit \ IO = println(List.sum(List.map(x -> x + 1, List.range(0, 10))))`), where 572 defs enter the phase after `TreeShaker1`:

| Monomorpher variant | Defs after the phase |
|---|---|
| `monomorph2`, eager (before this PR) | 1,117 |
| Old monomorpher (`Specialization`) | 500 |
| `monomorph2`, demand-driven (this PR) | **80** |

The eager solver nearly doubles its input because every tree-shaken def is emitted and every ground call site anywhere spawns specializations. The old monomorpher only demands polymorphic specializations from live code but emits all non-parametric defs unconditionally. The demand-driven solver gates both, so only what is transitively demanded from the entry points survives — reducing work for every phase between the monomorpher and `TreeShaker2`.

A consequence worth noting: demand-gating removes accidental coverage, so a missing demand in `ConstraintGen` (previously masked by an unrelated dead def's eager ground flow) now surfaces as a strict lookup failure in `Specialize`. Such a miss should be fixed by adding the missing constraint, never by weakening the gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
