### PR TITLE
fix: report predicate mismatches via a SchemaConflicted constraint

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -290,6 +290,20 @@ object ConstraintSolver2 {
           TypeConstraint.Conflicted(r1, r2, prov) :: cs1 ::: cs2
       }
 
+    case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov) =>
+      if (isEliminable(tpe1) || isEliminable(tpe2)) {
+        Nil
+      } else {
+        // (redU)
+        val (r1, cs1) = reduce(tpe1)(scope, renv, progress, eqenv, flix)
+        val (r2, cs2) = reduce(tpe2)(scope, renv, progress, eqenv, flix)
+        // Performance: Reuse this, if possible.
+        if ((r1 eq tpe1) && (r2 eq tpe2) && cs1.isEmpty && cs2.isEmpty)
+          constr :: Nil
+        else
+          TypeConstraint.SchemaConflicted(pred, r1, r2, prov) :: cs1 ::: cs2
+      }
+
     case TypeConstraint.EffConflicted(_) => constr :: Nil
   }
 
@@ -390,6 +404,7 @@ object ConstraintSolver2 {
     // Case 1: Non-trait constraint. Do nothing.
     case c: TypeConstraint.Equality => List(c)
     case c: TypeConstraint.Conflicted => List(c)
+    case c: TypeConstraint.SchemaConflicted => List(c)
     case c: TypeConstraint.EffConflicted => List(c)
 
     case c@TypeConstraint.Purification(sym, eff1, eff2, prov, nested0) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -28,7 +28,6 @@ import ca.uwaterloo.flix.language.phase.util.PredefinedTraits
 import ca.uwaterloo.flix.util.Build
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 /**
   * Interface to [[ConstraintSolver2]].
@@ -202,37 +201,9 @@ object ConstraintSolverInterface {
       val baseTpe2 = subst(baseType2)
       val fullTpe1 = subst(fullType1)
       val fullTpe2 = subst(fullType2)
-      val default = List(mkMismatchedTypesOrEffects(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc))
-
-      (baseTpe1.typeConstructor, baseTpe2.typeConstructor) match {
-        case (Some(TypeConstructor.Relation(arity1)), Some(TypeConstructor.Relation(arity2))) if arity1 != arity2 =>
-          findMismatchedPred(baseTpe1, baseTpe2, fullTpe1, fullTpe2) match {
-            case Some(pred) => List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, baseTpe1.loc, baseTpe2.loc, loc))
-            case None => default
-          }
-
-        case (Some(TypeConstructor.Lattice(arity1)), Some(TypeConstructor.Lattice(arity2))) if arity1 != arity2 =>
-          findMismatchedPred(baseTpe1, baseTpe2, fullTpe1, fullTpe2) match {
-            case Some(pred) => List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, baseTpe1.loc, baseTpe2.loc, loc))
-            case None => default
-          }
-
-        case (Some(TypeConstructor.Relation(_)), Some(TypeConstructor.Lattice(_))) =>
-          findMismatchedPred(baseTpe1, baseTpe2, fullTpe1, fullTpe2) match {
-            case Some(pred) => List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Relational, Denotation.Latticenal, baseTpe1.loc, baseTpe2.loc, loc))
-            case None => default
-          }
-
-        case (Some(TypeConstructor.Lattice(_)), Some(TypeConstructor.Relation(_))) =>
-          findMismatchedPred(baseTpe1, baseTpe2, fullTpe1, fullTpe2) match {
-            case Some(pred) => List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Latticenal, Denotation.Relational, baseTpe1.loc, baseTpe2.loc, loc))
-            case None => default
-          }
-
-        // A function type and a concrete non-function type can never be unified, regardless of effects.
-        case _ =>
-          mkArrowAndNonArrowError(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc).getOrElse(default)
-      }
+      // A function type and a concrete non-function type can never be unified, regardless of effects.
+      mkArrowAndNonArrowError(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc)
+        .getOrElse(List(mkMismatchedTypesOrEffects(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc)))
 
     case TypeConstraint.Equality(tpe1, tpe2, prov) =>
       List(mkMismatchedTypesOrEffects(subst(tpe1), subst(tpe2), subst(tpe1), subst(tpe2), renv, prov.loc))
@@ -259,6 +230,27 @@ object ConstraintSolverInterface {
 
     case TypeConstraint.Conflicted(tpe1, tpe2, prov) =>
       List(mkMismatchedTypesOrEffects(subst(tpe1), subst(tpe2), subst(tpe1), subst(tpe2), renv, prov.loc))
+
+    case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov) =>
+      val t1 = subst(tpe1)
+      val t2 = subst(tpe2)
+      (t1.typeConstructor, t2.typeConstructor) match {
+        case (Some(TypeConstructor.Relation(arity1)), Some(TypeConstructor.Relation(arity2))) if arity1 != arity2 =>
+          List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, t1.loc, t2.loc, prov.loc))
+
+        case (Some(TypeConstructor.Lattice(arity1)), Some(TypeConstructor.Lattice(arity2))) if arity1 != arity2 =>
+          List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, t1.loc, t2.loc, prov.loc))
+
+        case (Some(TypeConstructor.Relation(_)), Some(TypeConstructor.Lattice(_))) =>
+          List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Relational, Denotation.Latticenal, t1.loc, t2.loc, prov.loc))
+
+        case (Some(TypeConstructor.Lattice(_)), Some(TypeConstructor.Relation(_))) =>
+          List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Latticenal, Denotation.Relational, t1.loc, t2.loc, prov.loc))
+
+        // Neither an arity nor a denotation mismatch: report it as the equality it would otherwise have been.
+        case _ =>
+          mkTypeError(TypeConstraint.Equality(tpe1, tpe2, prov), subst, renv, root)
+      }
 
     case TypeConstraint.EffConflicted(err) => List(err)
 
@@ -290,47 +282,6 @@ object ConstraintSolverInterface {
       case _ =>
         TypeError.MismatchedTypes(baseType1, baseType2, fullType1, fullType2, renv, loc)
     }
-  }
-
-  /**
-    * Attempts to find the predicate in the schema types `fullType1` and `fullType2` whose
-    * payload types are `baseType1` and `baseType2`, respectively.
-    *
-    * The predicate is identified by comparing type constructors, so `baseType1` and `baseType2`
-    * must have different type constructors (e.g. relations of different arity).
-    *
-    * Returns `None` unless the predicate can be uniquely identified.
-    */
-  private def findMismatchedPred(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type): Option[Name.Pred] = {
-    val preds1 = getPredicates(fullType1)
-    val preds2 = getPredicates(fullType2)
-
-    // The set of predicates whose payloads match `baseType1` in `fullType1` and `baseType2` in `fullType2`.
-    val candidates = mutable.Set.empty[Name.Pred]
-    for ((pred1, payload1) <- preds1) {
-      if (payload1.typeConstructor == baseType1.typeConstructor) {
-        for ((pred2, payload2) <- preds2) {
-          if (pred1 == pred2 && payload2.typeConstructor == baseType2.typeConstructor) {
-            candidates += pred1
-          }
-        }
-      }
-    }
-
-    // The predicate is only identified if there is exactly one candidate.
-    if (candidates.size == 1) Some(candidates.head) else None
-  }
-
-  /**
-    * Returns the predicates of the schema or schema row type `tpe` paired with their payload types.
-    *
-    * Returns the empty list if `tpe` is not a schema or schema row type.
-    */
-  private def getPredicates(tpe: Type): List[(Name.Pred, Type)] = tpe match {
-    case Type.Apply(Type.Cst(TypeConstructor.Schema, _), row, _) => getPredicates(row)
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(pred), _), payload, _), rest, _) =>
-      (pred, payload) :: getPredicates(rest)
-    case _ => Nil
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
@@ -144,6 +144,7 @@ object Debug {
       val edges = nested.map { child => s"${constraintId(constr)} -> ${constraintId(child)};" }
       (header :: children ::: edges).mkString("\n")
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => s"""${constraintId(constr)} [label = "$tpe1 ≁ $tpe2"];"""
+    case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, _) => s"""${constraintId(constr)} [label = "$pred: $tpe1 ≁ $tpe2"];"""
     case TypeConstraint.EffConflicted(effErr) => format(effErr.toString)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
@@ -58,7 +58,7 @@ object SchemaConstraintSolver {
     // ( ℓ : τ₁  | ρ₁ ) ~ ( ℓ : τ₂  | ρ₂ )  =>  { τ₁ ~ τ₂, ρ₁ ~ ρ₂ }
     case (Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label1), _), t1, _), rest1, _), Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label2), _), t2, _), rest2, _)) if label1 == label2 =>
       progress.markProgress()
-      (List(TypeConstraint.Equality(t1, t2, prov), TypeConstraint.Equality(rest1, rest2, prov)), Substitution.empty)
+      (List(mkEqualityOrConflict(label1, t1, t2, prov), TypeConstraint.Equality(rest1, rest2, prov)), Substitution.empty)
 
     // If labels do not match, then we pivot the right row to make them match.
     //
@@ -69,7 +69,7 @@ object SchemaConstraintSolver {
       pivot(r2, label, t1, r1.typeVars.map(_.sym))(scope, renv, flix) match {
         case Some((Type.Apply(Type.Apply(_, t3, _), rest3, _), subst)) =>
           progress.markProgress()
-          (List(TypeConstraint.Equality(t1, t3, prov), TypeConstraint.Equality(rest1, rest3, prov)), subst)
+          (List(mkEqualityOrConflict(label, t1, t3, prov), TypeConstraint.Equality(rest1, rest3, prov)), subst)
 
         case None =>
           (List(TypeConstraint.Equality(tpe1, tpe2, prov)), Substitution.empty)
@@ -80,6 +80,20 @@ object SchemaConstraintSolver {
     // If nothing matches, we give up and return the constraints as we got them.
     case _ => (List(TypeConstraint.Equality(tpe1, tpe2, prov)), Substitution.empty)
   }
+
+  /**
+    * Returns the constraint relating the types `tpe1` and `tpe2` of the predicate `pred`.
+    *
+    * If both types have known but different type constructors (e.g. `Relation(2)` and `Relation(3)`,
+    * or `Relation(2)` and `Lattice(2)`) then they can never be unified. In that case we return a
+    * [[TypeConstraint.SchemaConflicted]] which records the predicate, so that a precise error can be
+    * reported later. Otherwise we return an ordinary equality constraint.
+    */
+  private def mkEqualityOrConflict(pred: Name.Pred, tpe1: Type, tpe2: Type, prov: Provenance): TypeConstraint =
+    (tpe1.typeConstructor, tpe2.typeConstructor) match {
+      case (Some(tc1), Some(tc2)) if tc1 != tc2 => TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov)
+      case _ => TypeConstraint.Equality(tpe1, tpe2, prov)
+    }
 
   /**
     * Rearranges the row so that the given label is at the front.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
@@ -85,6 +85,16 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
         else
           TypeConstraint.Conflicted(t1, t2, prov)
 
+      case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov) =>
+        // Check whether the substitution has to be applied.
+        val t1 = if (tpe1.typeVars.isEmpty) tpe1 else root(tpe1)
+        val t2 = if (tpe2.typeVars.isEmpty) tpe2 else root(tpe2)
+        // Performance: Reuse this, if possible.
+        if ((t1 eq tpe1) && (t2 eq tpe2))
+          constr
+        else
+          TypeConstraint.SchemaConflicted(pred, t1, t2, prov)
+
       case TypeConstraint.EffConflicted(_) => constr
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.language.phase.typer
 
-import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type}
 import ca.uwaterloo.flix.language.errors.TypeError
 
 
@@ -32,6 +32,7 @@ sealed trait TypeConstraint {
     case TypeConstraint.Trait(_, tpe, _) => tpe.size
     case TypeConstraint.Purification(_, eff1, eff2, _, nested) => eff1.size + eff2.size + nested.map(_.size).sum
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => tpe1.size + tpe2.size
+    case TypeConstraint.SchemaConflicted(_, tpe1, tpe2, _) => tpe1.size + tpe2.size
     case TypeConstraint.EffConflicted(_) => 0
   }
 
@@ -40,6 +41,7 @@ sealed trait TypeConstraint {
     case TypeConstraint.Trait(sym, tpe, _) => s"$sym[$tpe]"
     case TypeConstraint.Purification(sym, eff1, eff2, _, nested) => s"$eff1 ~ ($eff2)[$sym ↦ Pure] ∧ $nested"
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => s"$tpe1 ≁ $tpe2"
+    case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, _) => s"$pred: $tpe1 ≁ $tpe2"
     case TypeConstraint.EffConflicted(err) => err.toString
   }
 
@@ -98,6 +100,14 @@ object TypeConstraint {
     * A type constraint indicating that `tpe1` and `tpe2` cannot be unified.
     */
   case class Conflicted(tpe1: Type, tpe2: Type, prov: Provenance) extends TypeConstraint {
+    def loc: SourceLocation = prov.loc
+  }
+
+  /**
+    * A type constraint indicating that the types `tpe1` and `tpe2` of the predicate `pred` cannot
+    * be unified because their type constructors differ (e.g. in arity or denotation).
+    */
+  case class SchemaConflicted(pred: Name.Pred, tpe1: Type, tpe2: Type, prov: Provenance) extends TypeConstraint {
     def loc: SourceLocation = prov.loc
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
@@ -161,13 +161,14 @@ object Profiler {
   private def countVars(cs: List[TypeConstraint]): (Long, Long) = {
     val vars = scala.collection.mutable.HashSet.empty[Type.Var]
     def collect(c: TypeConstraint): Unit = c match {
-      case TypeConstraint.Equality(t1, t2, _)         => vars ++= t1.typeVars; vars ++= t2.typeVars
-      case TypeConstraint.Trait(_, t, _)              => vars ++= t.typeVars
-      case TypeConstraint.Conflicted(t1, t2, _)       => vars ++= t1.typeVars; vars ++= t2.typeVars
+      case TypeConstraint.Equality(t1, t2, _)            => vars ++= t1.typeVars; vars ++= t2.typeVars
+      case TypeConstraint.Trait(_, t, _)                 => vars ++= t.typeVars
+      case TypeConstraint.Conflicted(t1, t2, _)          => vars ++= t1.typeVars; vars ++= t2.typeVars
+      case TypeConstraint.SchemaConflicted(_, t1, t2, _) => vars ++= t1.typeVars; vars ++= t2.typeVars
       case TypeConstraint.Purification(_, e1, e2, _, nested) =>
         vars ++= e1.typeVars; vars ++= e2.typeVars
         nested.foreach(collect)
-      case TypeConstraint.EffConflicted(_)            => ()
+      case TypeConstraint.EffConflicted(_)               => ()
     }
     cs.foreach(collect)
     var tv = 0L

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -2759,7 +2759,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    }
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedTypes](result)
+    expectError[TypeError.MismatchedPredicateArity](result)
   }
 
   test("TypeError.ExtMatch.05") {
@@ -2774,7 +2774,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    }
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedTypes](result)
+    expectError[TypeError.MismatchedPredicateArity](result)
   }
 
   test("TypeError.ExtMatch.06") {
@@ -2921,6 +2921,79 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.MismatchedPredicateArity](result)
   }
 
+  test("TypeError.MismatchedPredicateArity.06") {
+    // Two predicates with the same arity mismatch.
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Foo(1). Bar(1). };
+        |    let p2 = #{ Foo(1, 2). Bar(1, 2). };
+        |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateArity](result)
+  }
+
+  test("TypeError.MismatchedPredicateArity.07") {
+    // The schemas are nested inside another type.
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = (#{ Foo(1). }, 1);
+        |    let p2 = (#{ Foo(1, 2). }, 2);
+        |    let _ = if (true) p1 else p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateArity](result)
+  }
+
+  test("TypeError.MismatchedPredicateArity.08") {
+    // The schemas are nested inside function types.
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let f1 = () -> #{ Foo(1). };
+        |    let f2 = () -> #{ Foo(1, 2). };
+        |    let _ = if (true) f1 else f2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateArity](result)
+  }
+
+  test("TypeError.MismatchedPredicateArity.09") {
+    // The schema is passed as an argument.
+    val input =
+      """
+        |def f(_p: #{ Foo(Int32) }): Unit = ()
+        |
+        |def main(): Unit \ IO =
+        |    let _ = f(#{ Foo(1, 2). });
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateArity](result)
+  }
+
+  test("TypeError.MismatchedPredicateArity.10") {
+    // The schema is checked against a type ascription.
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let _p: #{ Foo(Int32) } = #{ Foo(1, 2). };
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateArity](result)
+  }
+
   test("TypeError.MismatchedPredicateDenotation.01") {
     val input =
       """
@@ -2958,6 +3031,36 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    let p1 = #{ Foo(1, 2). };
         |    let p2 = #{ Foo(1; 2). };
         |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibAll)
+    expectError[TypeError.MismatchedPredicateDenotation](result)
+  }
+
+  test("TypeError.MismatchedPredicateDenotation.04") {
+    // Two predicates with the same denotation mismatch.
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Foo(1, 2). Bar(1, 2). };
+        |    let p2 = #{ Foo(1; 2). Bar(1; 2). };
+        |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibAll)
+    expectError[TypeError.MismatchedPredicateDenotation](result)
+  }
+
+  test("TypeError.MismatchedPredicateDenotation.05") {
+    // The schema is passed as an argument.
+    val input =
+      """
+        |def f(_p: #{ Foo(Int32, Int32) }): Unit = ()
+        |
+        |def main(): Unit \ IO =
+        |    let _ = f(#{ Foo(1; 2). });
         |    println("Hello World!")
         |
         |""".stripMargin


### PR DESCRIPTION
## Problem

#13161 reports `MismatchedPredicateArity` / `MismatchedPredicateDenotation` by reverse-engineering the predicate name after the fact: `findMismatchedPred` searches the provenance's full types for a predicate whose payload constructors match the failing constraint. That only works when the full types are bare schemas and the match is unique, so these all still fell back to the generic error:

- two predicates with the same mismatch (`#{ Foo(1). Bar(1). } <+> #{ Foo(1, 2). Bar(1, 2). }`) — ambiguous, reported as `Unable to unify 'Relation(Int32)' and 'Relation(Int32, Int32)'` with no predicate name;
- schemas nested inside another type (a tuple, an `Option`, a function type);
- schemas checked under `ExpectType` / `ExpectArgument` provenance (a type ascription or a function argument), which never entered the predicate-specific path at all.

## Approach

The predicate name is known at exactly one point: in `SchemaConstraintSolver.solve`, when two rows are paired on the same label. This PR records it there instead of recovering it later.

- New `TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov)`, a `Conflicted` that also carries the predicate.
- `SchemaConstraintSolver` emits it (via `mkEqualityOrConflict`) when both payloads have known but different head constructors — the exact negation of `constructorsMayUnify`, i.e. only for an equality that `(appU)` would have refused to decompose anyway. Solvability and substitutions are unchanged; a dead constraint is just labelled earlier. Otherwise an ordinary `Equality` is emitted as before.
- `ConstraintSolverInterface` builds the arity/denotation error from the constraint; anything else falls back to reporting the underlying `Equality`, so non-arity mismatches keep their existing messages.
- Mirror-of-`Conflicted` arms in `simplify`, `contextReduction`, `SubstitutionTree.apply`, `Debug.toSubDot`, `Profiler.countVars`, and `TypeConstraint.size`/`toString`.
- `findMismatchedPred` and `getPredicates` are removed; the `Match` arm returns to its pre-#13161 shape.

## Note on extensible variants

Extensible variants are encoded as `Extensible[schemaRow]` with the same `SchemaRowExtend(pred)` labels and `Relation(n)` payloads, so an `ematch` case whose arity disagrees with the scrutinee (`TypeError.ExtMatch.04`/`.05`) now reports `Mismatched predicate arity: 'X/6' and 'X/7'` — pointing at the `xvar X(…)` and the `case X(…)` — rather than the generic `MismatchedTypes`. The diagnosis and locations are right; only the noun "predicate" is imprecise for a variant case. The row solver cannot distinguish the two owners, so those two tests were updated to expect the more specific error. Neutralising the wording (or adding a dedicated error) can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEVAXuEu1PxxYdH9BM4che
