### PR TITLE
fix: report record label type mismatches via a RecordConflicted constraint

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -237,6 +237,7 @@ object ErrorCode {
   case object E7407 extends ErrorCode
   case object E7420 extends ErrorCode
   case object E7463 extends ErrorCode
+  case object E7491 extends ErrorCode
   case object E7512 extends ErrorCode
   case object E7574 extends ErrorCode
   case object E7623 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -514,6 +514,33 @@ object TypeError {
   }
 
   /**
+    * Mismatched Label Type.
+    *
+    * @param label the record label.
+    * @param tpe1  the first type of the label.
+    * @param tpe2  the second type of the label.
+    * @param renv  the rigidity environment.
+    * @param loc1  the location where the label has the first type.
+    * @param loc2  the location where the label has the second type.
+    * @param loc   the location where the unification error occurred.
+    */
+  case class MismatchedLabelType(label: Name.Label, tpe1: Type, tpe2: Type, renv: RigidityEnv, loc1: SourceLocation, loc2: SourceLocation, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+    def code: ErrorCode = ErrorCode.E7491
+
+    def summary: String = s"Mismatched types for label '${label.name}': '${formatType(tpe1, Some(renv))}' and '${formatType(tpe2, Some(renv))}'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Mismatched types for label '${cyan(label.name)}': '${red(formatType(tpe1, Some(renv)))}' and '${red(formatType(tpe2, Some(renv)))}'.
+         |
+         |${highlight(loc1, s"here '${label.name}' has type '${formatType(tpe1, Some(renv))}'.", fmt)}
+         |
+         |${highlight(loc2, s"here '${label.name}' has type '${formatType(tpe2, Some(renv))}'.", fmt)}
+         |""".stripMargin
+    }
+  }
+
+  /**
     * Mismatched Predicate Arity.
     *
     * @param pred   the predicate label.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -290,6 +290,20 @@ object ConstraintSolver2 {
           TypeConstraint.Conflicted(r1, r2, prov) :: cs1 ::: cs2
       }
 
+    case TypeConstraint.RecordConflicted(label, tpe1, tpe2, loc1, loc2, prov) =>
+      if (isEliminable(tpe1) || isEliminable(tpe2)) {
+        Nil
+      } else {
+        // (redU)
+        val (r1, cs1) = reduce(tpe1)(scope, renv, progress, eqenv, flix)
+        val (r2, cs2) = reduce(tpe2)(scope, renv, progress, eqenv, flix)
+        // Performance: Reuse this, if possible.
+        if ((r1 eq tpe1) && (r2 eq tpe2) && cs1.isEmpty && cs2.isEmpty)
+          constr :: Nil
+        else
+          TypeConstraint.RecordConflicted(label, r1, r2, loc1, loc2, prov) :: cs1 ::: cs2
+      }
+
     case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov) =>
       if (isEliminable(tpe1) || isEliminable(tpe2)) {
         Nil
@@ -404,6 +418,7 @@ object ConstraintSolver2 {
     // Case 1: Non-trait constraint. Do nothing.
     case c: TypeConstraint.Equality => List(c)
     case c: TypeConstraint.Conflicted => List(c)
+    case c: TypeConstraint.RecordConflicted => List(c)
     case c: TypeConstraint.SchemaConflicted => List(c)
     case c: TypeConstraint.EffConflicted => List(c)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -231,6 +231,9 @@ object ConstraintSolverInterface {
     case TypeConstraint.Conflicted(tpe1, tpe2, prov) =>
       List(mkMismatchedTypesOrEffects(subst(tpe1), subst(tpe2), subst(tpe1), subst(tpe2), renv, prov.loc))
 
+    case TypeConstraint.RecordConflicted(label, tpe1, tpe2, loc1, loc2, prov) =>
+      List(TypeError.MismatchedLabelType(label, subst(tpe1), subst(tpe2), renv, loc1, loc2, prov.loc))
+
     case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov) =>
       val t1 = subst(tpe1)
       val t2 = subst(tpe2)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
@@ -144,6 +144,7 @@ object Debug {
       val edges = nested.map { child => s"${constraintId(constr)} -> ${constraintId(child)};" }
       (header :: children ::: edges).mkString("\n")
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => s"""${constraintId(constr)} [label = "$tpe1 ≁ $tpe2"];"""
+    case TypeConstraint.RecordConflicted(label, tpe1, tpe2, _, _, _) => s"""${constraintId(constr)} [label = "$label: $tpe1 ≁ $tpe2"];"""
     case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, _) => s"""${constraintId(constr)} [label = "$pred: $tpe1 ≁ $tpe2"];"""
     case TypeConstraint.EffConflicted(effErr) => format(effErr.toString)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/RecordConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/RecordConstraintSolver.scala
@@ -55,7 +55,7 @@ object RecordConstraintSolver {
     // ( ℓ : τ₁  | ρ₁ ) ~ ( ℓ : τ₂  | ρ₂ )  =>  { τ₁ ~ τ₂, ρ₁ ~ ρ₂ }
     case (Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(label1), _), t1, _), rest1, _), Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(label2), _), t2, _), rest2, _)) if label1 == label2 =>
       progress.markProgress()
-      (List(TypeConstraint.Equality(t1, t2, prov), TypeConstraint.Equality(rest1, rest2, prov)), Substitution.empty)
+      (List(mkEqualityOrConflict(label1, label2, t1, t2, prov), TypeConstraint.Equality(rest1, rest2, prov)), Substitution.empty)
 
     // If labels do not match, then we pivot the right row to make them match.
     //
@@ -64,9 +64,9 @@ object RecordConstraintSolver {
     // { ℓ : τ₁ | ρ₁ } ~ ρ₂  => { τ₁ ~ τ₃, ρ₁ ~ ρ₃ } ; S
     case (r1@Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(label), _), t1, _), rest1, _), r2) =>
       pivot(r2, label, t1, r1.typeVars.map(_.sym))(scope, renv, flix) match {
-        case Some((Type.Apply(Type.Apply(_, t3, _), rest3, _), subst)) =>
+        case Some((Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(label3), _), t3, _), rest3, _), subst)) =>
           progress.markProgress()
-          (List(TypeConstraint.Equality(t1, t3, prov), TypeConstraint.Equality(rest1, rest3, prov)), subst)
+          (List(mkEqualityOrConflict(label, label3, t1, t3, prov), TypeConstraint.Equality(rest1, rest3, prov)), subst)
 
         case None =>
           (List(TypeConstraint.Equality(tpe1, tpe2, prov)), Substitution.empty)
@@ -77,6 +77,22 @@ object RecordConstraintSolver {
     // If nothing matches, we give up and return the constraints as we got them.
     case _ => (List(TypeConstraint.Equality(tpe1, tpe2, prov)), Substitution.empty)
   }
+
+  /**
+    * Returns the constraint relating the types `tpe1` and `tpe2` of the record label `label1` (= `label2`).
+    *
+    * The two labels are the two occurrences of the same label, one from each row.
+    *
+    * If both types have known but different type constructors (e.g. `Int32` and `String`) then
+    * they can never be unified. In that case we return a [[TypeConstraint.RecordConflicted]] which
+    * records the label and the location of each occurrence, so that a precise error can be reported
+    * later. Otherwise we return an ordinary equality constraint.
+    */
+  private def mkEqualityOrConflict(label1: Name.Label, label2: Name.Label, tpe1: Type, tpe2: Type, prov: Provenance): TypeConstraint =
+    (tpe1.typeConstructor, tpe2.typeConstructor) match {
+      case (Some(tc1), Some(tc2)) if tc1 != tc2 => TypeConstraint.RecordConflicted(label1, tpe1, tpe2, label1.loc, label2.loc, prov)
+      case _ => TypeConstraint.Equality(tpe1, tpe2, prov)
+    }
 
   /**
     * Rearranges the row so that the given label is at the front.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
@@ -85,6 +85,16 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
         else
           TypeConstraint.Conflicted(t1, t2, prov)
 
+      case TypeConstraint.RecordConflicted(label, tpe1, tpe2, loc1, loc2, prov) =>
+        // Check whether the substitution has to be applied.
+        val t1 = if (tpe1.typeVars.isEmpty) tpe1 else root(tpe1)
+        val t2 = if (tpe2.typeVars.isEmpty) tpe2 else root(tpe2)
+        // Performance: Reuse this, if possible.
+        if ((t1 eq tpe1) && (t2 eq tpe2))
+          constr
+        else
+          TypeConstraint.RecordConflicted(label, t1, t2, loc1, loc2, prov)
+
       case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov) =>
         // Check whether the substitution has to be applied.
         val t1 = if (tpe1.typeVars.isEmpty) tpe1 else root(tpe1)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
@@ -32,6 +32,7 @@ sealed trait TypeConstraint {
     case TypeConstraint.Trait(_, tpe, _) => tpe.size
     case TypeConstraint.Purification(_, eff1, eff2, _, nested) => eff1.size + eff2.size + nested.map(_.size).sum
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => tpe1.size + tpe2.size
+    case TypeConstraint.RecordConflicted(_, tpe1, tpe2, _, _, _) => tpe1.size + tpe2.size
     case TypeConstraint.SchemaConflicted(_, tpe1, tpe2, _) => tpe1.size + tpe2.size
     case TypeConstraint.EffConflicted(_) => 0
   }
@@ -41,6 +42,7 @@ sealed trait TypeConstraint {
     case TypeConstraint.Trait(sym, tpe, _) => s"$sym[$tpe]"
     case TypeConstraint.Purification(sym, eff1, eff2, _, nested) => s"$eff1 ~ ($eff2)[$sym ↦ Pure] ∧ $nested"
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => s"$tpe1 ≁ $tpe2"
+    case TypeConstraint.RecordConflicted(label, tpe1, tpe2, _, _, _) => s"$label: $tpe1 ≁ $tpe2"
     case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, _) => s"$pred: $tpe1 ≁ $tpe2"
     case TypeConstraint.EffConflicted(err) => err.toString
   }
@@ -100,6 +102,17 @@ object TypeConstraint {
     * A type constraint indicating that `tpe1` and `tpe2` cannot be unified.
     */
   case class Conflicted(tpe1: Type, tpe2: Type, prov: Provenance) extends TypeConstraint {
+    def loc: SourceLocation = prov.loc
+  }
+
+  /**
+    * A type constraint indicating that the types `tpe1` and `tpe2` of the record label `label`
+    * cannot be unified because their type constructors differ.
+    *
+    * `loc1` and `loc2` are the locations of the two occurrences of the label. (The locations of
+    * `tpe1` and `tpe2` are unreliable, since inferred types are often shared constants.)
+    */
+  case class RecordConflicted(label: Name.Label, tpe1: Type, tpe2: Type, loc1: SourceLocation, loc2: SourceLocation, prov: Provenance) extends TypeConstraint {
     def loc: SourceLocation = prov.loc
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
@@ -161,14 +161,15 @@ object Profiler {
   private def countVars(cs: List[TypeConstraint]): (Long, Long) = {
     val vars = scala.collection.mutable.HashSet.empty[Type.Var]
     def collect(c: TypeConstraint): Unit = c match {
-      case TypeConstraint.Equality(t1, t2, _)            => vars ++= t1.typeVars; vars ++= t2.typeVars
-      case TypeConstraint.Trait(_, t, _)                 => vars ++= t.typeVars
-      case TypeConstraint.Conflicted(t1, t2, _)          => vars ++= t1.typeVars; vars ++= t2.typeVars
-      case TypeConstraint.SchemaConflicted(_, t1, t2, _) => vars ++= t1.typeVars; vars ++= t2.typeVars
+      case TypeConstraint.Equality(t1, t2, _)                  => vars ++= t1.typeVars; vars ++= t2.typeVars
+      case TypeConstraint.Trait(_, t, _)                       => vars ++= t.typeVars
+      case TypeConstraint.Conflicted(t1, t2, _)                => vars ++= t1.typeVars; vars ++= t2.typeVars
+      case TypeConstraint.RecordConflicted(_, t1, t2, _, _, _) => vars ++= t1.typeVars; vars ++= t2.typeVars
+      case TypeConstraint.SchemaConflicted(_, t1, t2, _)       => vars ++= t1.typeVars; vars ++= t2.typeVars
       case TypeConstraint.Purification(_, e1, e2, _, nested) =>
         vars ++= e1.typeVars; vars ++= e2.typeVars
         nested.foreach(collect)
-      case TypeConstraint.EffConflicted(_)               => ()
+      case TypeConstraint.EffConflicted(_)                     => ()
     }
     cs.foreach(collect)
     var tv = 0L

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -2694,6 +2694,122 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.ExtraLabel](result)
   }
 
+  test("TypeError.MismatchedLabelType.01") {
+    val input =
+      """
+        |def f(): Unit \ IO =
+        |    let r1 = { x = 1 };
+        |    let r2 = { x = "a" };
+        |    let _ = if (true) r1 else r2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.02") {
+    // Two labels with mismatched types.
+    val input =
+      """
+        |def f(): Unit \ IO =
+        |    let r1 = { x = 1, y = 1 };
+        |    let r2 = { x = "a", y = "b" };
+        |    let _ = if (true) r1 else r2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.03") {
+    // The record is passed as an argument.
+    val input =
+      """
+        |def f(_r: { x = Int32 }): Unit = ()
+        |
+        |def g(): Unit \ IO =
+        |    let _ = f({ x = "a" });
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.04") {
+    // The record is passed as an argument to a function with an open record parameter.
+    val input =
+      """
+        |def f(_r: { x = Int32 | r }): Unit = ()
+        |
+        |def g(): Unit \ IO =
+        |    let _ = f({ x = "a", z = true });
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.05") {
+    // The record is checked against a type ascription.
+    val input =
+      """
+        |def f(): Unit \ IO =
+        |    let _r: { x = Int32 } = { x = "a" };
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.06") {
+    // The records are nested inside another type.
+    val input =
+      """
+        |def f(): Unit \ IO =
+        |    let r1 = ({ x = 1 }, 1);
+        |    let r2 = ({ x = "a" }, 2);
+        |    let _ = if (true) r1 else r2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.07") {
+    // The label is selected with the wrong type.
+    val input =
+      """
+        |def f(): Unit \ IO =
+        |    let r = { x = "a" };
+        |    let _: Int32 = r#x;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.08") {
+    // The mismatched label is inside a nested record.
+    val input =
+      """
+        |def f(): Unit \ IO =
+        |    let r1 = { x = { y = 1 } };
+        |    let r2 = { x = { y = "a" } };
+        |    let _ = if (true) r1 else r2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
   test("ExtMatchError#11283") {
     val input =
       """


### PR DESCRIPTION
## Problem

Records have errors for a label that is missing or extra (`UndefinedLabel`, `ExtraLabel`), but nothing for a label that is present on both sides with a different type. Every such mismatch reports generically, without naming the label:

- `if (true) { x = 1 } else { x = "a" }` → `Unable to unify 'Int32' and 'String'`, with the whole records as Type One/Two;
- two mismatched labels → two *identical* generic errors, with no way to tell which label is which;
- `f({ x = "a" })` against `f(_r: { x = Int32 })` → `Unexpected argument: expected '{ x = Int32 }', got '{ x = String }'`;
- records nested inside another type → generic, no label.

This is the record counterpart of #13167.

## Approach

The label is known at exactly one point: in `RecordConstraintSolver.solve`, when two rows are paired on the same label. This PR records it there.

- New `TypeConstraint.RecordConflicted(label, tpe1, tpe2, loc1, loc2, prov)`, a `Conflicted` that also carries the label and the location of each of its two occurrences.
- `RecordConstraintSolver` emits it (via `mkEqualityOrConflict`) when both label types have known but different head constructors — the negation of `constructorsMayUnify`, i.e. only for an equality that `(appU)` would have refused to decompose anyway. Solvability and substitutions are unchanged; a dead constraint is just labelled earlier.
- New `TypeError.MismatchedLabelType`, built from the constraint in `ConstraintSolverInterface`.
- Mirror-of-`Conflicted` arms in `simplify`, `contextReduction`, `SubstitutionTree.apply`, `Debug.toSubDot`, `Profiler.countVars`, and `TypeConstraint.size`/`toString`, each placed before the `SchemaConflicted` arm.

### Why the constraint carries locations

Unlike a predicate payload, which is built fresh per atom by `Type.mkRelation(tpes, loc)`, a record label's type is the type of an arbitrary expression — for `{ x = 1 }` it is the shared `Type.Int32` constant with an `Unknown` location. Using `tpe1.loc`/`tpe2.loc` (as `SchemaConflicted` does) therefore renders nothing useful for inferred types. The reliable per-side location is the label occurrence: `RecordRowExtend(label)` carries a `Name.Label` whose `loc` is the `x` token on that side (and whose equality ignores it), and the pairing arm binds one from each row. The error points at both:

```
>> Mismatched types for label 'x': 'Int32' and 'String'.

1 | def takesRec(_r: { x = Int32 }): Unit = ()
                       here 'x' has type 'Int32'.

17 |     let _ = takesRec({ x = "a" });
                            here 'x' has type 'String'.
```

## Scope

Every `MismatchedTypes`/`UnexpectedType`/`UnexpectedArg` that originated from a record label with a different head constructor now reports as `MismatchedLabelType`. Effect-only differences (`{ f = Unit -> Unit \ IO }` vs `{ f = Unit -> Unit }`) and mismatches *inside* a label (`{ x = (1, 1) }` vs `{ x = (1, "a") }`) share the `Arrow`/`Tuple` head, decompose as before, and are unaffected. Missing/extra labels under `Match` provenance (`if (true) { x = 1 } else { y = 1 }`) still report generically; that is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEVAXuEu1PxxYdH9BM4che
