### PR TITLE
fix: record labels and predicates in provenance to report nested mismatches

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -219,6 +219,7 @@ object ErrorCode {
   case object E6572 extends ErrorCode
   case object E6629 extends ErrorCode
   case object E6683 extends ErrorCode
+  case object E6710 extends ErrorCode
   case object E6736 extends ErrorCode
   case object E6794 extends ErrorCode
   case object E6805 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -516,15 +516,17 @@ object TypeError {
   /**
     * Mismatched Label Type.
     *
-    * @param label the record label.
-    * @param tpe1  the first type of the label.
-    * @param tpe2  the second type of the label.
-    * @param renv  the rigidity environment.
-    * @param loc1  the location where the label has the first type.
-    * @param loc2  the location where the label has the second type.
-    * @param loc   the location where the unification error occurred.
+    * @param label     the record label.
+    * @param tpe1      the first type (the part of the label's type that could not be unified).
+    * @param tpe2      the second type (the part of the label's type that could not be unified).
+    * @param fullType1 the first enclosing type.
+    * @param fullType2 the second enclosing type.
+    * @param renv      the rigidity environment.
+    * @param loc1      the location of the first occurrence of the label.
+    * @param loc2      the location of the second occurrence of the label.
+    * @param loc       the location where the unification error occurred.
     */
-  case class MismatchedLabelType(label: Name.Label, tpe1: Type, tpe2: Type, renv: RigidityEnv, loc1: SourceLocation, loc2: SourceLocation, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+  case class MismatchedLabelType(label: Name.Label, tpe1: Type, tpe2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc1: SourceLocation, loc2: SourceLocation, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
     def code: ErrorCode = ErrorCode.E7491
 
     def summary: String = s"Mismatched types for label '${label.name}': '${formatType(tpe1, Some(renv))}' and '${formatType(tpe2, Some(renv))}'."
@@ -533,9 +535,12 @@ object TypeError {
       import fmt.*
       s""">> Mismatched types for label '${cyan(label.name)}': '${red(formatType(tpe1, Some(renv)))}' and '${red(formatType(tpe2, Some(renv)))}'.
          |
-         |${highlight(loc1, s"here '${label.name}' has type '${formatType(tpe1, Some(renv))}'.", fmt)}
+         |${highlight(loc1, s"'${formatType(tpe1, Some(renv))}' comes from here.", fmt)}
          |
-         |${highlight(loc2, s"here '${label.name}' has type '${formatType(tpe2, Some(renv))}'.", fmt)}
+         |${highlight(loc2, s"'${formatType(tpe2, Some(renv))}' comes from here.", fmt)}
+         |
+         |Type One: ${cyan(formatType(fullType1, Some(renv)))}
+         |Type Two: ${magenta(formatType(fullType2, Some(renv)))}
          |""".stripMargin
     }
   }
@@ -592,6 +597,38 @@ object TypeError {
          |${highlight(loc1, s"here '${pred.name}' is a ${magenta(pretty(den1))}.", fmt)}
          |
          |${highlight(loc2, s"here '${pred.name}' is a ${magenta(pretty(den2))}.", fmt)}
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * Mismatched Predicate Types.
+    *
+    * @param pred      the predicate label.
+    * @param tpe1      the first type (the part of the predicate's type that could not be unified).
+    * @param tpe2      the second type (the part of the predicate's type that could not be unified).
+    * @param fullType1 the first enclosing type.
+    * @param fullType2 the second enclosing type.
+    * @param renv      the rigidity environment.
+    * @param loc1      the location of the first occurrence of the predicate.
+    * @param loc2      the location of the second occurrence of the predicate.
+    * @param loc       the location where the unification error occurred.
+    */
+  case class MismatchedPredicateTypes(pred: Name.Pred, tpe1: Type, tpe2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc1: SourceLocation, loc2: SourceLocation, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+    def code: ErrorCode = ErrorCode.E6710
+
+    def summary: String = s"Mismatched types for predicate '${pred.name}': '${formatType(tpe1, Some(renv))}' and '${formatType(tpe2, Some(renv))}'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Mismatched types for predicate '${cyan(pred.name)}': '${red(formatType(tpe1, Some(renv)))}' and '${red(formatType(tpe2, Some(renv)))}'.
+         |
+         |${highlight(loc1, s"'${formatType(tpe1, Some(renv))}' comes from here.", fmt)}
+         |
+         |${highlight(loc2, s"'${formatType(tpe2, Some(renv))}' comes from here.", fmt)}
+         |
+         |Type One: ${cyan(formatType(fullType1, Some(renv)))}
+         |Type Two: ${magenta(formatType(fullType2, Some(renv)))}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -290,34 +290,6 @@ object ConstraintSolver2 {
           TypeConstraint.Conflicted(r1, r2, prov) :: cs1 ::: cs2
       }
 
-    case TypeConstraint.RecordConflicted(label, tpe1, tpe2, loc1, loc2, prov) =>
-      if (isEliminable(tpe1) || isEliminable(tpe2)) {
-        Nil
-      } else {
-        // (redU)
-        val (r1, cs1) = reduce(tpe1)(scope, renv, progress, eqenv, flix)
-        val (r2, cs2) = reduce(tpe2)(scope, renv, progress, eqenv, flix)
-        // Performance: Reuse this, if possible.
-        if ((r1 eq tpe1) && (r2 eq tpe2) && cs1.isEmpty && cs2.isEmpty)
-          constr :: Nil
-        else
-          TypeConstraint.RecordConflicted(label, r1, r2, loc1, loc2, prov) :: cs1 ::: cs2
-      }
-
-    case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov) =>
-      if (isEliminable(tpe1) || isEliminable(tpe2)) {
-        Nil
-      } else {
-        // (redU)
-        val (r1, cs1) = reduce(tpe1)(scope, renv, progress, eqenv, flix)
-        val (r2, cs2) = reduce(tpe2)(scope, renv, progress, eqenv, flix)
-        // Performance: Reuse this, if possible.
-        if ((r1 eq tpe1) && (r2 eq tpe2) && cs1.isEmpty && cs2.isEmpty)
-          constr :: Nil
-        else
-          TypeConstraint.SchemaConflicted(pred, r1, r2, prov) :: cs1 ::: cs2
-      }
-
     case TypeConstraint.EffConflicted(_) => constr :: Nil
   }
 
@@ -418,8 +390,6 @@ object ConstraintSolver2 {
     // Case 1: Non-trait constraint. Do nothing.
     case c: TypeConstraint.Equality => List(c)
     case c: TypeConstraint.Conflicted => List(c)
-    case c: TypeConstraint.RecordConflicted => List(c)
-    case c: TypeConstraint.SchemaConflicted => List(c)
     case c: TypeConstraint.EffConflicted => List(c)
 
     case c@TypeConstraint.Purification(sym, eff1, eff2, prov, nested0) =>
@@ -736,7 +706,7 @@ object ConstraintSolver2 {
     * Returns true if the kind should be unified syntactically.
     */
   @tailrec
-  private def isSyntactic(k: Kind): Boolean = k match {
+  def isSyntactic(k: Kind): Boolean = k match {
     case Kind.Star => true
     case Kind.Predicate => true
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -205,6 +205,43 @@ object ConstraintSolverInterface {
       mkArrowAndNonArrowError(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc)
         .getOrElse(List(mkMismatchedTypesOrEffects(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc)))
 
+    case TypeConstraint.Equality(tpe1, tpe2, Provenance.Label(label, loc1, loc2, inner)) =>
+      if (ConstraintSolver2.isSyntactic(tpe1.kind)) {
+        // The leftover is (a part of) the type of the label.
+        val (fullType1, fullType2) = enclosingTypes(inner).getOrElse((tpe1, tpe2))
+        List(TypeError.MismatchedLabelType(label, subst(tpe1), subst(tpe2), subst(fullType1), subst(fullType2), renv, loc1, loc2, inner.loc))
+      } else {
+        // The leftover is an effect, a row, or the like: report it as the enclosing constraint would.
+        mkTypeError(TypeConstraint.Equality(tpe1, tpe2, inner), subst, renv, root)
+      }
+
+    case TypeConstraint.Equality(tpe1, tpe2, Provenance.Predicate(pred, loc1, loc2, inner)) =>
+      val t1 = subst(tpe1)
+      val t2 = subst(tpe2)
+      (t1.typeConstructor, t2.typeConstructor) match {
+        case (Some(TypeConstructor.Relation(arity1)), Some(TypeConstructor.Relation(arity2))) if arity1 != arity2 =>
+          List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, loc1, loc2, inner.loc))
+
+        case (Some(TypeConstructor.Lattice(arity1)), Some(TypeConstructor.Lattice(arity2))) if arity1 != arity2 =>
+          List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, loc1, loc2, inner.loc))
+
+        case (Some(TypeConstructor.Relation(_)), Some(TypeConstructor.Lattice(_))) =>
+          List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Relational, Denotation.Latticenal, loc1, loc2, inner.loc))
+
+        case (Some(TypeConstructor.Lattice(_)), Some(TypeConstructor.Relation(_))) =>
+          List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Latticenal, Denotation.Relational, loc1, loc2, inner.loc))
+
+        case _ =>
+          if (ConstraintSolver2.isSyntactic(t1.kind)) {
+            // The leftover is (a part of) a term type of the predicate.
+            val (fullType1, fullType2) = enclosingTypes(inner).getOrElse((tpe1, tpe2))
+            List(TypeError.MismatchedPredicateTypes(pred, t1, t2, subst(fullType1), subst(fullType2), renv, loc1, loc2, inner.loc))
+          } else {
+            // The leftover is an effect, a row, or the like: report it as the enclosing constraint would.
+            mkTypeError(TypeConstraint.Equality(tpe1, tpe2, inner), subst, renv, root)
+          }
+      }
+
     case TypeConstraint.Equality(tpe1, tpe2, prov) =>
       List(mkMismatchedTypesOrEffects(subst(tpe1), subst(tpe2), subst(tpe1), subst(tpe2), renv, prov.loc))
 
@@ -228,32 +265,15 @@ object ConstraintSolverInterface {
     case TypeConstraint.Conflicted(_, _, Provenance.Timeout(msg, loc)) =>
       List(TypeError.TooComplex(msg, loc))
 
+    // A conflict inside a record label or predicate is reported as the enclosing constraint would.
+    case TypeConstraint.Conflicted(tpe1, tpe2, Provenance.Label(_, _, _, inner)) =>
+      mkTypeError(TypeConstraint.Conflicted(tpe1, tpe2, inner), subst, renv, root)
+
+    case TypeConstraint.Conflicted(tpe1, tpe2, Provenance.Predicate(_, _, _, inner)) =>
+      mkTypeError(TypeConstraint.Conflicted(tpe1, tpe2, inner), subst, renv, root)
+
     case TypeConstraint.Conflicted(tpe1, tpe2, prov) =>
       List(mkMismatchedTypesOrEffects(subst(tpe1), subst(tpe2), subst(tpe1), subst(tpe2), renv, prov.loc))
-
-    case TypeConstraint.RecordConflicted(label, tpe1, tpe2, loc1, loc2, prov) =>
-      List(TypeError.MismatchedLabelType(label, subst(tpe1), subst(tpe2), renv, loc1, loc2, prov.loc))
-
-    case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov) =>
-      val t1 = subst(tpe1)
-      val t2 = subst(tpe2)
-      (t1.typeConstructor, t2.typeConstructor) match {
-        case (Some(TypeConstructor.Relation(arity1)), Some(TypeConstructor.Relation(arity2))) if arity1 != arity2 =>
-          List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, t1.loc, t2.loc, prov.loc))
-
-        case (Some(TypeConstructor.Lattice(arity1)), Some(TypeConstructor.Lattice(arity2))) if arity1 != arity2 =>
-          List(TypeError.MismatchedPredicateArity(pred, arity1, arity2, t1.loc, t2.loc, prov.loc))
-
-        case (Some(TypeConstructor.Relation(_)), Some(TypeConstructor.Lattice(_))) =>
-          List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Relational, Denotation.Latticenal, t1.loc, t2.loc, prov.loc))
-
-        case (Some(TypeConstructor.Lattice(_)), Some(TypeConstructor.Relation(_))) =>
-          List(TypeError.MismatchedPredicateDenotation(pred, Denotation.Latticenal, Denotation.Relational, t1.loc, t2.loc, prov.loc))
-
-        // Neither an arity nor a denotation mismatch: report it as the equality it would otherwise have been.
-        case _ =>
-          mkTypeError(TypeConstraint.Equality(tpe1, tpe2, prov), subst, renv, root)
-      }
 
     case TypeConstraint.EffConflicted(err) => List(err)
 
@@ -285,6 +305,25 @@ object ConstraintSolverInterface {
       case _ =>
         TypeError.MismatchedTypes(baseType1, baseType2, fullType1, fullType2, renv, loc)
     }
+  }
+
+  /**
+    * Returns the two types related by the constraint that `prov` describes, looking through any
+    * [[Provenance.Label]] and [[Provenance.Predicate]] wrappers.
+    *
+    * Returns `None` if the provenance does not relate two types.
+    */
+  @tailrec
+  private def enclosingTypes(prov: Provenance): Option[(Type, Type)] = prov match {
+    case Provenance.ExpectType(expected, actual, _) => Some((expected, actual))
+    case Provenance.ExpectEffect(expected, actual, _) => Some((expected, actual))
+    case Provenance.ExpectArgument(expected, actual, _, _, _) => Some((expected, actual))
+    case Provenance.Match(tpe1, tpe2, _) => Some((tpe1, tpe2))
+    case Provenance.Source(eff1, eff2, _) => Some((eff1, eff2))
+    case Provenance.Label(_, _, _, inner) => enclosingTypes(inner)
+    case Provenance.Predicate(_, _, _, inner) => enclosingTypes(inner)
+    case Provenance.NonUnitStatement(_, _) => None
+    case Provenance.Timeout(_, _) => None
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
@@ -144,8 +144,6 @@ object Debug {
       val edges = nested.map { child => s"${constraintId(constr)} -> ${constraintId(child)};" }
       (header :: children ::: edges).mkString("\n")
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => s"""${constraintId(constr)} [label = "$tpe1 ≁ $tpe2"];"""
-    case TypeConstraint.RecordConflicted(label, tpe1, tpe2, _, _, _) => s"""${constraintId(constr)} [label = "$label: $tpe1 ≁ $tpe2"];"""
-    case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, _) => s"""${constraintId(constr)} [label = "$pred: $tpe1 ≁ $tpe2"];"""
     case TypeConstraint.EffConflicted(effErr) => format(effErr.toString)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/EffectProvenance.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/EffectProvenance.scala
@@ -297,7 +297,7 @@ object EffectProvenance {
     var v: Set[Vertex] = Set.empty
     constraints.foreach {
       case TypeConstraint.Equality(tpe1, tpe2, prov) =>
-        val inf = prov match {
+        val inf = TypeConstraint.Provenance.unwrap(prov) match {
           case TypeConstraint.Provenance.ExpectEffect(effs, _, _) =>
             val l = if (effs.loc.isReal) effs.loc else prov.loc
             Some((SinkNode, IntermediateNode, l))

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/RecordConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/RecordConstraintSolver.scala
@@ -51,11 +51,15 @@ object RecordConstraintSolver {
 
     // If labels match, then we compare the label types and rest of the row.
     //
+    // The constraint on the label types records the label, and its two occurrences, in its
+    // provenance, so that a precise error can be reported if the label types fail to unify.
+    //
     // -------------------------------------------------------------
     // ( ℓ : τ₁  | ρ₁ ) ~ ( ℓ : τ₂  | ρ₂ )  =>  { τ₁ ~ τ₂, ρ₁ ~ ρ₂ }
     case (Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(label1), _), t1, _), rest1, _), Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(label2), _), t2, _), rest2, _)) if label1 == label2 =>
       progress.markProgress()
-      (List(mkEqualityOrConflict(label1, label2, t1, t2, prov), TypeConstraint.Equality(rest1, rest2, prov)), Substitution.empty)
+      val labelProv = Provenance.Label(label1, label1.loc, label2.loc, prov)
+      (List(TypeConstraint.Equality(t1, t2, labelProv), TypeConstraint.Equality(rest1, rest2, prov)), Substitution.empty)
 
     // If labels do not match, then we pivot the right row to make them match.
     //
@@ -66,7 +70,8 @@ object RecordConstraintSolver {
       pivot(r2, label, t1, r1.typeVars.map(_.sym))(scope, renv, flix) match {
         case Some((Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(label3), _), t3, _), rest3, _), subst)) =>
           progress.markProgress()
-          (List(mkEqualityOrConflict(label, label3, t1, t3, prov), TypeConstraint.Equality(rest1, rest3, prov)), subst)
+          val labelProv = Provenance.Label(label, label.loc, label3.loc, prov)
+          (List(TypeConstraint.Equality(t1, t3, labelProv), TypeConstraint.Equality(rest1, rest3, prov)), subst)
 
         case None =>
           (List(TypeConstraint.Equality(tpe1, tpe2, prov)), Substitution.empty)
@@ -77,22 +82,6 @@ object RecordConstraintSolver {
     // If nothing matches, we give up and return the constraints as we got them.
     case _ => (List(TypeConstraint.Equality(tpe1, tpe2, prov)), Substitution.empty)
   }
-
-  /**
-    * Returns the constraint relating the types `tpe1` and `tpe2` of the record label `label1` (= `label2`).
-    *
-    * The two labels are the two occurrences of the same label, one from each row.
-    *
-    * If both types have known but different type constructors (e.g. `Int32` and `String`) then
-    * they can never be unified. In that case we return a [[TypeConstraint.RecordConflicted]] which
-    * records the label and the location of each occurrence, so that a precise error can be reported
-    * later. Otherwise we return an ordinary equality constraint.
-    */
-  private def mkEqualityOrConflict(label1: Name.Label, label2: Name.Label, tpe1: Type, tpe2: Type, prov: Provenance): TypeConstraint =
-    (tpe1.typeConstructor, tpe2.typeConstructor) match {
-      case (Some(tc1), Some(tc2)) if tc1 != tc2 => TypeConstraint.RecordConflicted(label1, tpe1, tpe2, label1.loc, label2.loc, prov)
-      case _ => TypeConstraint.Equality(tpe1, tpe2, prov)
-    }
 
   /**
     * Rearranges the row so that the given label is at the front.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
@@ -54,11 +54,15 @@ object SchemaConstraintSolver {
 
     // If labels match, then we compare the label types and rest of the row.
     //
+    // The constraint on the predicate types records the predicate, and its two occurrences, in its
+    // provenance, so that a precise error can be reported if the predicate types fail to unify.
+    //
     // -------------------------------------------------------------
     // ( ℓ : τ₁  | ρ₁ ) ~ ( ℓ : τ₂  | ρ₂ )  =>  { τ₁ ~ τ₂, ρ₁ ~ ρ₂ }
     case (Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label1), _), t1, _), rest1, _), Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label2), _), t2, _), rest2, _)) if label1 == label2 =>
       progress.markProgress()
-      (List(mkEqualityOrConflict(label1, t1, t2, prov), TypeConstraint.Equality(rest1, rest2, prov)), Substitution.empty)
+      val predProv = Provenance.Predicate(label1, label1.loc, label2.loc, prov)
+      (List(TypeConstraint.Equality(t1, t2, predProv), TypeConstraint.Equality(rest1, rest2, prov)), Substitution.empty)
 
     // If labels do not match, then we pivot the right row to make them match.
     //
@@ -67,9 +71,10 @@ object SchemaConstraintSolver {
     // { ℓ : τ₁ | ρ₁ } ~ ρ₂  => { τ₁ ~ τ₃, ρ₁ ~ ρ₃ } ; S
     case (r1@Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label), _), t1, _), rest1, _), r2) =>
       pivot(r2, label, t1, r1.typeVars.map(_.sym))(scope, renv, flix) match {
-        case Some((Type.Apply(Type.Apply(_, t3, _), rest3, _), subst)) =>
+        case Some((Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label3), _), t3, _), rest3, _), subst)) =>
           progress.markProgress()
-          (List(mkEqualityOrConflict(label, t1, t3, prov), TypeConstraint.Equality(rest1, rest3, prov)), subst)
+          val predProv = Provenance.Predicate(label, label.loc, label3.loc, prov)
+          (List(TypeConstraint.Equality(t1, t3, predProv), TypeConstraint.Equality(rest1, rest3, prov)), subst)
 
         case None =>
           (List(TypeConstraint.Equality(tpe1, tpe2, prov)), Substitution.empty)
@@ -80,20 +85,6 @@ object SchemaConstraintSolver {
     // If nothing matches, we give up and return the constraints as we got them.
     case _ => (List(TypeConstraint.Equality(tpe1, tpe2, prov)), Substitution.empty)
   }
-
-  /**
-    * Returns the constraint relating the types `tpe1` and `tpe2` of the predicate `pred`.
-    *
-    * If both types have known but different type constructors (e.g. `Relation(2)` and `Relation(3)`,
-    * or `Relation(2)` and `Lattice(2)`) then they can never be unified. In that case we return a
-    * [[TypeConstraint.SchemaConflicted]] which records the predicate, so that a precise error can be
-    * reported later. Otherwise we return an ordinary equality constraint.
-    */
-  private def mkEqualityOrConflict(pred: Name.Pred, tpe1: Type, tpe2: Type, prov: Provenance): TypeConstraint =
-    (tpe1.typeConstructor, tpe2.typeConstructor) match {
-      case (Some(tc1), Some(tc2)) if tc1 != tc2 => TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov)
-      case _ => TypeConstraint.Equality(tpe1, tpe2, prov)
-    }
 
   /**
     * Rearranges the row so that the given label is at the front.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
@@ -85,26 +85,6 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
         else
           TypeConstraint.Conflicted(t1, t2, prov)
 
-      case TypeConstraint.RecordConflicted(label, tpe1, tpe2, loc1, loc2, prov) =>
-        // Check whether the substitution has to be applied.
-        val t1 = if (tpe1.typeVars.isEmpty) tpe1 else root(tpe1)
-        val t2 = if (tpe2.typeVars.isEmpty) tpe2 else root(tpe2)
-        // Performance: Reuse this, if possible.
-        if ((t1 eq tpe1) && (t2 eq tpe2))
-          constr
-        else
-          TypeConstraint.RecordConflicted(label, t1, t2, loc1, loc2, prov)
-
-      case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, prov) =>
-        // Check whether the substitution has to be applied.
-        val t1 = if (tpe1.typeVars.isEmpty) tpe1 else root(tpe1)
-        val t2 = if (tpe2.typeVars.isEmpty) tpe2 else root(tpe2)
-        // Performance: Reuse this, if possible.
-        if ((t1 eq tpe1) && (t2 eq tpe2))
-          constr
-        else
-          TypeConstraint.SchemaConflicted(pred, t1, t2, prov)
-
       case TypeConstraint.EffConflicted(_) => constr
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
@@ -18,6 +18,8 @@ package ca.uwaterloo.flix.language.phase.typer
 import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type}
 import ca.uwaterloo.flix.language.errors.TypeError
 
+import scala.annotation.tailrec
+
 
 /**
   * A constraint generated via type inference.
@@ -32,8 +34,6 @@ sealed trait TypeConstraint {
     case TypeConstraint.Trait(_, tpe, _) => tpe.size
     case TypeConstraint.Purification(_, eff1, eff2, _, nested) => eff1.size + eff2.size + nested.map(_.size).sum
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => tpe1.size + tpe2.size
-    case TypeConstraint.RecordConflicted(_, tpe1, tpe2, _, _, _) => tpe1.size + tpe2.size
-    case TypeConstraint.SchemaConflicted(_, tpe1, tpe2, _) => tpe1.size + tpe2.size
     case TypeConstraint.EffConflicted(_) => 0
   }
 
@@ -42,8 +42,6 @@ sealed trait TypeConstraint {
     case TypeConstraint.Trait(sym, tpe, _) => s"$sym[$tpe]"
     case TypeConstraint.Purification(sym, eff1, eff2, _, nested) => s"$eff1 ~ ($eff2)[$sym ↦ Pure] ∧ $nested"
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => s"$tpe1 ≁ $tpe2"
-    case TypeConstraint.RecordConflicted(label, tpe1, tpe2, _, _, _) => s"$label: $tpe1 ≁ $tpe2"
-    case TypeConstraint.SchemaConflicted(pred, tpe1, tpe2, _) => s"$pred: $tpe1 ≁ $tpe2"
     case TypeConstraint.EffConflicted(err) => err.toString
   }
 
@@ -105,25 +103,6 @@ object TypeConstraint {
     def loc: SourceLocation = prov.loc
   }
 
-  /**
-    * A type constraint indicating that the types `tpe1` and `tpe2` of the record label `label`
-    * cannot be unified because their type constructors differ.
-    *
-    * `loc1` and `loc2` are the locations of the two occurrences of the label. (The locations of
-    * `tpe1` and `tpe2` are unreliable, since inferred types are often shared constants.)
-    */
-  case class RecordConflicted(label: Name.Label, tpe1: Type, tpe2: Type, loc1: SourceLocation, loc2: SourceLocation, prov: Provenance) extends TypeConstraint {
-    def loc: SourceLocation = prov.loc
-  }
-
-  /**
-    * A type constraint indicating that the types `tpe1` and `tpe2` of the predicate `pred` cannot
-    * be unified because their type constructors differ (e.g. in arity or denotation).
-    */
-  case class SchemaConflicted(pred: Name.Pred, tpe1: Type, tpe2: Type, prov: Provenance) extends TypeConstraint {
-    def loc: SourceLocation = prov.loc
-  }
-
   case class EffConflicted(error: TypeError) extends TypeConstraint {
     def loc: SourceLocation = error.loc
   }
@@ -155,6 +134,30 @@ object TypeConstraint {
     case class Match(tpe1: Type, tpe2: Type, loc: SourceLocation) extends Provenance
 
     /**
+      * The constraint relates the types of the record label `label` in two record rows.
+      *
+      * `loc1` and `loc2` are the locations of the two occurrences of the label, and `inner` is the
+      * provenance of the constraint the two rows came from.
+      *
+      * The label is recorded here, rather than decided on when the rows are unified, because the
+      * label types may not be known until later. The provenance follows every constraint derived
+      * from the label types, so the label is available whenever any part of them fails to unify.
+      */
+    case class Label(label: Name.Label, loc1: SourceLocation, loc2: SourceLocation, inner: Provenance) extends Provenance {
+      def loc: SourceLocation = inner.loc
+    }
+
+    /**
+      * The constraint relates the types of the predicate `pred` in two schema rows.
+      *
+      * `loc1` and `loc2` are the locations of the two occurrences of the predicate, and `inner` is
+      * the provenance of the constraint the two rows came from. See [[Label]].
+      */
+    case class Predicate(pred: Name.Pred, loc1: SourceLocation, loc2: SourceLocation, inner: Provenance) extends Provenance {
+      def loc: SourceLocation = inner.loc
+    }
+
+    /**
       * The constraint indicates that the left effect is a variable representing the source effect on the right.
       */
     case class Source(eff1: Type.Var, eff2: Type, loc: SourceLocation) extends Provenance
@@ -169,5 +172,15 @@ object TypeConstraint {
       */
     // TODO this is an abuse of provenance. We should instead have a separate "conflict reason" type.
     case class Timeout(msg: String, loc: SourceLocation) extends Provenance
+
+    /**
+      * Returns the provenance underneath any [[Label]] and [[Predicate]] wrappers of `prov`.
+      */
+    @tailrec
+    def unwrap(prov: Provenance): Provenance = prov match {
+      case Label(_, _, _, inner) => unwrap(inner)
+      case Predicate(_, _, _, inner) => unwrap(inner)
+      case _ => prov
+    }
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
@@ -161,15 +161,13 @@ object Profiler {
   private def countVars(cs: List[TypeConstraint]): (Long, Long) = {
     val vars = scala.collection.mutable.HashSet.empty[Type.Var]
     def collect(c: TypeConstraint): Unit = c match {
-      case TypeConstraint.Equality(t1, t2, _)                  => vars ++= t1.typeVars; vars ++= t2.typeVars
-      case TypeConstraint.Trait(_, t, _)                       => vars ++= t.typeVars
-      case TypeConstraint.Conflicted(t1, t2, _)                => vars ++= t1.typeVars; vars ++= t2.typeVars
-      case TypeConstraint.RecordConflicted(_, t1, t2, _, _, _) => vars ++= t1.typeVars; vars ++= t2.typeVars
-      case TypeConstraint.SchemaConflicted(_, t1, t2, _)       => vars ++= t1.typeVars; vars ++= t2.typeVars
+      case TypeConstraint.Equality(t1, t2, _)         => vars ++= t1.typeVars; vars ++= t2.typeVars
+      case TypeConstraint.Trait(_, t, _)              => vars ++= t.typeVars
+      case TypeConstraint.Conflicted(t1, t2, _)       => vars ++= t1.typeVars; vars ++= t2.typeVars
       case TypeConstraint.Purification(_, e1, e2, _, nested) =>
         vars ++= e1.typeVars; vars ++= e2.typeVars
         nested.foreach(collect)
-      case TypeConstraint.EffConflicted(_)                     => ()
+      case TypeConstraint.EffConflicted(_)            => ()
     }
     cs.foreach(collect)
     var tv = 0L

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -2810,6 +2810,102 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.MismatchedLabelType](result)
   }
 
+  test("TypeError.MismatchedLabelType.09") {
+    // The label types are only known after the rows have been unified.
+    val input =
+      """
+        |def f(): Unit \ IO =
+        |    let r1 = { x = List#{1} };
+        |    let r2 = { x = List#{"a"} };
+        |    let _ = if (true) r1 else r2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibAll)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.10") {
+    // The label types are determined through a container argument.
+    val input =
+      """
+        |def f(): Unit \ IO =
+        |    let r1 = { x = List.reverse(List.Cons(1, List.Nil)) };
+        |    let r2 = { x = List.reverse(List.Cons("a", List.Nil)) };
+        |    let _ = if (true) r1 else r2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibAll)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.11") {
+    // The conflict is in the first of two type arguments.
+    val input =
+      """
+        |enum Pair[a, b] { case Pair(a, b) }
+        |
+        |def f(): Unit \ IO =
+        |    let r1 = { x = Pair.Pair(1, true) };
+        |    let r2 = { x = Pair.Pair("a", true) };
+        |    let _ = if (true) r1 else r2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.12") {
+    // The label type is a type alias.
+    val input =
+      """
+        |type alias Age = Int32
+        |
+        |def f(_r: { x = Age }): Unit = ()
+        |
+        |def g(): Unit \ IO =
+        |    let _ = f({ x = "a" });
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.13") {
+    // The label types differ only in their effects, which is not a label type mismatch.
+    val input =
+      """
+        |eff E { def op(): Unit }
+        |
+        |def f(_r: { g = Unit -> Unit }): Unit = ()
+        |
+        |def h(): Unit = f({ g = () -> E.op() })
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError](result)
+    rejectError[TypeError.MismatchedLabelType](result)
+  }
+
+  test("TypeError.MismatchedLabelType.14") {
+    // A missing label inside a nested record is not a label type mismatch.
+    val input =
+      """
+        |def f(_r: { x = { y = Int32 } }): Unit = ()
+        |
+        |def g(): Unit \ IO =
+        |    let _ = f({ x = { z = 1 } });
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[TypeError.UndefinedLabel](result)
+    rejectError[TypeError.MismatchedLabelType](result)
+  }
+
   test("ExtMatchError#11283") {
     val input =
       """
@@ -2820,7 +2916,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedTypes](result)
+    expectError[TypeError.MismatchedPredicateTypes](result)
   }
 
   test("TypeError.ExtMatch.01") {
@@ -3182,6 +3278,95 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |""".stripMargin
     val result = check(input, Options.TestWithLibAll)
     expectError[TypeError.MismatchedPredicateDenotation](result)
+  }
+
+  test("TypeError.MismatchedPredicateTypes.01") {
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Foo(1). };
+        |    let p2 = #{ Foo("a"). };
+        |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateTypes](result)
+  }
+
+  test("TypeError.MismatchedPredicateTypes.02") {
+    // The schema is passed as an argument.
+    val input =
+      """
+        |def f(_p: #{ Foo(Int32) }): Unit = ()
+        |
+        |def main(): Unit \ IO =
+        |    let _ = f(#{ Foo("a"). });
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateTypes](result)
+  }
+
+  test("TypeError.MismatchedPredicateTypes.03") {
+    // Two predicates with mismatched term types.
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Foo(1). Bar(1). };
+        |    let p2 = #{ Foo("a"). Bar("b"). };
+        |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateTypes](result)
+  }
+
+  test("TypeError.MismatchedPredicateTypes.04") {
+    // A lattice predicate with a mismatched key type.
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Foo(1; 2). };
+        |    let p2 = #{ Foo("a"; 2). };
+        |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibAll)
+    expectError[TypeError.MismatchedPredicateTypes](result)
+  }
+
+  test("TypeError.MismatchedPredicateTypes.05") {
+    // The mismatch is nested inside a term type.
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Foo((1, 1)). };
+        |    let p2 = #{ Foo((1, "a")). };
+        |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedPredicateTypes](result)
+  }
+
+  test("TypeError.MismatchedPredicateTypes.06") {
+    // The term types are only known after the rows have been unified.
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    let p1 = #{ Foo(List#{1}). };
+        |    let p2 = #{ Foo(List#{"a"}). };
+        |    let _ = p1 <+> p2;
+        |    println("Hello World!")
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibAll)
+    expectError[TypeError.MismatchedPredicateTypes](result)
   }
 
   test("Test.DefaultHandlerNotInModule.01") {


### PR DESCRIPTION
Closes #13169.

## Problem

#13167 and #13168 report a label/predicate mismatch only when the row solver can tell, *at the moment it pairs the two rows*, that the label types have different head constructors. Anything one level down still reports generically, without the label:

- `{ x = List#{1} }` vs `{ x = List#{"a"} }` → `Unable to unify 'Int32' and 'String'`
- `#{ Foo(1). }` vs `#{ Foo("a"). }` → same
- `{ x = (1, 1) }` vs `{ x = (1, "a") }` → same

A deeper structural check at pairing time (prototyped, not merged) does not fix this, because the row solver pairs each label **once**, in the same solver round in which the record equality is first decomposed, while `makeSubstitution` runs once per round. `List#{1}` desugars to `Vector.toList(Vector#{1})`; its element type is resolved through a constraint that must be decomposed again before it yields a binding, one round later. At pairing time the label types are `List[a]` vs `List[b]`, so any pairing-time judgment says "maybe", emits an unlabelled `Equality`, and the label is lost for good. The same holds for `Map#{…}`, `Set#{…}`, and any polymorphic call whose element type flows through a container argument (`List.reverse`, `List.map`, …).

## Approach

Record the label at pairing time instead of judging at pairing time. The row solvers always emit an ordinary `Equality` for the label types, wrapped in a new provenance:

```scala
case class Label(label: Name.Label, loc1: SourceLocation, loc2: SourceLocation, inner: Provenance)
case class Predicate(pred: Name.Pred, loc1: SourceLocation, loc2: SourceLocation, inner: Provenance)
```

`(appU)` already copies provenance onto every sub-constraint, and substitution/reduction keep it, so whenever *any* fragment of the label's type ends up as a leftover — in whatever round — the reporter knows the label, the two occurrences, and the enclosing constraint. The leftover pair is the pinpoint for free; no second structural walk is needed. The provenance is type-free: enclosing types for the message come from `inner` (`Match`/`ExpectType`/`ExpectArgument`).

- `ConstraintSolverInterface`: an `Equality(…, Label(…))` arm reports `MismatchedLabelType` for syntactic-kind leftovers and delegates to `inner` otherwise (so effect-only differences keep their effect errors and a missing label inside a nested record still reports `UndefinedLabel`); an `Equality(…, Predicate(…))` arm reports arity/denotation for `Relation`/`Lattice` head clashes, the new `MismatchedPredicateTypes` for term types, and delegates otherwise; `Conflicted` under either wrapper delegates. `EffectProvenance.buildGraph` looks through the wrappers via `Provenance.unwrap`.
- `RecordConflicted`, `SchemaConflicted`, their plumbing arms in `simplify`/`contextReduction`/`SubstitutionTree`/`Debug`/`Profiler`/`TypeConstraint`, and both `mkEqualityOrConflict`s are removed. `(appU)` is untouched: same-head applications are decomposed on purpose so that errors pinpoint the differing component.
- `MismatchedLabelType` now carries the pinpointed pair and the enclosing types; new `MismatchedPredicateTypes` (`E6710`). Both render as: headline with the pinpointed pair, `'Int32' comes from here.` at each occurrence, and `Type One`/`Type Two` with the enclosing types.

```
>> Mismatched types for label 'x': 'Int32' and 'String'.

7 |     let r1 = { x = List#{1} };
                   'Int32' comes from here.

8 |     let r2 = { x = List#{"a"} };
                   'String' comes from here.

Type One: { x = List[Int32] }
Type Two: { x = List[String] }
```

## Notes

- `ExtMatchError#11283` (`ematch xvar A(1) { case A() => … }`) is `Relation(Int32)` vs `Relation(Unit)` under predicate `A` and now reports `MismatchedPredicateTypes` rather than the generic `MismatchedTypes`; same precedent as `ExtMatch.04/.05` in #13167.
- Arity/denotation errors now highlight the two predicate occurrences (`Name.Pred.loc`) rather than the payload types' locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEVAXuEu1PxxYdH9BM4che
