### PR TITLE
refactor: use descriptor-based Java field resolution

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -17,11 +17,10 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.CompilationMessage
+import ca.uwaterloo.flix.language.ast.jvm.JavaField
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.util.collection.{ListMap, Nel}
-
-import java.lang.reflect.Field
 
 object KindedAst {
 
@@ -189,11 +188,11 @@ object KindedAst {
 
     case class GetField(exp: Expr, fieldName: Name.Ident, jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class PutField(field: Field, clazz: java.lang.Class[?], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutField(field: JavaField, clazz: java.lang.Class[?], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
-    case class GetStaticField(field: Field, loc: SourceLocation) extends Expr
+    case class GetStaticField(field: JavaField, tvar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class PutStaticField(field: Field, exp: Expr, loc: SourceLocation) extends Expr
+    case class PutStaticField(field: JavaField, exp: Expr, loc: SourceLocation) extends Expr
 
     case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], targs: List[Type], constructors: List[JvmConstructor], methods: List[JvmMethod], tvar: Type.Var, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -17,11 +17,10 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.CompilationMessage
+import ca.uwaterloo.flix.language.ast.jvm.JavaField
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.util.collection.{ListMap, Nel}
-
-import java.lang.reflect.Field
 
 object ResolvedAst {
 
@@ -202,11 +201,11 @@ object ResolvedAst {
 
     case class GetField(exp: Expr, fieldName: Name.Ident, loc: SourceLocation) extends Expr
 
-    case class PutField(field: Field, clazz: java.lang.Class[?], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutField(field: JavaField, clazz: java.lang.Class[?], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
-    case class GetStaticField(field: Field, loc: SourceLocation) extends Expr
+    case class GetStaticField(field: JavaField, loc: SourceLocation) extends Expr
 
-    case class PutStaticField(field: Field, exp: Expr, loc: SourceLocation) extends Expr
+    case class PutStaticField(field: JavaField, exp: Expr, loc: SourceLocation) extends Expr
 
     case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], targs: List[UnkindedType], constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -1,10 +1,11 @@
 package ca.uwaterloo.flix.language.ast
 
+import ca.uwaterloo.flix.language.ast.jvm.JavaField
 import ca.uwaterloo.flix.language.ast.shared.ScalaAnnotations.{EliminatedBy, IntroducedBy}
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization
 import ca.uwaterloo.flix.language.phase.{Kinder, monomorph, Simplifier}
 
-import java.lang.reflect.{Constructor, Field, Method}
+import java.lang.reflect.{Constructor, Method}
 import scala.collection.immutable.SortedSet
 
 /**
@@ -306,7 +307,7 @@ object TypeConstructor {
   /**
     * A type constructor that represents the type of a Java field.
     */
-  case class JvmField(field: Field) extends TypeConstructor {
+  case class JvmField(field: JavaField) extends TypeConstructor {
     def kind: Kind = Kind.Jvm
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -17,12 +17,13 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.CompilationMessage
+import ca.uwaterloo.flix.language.ast.jvm.JavaField
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, TraitEnv}
 import ca.uwaterloo.flix.util.collection.{ListMap, Nel}
 
-import java.lang.reflect.{Constructor, Field, Method}
+import java.lang.reflect.{Constructor, Method}
 
 object TypedAst {
 
@@ -236,13 +237,13 @@ object TypedAst {
 
     case class InvokeStaticMethod(method: Method, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class GetField(field: Field, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class GetField(field: JavaField, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class PutField(field: Field, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class PutField(field: JavaField, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class GetStaticField(field: Field, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class GetStaticField(field: JavaField, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class PutStaticField(field: Field, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class PutStaticField(field: JavaField, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], tpe: Type, eff: Type, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/JField.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/JField.scala
@@ -15,16 +15,15 @@
  */
 package ca.uwaterloo.flix.language.ast.shared
 
-import ca.uwaterloo.flix.util.ClassDescs
+import ca.uwaterloo.flix.language.ast.jvm.JavaField
 
 import java.lang.constant.ClassDesc
-import java.lang.reflect.Field
 
 object JField {
 
-  /** Returns the [[JField]] of the given reflective `field`. */
-  def of(field: Field): JField =
-    JField(ClassDescs.of(field.getDeclaringClass), field.getName)
+  /** Returns the [[JField]] of the given class-file field metadata. */
+  def of(field: JavaField): JField =
+    JField(field.ref.owner, field.ref.name)
 
 }
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -16,11 +16,12 @@
 
 package ca.uwaterloo.flix.language.dbg
 
+import ca.uwaterloo.flix.language.ast.jvm.JavaField
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{Name, Symbol}
 
 import java.lang.constant.ClassDesc
-import java.lang.reflect.{Constructor, Field, Method}
+import java.lang.reflect.{Constructor, Method}
 import scala.collection.immutable.SortedSet
 
 sealed trait DocAst
@@ -335,10 +336,6 @@ object DocAst {
       App(Dot(AsIs(javaClassName(m.owner)), AsIs(m.name)), ds)
     }
 
-    def JavaGetStaticField(f: Field): Expr = {
-      Dot(Native(f.getDeclaringClass), AsIs(f.getName))
-    }
-
     def JavaGetStaticField(f: JField): Expr = {
       Dot(AsIs(javaClassName(f.owner)), AsIs(f.name))
     }
@@ -351,20 +348,11 @@ object DocAst {
       App(AsIs(javaClassName(c.owner)), ds)
     }
 
-    def JavaGetField(f: Field, d: Expr): Expr =
-      DoubleDot(d, AsIs(f.getName))
-
     def JavaGetField(f: JField, d: Expr): Expr =
       DoubleDot(d, AsIs(f.name))
 
-    def JavaPutField(f: Field, d1: Expr, d2: Expr): Expr =
-      Assign(DoubleDot(d1, AsIs(f.getName)), d2)
-
     def JavaPutField(f: JField, d1: Expr, d2: Expr): Expr =
       Assign(DoubleDot(d1, AsIs(f.name)), d2)
-
-    def JavaPutStaticField(f: Field, d: Expr): Expr =
-      Assign(Dot(Native(f.getDeclaringClass), AsIs(f.getName)), d)
 
     def JavaPutStaticField(f: JField, d: Expr): Expr =
       Assign(Dot(AsIs(javaClassName(f.owner)), AsIs(f.name)), d)
@@ -439,7 +427,7 @@ object DocAst {
 
     case class JvmMethod(method: Method) extends Atom
 
-    case class JvmField(field: Field) extends Atom
+    case class JvmField(field: JavaField) extends Atom
 
 
     case class Not(tpe: Type) extends Composite
@@ -556,5 +544,3 @@ object DocAst {
 
   def Sym(sym: Symbol.CaseSym): Sym = Sym(sym.toString)
 }
-
-

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
@@ -437,7 +437,7 @@ object DocAstFormatter {
       case Type.JvmMethod(method) =>
         formatJavaClass(method.getClass)
       case Type.JvmField(field) =>
-        formatJavaClass(field.getClass)
+        text(Expr.javaClassName(field.ref.owner))
       case Type.Not(t) =>
         text("not") +: formatType(t)
       case Type.And(t1, t2) =>

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -3,6 +3,7 @@ package ca.uwaterloo.flix.language.dbg.printer
 import ca.uwaterloo.flix.language.ast.TypedAst.Pattern.Record
 import ca.uwaterloo.flix.language.ast.TypedAst.{Expr, ExtPattern, ExtTagPattern, Pattern}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{DefSymUse, LocalDefSymUse, SigSymUse}
+import ca.uwaterloo.flix.language.ast.shared.JField
 import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
 import ca.uwaterloo.flix.language.dbg.DocAst
 
@@ -83,10 +84,10 @@ object TypedAstPrinter {
     case Expr.InvokeMethod(method, exp, exps, _, _, _) => DocAst.Expr.JavaInvokeMethod(method, print(exp), exps.map(print))
     case Expr.InvokeSuperMethod(method, exps, _, _, _) => DocAst.Expr.JavaInvokeStaticMethod(method, exps.map(print))
     case Expr.InvokeStaticMethod(method, exps, _, _, _) => DocAst.Expr.JavaInvokeStaticMethod(method, exps.map(print))
-    case Expr.GetField(field, exp, _, _, _) => DocAst.Expr.JavaGetField(field, print(exp))
-    case Expr.PutField(field, exp1, exp2, _, _, _) => DocAst.Expr.JavaPutField(field, print(exp1), print(exp2))
-    case Expr.GetStaticField(field, _, _, _) => DocAst.Expr.JavaGetStaticField(field)
-    case Expr.PutStaticField(field, exp, _, _, _) => DocAst.Expr.JavaPutStaticField(field, print(exp))
+    case Expr.GetField(field, exp, _, _, _) => DocAst.Expr.JavaGetField(JField.of(field), print(exp))
+    case Expr.PutField(field, exp1, exp2, _, _, _) => DocAst.Expr.JavaPutField(JField.of(field), print(exp1), print(exp2))
+    case Expr.GetStaticField(field, _, _, _) => DocAst.Expr.JavaGetStaticField(JField.of(field))
+    case Expr.PutStaticField(field, exp, _, _, _) => DocAst.Expr.JavaPutStaticField(JField.of(field), print(exp))
     case Expr.NewObject(sym, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(sym, clazz.getName, TypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
     case Expr.NewChannel(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.GetChannel(_, _, _, _) => DocAst.Expr.Unknown

--- a/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
@@ -17,10 +17,11 @@ package ca.uwaterloo.flix.language.fmt
 
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.Type.JvmMember
+import ca.uwaterloo.flix.language.ast.jvm.JavaField
 import ca.uwaterloo.flix.language.ast.shared.{SymbolSet, VarText}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
-import java.lang.reflect.{Constructor, Field, Method}
+import java.lang.reflect.{Constructor, Method}
 
 /**
   * A well-kinded type in an easily-printable format.
@@ -294,7 +295,7 @@ object DisplayType {
 
   case class JvmConstructor(constructor: Constructor[?]) extends DisplayType
 
-  case class JvmField(field: Field) extends DisplayType
+  case class JvmField(field: JavaField) extends DisplayType
 
   case class JvmMethod(method: Method) extends DisplayType
 

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatTypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatTypeConstructor.scala
@@ -73,7 +73,7 @@ object FormatTypeConstructor {
     case TypeConstructor.Native(clazz) => clazz.getSimpleName
     case TypeConstructor.JvmConstructor(constructor) => s"Constructor(${constructor.getDeclaringClass.getSimpleName})"
     case TypeConstructor.JvmMethod(method) => s"Method(${method.getName})"
-    case TypeConstructor.JvmField(field) => s"Field(${field.getName})"
+    case TypeConstructor.JvmField(field) => s"Field(${field.ref.name})"
 
     // Tuples and relations
     case TypeConstructor.Tuple(arity) => s"Tuple$arity"

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -777,7 +777,8 @@ object Kinder {
         KindedAst.Expr.PutField(field, clazz, exp1, exp2, loc)
 
       case ResolvedAst.Expr.GetStaticField(field, loc) =>
-        KindedAst.Expr.GetStaticField(field, loc)
+        val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
+        KindedAst.Expr.GetStaticField(field, tvar, loc)
 
       case ResolvedAst.Expr.PutStaticField(field, exp0, loc) =>
         val exp = visitExp(exp0, kenv0, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -22,14 +22,12 @@ import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration
 import ca.uwaterloo.flix.language.ast.ResolvedAst.Pattern.Record
 import ca.uwaterloo.flix.language.ast.UnkindedType.*
-import ca.uwaterloo.flix.language.ast.jvm.JavaFieldRef
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
-import ca.uwaterloo.flix.language.phase.typer.JavaReductionOpsTEMP
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
@@ -811,25 +809,18 @@ object Resolver {
             // We have a static field access.
             val fieldName = qname.ident
 
-            // Old path (authoritative): resolve the static field with reflection.
-            val oldField = JvmUtils.getField(clazz, fieldName.name, static = true)
-
-            // New path (shadow only): resolve the static field from its owner descriptor.
             val owner = ClassDescs.of(clazz)
-            val oldResult = oldField.map(field =>
-              JavaFieldRef(ClassDescs.of(field.getDeclaringClass), field.getName, ClassDescs.of(field.getType)))
-            val newResult = JavaMemberResolver.field(owner, fieldName.name, static = true).map(_.map(_.ref))
-            JavaReductionOpsTEMP.compareField(owner, fieldName.name, oldResult, newResult, loc)
-
-            // TODO: Remove the old path once GetStaticField stores JavaField instead of Field.
-            oldField match {
-              case Some(field) =>
+            JavaMemberResolver.field(owner, fieldName.name, static = true) match {
+              case Result.Ok(Some(field)) =>
                 // Returns out of resolveExp
                 return ResolvedAst.Expr.GetStaticField(field, loc)
-              case None =>
+              case Result.Ok(None) =>
                 val error = ResolutionError.UndefinedJvmStaticField(clazz, fieldName, loc)
                 sctx.errors.add(error)
                 return ResolvedAst.Expr.Error(error)
+              case Result.Err(error) =>
+                val query = s"${owner.displayName()}.${fieldName.name}"
+                throw InternalCompilerException(s"Java field lookup failed for '$query': $error", loc)
             }
           case _ =>
           // Fallthrough to below.

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -511,8 +511,8 @@ object TypeReconstruction {
       val eff = Type.mkUnion(e1.eff, e2.eff, Type.IO, loc)
       TypedAst.Expr.PutField(field, e1, e2, tpe, eff, loc)
 
-    case KindedAst.Expr.GetStaticField(field, loc) =>
-      val tpe = instantiateJavaTypeWithObjectArgs(field.getType, loc)
+    case KindedAst.Expr.GetStaticField(field, tvar, loc) =>
+      val tpe = subst(tvar)
       val eff = Type.IO
       TypedAst.Expr.GetStaticField(field, tpe, eff, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -18,12 +18,13 @@ package ca.uwaterloo.flix.language.phase.typer
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.KindedAst.{Expr, ExtPattern, ExtTagPattern}
+import ca.uwaterloo.flix.language.ast.jvm.JavaField
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{DefSymUse, LocalDefSymUse, OpSymUse, SigSymUse}
 import ca.uwaterloo.flix.language.ast.shared.{CheckedCastType, RegionScope, VarText}
 import ca.uwaterloo.flix.language.ast.{Kind, KindedAst, Name, Scheme, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.unification.Substitution
 import ca.uwaterloo.flix.util.collection.{ListOps, Nel}
-import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils, Subeffecting}
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, JvmUtils, Subeffecting}
 
 import java.lang.reflect.{Modifier, ParameterizedType, TypeVariable}
 
@@ -997,7 +998,7 @@ object ConstraintGen {
         (resTpe, resEff)
 
       case Expr.PutField(field, clazz, exp1, exp2, loc) =>
-        val fieldType = Type.instantiateJavaTypeWithObjectArgs(field.getType, loc)
+        val fieldType = getJavaFieldType(field, loc)
         val classType = Type.instantiateJavaTypeWithObjectArgs(clazz, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
@@ -1007,17 +1008,18 @@ object ConstraintGen {
         val resEff = Type.mkUnion(eff1, eff2, Type.IO, loc)
         (resTpe, resEff)
 
-      case Expr.GetStaticField(field, loc) =>
-        val isFinal = Modifier.isFinal(field.getModifiers)
-        val fieldType = Type.instantiateJavaTypeWithObjectArgs(field.getType, loc)
+      case Expr.GetStaticField(field, tvar, loc) =>
+        val isFinal = Modifier.isFinal(field.modifiers)
+        val fieldType = getJavaFieldType(field, loc)
         val fieldReadEff = if (isFinal) Type.Pure else Type.IO
-        val resTpe = fieldType
+        c.unifyType(tvar, fieldType, loc)
+        val resTpe = tvar
         val resEff = fieldReadEff
         (resTpe, resEff)
 
       case Expr.PutStaticField(field, exp, loc) =>
         val (valueTyp, eff) = visitExp(exp)
-        c.expectType(expected = Type.instantiateJavaTypeWithObjectArgs(field.getType, loc), actual = valueTyp, exp.loc)
+        c.expectType(expected = getJavaFieldType(field, loc), actual = valueTyp, exp.loc)
         val resTpe = Type.Unit
         val resEff = Type.mkUnion(eff, Type.IO, loc)
         (resTpe, resEff)
@@ -1266,8 +1268,15 @@ object ConstraintGen {
           c.expectType(expected = Type.Bool, actual = guardTpe, g.loc)
           c.expectType(expected = Type.Pure, actual = guardEff, g.loc)
       }
+
       val (tpe, eff) = visitExp(exp)
       (patTpe, tpe, eff)
+  }
+
+  /** Returns the Flix type of the erased descriptor of `field`. */
+  private def getJavaFieldType(field: JavaField, loc: SourceLocation)(implicit flix: Flix): Type = {
+    val clazz = ClassDescs.load(field.ref.descriptor, flix.jarLoader)
+    Type.instantiateJavaTypeWithObjectArgs(clazz, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/JavaReductionOpsTEMP.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/JavaReductionOpsTEMP.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.phase.typer
 
 import ca.uwaterloo.flix.language.ast.SourceLocation
-import ca.uwaterloo.flix.language.ast.jvm.{JavaFieldRef, JavaMethodRef}
+import ca.uwaterloo.flix.language.ast.jvm.JavaMethodRef
 import ca.uwaterloo.flix.language.ast.shared.JConstructor
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaArgument
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaLookupError
@@ -73,26 +73,6 @@ private[phase] object JavaReductionOpsTEMP {
         if (!matches) {
           throw InternalCompilerException(
             s"Java method lookup mismatch for '$query': reflection=$oldResult, descriptor=$result",
-            loc
-          )
-        }
-    }
-  }
-
-  /** Compares the old reflective field result with the new descriptor-based field result. */
-  def compareField(owner: ClassDesc,
-                   name: String,
-                   oldResult: Option[JavaFieldRef],
-                   newResult: Result[Option[JavaFieldRef], JavaLookupError],
-                   loc: SourceLocation): Unit = {
-    val query = s"${owner.displayName()}.$name"
-    newResult match {
-      case Err(error) =>
-        throw InternalCompilerException(s"Java field shadow lookup failed for '$query': $error", loc)
-      case Ok(result) =>
-        if (oldResult != result) {
-          throw InternalCompilerException(
-            s"Java field lookup mismatch for '$query': reflection=$oldResult, descriptor=$result",
             loc
           )
         }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -18,17 +18,18 @@ package ca.uwaterloo.flix.language.phase.typer
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.Type.JvmMember
-import ca.uwaterloo.flix.language.ast.jvm.{JavaFieldRef, JavaMethodRef}
+import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethodRef}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
 import ca.uwaterloo.flix.language.ast.shared.{AssocTypeDef, JConstructor, JMethod, RegionScope}
 import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaArgument, JavaMemberResolver}
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, Substitution}
-import ca.uwaterloo.flix.util.{ClassDescs, JvmUtils}
+import ca.uwaterloo.flix.util.Result.{Err, Ok}
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, JvmUtils}
 import org.apache.commons.lang3.reflect.{ConstructorUtils, MethodUtils}
 
 import java.lang.constant.ConstantDescs.*
 import java.lang.constant.ClassDesc
-import java.lang.reflect.{Constructor, Field, GenericArrayType, Method, ParameterizedType, TypeVariable, WildcardType}
+import java.lang.reflect.{Constructor, GenericArrayType, Method, ParameterizedType, TypeVariable, WildcardType}
 import scala.annotation.tailrec
 
 object TypeReduction2 {
@@ -113,7 +114,8 @@ object TypeReduction2 {
 
         case Type.Cst(TypeConstructor.JvmField(field), _) =>
           progress.markProgress()
-          (instantiateJavaTypeWithFreshVars(field.getType, scope, loc), cs)
+          val clazz = ClassDescs.load(field.ref.descriptor, flix.jarLoader)
+          (instantiateJavaTypeWithFreshVars(clazz, scope, loc), cs)
 
         case t1 => t1.typeConstructor match {
           case Some(TypeConstructor.JvmMethod(method)) =>
@@ -393,24 +395,14 @@ object TypeReduction2 {
     val typeIsKnown = isKnown(thisObj)
     if (!typeIsKnown) return JavaFieldResolution.UnresolvedTypes
 
-    // Old path (authoritative): load the owner class and resolve the field with reflection.
-    val oldOwner = Type.classFromFlixType(thisObj)
-    val oldField = for {
-      owner <- oldOwner
-      member <- JvmUtils.getField(owner, fieldName, static = false)
-    } yield member
-
-    // New path (shadow only): resolve from the owner descriptor without passing a Class to the resolver.
-    oldOwner.foreach { clazz =>
-      val owner = ClassDescs.of(clazz)
-      val oldResult = oldField.map(field =>
-        JavaFieldRef(ClassDescs.of(field.getDeclaringClass), field.getName, ClassDescs.of(field.getType)))
-      val newResult = JavaMemberResolver.field(owner, fieldName, static = false).map(_.map(_.ref))
-      JavaReductionOpsTEMP.compareField(owner, fieldName, oldResult, newResult, loc)
+    val owner = getJavaTypeDesc(thisObj)
+    JavaMemberResolver.field(owner, fieldName, static = false) match {
+      case Ok(Some(field)) => JavaFieldResolution.Resolved(field)
+      case Ok(None) => JavaFieldResolution.NotFound
+      case Err(error) =>
+        val query = s"${owner.displayName()}.$fieldName"
+        throw InternalCompilerException(s"Java field lookup failed for '$query': $error", loc)
     }
-
-    // TODO: Remove the old path once the owner descriptor comes directly from Type and Resolved stores JavaField.
-    oldField.map(JavaFieldResolution.Resolved.apply).getOrElse(JavaFieldResolution.NotFound)
   }
 
   /**
@@ -441,7 +433,7 @@ object TypeReduction2 {
   private object JavaFieldResolution {
 
     /** One matching field. */
-    case class Resolved(field: Field) extends JavaFieldResolution
+    case class Resolved(field: JavaField) extends JavaFieldResolution
 
     /** No matching field. */
     case object NotFound extends JavaFieldResolution

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
@@ -139,8 +139,13 @@ object JavaMemberResolver {
     }
 
   /** Returns `Ok` with the selected public field, or `Err` if class metadata cannot be read. */
-  def field(owner: ClassDesc, name: String, static: Boolean)(implicit flix: Flix): Result[Option[JavaField], JavaLookupError] =
-    findField(owner, name, Set.empty).map(_.filter(f => Modifier.isStatic(f.modifiers) == static))
+  def field(owner: ClassDesc, name: String, static: Boolean)(implicit flix: Flix): Result[Option[JavaField], JavaLookupError] = {
+    if (owner.isClassOrInterface) {
+      findField(owner, name, Set.empty).map(_.filter(f => Modifier.isStatic(f.modifiers) == static))
+    } else {
+      Ok(None)
+    }
+  }
 
   /** Selects the best supported methods from `owner`, then retains the requested kind. */
   private def resolveMethods(owner: ClassDesc, name: String, arguments: List[JavaArgument], static: Boolean)(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] =

--- a/main/src/ca/uwaterloo/flix/util/ClassDescs.scala
+++ b/main/src/ca/uwaterloo/flix/util/ClassDescs.scala
@@ -18,8 +18,26 @@ package ca.uwaterloo.flix.util
 import ca.uwaterloo.flix.language.ast.SourceLocation
 
 import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.*
 
 object ClassDescs {
+
+  /**
+    * Loads the class represented by `desc` without initializing it.
+    */
+  def load(desc: ClassDesc, loader: ClassLoader): Class[?] = desc match {
+    case CD_boolean => java.lang.Boolean.TYPE
+    case CD_byte => java.lang.Byte.TYPE
+    case CD_short => java.lang.Short.TYPE
+    case CD_char => java.lang.Character.TYPE
+    case CD_int => java.lang.Integer.TYPE
+    case CD_long => java.lang.Long.TYPE
+    case CD_float => java.lang.Float.TYPE
+    case CD_double => java.lang.Double.TYPE
+    case CD_void => java.lang.Void.TYPE
+    case _ if desc.isArray => Class.forName(desc.descriptorString().replace('/', '.'), false, loader)
+    case _ => loader.loadClass(binaryNameOf(desc))
+  }
 
   /**
     * Returns the [[ClassDesc]] of the given loaded class `clazz`.

--- a/main/src/ca/uwaterloo/flix/util/JvmUtils.scala
+++ b/main/src/ca/uwaterloo/flix/util/JvmUtils.scala
@@ -21,23 +21,6 @@ import java.lang.reflect.{Field, Member, Method, Modifier, ParameterizedType, Ty
 object JvmUtils {
 
   /**
-    * Returns the (static/dynamic) `fieldName` field of `clazz` if it exists.
-    *
-    * Field name "length" of array classes always return `None` (see Class.getField).
-    *
-    * @param clazz the class to search
-    * @param static whether to find a static field or an instance field
-    */
-  def getField(clazz: Class[?], fieldName: String, static: Boolean): Option[Field] = {
-    try {
-      val field = clazz.getField(fieldName)
-      if (isStatic(field) == static) Some(field) else None
-    } catch {
-      case _: NoSuchFieldException => None
-    }
-  }
-
-  /**
     * Returns the static fields of the class.
     */
   def getStaticFields(clazz: Class[?]): List[Field] =


### PR DESCRIPTION
## Summary
- make descriptor-based Java field lookup authoritative for instance and static fields
- carry JavaField through field-bearing compiler data and lower it to JField
- remove reflective field lookup and field shadow comparison

## Testing
- ./mill --no-server flix.test.testOnly ca.uwaterloo.flix.language.phase.TestResolver ca.uwaterloo.flix.language.phase.TestTyper flix.CompilerSuite
- ./mill --no-server flix.test

No new tests were added; this relies on the existing compiler and standard-library coverage.