### PR TITLE
refactor: remove unused FlixEvents

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -685,8 +685,6 @@ class Flix {
     var tailPosAst = TailPos.run(effectBinderAst)
     effectBinderAst = null // Explicitly null-out such that the memory becomes eligible for GC.
 
-    flix.emitEvent(FlixEvent.AfterTailPos(tailPosAst))
-
     var eraserAst = Eraser.run(tailPosAst)
     tailPosAst = null // Explicitly null-out such that the memory becomes eligible for GC.
 

--- a/main/src/ca/uwaterloo/flix/api/FlixEvent.scala
+++ b/main/src/ca/uwaterloo/flix/api/FlixEvent.scala
@@ -15,8 +15,7 @@
  */
 package ca.uwaterloo.flix.api
 
-import ca.uwaterloo.flix.language.ast.shared.Source
-import ca.uwaterloo.flix.language.ast.{ReducedAst, Symbol, Token, TypedAst}
+import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
 import ca.uwaterloo.flix.language.phase.unification.set.Equation
 
@@ -26,21 +25,6 @@ import ca.uwaterloo.flix.language.phase.unification.set.Equation
 sealed trait FlixEvent
 
 object FlixEvent {
-
-  /**
-    * An event that is fired after the Lexer phase.
-    */
-  case class AfterLexer(sources: Map[Source, Array[Token]]) extends FlixEvent
-
-  /**
-    * An event that is fired after the tailpos phase.
-    */
-  case class AfterTailPos(root: ReducedAst.Root) extends FlixEvent
-
-  /**
-    * An event that is fired after the Typer phase.
-    */
-  case class AfterTyper(root: TypedAst.Root) extends FlixEvent
 
   /**
     * An event that is fired each time the JVM backend emits a class file for `sym`. `bytes` is


### PR DESCRIPTION
Removes the three `FlixEvent`s that no longer have listeners after the verifier ladder (#13178, #13179, #13181):

- `AfterLexer`: replaced by the direct `TokenVerifier` call under `--Xverify`.
- `AfterTyper`: was never emitted since #10394.
- `AfterTailPos`: its only listener was the removed `TypeVerifier`. Its emit in `Flix.codeGen` is deleted too.

The imports in `FlixEvent.scala` that only these events used (`Source`, `Token`, `ReducedAst`, `TypedAst`) go with them.

The remaining events are kept: `EmittedClass`, `InlinedDef` and `NewConstraintsDef` feed the compiler-top profiler, and `SolveEffEquations` feeds `ZhegalkinPerf`. The `FlixListener` mechanism is unchanged.

Last of four PRs in the ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Z2SunSYcVhcgWrbgHPoeQ
