### PR TITLE
fix: report Java metadata lookup failures

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -78,6 +78,7 @@ object ErrorCode {
   case object E1896 extends ErrorCode
   case object E1907 extends ErrorCode
   case object E1914 extends ErrorCode
+  case object E1925 extends ErrorCode
   case object E1952 extends ErrorCode
   case object E1960 extends ErrorCode
   case object E2018 extends ErrorCode
@@ -209,6 +210,7 @@ object ErrorCode {
   case object E6218 extends ErrorCode
   case object E6221 extends ErrorCode
   case object E6247 extends ErrorCode
+  case object E6258 extends ErrorCode
   case object E6285 extends ErrorCode
   case object E6289 extends ErrorCode
   case object E6358 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -944,6 +944,29 @@ object ResolutionError {
   }
 
   /**
+    * An error raised when Java class-file metadata required for member resolution cannot be read.
+    *
+    * @param query  the Java member being resolved.
+    * @param reason the reason the metadata lookup failed.
+    * @param loc    the location of the member access.
+    */
+  case class JavaMetadataLookupError(query: String, reason: String, loc: SourceLocation) extends ResolutionError {
+    def code: ErrorCode = ErrorCode.E1925
+
+    def summary: String = s"Unable to read Java class metadata while resolving '$query'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Unable to read Java class metadata while resolving '${red(query)}'.
+         |
+         |${highlight(loc, "metadata lookup failed", fmt)}
+         |
+         |${underline("Explanation:")} $reason
+         |""".stripMargin
+    }
+  }
+
+  /**
     * Undefined Kind Error.
     *
     * @param qn  the name.

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -328,6 +328,29 @@ object TypeError {
   }
 
   /**
+    * An error raised when Java class-file metadata required for member resolution cannot be read.
+    *
+    * @param query  the Java member being resolved.
+    * @param reason the reason the metadata lookup failed.
+    * @param loc    the location of the member access.
+    */
+  case class JavaMetadataLookupError(query: String, reason: String, loc: SourceLocation) extends TypeError {
+    def code: ErrorCode = ErrorCode.E6258
+
+    def summary: String = s"Unable to read Java class metadata while resolving '$query'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Unable to read Java class metadata while resolving '${red(query)}'.
+         |
+         |${highlight(loc, "metadata lookup failed", fmt)}
+         |
+         |${underline("Explanation:")} $reason
+         |""".stripMargin
+    }
+  }
+
+  /**
     * Associated type used where not allowed.
     *
     * @param sym the symbol of the associated type.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -28,7 +28,7 @@ import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
+import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaLookupError, JavaMemberResolver}
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
 
@@ -818,9 +818,14 @@ object Resolver {
                 val error = ResolutionError.UndefinedJvmStaticField(clazz, fieldName, loc)
                 sctx.errors.add(error)
                 return ResolvedAst.Expr.Error(error)
-              case Result.Err(error) =>
+              case Result.Err(error: JavaLookupError.UnsupportedDescriptor) =>
                 val query = s"${owner.displayName()}.${fieldName.name}"
                 throw InternalCompilerException(s"Java field lookup failed for '$query': $error", loc)
+              case Result.Err(error) =>
+                val query = s"${owner.displayName()}.${fieldName.name}"
+                val diagnostic = ResolutionError.JavaMetadataLookupError(query, error.explanation, loc)
+                sctx.errors.add(diagnostic)
+                return ResolvedAst.Expr.Error(diagnostic)
             }
           case _ =>
           // Fallthrough to below.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -291,6 +291,8 @@ object ConstraintSolver2 {
       }
 
     case TypeConstraint.EffConflicted(_) => constr :: Nil
+
+    case TypeConstraint.Error(_) => constr :: Nil
   }
 
   /**
@@ -391,6 +393,7 @@ object ConstraintSolver2 {
     case c: TypeConstraint.Equality => List(c)
     case c: TypeConstraint.Conflicted => List(c)
     case c: TypeConstraint.EffConflicted => List(c)
+    case c: TypeConstraint.Error => List(c)
 
     case c@TypeConstraint.Purification(sym, eff1, eff2, prov, nested0) =>
       val nested = ListOps.flatMapWithReuse(nested0)(contextReduction(_, progress)(scope.enter(sym), renv0, trenv, eqenv, flix))

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -277,6 +277,8 @@ object ConstraintSolverInterface {
 
     case TypeConstraint.EffConflicted(err) => List(err)
 
+    case TypeConstraint.Error(err) => List(err)
+
     case TypeConstraint.Trait(sym, tpe, loc) =>
       tpe.typeConstructor match {
         case Some(TypeConstructor.Arrow(_)) => List(TypeError.MissingInstanceArrow(sym, subst(tpe), renv, loc))

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
@@ -145,6 +145,7 @@ object Debug {
       (header :: children ::: edges).mkString("\n")
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => s"""${constraintId(constr)} [label = "$tpe1 ≁ $tpe2"];"""
     case TypeConstraint.EffConflicted(effErr) => format(effErr.toString)
+    case TypeConstraint.Error(err) => format(err.toString)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SubstitutionTree.scala
@@ -86,6 +86,8 @@ class SubstitutionTree private(val root: Substitution, val branches: Map[Symbol.
           TypeConstraint.Conflicted(t1, t2, prov)
 
       case TypeConstraint.EffConflicted(_) => constr
+
+      case TypeConstraint.Error(_) => constr
     }
   }
 
@@ -174,4 +176,3 @@ object SubstitutionTree {
     }
   }
 }
-

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
@@ -35,6 +35,7 @@ sealed trait TypeConstraint {
     case TypeConstraint.Purification(_, eff1, eff2, _, nested) => eff1.size + eff2.size + nested.map(_.size).sum
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => tpe1.size + tpe2.size
     case TypeConstraint.EffConflicted(_) => 0
+    case TypeConstraint.Error(_) => 0
   }
 
   override def toString: String = this match {
@@ -43,6 +44,7 @@ sealed trait TypeConstraint {
     case TypeConstraint.Purification(sym, eff1, eff2, _, nested) => s"$eff1 ~ ($eff2)[$sym ↦ Pure] ∧ $nested"
     case TypeConstraint.Conflicted(tpe1, tpe2, _) => s"$tpe1 ≁ $tpe2"
     case TypeConstraint.EffConflicted(err) => err.toString
+    case TypeConstraint.Error(err) => err.toString
   }
 
   def loc: SourceLocation
@@ -104,6 +106,11 @@ object TypeConstraint {
   }
 
   case class EffConflicted(error: TypeError) extends TypeConstraint {
+    def loc: SourceLocation = error.loc
+  }
+
+  /** A diagnostic produced while reducing a type constraint. */
+  case class Error(error: TypeError) extends TypeConstraint {
     def loc: SourceLocation = error.loc
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -18,13 +18,14 @@ package ca.uwaterloo.flix.language.phase.typer
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.Type.JvmMember
-import ca.uwaterloo.flix.language.ast.jvm.{JavaClass, JavaField, JavaMethod, JavaType, JavaTypeParameter, JavaTypeVariable}
+import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod, JavaType, JavaTypeParameter, JavaTypeVariable}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
 import ca.uwaterloo.flix.language.ast.shared.{AssocTypeDef, RegionScope}
-import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaArgument, JavaMemberResolver}
+import ca.uwaterloo.flix.language.errors.TypeError
+import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaArgument, JavaLookupError, JavaMemberResolver}
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, Substitution}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
-import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, Result}
 
 import java.lang.constant.ConstantDescs.*
 import java.lang.constant.ClassDesc
@@ -107,6 +108,10 @@ object TypeReduction2 {
     case Type.JvmToType(tpe, loc) =>
       val (t, cs) = reduce(tpe)
       t match {
+        case Type.Cst(TypeConstructor.Error(_, _), _) =>
+          progress.markProgress()
+          (Type.freshError(Kind.Star, loc), cs)
+
         case Type.Cst(TypeConstructor.JvmConstructor(constructor), _) =>
           progress.markProgress()
           val clazz = ClassDescs.load(constructor.ref.owner, flix.jarLoader)
@@ -129,6 +134,10 @@ object TypeReduction2 {
     case Type.JvmToEff(tpe, loc) =>
       val (t, cs) = reduce(tpe)
       t match {
+        case Type.Cst(TypeConstructor.Error(_, _), _) =>
+          progress.markProgress()
+          (Type.freshError(Kind.Eff, loc), cs)
+
         case Type.Cst(TypeConstructor.JvmConstructor(constructor), _) =>
           progress.markProgress()
           (PrimitiveEffects.getConstructorEffs(constructor, loc), cs)
@@ -147,19 +156,23 @@ object TypeReduction2 {
         case JvmMember.JvmConstructor(clazz, tpes) =>
           val (reducedTpes, css) = tpes.map(reduce(_)).unzip
           val cs = css.flatten
-          lookupConstructor(clazz, reducedTpes, loc) match {
+          lookupConstructor(clazz, reducedTpes) match {
             case JavaConstructorResolution.Resolved(constructor) =>
               progress.markProgress()
               (Type.Cst(TypeConstructor.JvmConstructor(constructor), loc), cs)
+            case JavaConstructorResolution.MetadataError(query, error) =>
+              recoverFromJavaMetadataError(query, error, loc, cs)
             case _ => (unresolved, cs)
           }
 
         case JvmMember.JvmField(_, tpe, name) =>
           val (reducedTpe, cs) = reduce(tpe)
-          lookupField(reducedTpe, name.name, loc) match {
+          lookupField(reducedTpe, name.name) match {
             case JavaFieldResolution.Resolved(field) =>
               progress.markProgress()
               (Type.Cst(TypeConstructor.JvmField(field), loc), cs)
+            case JavaFieldResolution.MetadataError(query, error) =>
+              recoverFromJavaMetadataError(query, error, loc, cs)
             case _ => (unresolved, cs)
           }
 
@@ -167,32 +180,51 @@ object TypeReduction2 {
           val (reducedTpe, cs0) = reduce(tpe)
           val (reducedTpes, css) = tpes.map(reduce(_)).unzip
           val cs = cs0 ::: css.flatten
-          lookupMethod(reducedTpe, name.name, reducedTpes, loc) match {
-            case JavaMethodResolution.Resolved(method) =>
-              val classTypeParameters = classTypeParametersOf(method, getJavaTypeDesc(reducedTpe), loc)
+          lookupMethod(reducedTpe, name.name, reducedTpes) match {
+            case JavaMethodResolution.Resolved(method, classTypeParameters, query) =>
               val classTypeArgs = extractClassTypeArgs(classTypeParameters, reducedTpe, scope, loc)
-              val (tpe, cs0) = instantiateMethod(method, classTypeParameters, classTypeArgs, reducedTpes, scope, loc)
-              progress.markProgress()
-              (tpe, cs ::: cs0)
+              instantiateMethod(method, classTypeParameters, classTypeArgs, reducedTpes, scope, loc) match {
+                case Ok((tpe, cs0)) =>
+                  progress.markProgress()
+                  (tpe, cs ::: cs0)
+                case Err(error) => recoverFromJavaMetadataError(query, error, loc, cs)
+              }
+            case JavaMethodResolution.MetadataError(query, error) =>
+              recoverFromJavaMetadataError(query, error, loc, cs)
             case _ => (unresolved, cs)
           }
 
         case JvmMember.JvmStaticMethod(clazz, name, tpes) =>
           val (reducedTpes, css) = tpes.map(reduce(_)).unzip
           val cs = css.flatten
-          lookupStaticMethod(clazz, name.name, reducedTpes, loc) match {
-            case JavaMethodResolution.Resolved(method) =>
+          lookupStaticMethod(clazz, name.name, reducedTpes) match {
+            case JavaMethodResolution.Resolved(method, classTypeParameters, query) =>
               // Class type parameters are not in scope for static methods.
-              val (tpe, cs0) = instantiateMethod(method, Nil, Nil, reducedTpes, scope, loc)
-              progress.markProgress()
-              (tpe, cs ::: cs0)
+              instantiateMethod(method, classTypeParameters, Nil, reducedTpes, scope, loc) match {
+                case Ok((tpe, cs0)) =>
+                  progress.markProgress()
+                  (tpe, cs ::: cs0)
+                case Err(error) => recoverFromJavaMetadataError(query, error, loc, cs)
+              }
+            case JavaMethodResolution.MetadataError(query, error) =>
+              recoverFromJavaMetadataError(query, error, loc, cs)
             case _ => (unresolved, cs)
           }
       }
   }
 
+  /** Recovers from a Java metadata failure with an error type and a retained diagnostic. */
+  private def recoverFromJavaMetadataError(query: String, error: JavaLookupError, loc: SourceLocation, cs: List[TypeConstraint])(implicit progress: Progress, flix: Flix): (Type, List[TypeConstraint]) = error match {
+    case _: JavaLookupError.UnsupportedDescriptor =>
+      throw InternalCompilerException(s"Java metadata lookup failed for '$query': $error", loc)
+    case _ =>
+      progress.markProgress()
+      val diagnostic = TypeError.JavaMetadataLookupError(query, error.explanation, loc)
+      (Type.freshError(Kind.Jvm, loc), TypeConstraint.Error(diagnostic) :: cs)
+  }
+
   /** Tries to find a constructor of `clazz` that takes arguments of type `ts`. */
-  private def lookupConstructor(clazz: Class[?], ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaConstructorResolution = {
+  private def lookupConstructor(clazz: Class[?], ts: List[Type])(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaConstructorResolution = {
     val typesAreKnown = ts.forall(isKnown)
     if (!typesAreKnown) return JavaConstructorResolution.UnresolvedTypes
 
@@ -205,39 +237,41 @@ object TypeReduction2 {
       case Ok(Nil) => JavaConstructorResolution.NotFound
       case Err(error) =>
         val query = s"${owner.displayName()}(${arguments.mkString(", ")})"
-        throw InternalCompilerException(s"Java constructor lookup failed for '$query': $error", loc)
+        JavaConstructorResolution.MetadataError(query, error)
     }
   }
 
   /** Tries to find a method of `thisObj` that takes arguments of type `ts`. */
-  private def lookupMethod(thisObj: Type, methodName: String, ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaMethodResolution = {
+  private def lookupMethod(thisObj: Type, methodName: String, ts: List[Type])(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaMethodResolution = {
     val typesAreKnown = isKnown(thisObj) && ts.forall(isKnown)
     if (!typesAreKnown) return JavaMethodResolution.UnresolvedTypes
 
     // Rigid type variables and other non-Java types fall back to Object.
-    retrieveMethod(getJavaTypeDesc(thisObj), methodName, ts, static = false, loc)
+    retrieveMethod(getJavaTypeDesc(thisObj), methodName, ts, static = false)
   }
 
   /** Tries to find a static method of `clazz` that takes arguments of type `ts`. */
-  private def lookupStaticMethod(clazz: Class[?], methodName: String, ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaMethodResolution = {
+  private def lookupStaticMethod(clazz: Class[?], methodName: String, ts: List[Type])(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaMethodResolution = {
     val typesAreKnown = ts.forall(isKnown)
     if (!typesAreKnown) return JavaMethodResolution.UnresolvedTypes
 
-    retrieveMethod(ClassDescs.of(clazz), methodName, ts, static = true, loc)
+    retrieveMethod(ClassDescs.of(clazz), methodName, ts, static = true)
   }
 
   /** Tries to find a static/dynamic method of `owner` that takes arguments of type `ts`. */
-  private def retrieveMethod(owner: ClassDesc, methodName: String, ts: List[Type], static: Boolean, loc: SourceLocation)(implicit flix: Flix): JavaMethodResolution = {
+  private def retrieveMethod(owner: ClassDesc, methodName: String, ts: List[Type], static: Boolean)(implicit flix: Flix): JavaMethodResolution = {
     val arguments = ts.map(getJavaArgument)
+    val kind = if (static) "static" else "instance"
+    val query = s"$kind ${owner.displayName()}.$methodName(${arguments.mkString(", ")})"
     JavaMemberResolver.methods(owner, methodName, arguments, static) match {
       // The resolver returns every method tied for the best match in a deterministic order.
       // We pick the first one.
-      case Ok(method :: _) => JavaMethodResolution.Resolved(method)
+      case Ok(method :: _) => classTypeParametersOf(method, owner) match {
+        case Ok(classTypeParameters) => JavaMethodResolution.Resolved(method, classTypeParameters, query)
+        case Err(error) => JavaMethodResolution.MetadataError(query, error)
+      }
       case Ok(Nil) => JavaMethodResolution.NotFound
-      case Err(error) =>
-        val kind = if (static) "static" else "instance"
-        val query = s"$kind ${owner.displayName()}.$methodName(${arguments.mkString(", ")})"
-        throw InternalCompilerException(s"Java method lookup failed for '$query': $error", loc)
+      case Err(error) => JavaMethodResolution.MetadataError(query, error)
     }
   }
 
@@ -289,7 +323,7 @@ object TypeReduction2 {
   }
 
   /** Tries to find a field of `thisObj` with the name `fieldName`. */
-  private def lookupField(thisObj: Type, fieldName: String, loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaFieldResolution = {
+  private def lookupField(thisObj: Type, fieldName: String)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaFieldResolution = {
     val typeIsKnown = isKnown(thisObj)
     if (!typeIsKnown) return JavaFieldResolution.UnresolvedTypes
 
@@ -297,9 +331,7 @@ object TypeReduction2 {
     JavaMemberResolver.field(owner, fieldName, static = false) match {
       case Ok(Some(field)) => JavaFieldResolution.Resolved(field)
       case Ok(None) => JavaFieldResolution.NotFound
-      case Err(error) =>
-        val query = s"${owner.displayName()}.$fieldName"
-        throw InternalCompilerException(s"Java field lookup failed for '$query': $error", loc)
+      case Err(error) => JavaFieldResolution.MetadataError(s"${owner.displayName()}.$fieldName", error)
     }
   }
 
@@ -336,6 +368,9 @@ object TypeReduction2 {
     /** No matching field. */
     case object NotFound extends JavaFieldResolution
 
+    /** Class-file metadata required for the lookup could not be read. */
+    case class MetadataError(query: String, error: JavaLookupError) extends JavaFieldResolution
+
     /**
       * The types used for the lookup are not resolved enough to decide on a field.
       *
@@ -356,6 +391,9 @@ object TypeReduction2 {
     /** No matching constructor. */
     case object NotFound extends JavaConstructorResolution
 
+    /** Class-file metadata required for the lookup could not be read. */
+    case class MetadataError(query: String, error: JavaLookupError) extends JavaConstructorResolution
+
     /**
       * The types used for the lookup are not resolved enough to decide on a constructor.
       *
@@ -371,10 +409,13 @@ object TypeReduction2 {
   private object JavaMethodResolution {
 
     /** One matching method. */
-    case class Resolved(method: JavaMethod) extends JavaMethodResolution
+    case class Resolved(method: JavaMethod, classTypeParameters: List[JavaTypeParameter], query: String) extends JavaMethodResolution
 
     /** No matching method. */
     case object NotFound extends JavaMethodResolution
+
+    /** Class-file metadata required for the lookup could not be read. */
+    case class MetadataError(query: String, error: JavaLookupError) extends JavaMethodResolution
 
     /**
       * The types used for the lookup are not resolved enough to decide on a method.
@@ -510,9 +551,9 @@ object TypeReduction2 {
     * The parameter and return types of a method found through the virtual method graph of `owner`
     * refer to the type parameters of `owner`, even if the method is declared by a supertype.
     */
-  private def classTypeParametersOf(method: JavaMethod, owner: ClassDesc, loc: SourceLocation)(implicit flix: Flix): List[JavaTypeParameter] =
-    if (Modifier.isStatic(method.modifiers) || !owner.isClassOrInterface) Nil
-    else lookupClass(owner, loc).typeParameters
+  private def classTypeParametersOf(method: JavaMethod, owner: ClassDesc)(implicit flix: Flix): Result[List[JavaTypeParameter], JavaLookupError] =
+    if (Modifier.isStatic(method.modifiers) || !owner.isClassOrInterface) Ok(Nil)
+    else flix.javaTypeProvider.lookupClass(owner).map(_.typeParameters)
 
   /**
     * Instantiates a resolved Java method: creates fresh type variables for method-level
@@ -526,13 +567,12 @@ object TypeReduction2 {
     *   - methodTypeArgs = [?t] (fresh var for `T`)
     *   - emits Equality(?t, String) for the `T` parameter
     */
-  private def instantiateMethod(method: JavaMethod, classTypeParameters: List[JavaTypeParameter], classTypeArgs: List[Type], argTypes: List[Type], scope: RegionScope, loc: SourceLocation)(implicit flix: Flix): (Type, List[TypeConstraint]) = {
+  private def instantiateMethod(method: JavaMethod, classTypeParameters: List[JavaTypeParameter], classTypeArgs: List[Type], argTypes: List[Type], scope: RegionScope, loc: SourceLocation)(implicit flix: Flix): Result[(Type, List[TypeConstraint]), JavaLookupError] = {
     val methodTypeArgs = method.typeParameters.map(_ => Type.freshVar(Kind.Star, loc)(scope, flix))
     val allTypeArgs = classTypeArgs ++ methodTypeArgs
     val base = Type.Cst(TypeConstructor.JvmMethod(method, classTypeParameters), loc)
     val tpe = Type.mkApply(base, allTypeArgs, loc)
-    val cs = mkArgConstraints(method, classTypeParameters, allTypeArgs, argTypes, loc)
-    (tpe, cs)
+    mkArgConstraints(method, classTypeParameters, allTypeArgs, argTypes, loc).map(cs => (tpe, cs))
   }
 
   /**
@@ -547,37 +587,37 @@ object TypeReduction2 {
     * argument type.
     */
   private def mkArgConstraints(method: JavaMethod, classTypeParameters: List[JavaTypeParameter], typeArgs: List[Type],
-    argTypes: List[Type], loc: SourceLocation)(implicit flix: Flix): List[TypeConstraint] = {
+    argTypes: List[Type], loc: SourceLocation)(implicit flix: Flix): Result[List[TypeConstraint], JavaLookupError] = {
     val substMap = buildTypeVarSubstitution(method, classTypeParameters, typeArgs)
-    argTypes.zip(method.parameterTypes).flatMap { case (argType, paramType) =>
+    Result.traverse(argTypes.zip(method.parameterTypes)) { case (argType, paramType) =>
       argType match {
         // `null` is a valid value of any reference type, so it must not constrain
         // the parameter's type variable. Emit no constraint and let the receiver
         // or surrounding context determine the type variable.
-        case Type.Cst(TypeConstructor.Null, _) => None
+        case Type.Cst(TypeConstructor.Null, _) => Ok(Nil)
         case _ => paramType match {
           case JavaType.Variable(variable, _) =>
-            substMap.get(variable).map { expectedType =>
+            Ok(substMap.get(variable).map { expectedType =>
               TypeConstraint.Equality(expectedType, argType,
                 TypeConstraint.Provenance.Match(expectedType, argType, loc))
-            }
+            }.toList)
           case pt: JavaType.Parameterized =>
             mkParamTypeConstraints(pt, argType, substMap, loc)
           case JavaType.GenericArray(component, _) =>
             // For varargs/array params (e.g., T[] in Stream.of(T...)), emit a constraint
             // linking the component type variable to the Flix array/vector element type.
-            (component, argType.typeArguments) match {
+            Ok((component, argType.typeArguments) match {
               case (JavaType.Variable(variable, _), elmType :: _) =>
                 substMap.get(variable).map { expectedType =>
                   TypeConstraint.Equality(expectedType, elmType,
                     TypeConstraint.Provenance.Match(expectedType, elmType, loc))
                 }.toList
               case _ => Nil
-            }
-          case _ => None
+            })
+          case _ => Ok(Nil)
         }
       }
-    }
+    }.map(_.flatten)
   }
 
   /**
@@ -617,7 +657,7 @@ object TypeReduction2 {
     *    Zips the Java type arguments with the Flix type arguments directly.
     */
   private def mkParamTypeConstraints(pt: JavaType.Parameterized, argType: Type,
-    substMap: Map[JavaTypeVariable, Type], loc: SourceLocation)(implicit flix: Flix): List[TypeConstraint] = {
+    substMap: Map[JavaTypeVariable, Type], loc: SourceLocation)(implicit flix: Flix): Result[List[TypeConstraint], JavaLookupError] = {
     argType match {
       case Type.Apply(Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Arrow(2), _), _, _), flixArg, _), flixRet, _) =>
         lookupFunIF(flixArg, flixRet) match {
@@ -625,28 +665,30 @@ object TypeReduction2 {
             val fiTypeArgs: Map[String, Type] =
               mapping.argParam.map(_ -> flixArg).toMap ++
               mapping.retParam.map(_ -> flixRet).toMap
-            val interfaceParamNames = lookupClass(pt.erasure, loc).typeParameters.map(_.variable.name)
-            interfaceParamNames.zip(pt.arguments).flatMap {
-              case (ifParamName, javaTypeArg) =>
-                resolveToTypeVariable(javaTypeArg).flatMap { methodTv =>
-                  for {
-                    expectedType <- substMap.get(methodTv)
-                    flixType <- fiTypeArgs.get(ifParamName)
-                  } yield TypeConstraint.Equality(expectedType, flixType,
-                    TypeConstraint.Provenance.Match(expectedType, flixType, loc))
+            flix.javaTypeProvider.lookupClass(pt.erasure).map { clazz =>
+              val interfaceParamNames = clazz.typeParameters.map(_.variable.name)
+              interfaceParamNames.zip(pt.arguments).flatMap {
+                case (ifParamName, javaTypeArg) =>
+                  resolveToTypeVariable(javaTypeArg).flatMap { methodTv =>
+                    for {
+                      expectedType <- substMap.get(methodTv)
+                      flixType <- fiTypeArgs.get(ifParamName)
+                    } yield TypeConstraint.Equality(expectedType, flixType,
+                      TypeConstraint.Provenance.Match(expectedType, flixType, loc))
+                  }
                 }
             }
-          case None => Nil
+          case None => Ok(Nil)
         }
       case _ =>
-        pt.arguments.zip(argType.typeArguments).flatMap {
+        Ok(pt.arguments.zip(argType.typeArguments).flatMap {
           case (JavaType.Variable(variable, _), flixArg) =>
             substMap.get(variable).map { expectedType =>
               TypeConstraint.Equality(expectedType, flixArg,
                 TypeConstraint.Provenance.Match(expectedType, flixArg, loc))
             }
           case _ => None
-        }
+        })
     }
   }
 
@@ -658,13 +700,6 @@ object TypeReduction2 {
         .orElse(lowerBounds.collectFirst { case JavaType.Variable(variable, _) => variable })
     case _ => None
   }
-
-  /** Returns the class metadata of `desc`, or throws if it cannot be read. */
-  private def lookupClass(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): JavaClass =
-    flix.javaTypeProvider.lookupClass(desc) match {
-      case Ok(clazz) => clazz
-      case Err(error) => throw InternalCompilerException(s"Java class lookup failed for '${desc.displayName()}': $error", loc)
-    }
 
   /** Loads the class of `desc` without initializing it. */
   private def loadClass(desc: ClassDesc)(implicit flix: Flix): Class[?] = ClassDescs.load(desc, flix.jarLoader)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaLookupError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaLookupError.scala
@@ -20,17 +20,26 @@ import java.lang.constant.ClassDesc
 /** An error encountered while looking up Java class-file metadata. */
 sealed trait JavaLookupError {
   def desc: ClassDesc
+
+  /** Returns a human-readable explanation of this lookup failure. */
+  def explanation: String
 }
 
 object JavaLookupError {
 
   /** The class file was found, but its metadata could not be read. */
-  case class InvalidClass(desc: ClassDesc, message: String) extends JavaLookupError
+  case class InvalidClass(desc: ClassDesc, message: String) extends JavaLookupError {
+    def explanation: String = s"The class file for '${desc.displayName()}' could not be read: $message"
+  }
 
   /** The class file for `desc` was not present in the configured class path. */
-  case class MissingClass(desc: ClassDesc) extends JavaLookupError
+  case class MissingClass(desc: ClassDesc) extends JavaLookupError {
+    def explanation: String = s"The class file for '${desc.displayName()}' was not found on the configured class path."
+  }
 
   /** `desc` does not denote a nominal reference type. */
-  case class UnsupportedDescriptor(desc: ClassDesc) extends JavaLookupError
+  case class UnsupportedDescriptor(desc: ClassDesc) extends JavaLookupError {
+    def explanation: String = s"'${desc.displayName()}' is not a Java class or interface descriptor."
+  }
 
 }

--- a/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/compilertop/Profiler.scala
@@ -168,6 +168,7 @@ object Profiler {
         vars ++= e1.typeVars; vars ++= e2.typeVars
         nested.foreach(collect)
       case TypeConstraint.EffConflicted(_)            => ()
+      case TypeConstraint.Error(_)                    => ()
     }
     cs.foreach(collect)
     var tv = 0L
@@ -363,4 +364,3 @@ final class Profiler(phaseProvider: () => Option[String]) extends FlixListener {
     if (sym.id.isEmpty) sym
     else new Symbol.DefnSym(None, sym.namespace, sym.text, sym.loc)
 }
-


### PR DESCRIPTION
## Summary
- report missing or invalid Java class-file metadata as compiler diagnostics instead of internal compiler errors
- cover field, constructor, instance method, static method, and generic method metadata lookups
- preserve ordinary member-not-found behavior and keep unsupported descriptors as internal invariants
- carry typer diagnostics through constraint reduction while propagating error types through JVM type and effect projections

## Testing
- `./mill --no-server flix.compile`
- `./mill --no-server flix.test.testOnly flix.CompilerSuite ca.uwaterloo.flix.language.phase.TestResolver ca.uwaterloo.flix.language.phase.TestTyper ca.uwaterloo.flix.language.phase.typer.jvm.TestJavaMemberResolver ca.uwaterloo.flix.language.phase.typer.jvm.TestByteBuddyJavaTypeProvider` (779 passed)
- `./mill --no-server flix.test` (16,637 passed, 8 ignored)

No new tests were added.