### PR TITLE
refactor: expose annotation retention and parameter names in JavaTypeProvider

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/jvm/JavaClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/jvm/JavaClass.scala
@@ -21,10 +21,16 @@ import java.lang.constant.ClassDesc
 case class JavaClass(
   desc: ClassDesc,
   modifiers: Int,
+  isRuntimeVisibleAnnotation: Boolean,
   typeParameters: List[JavaTypeParameter],
   superClass: Option[JavaType],
   interfaces: List[JavaType],
   declaredConstructors: List[JavaMethod],
   declaredMethods: List[JavaMethod],
   declaredFields: List[JavaField]
-)
+) {
+
+  /** Returns whether this class-file type is an annotation. */
+  def isAnnotation: Boolean = (modifiers & 0x2000) != 0
+
+}

--- a/main/src/ca/uwaterloo/flix/language/ast/jvm/JavaMethod.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/jvm/JavaMethod.scala
@@ -20,6 +20,7 @@ case class JavaMethod(
   ref: JavaMethodRef,
   modifiers: Int,
   typeParameters: List[JavaTypeParameter],
+  parameterNames: List[String],
   parameterTypes: List[JavaType],
   returnType: JavaType,
   isConstructor: Boolean,

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -28,6 +28,7 @@ import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.dynamic.scaffold.MethodGraph
 import net.bytebuddy.pool.TypePool
 
+import java.lang.annotation.{Retention, RetentionPolicy}
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
 import java.lang.reflect.{GenericSignatureFormatError, MalformedParameterizedTypeException}
 import java.nio.file.{Files, Path}
@@ -147,6 +148,7 @@ final case class ByteBuddyJavaTypeProvider(
     JavaClass(
       desc = desc,
       modifiers = tpe.getModifiers,
+      isRuntimeVisibleAnnotation = isRuntimeVisibleAnnotation(tpe),
       typeParameters = tpe.getTypeVariables.asScala.toList.map(toTypeParameter),
       superClass = Option(tpe.getSuperClass).map(toType),
       interfaces = tpe.getInterfaces.asScala.toList.map(toType),
@@ -178,6 +180,7 @@ final case class ByteBuddyJavaTypeProvider(
       ref = ref,
       modifiers = method.getModifiers,
       typeParameters = method.getTypeVariables.asScala.toList.map(toTypeParameter),
+      parameterNames = method.getParameters.asDefined().asScala.toList.map(_.getName),
       parameterTypes = method.getParameters.asTypeList().asScala.toList.map(toType),
       returnType = toType(method.getReturnType),
       isConstructor = method.isConstructor,
@@ -193,6 +196,16 @@ final case class ByteBuddyJavaTypeProvider(
       name = defined.getInternalName,
       descriptor = MethodTypeDesc.ofDescriptor(defined.getDescriptor)
     )
+  }
+
+  /** Returns whether `tpe` is an annotation with runtime retention. */
+  private def isRuntimeVisibleAnnotation(tpe: TypeDescription): Boolean = {
+    if (!tpe.isAnnotation) {
+      false
+    } else {
+      val retention = tpe.getDeclaredAnnotations.ofType(classOf[Retention])
+      retention != null && retention.getValue("value").resolve(classOf[RetentionPolicy]) == RetentionPolicy.RUNTIME
+    }
   }
 
   /** Converts a Byte Buddy generic type description to Java type metadata. */


### PR DESCRIPTION
## Summary

- expose annotation type and runtime-retention metadata through JavaClass
- expose method and constructor parameter names through JavaMethod
- populate both from Byte Buddy class-file metadata without loading target classes

## Verification

- ./mill --no-server flix.compile

Tests were not added or run, per request.