### PR TITLE
refactor: represent native types by class descriptors

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/effectlock/serialization/Deserialize.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/serialization/Deserialize.scala
@@ -19,6 +19,7 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.{AssocTypeSymUse, TraitSymUs
 import ca.uwaterloo.flix.language.ast.shared.{EqualityConstraint, RegionScope, TraitConstraint, VarText}
 import ca.uwaterloo.flix.language.ast.{Kind, Name, Scheme, SourceLocation, Symbol, Type, TypeConstructor}
 
+import java.lang.constant.ClassDesc
 import scala.collection.immutable.SortedSet
 
 object Deserialize {
@@ -86,7 +87,7 @@ object Deserialize {
     case Enum(sym, kind) => TypeConstructor.Enum(deserializeEnumSym(sym), deserializeKind(kind))
     case Struct(sym, kind) => TypeConstructor.Struct(deserializeStructSym(sym), deserializeKind(kind))
     case RestrictableEnum(sym, kind) => TypeConstructor.RestrictableEnum(deserializeRestrictableEnumSym(sym), deserializeKind(kind))
-    case Native(clazz) => TypeConstructor.Native(deserializeJvmClass(Native(clazz)))
+    case Native(desc, arity) => TypeConstructor.Native(ClassDesc.ofDescriptor(desc), arity)
     case Array => TypeConstructor.Array
     case ArrayWithoutRegion => TypeConstructor.ArrayWithoutRegion
     case Vector => TypeConstructor.Vector
@@ -146,18 +147,6 @@ object Deserialize {
   private def deserializeEnumSym(sym0: EnumSym): Symbol.EnumSym = sym0 match {
     case EnumSym(namespace, text) =>
       Symbol.mkEnumSym(deserializeNamespace(namespace), deserializeIdent(text))
-  }
-
-  private def deserializeJvmClass(clazz0: Native): Class[?] = clazz0.clazz match {
-    case "B" => Byte.getClass
-    case "C" => Char.getClass
-    case "D" => Double.getClass
-    case "F" => Float.getClass
-    case "I" => Int.getClass
-    case "J" => Long.getClass
-    case "S" => Short.getClass
-    case "Z" => Boolean.getClass
-    case clazz => Class.forName(clazz)
   }
 
   private def deserializeKindedTypeVarSym(sym0: VarSym): Symbol.KindedTypeVarSym = sym0 match {

--- a/main/src/ca/uwaterloo/flix/api/effectlock/serialization/Serialize.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/serialization/Serialize.scala
@@ -101,7 +101,7 @@ object Serialize {
     case TypeConstructor.Enum(sym, kind) => Enum(serializeEnumSym(sym), serializeKind(kind))
     case TypeConstructor.Struct(sym, kind) => Struct(serializeStructSym(sym), serializeKind(kind))
     case TypeConstructor.RestrictableEnum(sym, kind) => RestrictableEnum(serializeRestrictableEnumSym(sym), serializeKind(kind))
-    case TypeConstructor.Native(clazz) => serializeJvmClass(clazz)
+    case TypeConstructor.Native(desc, arity) => Native(desc.descriptorString(), arity)
     case TypeConstructor.JvmConstructor(_) => throw InternalCompilerException(s"Unexpected type constructor: '$tc0'", SourceLocation.Unknown)
     case TypeConstructor.JvmMethod(_, _) => throw InternalCompilerException(s"Unexpected type constructor: '$tc0'", SourceLocation.Unknown)
     case TypeConstructor.JvmField(_) => throw InternalCompilerException(s"Unexpected type constructor: '$tc0'", SourceLocation.Unknown)
@@ -160,10 +160,6 @@ object Serialize {
 
   private def serializeEnumSym(sym0: Symbol.EnumSym): EnumSym = {
     EnumSym(sym0.namespace, sym0.text)
-  }
-
-  private def serializeJvmClass(clazz: Class[?]): Native = {
-    Native(clazz.descriptorString())
   }
 
   private def serializeKindedTypeVarSym(sym0: Symbol.KindedTypeVarSym): VarSym = {

--- a/main/src/ca/uwaterloo/flix/api/effectlock/serialization/package.scala
+++ b/main/src/ca/uwaterloo/flix/api/effectlock/serialization/package.scala
@@ -111,7 +111,7 @@ package object serialization {
 
   case class RestrictableEnum(sym: RestrictableEnumSym, kind: SKind) extends STC
 
-  case class Native(clazz: String) extends STC
+  case class Native(desc: String, arity: Int) extends STC
 
   case object Array extends STC
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -867,7 +867,7 @@ object SemanticTokensProvider {
     case TypeConstructor.Enum(_, _) => true
     case TypeConstructor.Struct(_, _) => true
     case TypeConstructor.RestrictableEnum(_, _) => true
-    case TypeConstructor.Native(_) => true
+    case TypeConstructor.Native(_, _) => true
     case TypeConstructor.Array => true
     case TypeConstructor.Vector => true
     case TypeConstructor.Pure => true

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
@@ -15,17 +15,20 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
 import ca.uwaterloo.flix.language.ast.{Name, Type}
-import ca.uwaterloo.flix.util.JvmUtils
+import ca.uwaterloo.flix.util.{ClassDescs, JvmUtils}
 
 object InvokeMethodCompleter {
 
-  def getCompletions(obj: Type, name: Name.Ident): Iterable[MethodCompletion] = {
-    Type.classFromFlixType(obj) match {
+  def getCompletions(obj: Type, name: Name.Ident)(implicit flix: Flix): Iterable[MethodCompletion] = {
+    Type.descFromFlixType(obj) match {
       case None =>
         Nil
-      case Some(clazz) =>
+      case Some(desc) =>
+        // Transitional: loads the class since the method lookup still requires a loaded class.
+        val clazz = ClassDescs.load(desc, flix.jarLoader)
         JvmUtils.getInstanceMethods(clazz).sortBy(_.getName).map(MethodCompletion(name, Priority.Lowest(0), _))
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -21,9 +21,12 @@ import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{AssocTypeSymUse, TypeAliasSymUse}
 import ca.uwaterloo.flix.language.ast.shared.VarText.Absent
 import ca.uwaterloo.flix.language.fmt.{FormatOptions, FormatType}
+import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, Nel}
-import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, Result}
 
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.*
 import java.util.Objects
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedSet
@@ -954,9 +957,21 @@ object Type {
     }
 
   /**
-    * Constructs the a native type.
+    * Constructs the native type of the class `desc` with `arity` type parameters.
     */
-  def mkNative(clazz: Class[?], loc: SourceLocation): Type = Type.Cst(TypeConstructor.Native(clazz), loc)
+  def mkNative(desc: ClassDesc, arity: Int, loc: SourceLocation): Type = Type.Cst(TypeConstructor.Native(desc, arity), loc)
+
+  /**
+    * Constructs the native type of the loaded class `clazz`.
+    *
+    * Transitional: prefer `mkNative(desc, arity, loc)` since it does not require a loaded class.
+    */
+  def mkNative(clazz: Class[?], loc: SourceLocation): Type = mkNative(ClassDescs.of(clazz), clazz.getTypeParameters.length, loc)
+
+  /**
+    * Returns the `java.lang.Object` type.
+    */
+  def mkObject(loc: SourceLocation): Type = mkNative(CD_Object, 0, loc)
 
   /**
     * Constructs a RecordExtend type.
@@ -1300,46 +1315,43 @@ object Type {
   }
 
   /**
-    * Returns the Flix Type of a Java Class.
+    * Returns the Flix Type of the Java class `desc` whose element class has `arity` type parameters.
     *
-    * Arrays are returned with the [[Type.IO]] region.
+    * Arrays are returned with the [[Type.IO]] region. Since an array class has no type parameters
+    * of its own, `arity` is the number of type parameters of its (innermost) element class.
     *
-    * Returns a [[TypeConstructor.Native]] of `c` if nothing more specific is found.
+    * Returns a [[TypeConstructor.Native]] of `desc` if nothing more specific is found.
+    */
+  def getFlixType(desc: ClassDesc, arity: Int): Type = desc match {
+    case CD_boolean => Type.Bool
+    case CD_byte => Type.Int8
+    case CD_short => Type.Int16
+    case CD_int => Type.Int32
+    case CD_long => Type.Int64
+    case CD_char => Type.Char
+    case CD_float => Type.Float32
+    case CD_double => Type.Float64
+    case CD_void => Type.Unit
+    case CD_String => Type.Str
+    case JavaClasses.BigDecimal => Type.BigDecimal
+    case JavaClasses.BigInteger => Type.BigInt
+    case JavaClasses.Regex => Type.Regex
+    case _ if desc.isArray =>
+      val elmType = getFlixType(desc.componentType(), arity)
+      Type.mkArray(elmType, Type.IO, SourceLocation.Unknown)
+    case _ => Type.mkNative(desc, arity, SourceLocation.Unknown)
+  }
+
+  /**
+    * Returns the Flix Type of the loaded Java class `c`.
+    *
+    * Transitional: prefer `getFlixType(desc, arity)` since it does not require a loaded class.
     */
   def getFlixType(c: Class[?]): Type = {
-    if (c == java.lang.Boolean.TYPE) {
-      Type.Bool
-    } else if (c == java.lang.Byte.TYPE) {
-      Type.Int8
-    } else if (c == java.lang.Short.TYPE) {
-      Type.Int16
-    } else if (c == java.lang.Integer.TYPE) {
-      Type.Int32
-    } else if (c == java.lang.Long.TYPE) {
-      Type.Int64
-    } else if (c == java.lang.Character.TYPE) {
-      Type.Char
-    } else if (c == java.lang.Float.TYPE) {
-      Type.Float32
-    } else if (c == java.lang.Double.TYPE) {
-      Type.Float64
-    } else if (c == classOf[java.math.BigDecimal]) {
-      Type.BigDecimal
-    } else if (c == classOf[java.math.BigInteger]) {
-      Type.BigInt
-    } else if (c == classOf[java.lang.String]) {
-      Type.Str
-    } else if (c == classOf[java.util.regex.Pattern]) {
-      Type.Regex
-    } else if (c == java.lang.Void.TYPE) {
-      Type.Unit
-    } else if (c.isArray) {
-      val comp = c.getComponentType
-      val elmType = getFlixType(comp)
-      Type.mkArray(elmType, Type.IO, SourceLocation.Unknown)
-    } else {
-      Type.mkNative(c, SourceLocation.Unknown)
-    }
+    // An array class has no type parameters of its own, so we use those of its element class.
+    var elm = c
+    while (elm.isArray) elm = elm.getComponentType
+    getFlixType(ClassDescs.of(c), elm.getTypeParameters.length)
   }
 
   /**
@@ -1349,45 +1361,32 @@ object Type {
   def instantiateJavaTypeWithObjectArgs(c: Class[?], loc: SourceLocation): Type = {
     val base = getFlixType(c)
     val n = c.getTypeParameters.length
-    Type.mkApply(base, List.fill(n)(Type.mkNative(classOf[Object], loc)), loc)
+    Type.mkApply(base, List.fill(n)(Type.mkObject(loc)), loc)
   }
 
   /**
-    * Returns the [[Class]] object of `tpe`, if it exists.
+    * Returns the descriptor of the Java class of `tpe`, if it exists.
     *
     * Almost the inverse function of [[getFlixType]], but arrays and unit returns None.
     */
-  def classFromFlixType(tpe: Type): Option[Class[?]] = tpe match {
-    case Type.Bool =>
-      Some(java.lang.Boolean.TYPE)
-    case Type.Int8 =>
-      Some(java.lang.Byte.TYPE)
-    case Type.Int16 =>
-      Some(java.lang.Short.TYPE)
-    case Type.Int32 =>
-      Some(java.lang.Integer.TYPE)
-    case Type.Int64 =>
-      Some(java.lang.Long.TYPE)
-    case Type.Char =>
-      Some(java.lang.Character.TYPE)
-    case Type.Float32 =>
-      Some(java.lang.Float.TYPE)
-    case Type.Float64 =>
-      Some(java.lang.Double.TYPE)
-    case Type.Cst(TypeConstructor.BigDecimal, _) =>
-      Some(classOf[java.math.BigDecimal])
-    case Type.Cst(TypeConstructor.BigInt, _) =>
-      Some(classOf[java.math.BigInteger])
-    case Type.Cst(TypeConstructor.Str, _) =>
-      Some(classOf[String])
-    case Type.Cst(TypeConstructor.Regex, _) =>
-      Some(classOf[java.util.regex.Pattern])
-    case Type.Cst(TypeConstructor.Native(clazz), _) =>
-      Some(clazz)
+  def descFromFlixType(tpe: Type): Option[ClassDesc] = tpe match {
+    case Type.Bool => Some(CD_boolean)
+    case Type.Int8 => Some(CD_byte)
+    case Type.Int16 => Some(CD_short)
+    case Type.Int32 => Some(CD_int)
+    case Type.Int64 => Some(CD_long)
+    case Type.Char => Some(CD_char)
+    case Type.Float32 => Some(CD_float)
+    case Type.Float64 => Some(CD_double)
+    case Type.Cst(TypeConstructor.BigDecimal, _) => Some(JavaClasses.BigDecimal)
+    case Type.Cst(TypeConstructor.BigInt, _) => Some(JavaClasses.BigInteger)
+    case Type.Cst(TypeConstructor.Str, _) => Some(CD_String)
+    case Type.Cst(TypeConstructor.Regex, _) => Some(JavaClasses.Regex)
+    case Type.Cst(TypeConstructor.Native(desc, _), _) => Some(desc)
     case _ =>
       // Peel off type applications (e.g., ArrayList[String]) and check the base type.
       tpe.baseType match {
-        case Type.Cst(TypeConstructor.Native(clazz), _) => Some(clazz)
+        case Type.Cst(TypeConstructor.Native(desc, _), _) => Some(desc)
         case _ => None
       }
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -5,6 +5,7 @@ import ca.uwaterloo.flix.language.ast.shared.ScalaAnnotations.{EliminatedBy, Int
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization
 import ca.uwaterloo.flix.language.phase.{Kinder, monomorph, Simplifier}
 
+import java.lang.constant.ClassDesc
 import scala.collection.immutable.SortedSet
 
 /**
@@ -264,15 +265,17 @@ object TypeConstructor {
   case class RestrictableEnum(sym: Symbol.RestrictableEnumSym, kind: Kind) extends TypeConstructor
 
   /**
-    * A type constructor that represents the type of JVM classes.
+    * A type constructor that represents the type of the JVM class `desc`.
     *
-    * The kind depends on the number of type parameters of the class:
-    * - `Native(classOf[String])` has kind `Star` (no type parameters).
-    * - `Native(classOf[ArrayList])` has kind `Star -> Star` (one type parameter).
-    * - `Native(classOf[HashMap])` has kind `Star -> Star -> Star` (two type parameters).
+    * `arity` is the number of type parameters of the class, which determines the kind:
+    * - `Native(String, 0)` has kind `Star` (no type parameters).
+    * - `Native(ArrayList, 1)` has kind `Star -> Star` (one type parameter).
+    * - `Native(HashMap, 2)` has kind `Star -> Star -> Star` (two type parameters).
+    *
+    * Unlike [[Class]], a [[Native]] does not retain a loaded class.
     */
-  case class Native(clazz: Class[?]) extends TypeConstructor {
-    def kind: Kind = Kind.mkArrow(clazz.getTypeParameters.length)
+  case class Native(desc: ClassDesc, arity: Int) extends TypeConstructor {
+    def kind: Kind = Kind.mkArrow(arity)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/UnkindedType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/UnkindedType.scala
@@ -23,6 +23,8 @@ import ca.uwaterloo.flix.language.phase.Resolver
 import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.Nel
 
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.CD_Object
 import java.util.Objects
 import scala.collection.immutable.SortedSet
 
@@ -91,7 +93,7 @@ sealed trait UnkindedType {
     case UnkindedType.RestrictableEnum(_, _) => SortedSet.empty
     case UnkindedType.UnappliedAlias(_, _) => SortedSet.empty
     case UnkindedType.UnappliedAssocType(_, _) => SortedSet.empty
-    case UnkindedType.UnappliedNative(_, _) => SortedSet.empty
+    case UnkindedType.UnappliedNative(_, _, _) => SortedSet.empty
     case UnkindedType.Apply(tpe1, tpe2, _) => tpe1.definiteTypeVars ++ tpe2.definiteTypeVars
     case UnkindedType.Arrow(eff, _, _) => eff.iterator.flatMap(_.definiteTypeVars).to(SortedSet)
     case UnkindedType.CaseSet(_, _) => SortedSet.empty
@@ -212,11 +214,11 @@ object UnkindedType {
   }
 
   /**
-    * An unapplied native Java type with type parameters.
+    * An unapplied native Java type `desc` with `arity` type parameters.
     * Only exists temporarily in the Resolver until it's converted to a [[Cst]].
     */
   @EliminatedBy(Resolver.getClass)
-  case class UnappliedNative(clazz: java.lang.Class[?], loc: SourceLocation) extends UnkindedType
+  case class UnappliedNative(desc: ClassDesc, arity: Int, loc: SourceLocation) extends UnkindedType
 
   /**
     * A type application.
@@ -384,10 +386,8 @@ object UnkindedType {
   /**
     * Returns the java.lang.Object type.
     */
-  def mkObject(loc: SourceLocation): UnkindedType = {
-    val obj = Class.forName("java.lang.Object")
-    UnkindedType.Cst(TypeConstructor.Native(obj), loc)
-  }
+  def mkObject(loc: SourceLocation): UnkindedType =
+    UnkindedType.Cst(TypeConstructor.Native(CD_Object, 0), loc)
 
   /**
     * Constructs the apply type base[t_1, ,..., t_n].
@@ -563,6 +563,6 @@ object UnkindedType {
     case tpe: UnkindedType.Error => tpe
     case UnappliedAlias(_, loc) => throw InternalCompilerException("unexpected unapplied alias", loc)
     case UnappliedAssocType(_, loc) => throw InternalCompilerException("unexpected unapplied associated type", loc)
-    case UnappliedNative(_, loc) => throw InternalCompilerException("unexpected unapplied native type", loc)
+    case UnappliedNative(_, _, loc) => throw InternalCompilerException("unexpected unapplied native type", loc)
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.dbg
 import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod}
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{Name, Symbol}
+import ca.uwaterloo.flix.util.ClassDescs
 
 import java.lang.constant.ClassDesc
 import scala.collection.immutable.SortedSet
@@ -139,8 +140,6 @@ object DocAst {
 
     case class Lambda(fparams: List[Expr.AscriptionTpe], body: Expr) extends Composite
 
-    case class Native(clazz: Class[?]) extends Atom
-
     val Unknown: Expr =
       Meta("unknown exp")
 
@@ -250,7 +249,7 @@ object DocAst {
       Binary(d1, "===", d2)
 
     def InstanceOf(d: Expr, clazz: Class[?]): Expr =
-      Binary(d, "instanceof", Native(clazz))
+      InstanceOf(d, ClassDescs.of(clazz))
 
     def InstanceOf(d: Expr, clazz: ClassDesc): Expr =
       Binary(d, "instanceof", AsIs(javaClassName(clazz)))
@@ -416,7 +415,7 @@ object DocAst {
 
     case class SchemaExtend(name: String, tpe: Type, rest: Type) extends Atom
 
-    case class Native(clazz: Class[?]) extends Atom
+    case class Native(desc: ClassDesc) extends Atom
 
     case class JvmConstructor(constructor: JavaMethod) extends Atom
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
@@ -224,17 +224,12 @@ object DocAstFormatter {
         group(text("new") +: text(className) +: curly(
           semiSepOpt(allFormatted)
         ))
-      case Native(clazz) =>
-        formatJavaClass(clazz)
     }
     d0 match {
       case _: Composite if paren => parens(doc)
       case _: Composite | _: Atom => doc
     }
   }
-
-  private def formatJavaClass(clazz: Class[?]): Doc =
-    text(clazz.getName)
 
   private def formatJvmConstructor(c: JvmConstructor)(implicit i: Indent): Doc = {
     val JvmConstructor(clo, _) = c
@@ -430,8 +425,8 @@ object DocAstFormatter {
           case None =>
             text("#") |:: curlyTuple(predicatesf)
         }
-      case Type.Native(clazz) =>
-        formatJavaClass(clazz)
+      case Type.Native(desc) =>
+        text(Expr.javaClassName(desc))
       case Type.JvmConstructor(constructor) =>
         text(Expr.javaClassName(constructor.ref.owner))
       case Type.JvmMethod(method) =>

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypeConstructorPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypeConstructorPrinter.scala
@@ -59,7 +59,7 @@ object TypeConstructorPrinter {
     case TypeConstructor.Enum(sym, _) => DocAst.Type.AsIs(sym.toString)
     case TypeConstructor.Struct(sym, _) => DocAst.Type.AsIs(sym.toString)
     case TypeConstructor.RestrictableEnum(sym, _) => DocAst.Type.AsIs(sym.toString)
-    case TypeConstructor.Native(clazz) => DocAst.Type.Native(clazz)
+    case TypeConstructor.Native(desc, _) => DocAst.Type.Native(desc)
     case TypeConstructor.JvmConstructor(constructor) => DocAst.Type.JvmConstructor(constructor)
     case TypeConstructor.JvmMethod(method, _) => DocAst.Type.JvmMethod(method)
     case TypeConstructor.JvmField(field) => DocAst.Type.JvmField(field)

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/UnkindedTypePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/UnkindedTypePrinter.scala
@@ -3,6 +3,7 @@ package ca.uwaterloo.flix.language.dbg.printer
 import ca.uwaterloo.flix.language.ast.{TypeConstructor, UnkindedType}
 import ca.uwaterloo.flix.language.dbg.DocAst
 import ca.uwaterloo.flix.language.dbg.DocAst.Type
+import ca.uwaterloo.flix.util.ClassDescs
 
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedSet
@@ -68,7 +69,7 @@ object UnkindedTypePrinter {
       case (UnkindedType.RestrictableEnum(sym, _), _) => Type.AsIs(sym.toString)
       case (UnkindedType.UnappliedAlias(sym, _), _) => Type.AsIs(sym.toString)
       case (UnkindedType.UnappliedAssocType(sym, _), _) => Type.AsIs(sym.toString)
-      case (UnkindedType.UnappliedNative(clazz, _), _) => Type.AsIs(clazz.getSimpleName)
+      case (UnkindedType.UnappliedNative(desc, _, _), _) => Type.AsIs(ClassDescs.simpleNameOf(desc))
       case (UnkindedType.Arrow(eff0, arity, _), _) if args.lengthIs == arity && arity >= 2 =>
         // `(a1, a2, ..) -> b \ ef` is represented as `List(a1, a2, .., b)`
         // safe match because of the case guard

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -20,7 +20,9 @@ import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, TraitU
 import ca.uwaterloo.flix.language.ast.{Kind, Name, SourceLocation, Symbol, TypedAst, UnkindedType}
 import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
-import ca.uwaterloo.flix.util.{Formatter, Grammar}
+import ca.uwaterloo.flix.util.{ClassDescs, Formatter, Grammar}
+
+import java.lang.constant.ClassDesc
 
 /**
   * A common super-type for resolution errors.
@@ -1253,23 +1255,24 @@ object ResolutionError {
     * @param expectedArity the number of type arguments expected.
     * @param loc           the location where the error occurred.
     */
-  case class IllegalRawJavaType(clazz: java.lang.Class[?], expectedArity: Int, loc: SourceLocation) extends ResolutionError {
+  case class IllegalRawJavaType(clazz: ClassDesc, expectedArity: Int, loc: SourceLocation) extends ResolutionError {
     def code: ErrorCode = ErrorCode.E3692
 
+    private val name = ClassDescs.simpleNameOf(clazz)
     private val expected = Grammar.n_things(expectedArity, "type argument")
-    private val example = s"${clazz.getSimpleName}[${List.fill(expectedArity)("t").mkString(", ")}]"
+    private val example = s"$name[${List.fill(expectedArity)("t").mkString(", ")}]"
 
     def summary: String =
-      s"Missing type arguments: '${clazz.getSimpleName}' expects $expected."
+      s"Missing type arguments: '$name' expects $expected."
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Missing type arguments: '${red(clazz.getSimpleName)}' expects $expected.
+      s""">> Missing type arguments: '${red(name)}' expects $expected.
          |
          |${highlight(loc, "missing type arguments", fmt)}
          |
          |${underline("Explanation:")} Java generic types cannot be used without type arguments.
-         |Use '${cyan(example)}' instead of '${red(clazz.getSimpleName)}'.
+         |Use '${cyan(example)}' instead of '${red(name)}'.
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -6,7 +6,9 @@ import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type, TypedAst}
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
 import ca.uwaterloo.flix.language.fmt.FormatType
-import ca.uwaterloo.flix.util.Formatter
+import ca.uwaterloo.flix.util.{ClassDescs, Formatter}
+
+import java.lang.constant.ClassDesc
 
 /** A common super-type for safety errors. */
 sealed trait SafetyError extends CompilationMessage {
@@ -88,7 +90,7 @@ object SafetyError {
     * @param to   the destination type.
     * @param loc  the source location of the cast.
     */
-  case class IllegalCheckedCastFromNonJava(from: Type, to: java.lang.Class[?], loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+  case class IllegalCheckedCastFromNonJava(from: Type, to: ClassDesc, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
     def code: ErrorCode = ErrorCode.E3807
 
     def summary: String = "Impossible cast: cannot cast a Flix type to a Java type."
@@ -141,7 +143,7 @@ object SafetyError {
     * @param to   the destination type.
     * @param loc  the source location of the cast.
     */
-  case class IllegalCheckedCastToNonJava(from: java.lang.Class[?], to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+  case class IllegalCheckedCastToNonJava(from: ClassDesc, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
     def code: ErrorCode = ErrorCode.E4029
 
     def summary: String = "Impossible cast: cannot cast a Java type to a Flix type."
@@ -215,14 +217,16 @@ object SafetyError {
     *
     * @param loc the location of the catch parameter.
     */
-  case class IllegalCatchType(clazz: java.lang.Class[?], loc: SourceLocation) extends SafetyError {
+  case class IllegalCatchType(clazz: ClassDesc, loc: SourceLocation) extends SafetyError {
     def code: ErrorCode = ErrorCode.E4354
 
-    def summary: String = s"Unexpected catch type: '${clazz.getName}' is not a subclass of Throwable."
+    private val name = ClassDescs.binaryNameOf(clazz)
+
+    def summary: String = s"Unexpected catch type: '$name' is not a subclass of Throwable."
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Unexpected catch type: '${red(clazz.getName)}' is not a subclass of Throwable.
+      s""">> Unexpected catch type: '${red(name)}' is not a subclass of Throwable.
          |
          |${highlight(loc, "unexpected type", fmt)}
          |
@@ -624,5 +628,13 @@ object SafetyError {
       Type.getFlixType(tpe).toString
     else
       tpe.getName
+  }
+
+  /** Returns the string representation of the Java type `desc`. */
+  private def formatJavaType(desc: ClassDesc): String = {
+    if (desc.isPrimitive || desc.isArray)
+      Type.getFlixType(desc, 0).toString
+    else
+      ClassDescs.binaryNameOf(desc)
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.shared.{Denotation, EffSymOrRigidVar, SymbolSet}
 import ca.uwaterloo.flix.language.fmt.FormatType.formatType
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
-import ca.uwaterloo.flix.util.{Formatter, Grammar}
+import ca.uwaterloo.flix.util.{ClassDescs, Formatter, Grammar}
 
 /**
   * A common super-type for type errors.
@@ -316,7 +316,8 @@ object TypeError {
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      val availableFields = Type.classFromFlixType(tpe).map(getFieldsByName).getOrElse(Nil)
+      // Transitional: loads the class since the field lookup still requires a loaded class.
+      val availableFields = Type.descFromFlixType(tpe).map(desc => getFieldsByName(ClassDescs.load(desc, flix.jarLoader))).getOrElse(Nil)
       s""">> Field not found: '${red(fieldName.name)}' on type '${magenta(formatType(tpe))}'.
          |
          |${highlight(loc, "cannot find field", fmt)}

--- a/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
@@ -19,7 +19,7 @@ import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.Type.JvmMember
 import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod}
 import ca.uwaterloo.flix.language.ast.shared.{SymbolSet, VarText}
-import ca.uwaterloo.flix.util.InternalCompilerException
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 
 /**
   * A well-kinded type in an easily-printable format.
@@ -519,7 +519,7 @@ object DisplayType {
           mkApply(Name(amb.qualify(sym)), t.typeArguments.map(visit))
         case TypeConstructor.Struct(sym, _) => mkApply(Name(amb.qualify(sym)), t.typeArguments.map(visit))
         case TypeConstructor.RestrictableEnum(sym, _) => mkApply(Name(amb.qualify(sym)), t.typeArguments.map(visit))
-        case TypeConstructor.Native(clazz) => mkApply(Name(clazz.getName), t.typeArguments.map(visit))
+        case TypeConstructor.Native(desc, _) => mkApply(Name(ClassDescs.binaryNameOf(desc)), t.typeArguments.map(visit))
         case TypeConstructor.JvmConstructor(constructor) => mkApply(JvmConstructor(constructor), t.typeArguments.map(visit))
         case TypeConstructor.JvmMethod(method, _) => mkApply(JvmMethod(method), t.typeArguments.map(visit))
         case TypeConstructor.JvmField(field) => mkApply(JvmField(field), t.typeArguments.map(visit))

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatTypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatTypeConstructor.scala
@@ -16,6 +16,7 @@
 package ca.uwaterloo.flix.language.fmt
 
 import ca.uwaterloo.flix.language.ast.TypeConstructor
+import ca.uwaterloo.flix.util.ClassDescs
 
 object FormatTypeConstructor {
 
@@ -70,7 +71,7 @@ object FormatTypeConstructor {
     case TypeConstructor.RestrictableEnum(sym, _) => sym.name
 
     // JVM types
-    case TypeConstructor.Native(clazz) => clazz.getSimpleName
+    case TypeConstructor.Native(desc, _) => ClassDescs.simpleNameOf(desc)
     case TypeConstructor.JvmConstructor(constructor) => s"Constructor(${constructor.ref.owner.displayName()})"
     case TypeConstructor.JvmMethod(method, _) => s"Method(${method.ref.name})"
     case TypeConstructor.JvmField(field) => s"Field(${field.ref.name})"

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -25,6 +25,7 @@ import ca.uwaterloo.flix.runtime.shell.Shell
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, Nel}
 import ca.uwaterloo.flix.util.{ParOps, Result}
 
+import java.lang.constant.ConstantDescs.CD_Object
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.annotation.tailrec
@@ -462,7 +463,7 @@ object EntryPoints {
       case Type.Cst(TypeConstructor.Int16, _) => Result.Ok(true)
       case Type.Cst(TypeConstructor.Int32, _) => Result.Ok(true)
       case Type.Cst(TypeConstructor.Int64, _) => Result.Ok(true)
-      case Type.Cst(TypeConstructor.Native(clazz), _) if clazz == classOf[java.lang.Object] => Result.Ok(true)
+      case Type.Cst(TypeConstructor.Native(desc, _), _) if desc == CD_Object => Result.Ok(true)
       case Type.Cst(_, _) => Result.Ok(false)
       case Type.Apply(_, _, _) => Result.Ok(false)
       case Type.Alias(_, _, t, _) => isExportableType(t)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -32,6 +32,7 @@ import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
 
+import java.lang.constant.ClassDesc
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.unused
 import scala.collection.immutable.SortedSet
@@ -1686,7 +1687,7 @@ object Resolver {
           case Result.Err(error) =>
             // Probe whether the name actually refers to a Java class — if so, body shape mismatched.
             val t = resolveType(tpe, Some(Kind.Star), Wildness.ForbidWild, scp0, taenv, ns0, root)
-            getNativeClassFromType(UnkindedType.eraseAliases(t)) match {
+            getNativeDescFromType(UnkindedType.eraseAliases(t)) match {
               case Some(_) =>
                 if (region0.isDefined) sctx.errors.add(ResolutionError.NewObjectWithStructRegion(qname, loc))
                 if (fields0.nonEmpty) sctx.errors.add(ResolutionError.NewObjectWithStructFields(qname, loc))
@@ -2666,13 +2667,12 @@ object Resolver {
             }
         }
 
-      case UnkindedType.UnappliedNative(clazz, loc) =>
-        val expectedArity = clazz.getTypeParameters.length
-        if (targs.length < expectedArity) {
-          sctx.errors.add(ResolutionError.IllegalRawJavaType(clazz, expectedArity, loc))
+      case UnkindedType.UnappliedNative(desc, arity, loc) =>
+        if (targs.length < arity) {
+          sctx.errors.add(ResolutionError.IllegalRawJavaType(desc, arity, loc))
           UnkindedType.Error(loc)
         } else {
-          val cst = UnkindedType.Cst(TypeConstructor.Native(clazz), loc)
+          val cst = UnkindedType.Cst(TypeConstructor.Native(desc, arity), loc)
           val resolvedArgs = targs.map(finishResolveType(_, taenv))
           UnkindedType.mkApply(cst, resolvedArgs, tpe0.loc)
         }
@@ -3534,13 +3534,22 @@ object Resolver {
     * Looks up the Java class from a (possibly applied) native unkinded type by
     * traversing type applications to find the base `Native` type constructor.
     *
-    * Example: `UnkindedType.Cst(Native(classOf[String]))` returns `Some(classOf[String])`.
-    * Example: `UnkindedType.Apply(Cst(Native(classOf[ArrayList])), Cst(Native(classOf[String])))` returns `Some(classOf[ArrayList])`.
+    * Example: `UnkindedType.Cst(Native(String, 0))` returns `Some(classOf[String])`.
+    * Example: `UnkindedType.Apply(Cst(Native(ArrayList, 1)), Cst(Native(String, 0)))` returns `Some(classOf[ArrayList])`.
+    *
+    * Transitional: loads the class since the AST still refers to loaded classes.
     */
-  private def getNativeClassFromType(tpe: UnkindedType): Option[Class[?]] = tpe match {
-    case UnkindedType.Cst(TypeConstructor.Native(clazz), _) => Some(clazz)
-    case UnkindedType.UnappliedNative(clazz, _) => Some(clazz)
-    case UnkindedType.Apply(t1, _, _) => getNativeClassFromType(t1)
+  private def getNativeClassFromType(tpe: UnkindedType)(implicit flix: Flix): Option[Class[?]] =
+    getNativeDescFromType(tpe).map(ClassDescs.load(_, flix.jarLoader))
+
+  /**
+    * Looks up the Java class descriptor from a (possibly applied) native unkinded type by
+    * traversing type applications to find the base `Native` type constructor.
+    */
+  private def getNativeDescFromType(tpe: UnkindedType): Option[ClassDesc] = tpe match {
+    case UnkindedType.Cst(TypeConstructor.Native(desc, _), _) => Some(desc)
+    case UnkindedType.UnappliedNative(desc, _, _) => Some(desc)
+    case UnkindedType.Apply(t1, _, _) => getNativeDescFromType(t1)
     case _ => None
   }
 
@@ -3567,7 +3576,7 @@ object Resolver {
     case "java.util.function.DoubleConsumer" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkUnit(loc), loc)
     case "java.util.function.DoublePredicate" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkBool(loc), loc)
     case "java.util.function.DoubleUnaryOperator" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkFloat64(loc), loc)
-    case _ => UnkindedType.UnappliedNative(clazz, loc)
+    case _ => UnkindedType.UnappliedNative(ClassDescs.of(clazz), clazz.getTypeParameters.length, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -9,13 +9,16 @@ import ca.uwaterloo.flix.language.ast.{ChangeSet, RigidityEnv, SourceLocation, S
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
+import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
 import ca.uwaterloo.flix.language.phase.typer.{ConstraintGen, ConstraintSolver2}
 import ca.uwaterloo.flix.language.phase.unification.EqualityEnv
 import ca.uwaterloo.flix.util.collection.{ListOps, MapOps}
-import ca.uwaterloo.flix.util.{JvmUtils, ParOps}
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, JvmUtils, ParOps, Result}
 
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.{CD_Object, CD_String, CD_Throwable}
 import java.lang.reflect.{ParameterizedType, TypeVariable}
-import java.math.BigInteger
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.CollectionHasAsScala
@@ -441,7 +444,7 @@ object Safety {
       (Type.eraseAliases(from).baseType, Type.eraseAliases(to).baseType) match {
 
         // Allow casting Null to a Java type.
-        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Native(_), _)) => ()
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Native(_, _), _)) => ()
         case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigInt, _)) => ()
         case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigDecimal, _)) => ()
         case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Str, _)) => ()
@@ -449,28 +452,28 @@ object Safety {
         case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Array, _)) => ()
 
         // Allow casting one Java type to another if there is a subtype relationship.
-        case (Type.Cst(TypeConstructor.Native(left), _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(left)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+        case (Type.Cst(TypeConstructor.Native(left, _), _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
+          if (isSubtype(left, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for String.
-        case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[String])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+        case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
+          if (isSubtype(CD_String, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for Regex.
-        case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[java.util.regex.Pattern])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+        case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
+          if (isSubtype(JavaClasses.Regex, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for BigInt.
-        case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[BigInteger])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+        case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
+          if (isSubtype(JavaClasses.BigInteger, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for BigDecimal.
-        case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[java.math.BigDecimal])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+        case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
+          if (isSubtype(JavaClasses.BigDecimal, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for Arrays.
-        case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[Array[Object]])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+        case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
+          if (isSubtype(CD_Object.arrayType(), right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Disallow casting a type variable.
         case (src@Type.Var(_, _), _) =>
@@ -481,12 +484,12 @@ object Safety {
           sctx.errors.add(IllegalCheckedCastToVar(from, dst, loc))
 
         // Disallow casting a Java type to any other type.
-        case (Type.Cst(TypeConstructor.Native(clazz), _), _) =>
-          sctx.errors.add(IllegalCheckedCastToNonJava(clazz, to, loc))
+        case (Type.Cst(TypeConstructor.Native(desc, _), _), _) =>
+          sctx.errors.add(IllegalCheckedCastToNonJava(desc, to, loc))
 
         // Disallow casting a Java type to any other type (symmetric case).
-        case (_, Type.Cst(TypeConstructor.Native(clazz), _)) =>
-          sctx.errors.add(IllegalCheckedCastFromNonJava(from, clazz, loc))
+        case (_, Type.Cst(TypeConstructor.Native(desc, _), _)) =>
+          sctx.errors.add(IllegalCheckedCastFromNonJava(from, desc, loc))
 
         // Disallow all other casts.
         case _ => sctx.errors.add(IllegalCheckedCast(from, to, loc))
@@ -569,8 +572,8 @@ object Safety {
         case (_, Some(Type.Var(_, _))) => ()
 
         // Allow casts between Java types.
-        case (Type.Cst(TypeConstructor.Native(_), _), _) => ()
-        case (_, Some(Type.Cst(TypeConstructor.Native(_), _))) => ()
+        case (Type.Cst(TypeConstructor.Native(_, _), _), _) => ()
+        case (_, Some(Type.Cst(TypeConstructor.Native(_, _), _))) => ()
 
         // Disallow casting a Boolean to another primitive type.
         case (Type.Bool, Some(t2)) if primitives.filter(_ != Type.Bool).contains(t2) =>
@@ -762,14 +765,16 @@ object Safety {
     * @param clazz the Java class specified in the catch clause
     * @param loc   the location of the catch parameter.
     */
-  private def checkCatchClass(clazz: Class[?], loc: SourceLocation)(implicit sctx: SharedContext): Unit =
-    if (!isThrowable(clazz)) {
-      sctx.errors.add(IllegalCatchType(clazz, loc))
+  private def checkCatchClass(clazz: Class[?], loc: SourceLocation)(implicit sctx: SharedContext, flix: Flix): Unit = {
+    val desc = ClassDescs.of(clazz)
+    if (!isThrowable(desc, loc)) {
+      sctx.errors.add(IllegalCatchType(desc, loc))
     }
+  }
 
-  /** Returns `true` if `clazz` is [[java.lang.Throwable]] or a subclass of it. */
-  private def isThrowable(clazz: Class[?]): Boolean =
-    classOf[Throwable].isAssignableFrom(clazz)
+  /** Returns `true` if `desc` is [[java.lang.Throwable]] or a subclass of it. */
+  private def isThrowable(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
+    isSubtype(desc, CD_Throwable, loc)
 
   /** Checks that the type of the argument to `throw` is [[java.lang.Throwable]] or a subclass. */
   private def checkThrow(exp: Expr)(implicit sctx: SharedContext, flix: Flix): Unit =
@@ -777,10 +782,28 @@ object Safety {
 
   /** Returns `true` if `tpe` is [[java.lang.Throwable]] or a subclass of it. */
   @tailrec
-  private def isThrowableType(tpe0: Type): Boolean = tpe0 match {
-    case Type.Cst(TypeConstructor.Native(clazz), _) => isThrowable(clazz)
+  private def isThrowableType(tpe0: Type)(implicit flix: Flix): Boolean = tpe0 match {
+    case Type.Cst(TypeConstructor.Native(desc, _), loc) => isThrowable(desc, loc)
     case Type.Alias(_, _, tpe, _) => isThrowableType(tpe)
     case _ => false
+  }
+
+  /**
+    * Returns `true` if the Java type `sub` is a subtype of the Java type `sup`.
+    *
+    * A primitive type is only a subtype of itself. Reference types, including arrays,
+    * are checked against the class-file metadata of the Java type provider.
+    */
+  private def isSubtype(sub: ClassDesc, sup: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean = {
+    if (sub.isPrimitive || sup.isPrimitive) {
+      sub == sup
+    } else {
+      JavaMemberResolver.isReferenceSubtype(sub, sup) match {
+        case Result.Ok(result) => result
+        case Result.Err(error) =>
+          throw InternalCompilerException(s"Java subtype check failed for '${sub.displayName()} <: ${sup.displayName()}': $error", loc)
+      }
+    }
   }
 
   /**
@@ -830,7 +853,7 @@ object Safety {
         case JvmMethod(_, ident, fparams, _, _, _, methodLoc) =>
           val firstParam = fparams.head
           firstParam.tpe match {
-            case t if Type.classFromFlixType(Type.eraseAliases(t)).contains(clazz) =>
+            case t if Type.descFromFlixType(Type.eraseAliases(t)).contains(ClassDescs.of(clazz)) =>
               ()
             case Type.Unit =>
               // Unit arguments are likely inserted by the compiler.
@@ -901,7 +924,7 @@ object Safety {
     */
   private def resolveJavaType(javaType: java.lang.reflect.Type, substMap: Map[String, Type], loc: SourceLocation): Type = javaType match {
     case tv: TypeVariable[_] =>
-      substMap.getOrElse(tv.getName, Type.instantiateJavaTypeWithObjectArgs(classOf[Object], loc))
+      substMap.getOrElse(tv.getName, Type.mkObject(loc))
     case pt: ParameterizedType =>
       pt.getRawType match {
         case rawClazz: Class[_] =>
@@ -909,12 +932,12 @@ object Safety {
           val resolvedArgs = pt.getActualTypeArguments.toList.map(resolveJavaType(_, substMap, loc))
           Type.mkApply(base, resolvedArgs, loc)
         case _ =>
-          Type.instantiateJavaTypeWithObjectArgs(classOf[Object], loc)
+          Type.mkObject(loc)
       }
     case clazz: Class[_] =>
       Type.instantiateJavaTypeWithObjectArgs(clazz, loc)
     case _ =>
-      Type.instantiateJavaTypeWithObjectArgs(classOf[Object], loc)
+      Type.mkObject(loc)
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, JMethod, Modifi
 import ca.uwaterloo.flix.language.ast.{Purity, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.util.collection.{ListOps, MapOps, Nel}
-import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, ParOps}
+import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
 import scala.annotation.tailrec
@@ -360,7 +360,7 @@ object Simplifier {
             val enumSym = new Symbol.EnumSym(None, sym.namespace, sym.name, sym.loc)
             SimpleType.mkEnum(enumSym, targs.map(visitType))
 
-          case TypeConstructor.Native(clazz) => SimpleType.Native(ClassDescs.of(clazz))
+          case TypeConstructor.Native(desc, _) => SimpleType.Native(desc)
 
           case TypeConstructor.Array =>
             // Remove the region from the array.
@@ -533,7 +533,7 @@ object Simplifier {
             val enumSym = new Symbol.EnumSym(None, sym.namespace, sym.name, sym.loc)
             Type.mkEnum(enumSym, targs.map(visitPolyType), loc)
 
-          case TypeConstructor.Native(_) => cst
+          case TypeConstructor.Native(_, _) => cst
 
           case TypeConstructor.Array =>
             // Remove the region from the array.

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -1085,16 +1085,19 @@ object Lowering {
     * Returns the Flix Type for the Java wrapper class of a primitive type.
     * E.g., `Bool` -> `Native(java.lang.Boolean)`, `Int32` -> `Native(java.lang.Integer)`.
     */
-  private def boxedWrapperType(tpe: Type, loc: SourceLocation): Type = tpe match {
-    case Type.Bool => Type.Cst(TypeConstructor.Native(classOf[java.lang.Boolean]), loc)
-    case Type.Char => Type.Cst(TypeConstructor.Native(classOf[java.lang.Character]), loc)
-    case Type.Int8 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Byte]), loc)
-    case Type.Int16 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Short]), loc)
-    case Type.Int32 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Integer]), loc)
-    case Type.Int64 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Long]), loc)
-    case Type.Float32 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Float]), loc)
-    case Type.Float64 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Double]), loc)
-    case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+  private def boxedWrapperType(tpe: Type, loc: SourceLocation): Type = {
+    import java.lang.constant.ConstantDescs.*
+    tpe match {
+      case Type.Bool => Type.mkNative(CD_Boolean, 0, loc)
+      case Type.Char => Type.mkNative(CD_Character, 0, loc)
+      case Type.Int8 => Type.mkNative(CD_Byte, 0, loc)
+      case Type.Int16 => Type.mkNative(CD_Short, 0, loc)
+      case Type.Int32 => Type.mkNative(CD_Integer, 0, loc)
+      case Type.Int64 => Type.mkNative(CD_Long, 0, loc)
+      case Type.Float32 => Type.mkNative(CD_Float, 0, loc)
+      case Type.Float64 => Type.mkNative(CD_Double, 0, loc)
+      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -606,7 +606,7 @@ object Specialization {
         val caseSym = root.enums(jvmValueEnumSym).cases.values.find(_.sym.name == caseName).get.sym
         val symUse = CaseSymUse(caseSym, loc)
         val tagArg = if (caseName == "JvmObject") {
-          val objType = Type.mkNative(classOf[java.lang.Object], loc)
+          val objType = Type.mkObject(loc)
           Expr.UncheckedCast(e, Some(objType), None, objType, Type.Pure, loc)
         } else {
           e

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -233,7 +233,7 @@ private[monomorph2] object SpecializeAndLower {
         val caseName = jvmTypeCaseName(expTpe.baseType)
         val caseSym = findCaseSym(jvmValueEnumSym, caseName)
         val tagArg = if (caseName == "JvmObject") {
-          val objType = Type.mkNative(classOf[java.lang.Object], loc)
+          val objType = Type.mkObject(loc)
           mkCast(e, objType, Type.Pure, loc)
         } else {
           e
@@ -1180,16 +1180,19 @@ private[monomorph2] object SpecializeAndLower {
     * Returns the Flix Type for the Java wrapper class of a primitive type.
     * E.g., `Bool` -> `Native(java.lang.Boolean)`, `Int32` -> `Native(java.lang.Integer)`.
     */
-  private def boxedWrapperType(tpe: Type, loc: SourceLocation): Type = tpe match {
-    case Type.Bool => Type.Cst(TypeConstructor.Native(classOf[java.lang.Boolean]), loc)
-    case Type.Char => Type.Cst(TypeConstructor.Native(classOf[java.lang.Character]), loc)
-    case Type.Int8 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Byte]), loc)
-    case Type.Int16 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Short]), loc)
-    case Type.Int32 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Integer]), loc)
-    case Type.Int64 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Long]), loc)
-    case Type.Float32 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Float]), loc)
-    case Type.Float64 => Type.Cst(TypeConstructor.Native(classOf[java.lang.Double]), loc)
-    case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+  private def boxedWrapperType(tpe: Type, loc: SourceLocation): Type = {
+    import java.lang.constant.ConstantDescs.*
+    tpe match {
+      case Type.Bool => Type.mkNative(CD_Boolean, 0, loc)
+      case Type.Char => Type.mkNative(CD_Character, 0, loc)
+      case Type.Int8 => Type.mkNative(CD_Byte, 0, loc)
+      case Type.Int16 => Type.mkNative(CD_Short, 0, loc)
+      case Type.Int32 => Type.mkNative(CD_Integer, 0, loc)
+      case Type.Int64 => Type.mkNative(CD_Long, 0, loc)
+      case Type.Float32 => Type.mkNative(CD_Float, 0, loc)
+      case Type.Float64 => Type.mkNative(CD_Double, 0, loc)
+      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -261,12 +261,12 @@ object TypeReduction2 {
     case Type.Cst(TypeConstructor.BigInt, _) => ClassDesc.of("java.math.BigInteger")
     case Type.Cst(TypeConstructor.Str, _) => CD_String
     case Type.Cst(TypeConstructor.Regex, _) => ClassDesc.of("java.util.regex.Pattern")
-    case Type.Cst(TypeConstructor.Native(clazz), _) => ClassDescs.of(clazz)
+    case Type.Cst(TypeConstructor.Native(desc, _), _) => desc
 
     // Parameterized Java types erase to their native base type.
     case Type.Apply(_, _, _) if isNativeBase(tpe) =>
       tpe.baseType match {
-        case Type.Cst(TypeConstructor.Native(clazz), _) => ClassDescs.of(clazz)
+        case Type.Cst(TypeConstructor.Native(desc, _), _) => desc
         case _ => CD_Object
       }
 
@@ -388,7 +388,7 @@ object TypeReduction2 {
   /** Returns `true` if the base type of a chain of applications is a `Native` constructor. */
   @tailrec
   private def isNativeBase(tpe: Type): Boolean = tpe match {
-    case Type.Cst(TypeConstructor.Native(_), _) => true
+    case Type.Cst(TypeConstructor.Native(_, _), _) => true
     case Type.Apply(t1, _, _) => isNativeBase(t1)
     case _ => false
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
@@ -448,7 +448,7 @@ object JavaMemberResolver {
     *
     * Returns `Ok(true)` for a subtype, `Ok(false)` otherwise, or `Err` if nominal hierarchy metadata is missing.
     */
-  private def isReferenceSubtype(source: ClassDesc, target: ClassDesc)(implicit flix: Flix): Result[Boolean, JavaLookupError] = {
+  def isReferenceSubtype(source: ClassDesc, target: ClassDesc)(implicit flix: Flix): Result[Boolean, JavaLookupError] = {
     if (source == target) {
       // Every reference type is a subtype of itself.
       Ok(true)

--- a/main/src/ca/uwaterloo/flix/util/ClassDescs.scala
+++ b/main/src/ca/uwaterloo/flix/util/ClassDescs.scala
@@ -74,12 +74,35 @@ object ClassDescs {
   }
 
   /**
-    * Returns the binary name (e.g. `java.lang.String`) of the class or interface `desc`.
+    * Returns the binary name of `desc` as [[Class.getName]] would return it,
+    * e.g. `java.lang.String`, `int`, or `[Ljava.lang.String;`.
     */
   def binaryNameOf(desc: ClassDesc): String = {
-    // Strip the leading `L` and trailing `;` of the descriptor and replace `/` with `.`.
-    val descriptor = desc.descriptorString()
-    descriptor.substring(1, descriptor.length - 1).replace('/', '.')
+    if (desc.isPrimitive) {
+      desc.displayName()
+    } else if (desc.isArray) {
+      // The binary name of an array type is its descriptor with `/` replaced by `.`.
+      desc.descriptorString().replace('/', '.')
+    } else {
+      // Strip the leading `L` and trailing `;` of the descriptor and replace `/` with `.`.
+      val descriptor = desc.descriptorString()
+      descriptor.substring(1, descriptor.length - 1).replace('/', '.')
+    }
+  }
+
+  /**
+    * Returns the simple name of `desc` as [[Class.getSimpleName]] would return it,
+    * e.g. `String`, `Entry` (for `java.util.Map$Entry`), `int`, or `String[]`.
+    */
+  def simpleNameOf(desc: ClassDesc): String = {
+    if (desc.isArray) {
+      simpleNameOf(desc.componentType()) + "[]"
+    } else {
+      // The display name is the unqualified name, e.g. `Map$Entry` for a nested class.
+      val name = desc.displayName()
+      val idx = name.lastIndexOf('$')
+      if (idx >= 0 && idx < name.length - 1) name.substring(idx + 1) else name
+    }
   }
 
 }


### PR DESCRIPTION
Replaces the loaded `Class` in `TypeConstructor.Native` and `UnkindedType.UnappliedNative` with a `ClassDesc` and the number of type parameters. This is the first step in removing Java reflection from the frontend: every remaining `Class[?]` in the compiler flows out of `Native`, so once it holds a descriptor the rest can follow.

**Changes**

- `TypeConstructor.Native(desc: ClassDesc, arity: Int)` computes its kind from the stored arity. `UnkindedType.UnappliedNative` has the same shape.
- `Type` gains descriptor-based `mkNative`, `mkObject`, `getFlixType`, and `descFromFlixType`. The `Class`-based `mkNative` and `getFlixType` remain as transitional shims for the AST nodes that still carry a loaded class.
- Safety checked casts and catch/throw checks use `JavaMemberResolver.isReferenceSubtype` (now public) instead of `Class.isAssignableFrom`.
- `SafetyError` cast/catch errors and `ResolutionError.IllegalRawJavaType` take a `ClassDesc`. `ClassDescs.binaryNameOf` now mirrors `Class.getName` for primitives and arrays, and `ClassDescs.simpleNameOf` mirrors `Class.getSimpleName`, so messages are unchanged.
- Effect-lock serialization stores the descriptor and arity instead of calling `Class.forName`.
- Lowering's boxed wrapper types, the type formatters, and the debug printers are descriptor-based.

**Transitional class loads, to be removed by follow-up PRs**

- `Resolver.getNativeClassFromType` loads the class because `NewObject` still needs a `Class` for Safety and Lowering.
- `TypeError.FieldNotFound` hints and `InvokeMethodCompleter` load the class to list members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3L1U3oBUhdk6DdhvPn9VM
