### PR TITLE
perf: cache Java type provider queries

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -32,6 +32,7 @@ import java.lang.annotation.{Retention, RetentionPolicy}
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
 import java.lang.reflect.{GenericSignatureFormatError, MalformedParameterizedTypeException}
 import java.nio.file.{Files, Path}
+import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters.*
 
 object ByteBuddyJavaTypeProvider {
@@ -94,29 +95,42 @@ final case class ByteBuddyJavaTypeProvider(
   pool: TypePool
 ) extends JavaTypeProvider {
 
+  /** Caches converted class metadata for the lifetime of this provider. */
+  private val classCache = new ConcurrentHashMap[ClassDesc, Result[JavaClass, JavaLookupError]]()
+
+  /** Caches compiled virtual method graphs for the lifetime of this provider. */
+  private val virtualMethodsCache = new ConcurrentHashMap[ClassDesc, Result[List[JavaMethod], JavaLookupError]]()
+
+  /** Caches nominal subtype queries for the lifetime of this provider. */
+  private val subtypeCache = new ConcurrentHashMap[(ClassDesc, ClassDesc), Result[Boolean, JavaLookupError]]()
+
   /** Returns `Ok` with metadata for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
   override def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError] =
-    resolve(desc).map(toClass)
+    classCache.computeIfAbsent(desc, d => resolve(d).map(toClass))
 
   /** Returns `Ok` with the virtual method graph for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
   override def virtualMethods(desc: ClassDesc): Result[List[JavaMethod], JavaLookupError] =
-    resolve(desc).map { tpe =>
-      MethodGraph.Compiler.Default.forJavaHierarchy().compile(tpe: TypeDefinition).listNodes().asScala
-        .map(_.getRepresentative)
-        .filter(_.isVirtual)
-        .map(toMethod)
-        .toList
-        .sortBy(m => (m.ref.name, m.ref.descriptor.descriptorString()))
-    }
+    virtualMethodsCache.computeIfAbsent(desc, d =>
+      resolve(d).map { tpe =>
+        MethodGraph.Compiler.Default.forJavaHierarchy().compile(tpe: TypeDefinition).listNodes().asScala
+          .map(_.getRepresentative)
+          .filter(_.isVirtual)
+          .map(toMethod)
+          .toList
+          .sortBy(m => (m.ref.name, m.ref.descriptor.descriptorString()))
+      }
+    )
 
   /** Returns `Ok` with the subtype result, or `Err` if either descriptor is unsupported, missing, or invalid. */
   override def isSubtype(subtype: ClassDesc, supertype: ClassDesc): Result[Boolean, JavaLookupError] = {
     if (subtype == supertype) {
       Ok(true)
     } else {
-      resolve(subtype).flatMap { sub =>
-        resolve(supertype).map(sup => sub.isAssignableTo(sup))
-      }
+      subtypeCache.computeIfAbsent((subtype, supertype), key =>
+        resolve(key._1).flatMap { sub =>
+          resolve(key._2).map(sup => sub.isAssignableTo(sup))
+        }
+      )
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -106,36 +106,44 @@ final case class ByteBuddyJavaTypeProvider(
 
   /** Returns `Ok` with metadata for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
   override def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError] =
-    classCache.computeIfAbsent(desc, d => resolve(d).map(toClass))
+    classCache.computeIfAbsent(desc, d => lookupClassDirect(d))
 
   /** Returns `Ok` with the virtual method graph for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
   override def virtualMethods(desc: ClassDesc): Result[List[JavaMethod], JavaLookupError] =
-    virtualMethodsCache.computeIfAbsent(desc, d =>
-      resolve(d).map { tpe =>
-        MethodGraph.Compiler.Default.forJavaHierarchy().compile(tpe: TypeDefinition).listNodes().asScala
-          .map(_.getRepresentative)
-          .filter(_.isVirtual)
-          .map(toMethod)
-          .toList
-          .sortBy(m => (m.ref.name, m.ref.descriptor.descriptorString()))
-      }
-    )
+    virtualMethodsCache.computeIfAbsent(desc, d => virtualMethodsDirect(d))
 
   /** Returns `Ok` with the subtype result, or `Err` if either descriptor is unsupported, missing, or invalid. */
-  override def isSubtype(subtype: ClassDesc, supertype: ClassDesc): Result[Boolean, JavaLookupError] = {
-    if (subtype == supertype) {
-      Ok(true)
-    } else {
-      subtypeCache.computeIfAbsent((subtype, supertype), key =>
-        resolve(key._1).flatMap { sub =>
-          resolve(key._2).map(sup => sub.isAssignableTo(sup))
-        }
-      )
-    }
-  }
+  override def isSubtype(subtype: ClassDesc, supertype: ClassDesc): Result[Boolean, JavaLookupError] =
+    subtypeCache.computeIfAbsent((subtype, supertype), key => isSubtypeDirect(key._1, key._2))
 
   /** Closes the underlying class-file locator and its owned resources. */
   override def close(): Unit = locator.close()
+
+  /** Computes [[lookupClass]] without consulting the cache. */
+  private def lookupClassDirect(desc: ClassDesc): Result[JavaClass, JavaLookupError] =
+    resolve(desc).map(toClass)
+
+  /** Computes [[virtualMethods]] without consulting the cache. */
+  private def virtualMethodsDirect(desc: ClassDesc): Result[List[JavaMethod], JavaLookupError] =
+    resolve(desc).map { tpe =>
+      MethodGraph.Compiler.Default.forJavaHierarchy().compile(tpe: TypeDefinition).listNodes().asScala
+        .map(_.getRepresentative)
+        .filter(_.isVirtual)
+        .map(toMethod)
+        .toList
+        .sortBy(m => (m.ref.name, m.ref.descriptor.descriptorString()))
+    }
+
+  /** Computes [[isSubtype]] without consulting the cache. */
+  private def isSubtypeDirect(subtype: ClassDesc, supertype: ClassDesc): Result[Boolean, JavaLookupError] = {
+    if (subtype == supertype) {
+      Ok(true)
+    } else {
+      resolve(subtype).flatMap { sub =>
+        resolve(supertype).map(sup => sub.isAssignableTo(sup))
+      }
+    }
+  }
 
   /** Returns `Ok` with the resolved type, or `Err` if `desc` is unsupported, missing, or invalid. */
   private def resolve(desc: ClassDesc): Result[TypeDescription, JavaLookupError] = {


### PR DESCRIPTION
Cache converted Java class metadata, compiled virtual method graphs, and nominal subtype results in the per-compiler Byte Buddy Java type provider. The caches use concurrent maps because typer work is parallel.

With `./mill flix.run Xperf --frontend --par --n 50`, median throughput increased from 99,506 to 112,935 lines/sec (+13.5%).