### PR TITLE
refactor: resolve Java classes from descriptors

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -20,8 +20,10 @@ import ca.uwaterloo.flix.api.lsp.{Command, CompletionItem, CompletionItemKind, C
 import ca.uwaterloo.flix.language.ast.shared.AnchorPosition
 import ca.uwaterloo.flix.language.ast.{Name, ResolvedAst, SourceLocation, Symbol, Type, TypedAst}
 import ca.uwaterloo.flix.language.fmt.{FormatScheme, FormatType}
+import ca.uwaterloo.flix.util.ClassDescs
 import ca.uwaterloo.flix.util.collection.Nel
 
+import java.lang.constant.ClassDesc
 import java.lang.reflect.{Field, Method}
 
 /**
@@ -157,7 +159,7 @@ sealed trait Completion {
       )
 
     case Completion.LocalJavaClassCompletion(name, clazz, range, priority) =>
-      val description = Option(clazz.getCanonicalName)
+      val description = Some(ClassDescs.binaryNameOf(clazz).replace('$', '.'))
       val labelDetails = CompletionItemLabelDetails(None, description)
       CompletionItem(
         label = name,
@@ -681,7 +683,7 @@ object Completion {
     * @param range    the range of the completion.
     * @param priority the priority of the completion.
     */
-  case class LocalJavaClassCompletion(name: String, clazz: Class[?], range: Range, priority: Priority) extends Completion
+  case class LocalJavaClassCompletion(name: String, clazz: ClassDesc, range: Range, priority: Priority) extends Completion
 
   /**
     * Represents a local def completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/GetStaticFieldCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/GetStaticFieldCompleter.scala
@@ -15,14 +15,18 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.FieldCompletion
 import ca.uwaterloo.flix.language.ast.Name
-import ca.uwaterloo.flix.util.JvmUtils
+import ca.uwaterloo.flix.util.{ClassDescs, JvmUtils}
+
+import java.lang.constant.ClassDesc
 
 object GetStaticFieldCompleter {
 
-  def getCompletions(clazz: Class[?], field: Name.Ident): List[Completion] = {
-    JvmUtils.getStaticFields(clazz).sortBy(_.getName).map(FieldCompletion(field, Priority.Lowest(0), _))
+  def getCompletions(clazz: ClassDesc, field: Name.Ident)(implicit flix: Flix): List[Completion] = {
+    // Transitional: loads the class since the member listing still requires a loaded class.
+    JvmUtils.getStaticFields(ClassDescs.load(clazz, flix.jarLoader)).sortBy(_.getName).map(FieldCompletion(field, Priority.Lowest(0), _))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeStaticMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeStaticMethodCompleter.scala
@@ -15,14 +15,18 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
 import ca.uwaterloo.flix.language.ast.Name
-import ca.uwaterloo.flix.util.JvmUtils
+import ca.uwaterloo.flix.util.{ClassDescs, JvmUtils}
+
+import java.lang.constant.ClassDesc
 
 object InvokeStaticMethodCompleter {
 
-  def getCompletions(clazz: Class[?], field: Name.Ident): List[Completion] = {
-    JvmUtils.getStaticMethods(clazz).sortBy(_.getName).map(MethodCompletion(field, Priority.Lowest(0), _))
+  def getCompletions(clazz: ClassDesc, field: Name.Ident)(implicit flix: Flix): List[Completion] = {
+    // Transitional: loads the class since the member listing still requires a loaded class.
+    JvmUtils.getStaticMethods(ClassDescs.load(clazz, flix.jarLoader)).sortBy(_.getName).map(MethodCompletion(field, Priority.Lowest(0), _))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -49,7 +49,7 @@ object LocalScopeCompleter {
     */
   private def mkJavaClassCompletion(name: String, resolutions: List[Resolution], range: Range): Iterable[Completion] = {
     resolutions.collect {
-      case Resolution.JavaClass(clazz) => Completion.LocalJavaClassCompletion(name, clazz, range, Priority.High(0))
+      case Resolution.JavaClass(clazz) => Completion.LocalJavaClassCompletion(name, clazz.desc, range, Priority.High(0))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -22,6 +22,8 @@ import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.util.collection.{ListMap, Nel}
 
+import java.lang.constant.ClassDesc
+
 object KindedAst {
 
   val empty: Root = Root(Map.empty, Map.empty, ListMap.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, ListMap.empty, None, Map.empty, AvailableClasses.empty, Map.empty)
@@ -159,7 +161,7 @@ object KindedAst {
 
     case class Ascribe(exp: Expr, expectedType: Option[Type], expectedPur: Option[Type], tvar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Expr, clazz: ClassDesc, loc: SourceLocation) extends Expr
 
     case class CheckedCast(cast: CheckedCastType, exp: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
@@ -176,25 +178,25 @@ object KindedAst {
 
     case class RunWith(exp1: Expr, exp2: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class InvokeConstructor(clazz: Class[?], exps: List[Expr], jvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class InvokeConstructor(clazz: ClassDesc, exps: List[Expr], jvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class InvokeSuperConstructor(clazz: Class[?], exps: List[Expr], jvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class InvokeSuperConstructor(clazz: ClassDesc, exps: List[Expr], jvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
     case class InvokeMethod(exp: Expr, methodName: Name.Ident, exps: List[Expr], jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class InvokeSuperMethod(clazz: Class[?], methodName: Name.Ident, exps: List[Expr], targs: List[Type], jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class InvokeSuperMethod(clazz: ClassDesc, methodName: Name.Ident, exps: List[Expr], targs: List[Type], jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class InvokeStaticMethod(clazz: Class[?], methodName: Name.Ident, exps: List[Expr], jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class InvokeStaticMethod(clazz: ClassDesc, methodName: Name.Ident, exps: List[Expr], jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
     case class GetField(exp: Expr, fieldName: Name.Ident, jvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class PutField(field: JavaField, clazz: java.lang.Class[?], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutField(field: JavaField, clazz: ClassDesc, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
     case class GetStaticField(field: JavaField, tvar: Type.Var, loc: SourceLocation) extends Expr
 
     case class PutStaticField(field: JavaField, exp: Expr, loc: SourceLocation) extends Expr
 
-    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], targs: List[Type], constructors: List[JvmConstructor], methods: List[JvmMethod], tvar: Type.Var, loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: JClass, targs: List[Type], constructors: List[JvmConstructor], methods: List[JvmMethod], tvar: Type.Var, loc: SourceLocation) extends Expr
 
     case class NewChannel(exp: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
 
@@ -349,7 +351,7 @@ object KindedAst {
 
   case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr, loc: SourceLocation)
+  case class CatchRule(sym: Symbol.VarSym, clazz: ClassDesc, exp: Expr, loc: SourceLocation)
 
   case class HandlerRule(symUse: OpSymUse, fparams: Nel[FormalParam], exp: Expr, tvar: Type.Var, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -22,6 +22,8 @@ import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.util.collection.{ListMap, Nel}
 
+import java.lang.constant.ClassDesc
+
 object ResolvedAst {
 
   val empty: Root = Root(Map.empty, Map.empty, ListMap.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, ListMap.empty, List.empty, None, Map.empty, AvailableClasses.empty, Map.empty)
@@ -172,7 +174,7 @@ object ResolvedAst {
 
     case class Ascribe(exp: Expr, expectedType: Option[UnkindedType], expectedEff: Option[UnkindedType], loc: SourceLocation) extends Expr
 
-    case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Expr, clazz: ClassDesc, loc: SourceLocation) extends Expr
 
     case class CheckedCast(cast: CheckedCastType, exp: Expr, loc: SourceLocation) extends Expr
 
@@ -189,25 +191,25 @@ object ResolvedAst {
 
     case class RunWith(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
-    case class InvokeConstructor(clazz: Class[?], exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeConstructor(clazz: ClassDesc, exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeSuperConstructor(clazz: Class[?], exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeSuperConstructor(clazz: ClassDesc, exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class InvokeMethod(exp: Expr, methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeSuperMethod(clazz: Class[?], methodName: Name.Ident, exps: List[Expr], targs: List[UnkindedType], loc: SourceLocation) extends Expr
+    case class InvokeSuperMethod(clazz: ClassDesc, methodName: Name.Ident, exps: List[Expr], targs: List[UnkindedType], loc: SourceLocation) extends Expr
 
-    case class InvokeStaticMethod(clazz: Class[?], methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeStaticMethod(clazz: ClassDesc, methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class GetField(exp: Expr, fieldName: Name.Ident, loc: SourceLocation) extends Expr
 
-    case class PutField(field: JavaField, clazz: java.lang.Class[?], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class PutField(field: JavaField, clazz: ClassDesc, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
 
     case class GetStaticField(field: JavaField, loc: SourceLocation) extends Expr
 
     case class PutStaticField(field: JavaField, exp: Expr, loc: SourceLocation) extends Expr
 
-    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], targs: List[UnkindedType], constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: JClass, targs: List[UnkindedType], constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
     case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
 
@@ -363,7 +365,7 @@ object ResolvedAst {
 
   case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, tpe: UnkindedType, eff: Option[UnkindedType], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[?], exp: Expr, loc: SourceLocation)
+  case class CatchRule(sym: Symbol.VarSym, clazz: ClassDesc, exp: Expr, loc: SourceLocation)
 
   case class HandlerRule(symUse: OpSymUse, fparams: Nel[FormalParam], exp: Expr, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -625,7 +625,7 @@ object Type {
     /**
       * A Java constructor, defined by its class and argument types.
       */
-    case class JvmConstructor(clazz: Class[?], tpes: List[Type]) extends JvmMember
+    case class JvmConstructor(clazz: ClassDesc, tpes: List[Type]) extends JvmMember
 
     /**
       * A Java field, defined by the receiver type and the field name.
@@ -640,7 +640,7 @@ object Type {
     /**
       * A Java static method, defined by the class, the method name, and the argument types.
       */
-    case class JvmStaticMethod(clazz: Class[?], name: Name.Ident, tpes: List[Type]) extends JvmMember
+    case class JvmStaticMethod(clazz: ClassDesc, name: Name.Ident, tpes: List[Type]) extends JvmMember
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -960,13 +960,6 @@ object Type {
     * Constructs the native type of the class `desc` with `arity` type parameters.
     */
   def mkNative(desc: ClassDesc, arity: Int, loc: SourceLocation): Type = Type.Cst(TypeConstructor.Native(desc, arity), loc)
-
-  /**
-    * Constructs the native type of the loaded class `clazz`.
-    *
-    * Transitional: prefer `mkNative(desc, arity, loc)` since it does not require a loaded class.
-    */
-  def mkNative(clazz: Class[?], loc: SourceLocation): Type = mkNative(ClassDescs.of(clazz), clazz.getTypeParameters.length, loc)
 
   /**
     * Returns the `java.lang.Object` type.
@@ -1353,16 +1346,6 @@ object Type {
     var elm = c
     while (elm.isArray) elm = elm.getComponentType
     getFlixType(ClassDescs.of(c), elm.getTypeParameters.length)
-  }
-
-  /**
-    * Returns a fully-applied Flix type for the given Java class, with `Object` type arguments
-    * for generic classes. Use this in ground-type contexts that need kind `Star`.
-    */
-  def instantiateJavaTypeWithObjectArgs(c: Class[?], loc: SourceLocation): Type = {
-    val base = getFlixType(c)
-    val n = c.getTypeParameters.length
-    Type.mkApply(base, List.fill(n)(Type.mkObject(loc)), loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -23,6 +23,8 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, TraitEnv}
 import ca.uwaterloo.flix.util.collection.{ListMap, Nel}
 
+import java.lang.constant.ClassDesc
+
 object TypedAst {
 
   val empty: Root = Root(Map.empty, Map.empty, ListMap.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, ListMap.empty, None, Set.empty, List.empty,Map.empty, TraitEnv.empty, EqualityEnv.empty, AvailableClasses.empty, LabelledPrecedenceGraph.empty, DependencyGraph.empty, Map.empty)
@@ -202,7 +204,7 @@ object TypedAst {
 
     case class Ascribe(exp: Expr, expectedType: Option[Type], expectedEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr {
+    case class InstanceOf(exp: Expr, clazz: ClassDesc, loc: SourceLocation) extends Expr {
       def eff: Type = exp.eff
 
       def tpe: Type = Type.Bool
@@ -243,7 +245,7 @@ object TypedAst {
 
     case class PutStaticField(field: JavaField, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class NewObject(sym: Symbol.AnonClassSym, clazz: java.lang.Class[?], tpe: Type, eff: Type, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(sym: Symbol.AnonClassSym, clazz: JClass, tpe: Type, eff: Type, constructors: List[JvmConstructor], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
     case class NewChannel(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
@@ -408,7 +410,7 @@ object TypedAst {
 
   case class JvmMethod(ann: List[JvmAnnotation], ident: Name.Ident, fparams: Nel[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
 
-  case class CatchRule(bnd: Binder, clazz: java.lang.Class[?], exp: Expr, loc: SourceLocation)
+  case class CatchRule(bnd: Binder, clazz: ClassDesc, exp: Expr, loc: SourceLocation)
 
   case class HandlerRule(op: OpSymUse, fparams: Nel[FormalParam], exp: Expr, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/JClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/JClass.scala
@@ -15,17 +15,7 @@
  */
 package ca.uwaterloo.flix.language.ast.shared
 
-import ca.uwaterloo.flix.util.ClassDescs
-
 import java.lang.constant.ClassDesc
-
-object JClass {
-
-  /** Returns the [[JClass]] of the given loaded class `clazz`. */
-  def of(clazz: Class[?]): JClass =
-    JClass(ClassDescs.of(clazz), clazz.isInterface)
-
-}
 
 /**
   * A nominal reference to the Java class or interface `desc`.

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/LocalScope.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/LocalScope.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.ast.shared
 import ca.uwaterloo.flix.language.ast.UnkindedType
 import ca.uwaterloo.flix.util.collection.ListMap
 
-import java.lang.{Class => JClass}
+import java.lang.constant.ClassDesc
 
 /**
   * Companion object for the [[LocalScope]] class.
@@ -42,7 +42,7 @@ object LocalScope {
   * @param superClass `None` means super calls are illegal here; `Some(clazz)` means super calls resolve to `clazz`.
   * @param superTargs the type arguments of the enclosing NewObject expression, if any.
   */
-case class LocalScope(scp: ListMap[String, Resolution], superClass: Option[JClass[?]] = None, superTargs: List[UnkindedType] = Nil) {
+case class LocalScope(scp: ListMap[String, Resolution], superClass: Option[ClassDesc] = None, superTargs: List[UnkindedType] = Nil) {
   /**
     * Returns the map of variable names to their resolutions.
     */
@@ -76,7 +76,7 @@ case class LocalScope(scp: ListMap[String, Resolution], superClass: Option[JClas
   def resolve(name: String): Option[Resolution] =
     scp.get(name).headOption
 
-  def withSuperClass(clazz: Option[JClass[?]]): LocalScope = copy(superClass = clazz)
+  def withSuperClass(clazz: Option[ClassDesc]): LocalScope = copy(superClass = clazz)
 
   def withSuperTargs(targs: List[UnkindedType]): LocalScope = copy(superTargs = targs)
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/Resolution.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/Resolution.scala
@@ -26,7 +26,7 @@ sealed trait Resolution
 object Resolution {
   case class Declaration(decl: NamedAst.Declaration) extends Resolution
 
-  case class JavaClass(clazz: Class[?]) extends Resolution
+  case class JavaClass(clazz: ca.uwaterloo.flix.language.ast.jvm.JavaClass) extends Resolution
 
   case class Var(sym: Symbol.VarSym) extends Resolution
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/UseOrImport.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/UseOrImport.scala
@@ -15,6 +15,7 @@
  */
 package ca.uwaterloo.flix.language.ast.shared
 
+import ca.uwaterloo.flix.language.ast.jvm.JavaClass
 import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Sourceable, Symbol}
 
 /**
@@ -34,7 +35,7 @@ object UseOrImport {
   /**
     * An import of a Java class.
     */
-  case class Import(clazz: Class[?], alias: Name.Ident, loc: SourceLocation) extends UseOrImport {
+  case class Import(clazz: JavaClass, alias: Name.Ident, loc: SourceLocation) extends UseOrImport {
     val src: Source = loc.source
   }
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -19,7 +19,6 @@ package ca.uwaterloo.flix.language.dbg
 import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod}
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{Name, Symbol}
-import ca.uwaterloo.flix.util.ClassDescs
 
 import java.lang.constant.ClassDesc
 import scala.collection.immutable.SortedSet
@@ -247,9 +246,6 @@ object DocAst {
 
     def RefEq(d1: Expr, d2: Expr): Expr =
       Binary(d1, "===", d2)
-
-    def InstanceOf(d: Expr, clazz: Class[?]): Expr =
-      InstanceOf(d, ClassDescs.of(clazz))
 
     def InstanceOf(d: Expr, clazz: ClassDesc): Expr =
       Binary(d, "instanceof", AsIs(javaClassName(clazz)))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -96,7 +96,7 @@ object ResolvedAstPrinter {
     case Expr.Unsafe(exp, runEff, asEff, _) => DocAst.Expr.Unsafe(print(exp), UnkindedTypePrinter.print(runEff), asEff.map(UnkindedTypePrinter.print))
 
     case Expr.TryCatch(exp, rules, _) => DocAst.Expr.TryCatch(print(exp), rules.map {
-      case ResolvedAst.CatchRule(sym, clazz, body, _) => (sym, clazz.getName, print(body))
+      case ResolvedAst.CatchRule(sym, clazz, body, _) => (sym, DocAst.Expr.javaClassName(clazz), print(body))
     })
     case Expr.Throw(exp, _) => DocAst.Expr.Throw(print(exp))
     case Expr.Handler(symUse, rules, _) => DocAst.Expr.Handler(symUse.sym, rules.map {

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -88,7 +88,7 @@ object TypedAstPrinter {
     case Expr.PutField(field, exp1, exp2, _, _, _) => DocAst.Expr.JavaPutField(JField.of(field), print(exp1), print(exp2))
     case Expr.GetStaticField(field, _, _, _) => DocAst.Expr.JavaGetStaticField(JField.of(field))
     case Expr.PutStaticField(field, exp, _, _, _) => DocAst.Expr.JavaPutStaticField(JField.of(field), print(exp))
-    case Expr.NewObject(sym, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(sym, clazz.getName, TypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
+    case Expr.NewObject(sym, clazz, tpe, _, constructors, methods, _) => DocAst.Expr.NewObject(sym, DocAst.Expr.javaClassName(clazz.desc), TypePrinter.print(tpe), constructors.map(printJvmConstructor), methods.map(printJvmMethod))
     case Expr.NewChannel(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.GetChannel(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.PutChannel(_, _, _, _, _) => DocAst.Expr.Unknown
@@ -134,7 +134,7 @@ object TypedAstPrinter {
     * Returns the [[DocAst]] representation of `rule`.
     */
   private def printCatchRule(rule: TypedAst.CatchRule): (Symbol.VarSym, String, DocAst.Expr) = rule match {
-    case TypedAst.CatchRule(bnd, clazz, exp, _) => (bnd.sym, clazz.getName, print(exp))
+    case TypedAst.CatchRule(bnd, clazz, exp, _) => (bnd.sym, DocAst.Expr.javaClassName(clazz), print(exp))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -931,14 +931,14 @@ object ResolutionError {
     * @param field the field name.
     * @param loc   the location of the field access.
     */
-  case class UndefinedJvmStaticField(clazz: Class[?], field: Name.Ident, loc: SourceLocation) extends ResolutionError {
+  case class UndefinedJvmStaticField(clazz: ClassDesc, field: Name.Ident, loc: SourceLocation) extends ResolutionError {
     def code: ErrorCode = ErrorCode.E1914
 
     def summary: String = s"Undefined static field: '${field.name}'."
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Undefined static field '${red(field.name)}' in class '${cyan(clazz.getName)}'.
+      s""">> Undefined static field '${red(field.name)}' in class '${cyan(ClassDescs.binaryNameOf(clazz))}'.
          |
          |${highlight(loc, "field not found", fmt)}
          |""".stripMargin

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -20,10 +20,15 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.jvm.JavaMethod
 import ca.uwaterloo.flix.language.ast.shared.{Denotation, EffSymOrRigidVar, SymbolSet}
 import ca.uwaterloo.flix.language.fmt.FormatType.formatType
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
 import ca.uwaterloo.flix.util.{ClassDescs, Formatter, Grammar}
+
+import java.lang.constant.ClassDesc
+import java.lang.reflect.Modifier
+import scala.jdk.CollectionConverters.*
 
 /**
   * A common super-type for type errors.
@@ -97,14 +102,14 @@ object TypeError {
     * @param renv the rigidity environment.
     * @param loc  the location where the error occurred.
     */
-  case class ConstructorNotFound(clazz: Class[?], tpes: List[Type], renv: RigidityEnv, loc: SourceLocation) extends TypeError {
+  case class ConstructorNotFound(clazz: ClassDesc, tpes: List[Type], renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
     def code: ErrorCode = ErrorCode.E6025
 
-    def summary: String = s"Constructor not found: '${clazz.getName}' with arguments (${tpes.mkString(", ")})."
+    def summary: String = s"Constructor not found: '${ClassDescs.binaryNameOf(clazz)}' with arguments (${tpes.mkString(", ")})."
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Constructor not found: '${red(clazz.getName)}' with arguments (${cyan(tpes.mkString(", "))}).
+      s""">> Constructor not found: '${red(ClassDescs.binaryNameOf(clazz))}' with arguments (${cyan(tpes.mkString(", "))}).
          |
          |${highlight(loc, "cannot find constructor", fmt)}
          |
@@ -906,14 +911,14 @@ object TypeError {
     * @param renv       the rigidity environment.
     * @param loc        the location where the error occurred.
     */
-  case class StaticMethodNotFound(clazz: Class[?], methodName: Name.Ident, tpes: List[Type], renv: RigidityEnv, loc: SourceLocation) extends TypeError {
+  case class StaticMethodNotFound(clazz: ClassDesc, methodName: Name.Ident, tpes: List[Type], renv: RigidityEnv, loc: SourceLocation) extends TypeError {
     def code: ErrorCode = ErrorCode.E6358
 
-    def summary: String = s"Static method not found: '${methodName.name}' in class '${clazz.getName}'."
+    def summary: String = s"Static method not found: '${methodName.name}' in class '${ClassDescs.binaryNameOf(clazz)}'."
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Static method not found: '${red(methodName.name)}' in class '${magenta(clazz.getName)}' with arguments (${cyan(tpes.mkString(", "))}).
+      s""">> Static method not found: '${red(methodName.name)}' in class '${magenta(ClassDescs.binaryNameOf(clazz))}' with arguments (${cyan(tpes.mkString(", "))}).
          |
          |${highlight(loc, "cannot find static method", fmt)}
          |
@@ -1096,10 +1101,11 @@ object TypeError {
   }
 
   /**
-    * Returns the constructors of the given class sorted by parameter count.
+    * Returns the public constructors of the given class sorted by parameter count.
     */
-  private def getConstructorsByArgs(clazz: Class[?]): List[java.lang.reflect.Constructor[?]] = {
-    clazz.getConstructors.sortBy(_.getParameterTypes.length).toList
+  private def getConstructorsByArgs(clazz: ClassDesc)(implicit flix: Flix): List[JavaMethod] = {
+    val constructors = flix.javaTypeProvider.lookupClass(clazz).toOption.toList.flatMap(_.declaredConstructors)
+    constructors.filter(c => Modifier.isPublic(c.modifiers)).sortBy(_.parameterTypes.length)
   }
 
   /**
@@ -1112,9 +1118,9 @@ object TypeError {
   /**
     * Returns a formatted string representation of a Java constructor.
     */
-  private def formatConstructor(clazz: Class[?], c: java.lang.reflect.Constructor[?]): String = {
-    val params = c.getParameterTypes.map(formatJavaType).mkString(", ")
-    s"${clazz.getSimpleName}($params)"
+  private def formatConstructor(clazz: ClassDesc, c: JavaMethod): String = {
+    val params = c.ref.descriptor.parameterList().asScala.map(formatJavaType).mkString(", ")
+    s"${ClassDescs.simpleNameOf(clazz)}($params)"
   }
 
   /**
@@ -1132,6 +1138,16 @@ object TypeError {
       Type.getFlixType(tpe).toString
     else
       tpe.getName
+  }
+
+  /**
+    * Returns the Flix-style string representation of the Java type `desc`.
+    */
+  private def formatJavaType(desc: ClassDesc): String = {
+    if (desc.isPrimitive || desc.isArray)
+      Type.getFlixType(desc, 0).toString
+    else
+      ClassDescs.binaryNameOf(desc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/DisplayType.scala
@@ -379,10 +379,10 @@ object DisplayType {
       case Type.JvmToEff(tpe, _) =>
         mkApply(DisplayType.JvmToEff(visit(tpe)), t.typeArguments.map(visit))
       case Type.UnresolvedJvmType(member, _) => member match {
-        case JvmMember.JvmConstructor(clazz, tpes) => DisplayType.JvmUnresolvedConstructor(clazz.getSimpleName, tpes.map(visit))
+        case JvmMember.JvmConstructor(clazz, tpes) => DisplayType.JvmUnresolvedConstructor(ClassDescs.simpleNameOf(clazz), tpes.map(visit))
         case JvmMember.JvmMethod(tpe, name, tpes) => DisplayType.JvmUnresolvedMethod(visit(tpe), name.name, tpes.map(visit))
         case JvmMember.JvmField(_, tpe, name) => DisplayType.JvmUnresolvedField(visit(tpe), name.name)
-        case JvmMember.JvmStaticMethod(clazz, name, tpes) => DisplayType.JvmUnresolvedStaticMethod(clazz.getSimpleName, name.name, tpes.map(visit))
+        case JvmMember.JvmStaticMethod(clazz, name, tpes) => DisplayType.JvmUnresolvedStaticMethod(ClassDescs.simpleNameOf(clazz), name.name, tpes.map(visit))
       }
       case Type.Cst(tc, _) => tc match {
         case TypeConstructor.Void => Void

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
@@ -24,8 +24,10 @@ import ca.uwaterloo.flix.language.ast.shared.Constant
 import ca.uwaterloo.flix.language.ast.shared.SymUse.CaseSymUse
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.PatMatchError
-import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
+import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Result}
 
+import java.lang.constant.ClassDesc
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -586,11 +588,11 @@ object PatMatch2 {
     * A catch rule is redundant if a preceding rule catches the same exception
     * class or a superclass of it, making the later rule impossible to reach.
     */
-  private def checkCatchRules(rules: List[TypedAst.CatchRule])(implicit sctx: SharedContext): Unit = {
+  private def checkCatchRules(rules: List[TypedAst.CatchRule])(implicit sctx: SharedContext, flix: Flix): Unit = {
     var precedingRules: List[TypedAst.CatchRule] = Nil
     for (rule <- rules) {
       // Check if any preceding rule's class is a superclass of (or equal to) this rule's class.
-      precedingRules.find(prev => prev.clazz.isAssignableFrom(rule.clazz)) match {
+      precedingRules.find(prev => isSubtype(rule.clazz, prev.clazz, rule.loc)) match {
         case Some(coveringRule) =>
           sctx.errors.add(PatMatchError.RedundantCatchRule(coveringRule.loc, rule.loc))
         case None => ()
@@ -598,6 +600,13 @@ object PatMatch2 {
       precedingRules = precedingRules :+ rule
     }
   }
+
+  /** Returns `true` if the Java class `sub` is a subtype of `sup`, or throws if their metadata cannot be read. */
+  private def isSubtype(sub: ClassDesc, sup: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
+    JavaMemberResolver.isReferenceSubtype(sub, sup) match {
+      case Result.Ok(result) => result
+      case Result.Err(error) => throw InternalCompilerException(s"Java subtype check failed for '${sub.displayName()} <: ${sup.displayName()}': $error", loc)
+    }
 
   // ─────────────────────────────────────────────────────────────
   //  Section 3: Run / Visitors

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -28,11 +28,13 @@ import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
+import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaLookupError, JavaMemberResolver, JavaTypes}
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
 
 import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.CD_Object
+import java.lang.reflect.Modifier
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.unused
 import scala.collection.immutable.SortedSet
@@ -810,13 +812,13 @@ object Resolver {
             // We have a static field access.
             val fieldName = qname.ident
 
-            val owner = ClassDescs.of(clazz)
+            val owner = clazz.desc
             JavaMemberResolver.field(owner, fieldName.name, static = true) match {
               case Result.Ok(Some(field)) =>
                 // Returns out of resolveExp
                 return ResolvedAst.Expr.GetStaticField(field, loc)
               case Result.Ok(None) =>
-                val error = ResolutionError.UndefinedJvmStaticField(clazz, fieldName, loc)
+                val error = ResolutionError.UndefinedJvmStaticField(owner, fieldName, loc)
                 sctx.errors.add(error)
                 return ResolvedAst.Expr.Error(error)
               case Result.Err(error) =>
@@ -911,9 +913,9 @@ object Resolver {
             // Returns out of resolveExp
             return es match {
               case ResolvedAst.Expr.Cst(Constant.Unit, _) :: Nil =>
-                ResolvedAst.Expr.InvokeStaticMethod(clazz, methodName, Nil, outerLoc)
+                ResolvedAst.Expr.InvokeStaticMethod(clazz.desc, methodName, Nil, outerLoc)
               case _ =>
-                ResolvedAst.Expr.InvokeStaticMethod(clazz, methodName, es, outerLoc)
+                ResolvedAst.Expr.InvokeStaticMethod(clazz.desc, methodName, es, outerLoc)
             }
           case _ =>
           // Fallthrough to below.
@@ -1159,7 +1161,7 @@ object Resolver {
       val e = resolveExp(exp, scp0)
       scp0.get(className.name) match {
         case List(Resolution.JavaClass(clazz)) =>
-          ResolvedAst.Expr.InstanceOf(e, clazz, loc)
+          ResolvedAst.Expr.InstanceOf(e, clazz.desc, loc)
         case _ =>
           val error = ResolutionError.UndefinedJvmClass(className, AnchorPosition.mkImportOrUseAnchor(ns0), "", loc)
           sctx.errors.add(error)
@@ -1189,10 +1191,10 @@ object Resolver {
           val scp = scp0 ++ mkVarScp(sym)
           val b = resolveExp(body, scp)
           lookupJvmClass2(className, ns0, scp0) match {
-            case Result.Ok(clazz) => ResolvedAst.CatchRule(sym, clazz, b, ruleLoc)
+            case Result.Ok(clazz) => ResolvedAst.CatchRule(sym, clazz.desc, b, ruleLoc)
             case Result.Err(error) =>
               sctx.errors.add(error)
-              ResolvedAst.CatchRule(sym, classOf[Object], b, ruleLoc)
+              ResolvedAst.CatchRule(sym, CD_Object, b, ruleLoc)
           }
       }
 
@@ -1222,7 +1224,7 @@ object Resolver {
       val es = exps.map(resolveExp(_, scp0))
       scp0.get(className.name) match {
         case List(Resolution.JavaClass(clazz)) =>
-          ResolvedAst.Expr.InvokeConstructor(clazz, es, loc)
+          ResolvedAst.Expr.InvokeConstructor(clazz.desc, es, loc)
         case _ =>
           val error = ResolutionError.UndefinedNew(className, AnchorPosition.mkImportOrUseAnchor(ns0), scp0, loc)
           sctx.errors.add(error)
@@ -1733,13 +1735,14 @@ object Resolver {
       case None =>
         val t = resolveType(tpe, Some(Kind.Star), Wildness.ForbidWild, scp0, taenv, ns0, root)
         val erased = UnkindedType.eraseAliases(t)
-        getNativeClassFromType(erased) match {
-          case Some(clazz) =>
+        getNativeDescFromType(erased) match {
+          case Some(desc) =>
             val targs = erased.typeArguments
-            val superScp = scp0.withSuperClass(Some(clazz)).withSuperTargs(targs)
+            val superScp = scp0.withSuperClass(Some(desc)).withSuperTargs(targs)
             val cs = constructors.map(visitJvmConstructor(_, superScp))
             val ms = methods.map(visitJvmMethod(_, superScp))
             val anonClassSym = Symbol.mkFreshAnonClassSym(loc);
+            val clazz = JClass(desc, Modifier.isInterface(JavaTypes.lookupClass(desc, loc).modifiers))
             ResolvedAst.Expr.NewObject(anonClassSym, clazz, targs, cs, ms, loc)
           case None =>
             erased match {
@@ -1771,9 +1774,7 @@ object Resolver {
     lookupJvmClass2(ann.name, ns0, scp0) match {
       case Result.Ok(clazz) =>
         if (clazz.isAnnotation) {
-          val retention = clazz.getAnnotation(classOf[java.lang.annotation.Retention])
-          val isRuntimeVisible = retention != null && retention.value() == java.lang.annotation.RetentionPolicy.RUNTIME
-          Some(JvmAnnotation(ClassDescs.of(clazz), isRuntimeVisible, ann.loc))
+          Some(JvmAnnotation(clazz.desc, clazz.isRuntimeVisibleAnnotation, ann.loc))
         } else {
           sctx.errors.add(ResolutionError.IllegalNonJavaAnnotation(ann.name.name, ann.loc))
           None
@@ -2778,7 +2779,7 @@ object Resolver {
     /**
       * The result is a Java class.
       */
-    case class JavaClass(clazz: Class[?]) extends TypeLookupResult
+    case class JavaClass(clazz: ca.uwaterloo.flix.language.ast.jvm.JavaClass) extends TypeLookupResult
 
     /**
       * The result is an associated type constructor.
@@ -3307,21 +3308,34 @@ object Resolver {
   }
 
   /**
-    * Returns the class reflection object for the given `className`.
+    * Returns the class metadata for the given `className`, read from its class file.
     */
-  private def lookupJvmClass(className: String, ns0: Name.NName, loc: SourceLocation)(implicit flix: Flix): Result[Class[?], ResolutionError] = try {
-    // Don't initialize the class; we don't want to execute static initializers.
-    val initialize = false
-    Result.Ok(Class.forName(className, initialize, flix.jarLoader))
-  } catch {
-    case ex: ClassNotFoundException => Result.Err(ResolutionError.UndefinedJvmImport(className, AnchorPosition.mkImportOrUseAnchor(ns0), ex.getMessage, loc))
-    case ex: NoClassDefFoundError => Result.Err(ResolutionError.UndefinedJvmImport(className, AnchorPosition.mkImportOrUseAnchor(ns0), ex.getMessage, loc))
+  private def lookupJvmClass(className: String, ns0: Name.NName, loc: SourceLocation)(implicit flix: Flix): Result[ca.uwaterloo.flix.language.ast.jvm.JavaClass, ResolutionError] = {
+    def undefined(message: String): ResolutionError =
+      ResolutionError.UndefinedJvmImport(className, AnchorPosition.mkImportOrUseAnchor(ns0), message, loc)
+
+    // A name that is not a valid binary class name has no descriptor.
+    val desc = try {
+      Some(ClassDesc.of(className))
+    } catch {
+      case _: IllegalArgumentException => None
+    }
+
+    desc match {
+      case None => Result.Err(undefined(s"'$className' is not a valid class name."))
+      case Some(d) => flix.javaTypeProvider.lookupClass(d) match {
+        case Result.Ok(clazz) => Result.Ok(clazz)
+        case Result.Err(JavaLookupError.MissingClass(_)) => Result.Err(undefined(s"The class '$className' was not found on the class path."))
+        case Result.Err(JavaLookupError.InvalidClass(_, message)) => Result.Err(undefined(s"The class file of '$className' could not be read: $message"))
+        case Result.Err(JavaLookupError.UnsupportedDescriptor(_)) => Result.Err(undefined(s"'$className' does not denote a class or interface."))
+      }
+    }
   }
 
   /**
-    * Returns the class reflection object for the given `className`.
+    * Returns the class metadata for the given `className`, falling back to the imported classes in scope.
     */
-  private def lookupJvmClass2(className: Name.Ident, ns0: Name.NName, scp0: LocalScope)(implicit flix: Flix): Result[Class[?], ResolutionError] = {
+  private def lookupJvmClass2(className: Name.Ident, ns0: Name.NName, scp0: LocalScope)(implicit flix: Flix): Result[ca.uwaterloo.flix.language.ast.jvm.JavaClass, ResolutionError] = {
     lookupJvmClass(className.name, ns0, className.loc) match {
       case Result.Ok(clazz) => Result.Ok(clazz)
       case Result.Err(e) => scp0.get(className.name) match {
@@ -3531,20 +3545,11 @@ object Resolver {
   private def mkTypeVarScp(sym: Symbol.RegionSym): LocalScope = LocalScope.singleton(sym.text, Resolution.Region(sym))
 
   /**
-    * Looks up the Java class from a (possibly applied) native unkinded type by
-    * traversing type applications to find the base `Native` type constructor.
-    *
-    * Example: `UnkindedType.Cst(Native(String, 0))` returns `Some(classOf[String])`.
-    * Example: `UnkindedType.Apply(Cst(Native(ArrayList, 1)), Cst(Native(String, 0)))` returns `Some(classOf[ArrayList])`.
-    *
-    * Transitional: loads the class since the AST still refers to loaded classes.
-    */
-  private def getNativeClassFromType(tpe: UnkindedType)(implicit flix: Flix): Option[Class[?]] =
-    getNativeDescFromType(tpe).map(ClassDescs.load(_, flix.jarLoader))
-
-  /**
     * Looks up the Java class descriptor from a (possibly applied) native unkinded type by
     * traversing type applications to find the base `Native` type constructor.
+    *
+    * Example: `UnkindedType.Cst(Native(String, 0))` returns `Some(String)`.
+    * Example: `UnkindedType.Apply(Cst(Native(ArrayList, 1)), Cst(Native(String, 0)))` returns `Some(ArrayList)`.
     */
   private def getNativeDescFromType(tpe: UnkindedType): Option[ClassDesc] = tpe match {
     case UnkindedType.Cst(TypeConstructor.Native(desc, _), _) => Some(desc)
@@ -3556,7 +3561,7 @@ object Resolver {
   /**
     * Converts the class into a Flix type.
     */
-  private def flixifyType(clazz: Class[?], loc: SourceLocation): UnkindedType = clazz.getName match {
+  private def flixifyType(clazz: ca.uwaterloo.flix.language.ast.jvm.JavaClass, loc: SourceLocation): UnkindedType = ClassDescs.binaryNameOf(clazz.desc) match {
     case "java.math.BigDecimal" => UnkindedType.Cst(TypeConstructor.BigDecimal, loc)
     case "java.math.BigInteger" => UnkindedType.Cst(TypeConstructor.BigInt, loc)
     case "java.lang.String" => UnkindedType.Cst(TypeConstructor.Str, loc)
@@ -3576,7 +3581,7 @@ object Resolver {
     case "java.util.function.DoubleConsumer" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkUnit(loc), loc)
     case "java.util.function.DoublePredicate" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkBool(loc), loc)
     case "java.util.function.DoubleUnaryOperator" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkFloat64(loc), loc)
-    case _ => UnkindedType.UnappliedNative(ClassDescs.of(clazz), clazz.getTypeParameters.length, loc)
+    case _ => UnkindedType.UnappliedNative(clazz.desc, clazz.typeParameters.length, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -15,7 +15,7 @@ import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaMemberResolver, JavaTypes
 import ca.uwaterloo.flix.language.phase.typer.{ConstraintGen, ConstraintSolver2}
 import ca.uwaterloo.flix.language.phase.unification.EqualityEnv
 import ca.uwaterloo.flix.util.collection.ListOps
-import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, ParOps, Result}
+import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Result}
 
 import java.lang.constant.ClassDesc
 import java.lang.constant.ConstantDescs.{CD_Object, CD_String, CD_Throwable}
@@ -766,10 +766,9 @@ object Safety {
     * @param clazz the Java class specified in the catch clause
     * @param loc   the location of the catch parameter.
     */
-  private def checkCatchClass(clazz: Class[?], loc: SourceLocation)(implicit sctx: SharedContext, flix: Flix): Unit = {
-    val desc = ClassDescs.of(clazz)
-    if (!isThrowable(desc, loc)) {
-      sctx.errors.add(IllegalCatchType(desc, loc))
+  private def checkCatchClass(clazz: ClassDesc, loc: SourceLocation)(implicit sctx: SharedContext, flix: Flix): Unit = {
+    if (!isThrowable(clazz, loc)) {
+      sctx.errors.add(IllegalCatchType(clazz, loc))
     }
   }
 
@@ -824,7 +823,7 @@ object Safety {
   private def checkObjectImplementation(newObject: Expr.NewObject)(implicit flix: Flix, sctx: SharedContext): Unit = newObject match {
     case Expr.NewObject(_, clazz0, tpe0, _, cs, methods, loc) =>
       val tpe = Type.eraseAliases(tpe0)
-      val clazz = ClassDescs.of(clazz0)
+      val clazz = clazz0.desc
       val javaClass = JavaTypes.lookupClass(clazz, loc)
       // `clazz` must be an interface or have a non-private constructor without arguments
       // (unless user-defined constructors are provided).

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -18,7 +18,6 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.*
-import ca.uwaterloo.flix.language.ast.Type.instantiateJavaTypeWithObjectArgs
 import ca.uwaterloo.flix.language.ast.TypedAst.ApplyPosition
 import ca.uwaterloo.flix.language.ast.jvm.JavaMethod
 import ca.uwaterloo.flix.language.ast.shared.{CheckedCastType, Constant, Decreasing}
@@ -396,7 +395,7 @@ object TypeReconstruction {
       val rs = rules map {
         case KindedAst.CatchRule(sym, clazz, body, ruleLoc) =>
           val b = visitExp(body)
-          val bnd = TypedAst.Binder(sym, Type.mkNative(clazz, SourceLocation.Unknown))
+          val bnd = TypedAst.Binder(sym, JavaTypes.flixTypeOf(clazz, ruleLoc))
           TypedAst.CatchRule(bnd, clazz, b, ruleLoc)
       }
       val tpe = rs.head.exp.tpe
@@ -430,7 +429,7 @@ object TypeReconstruction {
     case KindedAst.Expr.InvokeConstructor(clazz, exps, jvar, evar, loc) =>
       val es0 = exps.map(visitExp)
       val constructorTpe = subst(jvar)
-      val tpe = Type.instantiateJavaTypeWithObjectArgs(clazz, loc)
+      val tpe = JavaTypes.instantiateWithObjectArgs(clazz, loc)
       val eff = subst(evar)
       constructorTpe match {
         case Type.Cst(TypeConstructor.JvmConstructor(constructor), _) =>
@@ -443,7 +442,7 @@ object TypeReconstruction {
     case KindedAst.Expr.InvokeSuperConstructor(clazz, exps, jvar, evar, loc) =>
       val es0 = exps.map(visitExp)
       val constructorTpe = subst(jvar)
-      val tpe = Type.instantiateJavaTypeWithObjectArgs(clazz, loc)
+      val tpe = JavaTypes.instantiateWithObjectArgs(clazz, loc)
       val eff = subst(evar)
       constructorTpe match {
         case Type.Cst(TypeConstructor.JvmConstructor(constructor), _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -28,7 +28,7 @@ import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoAst, Name, SemanticOp, Sour
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization.Context
 import ca.uwaterloo.flix.language.phase.monomorph.Symbols.{Defs, Enums, Types}
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
-import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, Result}
+import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListOps, Nel}
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
@@ -437,7 +437,7 @@ object Lowering {
         MonoAst.Expr.Stm(List(e), MonoAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc), Type.Bool, e.eff, loc)
       } else {
         // If it's a reference type, then do the instanceof check
-        MonoAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(ClassDescs.of(clazz)), List(e), Type.Bool, e.eff, loc)
+        MonoAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(clazz), List(e), Type.Bool, e.eff, loc)
       }
 
     case TypedAst.Expr.CheckedCast(_, exp, tpe, eff, loc) =>
@@ -571,10 +571,10 @@ object Lowering {
         val thisTpe = lowerType(thisParam.tpe)
         val thisRef = MonoAst.Expr.Var(thisParam.bnd.sym, thisTpe, loc)
         implicit val lctx: LocalContext = LocalContext(Some(sym), Some(thisRef))
-        lowerJvmMethod(m, clazz)
+        lowerJvmMethod(m, clazz.desc)
       }
       val t = lowerType(tpe)
-      MonoAst.Expr.NewObject(sym, JClass.of(clazz), t, eff, cs, ms, loc)
+      MonoAst.Expr.NewObject(sym, clazz, t, eff, cs, ms, loc)
 
     case TypedAst.Expr.NewChannel(exp, tpe, eff, loc) =>
       val e = lowerExp(exp)
@@ -674,7 +674,7 @@ object Lowering {
   /**
     * Lowers the given JvmMethod `method`.
     */
-  private def lowerJvmMethod(method: TypedAst.JvmMethod, clazz: Class[?])(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.JvmMethod = method match {
+  private def lowerJvmMethod(method: TypedAst.JvmMethod, clazz: ClassDesc)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.JvmMethod = method match {
     case TypedAst.JvmMethod(ann, ident, fparams, exp, _, eff, loc) =>
       val fs = fparams.map(lowerFormalParam)
       val e0 = lowerExp(exp)
@@ -683,7 +683,7 @@ object Lowering {
       // box it so the value matches the erased JVM signature. This mirrors the boxing applied
       // to generic Java method *calls* above (see `boxIfNecessary` in InvokeMethod), and the
       // call site unboxes the result symmetrically.
-      val overridden = overriddenJavaMethod(ClassDescs.of(clazz), ident.name, fparams.tail.length, loc)
+      val overridden = overriddenJavaMethod(clazz, ident.name, fparams.tail.length, loc)
       val e = overridden match {
         case Some(m) => boxIfNecessary(e0, m.ref.descriptor.returnType())
         case None => e0
@@ -709,7 +709,7 @@ object Lowering {
   private def lowerCatchRule(rule: TypedAst.CatchRule)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): MonoAst.CatchRule = rule match {
     case TypedAst.CatchRule(bnd, clazz, exp, _) =>
       val e = lowerExp(exp)
-      MonoAst.CatchRule(bnd.sym, ClassDescs.of(clazz), e)
+      MonoAst.CatchRule(bnd.sym, clazz, e)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -27,7 +27,7 @@ import ca.uwaterloo.flix.language.phase.monomorph2.Specialize.*
 import ca.uwaterloo.flix.language.phase.monomorph2.Symbols.{Defs, Enums, Types}
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListOps, Nel}
-import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, Result}
+import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
 import java.lang.reflect.Modifier
@@ -441,7 +441,7 @@ private[monomorph2] object SpecializeAndLower {
         MonoAst.Expr.Stm(List(e), MonoAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc), Type.Bool, e.eff, loc)
       } else {
         // If it's a reference type, then do the instanceof check
-        MonoAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(ClassDescs.of(clazz)), List(e), Type.Bool, e.eff, loc)
+        MonoAst.Expr.ApplyAtomic(AtomicOp.InstanceOf(clazz), List(e), Type.Bool, e.eff, loc)
       }
 
     case TypedAst.Expr.CheckedCast(_, exp, tpe, eff, loc) =>
@@ -575,7 +575,7 @@ private[monomorph2] object SpecializeAndLower {
           // for a generic interface method) but the Flix result is primitive, box it to match the
           // erased signature. This mirrors the boxing applied to generic Java method calls (see
           // `boxIfNecessary` in `mkJavaInvoke`), and the call site unboxes the result symmetrically.
-          val overridden = overriddenJavaMethod(ClassDescs.of(clazz), mIdent.name, fs.tail.length, mLoc)
+          val overridden = overriddenJavaMethod(clazz.desc, mIdent.name, fs.tail.length, mLoc)
           val e = overridden match {
             case Some(m) => boxIfNecessary(e0, m.ref.descriptor.returnType())
             case None => e0
@@ -583,7 +583,7 @@ private[monomorph2] object SpecializeAndLower {
           MonoAst.JvmMethod(mAnn, mIdent, fs, e, e.tpe, subst(mEff), overridden.map(mkJMethod(_, mLoc)), mLoc)
       }
       val t = visitType(tpe, subst)
-      MonoAst.Expr.NewObject(freshSym, JClass.of(clazz), t, subst(eff), cs, ms, loc)
+      MonoAst.Expr.NewObject(freshSym, clazz, t, subst(eff), cs, ms, loc)
 
     case TypedAst.Expr.NewChannel(exp, tpe, eff, loc) =>
       val e = visitExp(exp, env0, subst)
@@ -689,7 +689,7 @@ private[monomorph2] object SpecializeAndLower {
       val freshSym = Symbol.freshVarSym(bnd.sym)
       val env1 = env0 + (bnd.sym -> freshSym)
       val e = visitExp(exp, env1, subst)
-      MonoAst.CatchRule(freshSym, ClassDescs.of(clazz0), e)
+      MonoAst.CatchRule(freshSym, clazz0, e)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -25,9 +25,10 @@ import ca.uwaterloo.flix.language.ast.{Kind, KindedAst, Name, Scheme, SemanticOp
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaTypes
 import ca.uwaterloo.flix.language.phase.unification.Substitution
 import ca.uwaterloo.flix.util.collection.{ListOps, Nel}
-import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils, Subeffecting}
+import ca.uwaterloo.flix.util.{InternalCompilerException, Subeffecting}
 
-import java.lang.reflect.{Modifier, ParameterizedType, TypeVariable}
+import java.lang.constant.ClassDesc
+import java.lang.reflect.Modifier
 
 /**
   * This phase generates a list of type constraints, which include
@@ -963,8 +964,8 @@ object ConstraintGen {
 
       case Expr.InvokeSuperMethod(clazz, methodName, exps, targs, jvar, tvar, evar, loc) =>
         val baseEff = Type.JvmToEff(jvar, loc)
-        val clazzTpe = if (targs.nonEmpty) Type.mkApply(Type.mkNative(clazz, loc), targs, loc)
-                       else Type.instantiateJavaTypeWithObjectArgs(clazz, loc)
+        val clazzTpe = if (targs.nonEmpty) Type.mkApply(JavaTypes.flixTypeOf(clazz, loc), targs, loc)
+                       else JavaTypes.instantiateWithObjectArgs(clazz, loc)
         val (tpes, effs) = exps.map(visitExp).unzip
         c.unifyType(jvar, Type.UnresolvedJvmType(Type.JvmMember.JvmMethod(clazzTpe, methodName, tpes), loc), loc)
         c.unifyType(tvar, Type.JvmToType(jvar, loc), loc)
@@ -1000,7 +1001,7 @@ object ConstraintGen {
 
       case Expr.PutField(field, clazz, exp1, exp2, loc) =>
         val fieldType = getJavaFieldType(field, loc)
-        val classType = Type.instantiateJavaTypeWithObjectArgs(clazz, loc)
+        val classType = JavaTypes.instantiateWithObjectArgs(clazz, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
         c.expectType(expected = classType, actual = tpe1, exp1.loc)
@@ -1027,8 +1028,7 @@ object ConstraintGen {
 
       case Expr.NewObject(_, clazz, targs, constructors, methods, tvar, loc) =>
         constructors.foreach(visitJvmConstructor)
-        val resTpe = if (targs.nonEmpty) Type.mkApply(Type.mkNative(clazz, loc), targs, loc)
-                     else Type.mkNative(clazz, loc)
+        val resTpe = Type.mkApply(JavaTypes.flixTypeOf(clazz.desc, loc), targs, loc)
         c.unifyType(tvar, resTpe, loc)
 
         methods.foreach(visitJvmMethod)
@@ -1285,7 +1285,7 @@ object ConstraintGen {
     */
   private def visitCatchRule(rule: KindedAst.CatchRule)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = rule match {
     case KindedAst.CatchRule(sym, clazz, exp, _) =>
-      c.expectType(expected = Type.mkNative(clazz, sym.loc), sym.tvar, sym.loc)
+      c.expectType(expected = JavaTypes.flixTypeOf(clazz, sym.loc), sym.tvar, sym.loc)
       visitExp(exp)
   }
 
@@ -1474,16 +1474,8 @@ object ConstraintGen {
   }
 
   /** Builds the result type for a constructor call, using fresh type variables for generic classes. */
-  private def mkConstructorType(clazz: Class[?], loc: SourceLocation)(implicit scope: RegionScope, flix: Flix): Type = {
-    val numTypeParams = clazz.getTypeParameters.length
-    if (numTypeParams > 0) {
-      val baseTpe = Type.mkNative(clazz, loc)
-      val typeArgs = List.fill(numTypeParams)(freshVar(Kind.Star, loc))
-      Type.mkApply(baseTpe, typeArgs, loc)
-    } else {
-      Type.getFlixType(clazz)
-    }
-  }
+  private def mkConstructorType(clazz: ClassDesc, loc: SourceLocation)(implicit scope: RegionScope, flix: Flix): Type =
+    JavaTypes.instantiateWithFreshVars(clazz, scope, loc)
 
   /** Returns `true` if `exp` is a JVM interop invocation (constructor, method, or static method). */
   private def isJvmInvoke(exp: KindedAst.Expr): Boolean = exp match {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.ast.shared.{AssocTypeDef, RegionScope}
 import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaArgument, JavaMemberResolver, JavaTypes}
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, Substitution}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
-import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
+import ca.uwaterloo.flix.util.InternalCompilerException
 
 import java.lang.constant.ConstantDescs.*
 import java.lang.constant.ClassDesc
@@ -145,7 +145,7 @@ object TypeReduction2 {
         case JvmMember.JvmConstructor(clazz, tpes) =>
           val (reducedTpes, css) = tpes.map(reduce(_)).unzip
           val cs = css.flatten
-          lookupConstructor(ClassDescs.of(clazz), reducedTpes, loc) match {
+          lookupConstructor(clazz, reducedTpes, loc) match {
             case JavaConstructorResolution.Resolved(constructor) =>
               progress.markProgress()
               (Type.Cst(TypeConstructor.JvmConstructor(constructor), loc), cs)
@@ -178,7 +178,7 @@ object TypeReduction2 {
         case JvmMember.JvmStaticMethod(clazz, name, tpes) =>
           val (reducedTpes, css) = tpes.map(reduce(_)).unzip
           val cs = css.flatten
-          lookupStaticMethod(ClassDescs.of(clazz), name.name, reducedTpes, loc) match {
+          lookupStaticMethod(clazz, name.name, reducedTpes, loc) match {
             case JavaMethodResolution.Resolved(method) =>
               // Class type parameters are not in scope for static methods.
               val (tpe, cs0) = instantiateMethod(method, Nil, Nil, reducedTpes, scope, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import ca.uwaterloo.flix.util.{ClassDescs, Result}
 import net.bytebuddy.ClassFileVersion
 import net.bytebuddy.description.TypeVariableSource
+import net.bytebuddy.description.enumeration.EnumerationDescription
 import net.bytebuddy.description.field.FieldDescription
 import net.bytebuddy.description.method.MethodDescription
 import net.bytebuddy.description.`type`.{TypeDefinition, TypeDescription}
@@ -226,7 +227,8 @@ final case class ByteBuddyJavaTypeProvider(
       false
     } else {
       val retention = tpe.getDeclaredAnnotations.ofType(classOf[Retention])
-      retention != null && retention.getValue("value").resolve(classOf[RetentionPolicy]) == RetentionPolicy.RUNTIME
+      // The policy is read from the class file, so it is an enumeration description rather than a loaded enum constant.
+      retention != null && retention.getValue("value").resolve(classOf[EnumerationDescription]).getValue == RetentionPolicy.RUNTIME.name()
     }
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -15,6 +15,7 @@
  */
 package ca.uwaterloo.flix.language.phase.typer.jvm
 
+import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.jvm.JavaType.{Parameterized, Variable}
 import ca.uwaterloo.flix.language.ast.jvm.JavaTypeVariable
 import ca.uwaterloo.flix.language.ast.jvm.JavaTypeVariableOwner.Class
@@ -177,6 +178,40 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
           assert(hasDeclaredCompareTo)
         case Err(error) => fail(error.toString)
       }
+    } finally provider.close()
+  }
+
+  test("lookupClass.Annotation.RuntimeRetention") {
+    val flix = new Flix
+    try {
+      flix.javaTypeProvider.lookupClass(ClassDesc.of("dev.flix.test.TestJvmAnnotation")) match {
+        case Ok(clazz) =>
+          assert(clazz.isAnnotation)
+          assert(clazz.isRuntimeVisibleAnnotation)
+        case Err(error) => fail(error.toString)
+      }
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("lookupClass.Annotation.ClassRetention") {
+    val flix = new Flix
+    try {
+      flix.javaTypeProvider.lookupClass(ClassDesc.of("dev.flix.test.TestJvmAnnotationClassRetention")) match {
+        case Ok(clazz) =>
+          assert(clazz.isAnnotation)
+          assert(!clazz.isRuntimeVisibleAnnotation)
+        case Err(error) => fail(error.toString)
+      }
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("lookupClass.Annotation.PlatformRetention") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
+      // Deprecated has runtime retention, Override has source retention, and String is not an annotation.
+      assert(provider.lookupClass(ClassDesc.of("java.lang.Deprecated")).map(_.isRuntimeVisibleAnnotation) == Ok(true))
+      assert(provider.lookupClass(ClassDesc.of("java.lang.Override")).map(_.isRuntimeVisibleAnnotation) == Ok(false))
+      assert(provider.lookupClass(ClassDesc.of("java.lang.String")).map(c => (c.isAnnotation, c.isRuntimeVisibleAnnotation)) == Ok((false, false)))
     } finally provider.close()
   }
 


### PR DESCRIPTION
The Resolver looks Java classes up through the `JavaTypeProvider` instead of `Class.forName`, and the resolved, kinded, and typed ASTs carry a `ClassDesc` (or a `JClass` for new-object expressions) instead of a loaded `Class`. After this, the only `Class[?]` left in the compiler are the runtime (`JvmLoader`, `FlixClassLoader`), the documentation annotations, and the shims that the LSP completers and `TypeError.FieldNotFound` still use until the next PR.

**Changes**

- `Resolver.lookupJvmClass` builds a `ClassDesc` from the import name and calls `lookupClass`. Each `JavaLookupError` maps to an `UndefinedJvmImport` with a specific message. `Resolution.JavaClass` and `UseOrImport.Import` hold the `JavaClass` metadata, so type-parameter arity, the interface flag, and annotation retention are read without further lookups. `LocalScope.superClass` is a `ClassDesc`.
- `InstanceOf`, `InvokeConstructor`, `InvokeSuperConstructor`, `InvokeSuperMethod`, `InvokeStaticMethod`, `PutField`, and `CatchRule` carry a `ClassDesc`; `NewObject` carries a `JClass`; `Type.JvmMember.JvmConstructor` and `JvmStaticMethod` carry a `ClassDesc`.
- ConstraintGen and TypeReconstruction build the class types with `JavaTypes`. Safety, PatMatch2 (catch-rule redundancy via `isReferenceSubtype`), Lowering, SpecializeAndLower, and the printers consume the descriptors directly.
- `TypeError.ConstructorNotFound` lists its candidates from class metadata; `StaticMethodNotFound`, `UndefinedJvmStaticField`, and the LSP class completion format descriptors.
- Removed: `Type.mkNative(Class)`, `Type.instantiateJavaTypeWithObjectArgs`, `JClass.of(Class)`, and the class-loading `Resolver.getNativeClassFromType`.

**Bug fix**

`ByteBuddyJavaTypeProvider.isRuntimeVisibleAnnotation` (from #13186) resolved the retention value as a loaded `RetentionPolicy`, but class-file metadata yields an `EnumerationDescription`, which threw `ClassCastException`. Nothing looked annotations up through the provider until now. It compares the constant name instead, with tests for runtime, class, and source retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3L1U3oBUhdk6DdhvPn9VM
