### PR TITLE
refactor: build Java diagnostics and completions from descriptors

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -17,6 +17,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.{Command, CompletionItem, CompletionItemKind, CompletionItemLabelDetails, InsertTextFormat, LspUtil, Position, Range, TextEdit}
+import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod}
 import ca.uwaterloo.flix.language.ast.shared.AnchorPosition
 import ca.uwaterloo.flix.language.ast.{Name, ResolvedAst, SourceLocation, Symbol, Type, TypedAst}
 import ca.uwaterloo.flix.language.fmt.{FormatScheme, FormatType}
@@ -24,7 +25,7 @@ import ca.uwaterloo.flix.util.ClassDescs
 import ca.uwaterloo.flix.util.collection.Nel
 
 import java.lang.constant.ClassDesc
-import java.lang.reflect.{Field, Method}
+import scala.jdk.CollectionConverters.*
 
 /**
   * A common super-type for auto-completions.
@@ -475,8 +476,8 @@ sealed trait Completion {
       )
 
     case Completion.FieldCompletion(ident, priority, field) =>
-      val label = field.getName
-      val text = field.getName
+      val label = field.ref.name
+      val text = field.ref.name
       val range = Range.from(ident.loc)
 
       CompletionItem(
@@ -497,17 +498,18 @@ sealed trait Completion {
       )
 
     case Completion.MethodCompletion(ident, priority, method) =>
-      val argsWithName = method.getParameters.map(_.getName)
-      val argsWithNameAndType = method.getParameters.map(p => p.getName + ": " + p.getType.getSimpleName)
-      val returnType = method.getReturnType.getSimpleName
+      val argsWithName = method.parameterNames
+      val argTypes = method.ref.descriptor.parameterList().asScala.toList.map(ClassDescs.simpleNameOf)
+      val argsWithNameAndType = argsWithName.zip(argTypes).map { case (name, tpe) => name + ": " + tpe }
+      val returnType = ClassDescs.simpleNameOf(method.ref.descriptor.returnType())
       val returnEffect = "IO"
 
-      val label = method.getName
+      val label = method.ref.name
       val labelDetails = CompletionItemLabelDetails(
         Some("(" + argsWithNameAndType.mkString(", ") + "): " + returnType + " \\ " + returnEffect),
         None
       )
-      val text = method.getName + "(" + argsWithName.zipWithIndex.map { case (arg, i) => s"$${${i + 1}:$arg}" }.mkString(", ") + ")"
+      val text = method.ref.name + "(" + argsWithName.zipWithIndex.map { case (arg, i) => s"$${${i + 1}:$arg}" }.mkString(", ") + ")"
       val range = Range.from(ident.loc)
 
       CompletionItem(
@@ -896,7 +898,7 @@ object Completion {
     * @param priority the priority of the completion.
     * @param field    the candidate field.
     */
-  case class FieldCompletion(ident: Name.Ident, priority: Priority, field: Field) extends Completion
+  case class FieldCompletion(ident: Name.Ident, priority: Priority, field: JavaField) extends Completion
 
   /**
     * Represents a Java method completion.
@@ -905,7 +907,7 @@ object Completion {
     * @param priority the priority of the completion.
     * @param method   the candidate method.
     */
-  case class MethodCompletion(ident: Name.Ident, priority: Priority, method: Method) extends Completion
+  case class MethodCompletion(ident: Name.Ident, priority: Priority, method: JavaMethod) extends Completion
 
   /**
     * Represents a hole completion.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/GetStaticFieldCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/GetStaticFieldCompleter.scala
@@ -18,15 +18,16 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.FieldCompletion
 import ca.uwaterloo.flix.language.ast.Name
-import ca.uwaterloo.flix.util.{ClassDescs, JvmUtils}
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
 
 import java.lang.constant.ClassDesc
+import java.lang.reflect.Modifier
 
 object GetStaticFieldCompleter {
 
   def getCompletions(clazz: ClassDesc, field: Name.Ident)(implicit flix: Flix): List[Completion] = {
-    // Transitional: loads the class since the member listing still requires a loaded class.
-    JvmUtils.getStaticFields(ClassDescs.load(clazz, flix.jarLoader)).sortBy(_.getName).map(FieldCompletion(field, Priority.Lowest(0), _))
+    val fields = JavaMemberResolver.fields(clazz).toOption.getOrElse(Nil)
+    fields.filter(f => Modifier.isStatic(f.modifiers)).map(FieldCompletion(field, Priority.Lowest(0), _))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
 import ca.uwaterloo.flix.language.ast.{Name, Type}
-import ca.uwaterloo.flix.util.{ClassDescs, JvmUtils}
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
 
 object InvokeMethodCompleter {
 
@@ -27,9 +27,7 @@ object InvokeMethodCompleter {
       case None =>
         Nil
       case Some(desc) =>
-        // Transitional: loads the class since the method lookup still requires a loaded class.
-        val clazz = ClassDescs.load(desc, flix.jarLoader)
-        JvmUtils.getInstanceMethods(clazz).sortBy(_.getName).map(MethodCompletion(name, Priority.Lowest(0), _))
+        JavaMemberResolver.instanceMethods(desc).toOption.getOrElse(Nil).map(MethodCompletion(name, Priority.Lowest(0), _))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeStaticMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeStaticMethodCompleter.scala
@@ -18,15 +18,14 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
 import ca.uwaterloo.flix.language.ast.Name
-import ca.uwaterloo.flix.util.{ClassDescs, JvmUtils}
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
 
 import java.lang.constant.ClassDesc
 
 object InvokeStaticMethodCompleter {
 
   def getCompletions(clazz: ClassDesc, field: Name.Ident)(implicit flix: Flix): List[Completion] = {
-    // Transitional: loads the class since the member listing still requires a loaded class.
-    JvmUtils.getStaticMethods(ClassDescs.load(clazz, flix.jarLoader)).sortBy(_.getName).map(MethodCompletion(field, Priority.Lowest(0), _))
+    JavaMemberResolver.staticMethods(clazz).toOption.getOrElse(Nil).map(MethodCompletion(field, Priority.Lowest(0), _))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.shared.VarText.Absent
 import ca.uwaterloo.flix.language.fmt.{FormatOptions, FormatType}
 import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, Nel}
-import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, Result}
+import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
 
 import java.lang.constant.ClassDesc
 import java.lang.constant.ConstantDescs.*
@@ -1334,18 +1334,6 @@ object Type {
       val elmType = getFlixType(desc.componentType(), arity)
       Type.mkArray(elmType, Type.IO, SourceLocation.Unknown)
     case _ => Type.mkNative(desc, arity, SourceLocation.Unknown)
-  }
-
-  /**
-    * Returns the Flix Type of the loaded Java class `c`.
-    *
-    * Transitional: prefer `getFlixType(desc, arity)` since it does not require a loaded class.
-    */
-  def getFlixType(c: Class[?]): Type = {
-    // An array class has no type parameters of its own, so we use those of its element class.
-    var elm = c
-    while (elm.isArray) elm = elm.getComponentType
-    getFlixType(ClassDescs.of(c), elm.getTypeParameters.length)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -20,10 +20,11 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.TypedAst
-import ca.uwaterloo.flix.language.ast.jvm.JavaMethod
+import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod}
 import ca.uwaterloo.flix.language.ast.shared.{Denotation, EffSymOrRigidVar, SymbolSet}
 import ca.uwaterloo.flix.language.fmt.FormatType.formatType
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
 import ca.uwaterloo.flix.util.{ClassDescs, Formatter, Grammar}
 
 import java.lang.constant.ClassDesc
@@ -321,8 +322,7 @@ object TypeError {
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      // Transitional: loads the class since the field lookup still requires a loaded class.
-      val availableFields = Type.descFromFlixType(tpe).map(desc => getFieldsByName(ClassDescs.load(desc, flix.jarLoader))).getOrElse(Nil)
+      val availableFields = Type.descFromFlixType(tpe).toList.flatMap(desc => JavaMemberResolver.fields(desc).toOption.getOrElse(Nil))
       s""">> Field not found: '${red(fieldName.name)}' on type '${magenta(formatType(tpe))}'.
          |
          |${highlight(loc, "cannot find field", fmt)}
@@ -1109,13 +1109,6 @@ object TypeError {
   }
 
   /**
-    * Returns the fields of the given class sorted by name.
-    */
-  private def getFieldsByName(clazz: Class[?]): List[java.lang.reflect.Field] = {
-    clazz.getFields.sortBy(_.getName).toList
-  }
-
-  /**
     * Returns a formatted string representation of a Java constructor.
     */
   private def formatConstructor(clazz: ClassDesc, c: JavaMethod): String = {
@@ -1126,18 +1119,8 @@ object TypeError {
   /**
     * Returns a formatted string representation of a Java field.
     */
-  private def formatField(f: java.lang.reflect.Field): String = {
-    s"${f.getName}: ${formatJavaType(f.getType)}"
-  }
-
-  /**
-    * Returns the Flix-style string representation of a Java type.
-    */
-  private def formatJavaType(tpe: Class[?]): String = {
-    if (tpe.isPrimitive || tpe.isArray)
-      Type.getFlixType(tpe).toString
-    else
-      tpe.getName
+  private def formatField(f: JavaField): String = {
+    s"${f.ref.name}: ${formatJavaType(f.ref.descriptor)}"
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
@@ -167,9 +167,53 @@ object JavaMemberResolver {
     * method has type `(T) -> T` where `T` is the type parameter of `UnaryOperator`.
     */
   def overridableMethods(owner: ClassDesc)(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] =
+    virtualMethodsWhere(owner, isOverridable)
+
+  /**
+    * Returns `Ok` with the public instance methods of `owner`, including inherited methods, or `Err` if class
+    * metadata cannot be read.
+    *
+    * An array exposes the methods of `Object` and a primitive type exposes no methods. Since an interface does not
+    * inherit from `Object`, the public methods of `Object` are added for an interface unless it declares a method
+    * with the same erased signature. Bridge and synthetic methods are excluded.
+    */
+  def instanceMethods(owner: ClassDesc)(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] = {
+    if (owner.isArray) instanceMethods(CD_Object)
+    else if (owner.isPrimitive) Ok(Nil)
+    else virtualMethodsWhere(owner, isPublicInstance)
+  }
+
+  /**
+    * Returns `Ok` with the public static methods of `owner`, including those inherited from superclasses, or `Err`
+    * if class metadata cannot be read.
+    *
+    * Static methods of superinterfaces are not inherited, and a static method hides an inherited static method with
+    * the same erased signature.
+    */
+  def staticMethods(owner: ClassDesc)(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] = {
+    if (!owner.isClassOrInterface) Ok(Nil)
+    else staticMethodsWhere(owner, _ => true, Set.empty).map(_.sortBy(method => (method.ref.name, method.ref.descriptor.descriptorString())))
+  }
+
+  /**
+    * Returns `Ok` with the public fields of `owner`, including those inherited from superclasses and superinterfaces,
+    * sorted by name, or `Err` if class metadata cannot be read.
+    */
+  def fields(owner: ClassDesc)(implicit flix: Flix): Result[List[JavaField], JavaLookupError] = {
+    if (!owner.isClassOrInterface) Ok(Nil)
+    else collectFields(owner, Set.empty).map(_.distinctBy(_.ref).sortBy(_.ref.name))
+  }
+
+  /**
+    * Returns the virtual methods of `owner` that satisfy `keep`, sorted by name and descriptor.
+    *
+    * Since an interface does not inherit from `Object`, the public methods of `Object` that satisfy `keep` are added
+    * for an interface unless it declares a method with the same erased signature.
+    */
+  private def virtualMethodsWhere(owner: ClassDesc, keep: JavaMethod => Boolean)(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] =
     flix.javaTypeProvider.lookupClass(owner).flatMap { clazz =>
       flix.javaTypeProvider.virtualMethods(owner).flatMap { virtualMethods =>
-        val declared = virtualMethods.filter(isOverridable)
+        val declared = virtualMethods.filter(keep)
         if (!Modifier.isInterface(clazz.modifiers)) {
           Ok(declared)
         } else {
@@ -177,13 +221,26 @@ object JavaMemberResolver {
           flix.javaTypeProvider.virtualMethods(CD_Object).map { objectMethods =>
             val declaredKeys = virtualMethods.map(methodKey).toSet
             val inherited = objectMethods.filter { method =>
-              Modifier.isPublic(method.modifiers) && isOverridable(method) && !declaredKeys.contains(methodKey(method))
+              Modifier.isPublic(method.modifiers) && keep(method) && !declaredKeys.contains(methodKey(method))
             }
             (declared ::: inherited).sortBy(method => (method.ref.name, method.ref.descriptor.descriptorString()))
           }
         }
       }
     }
+
+  /** Returns the public fields declared by `owner` and its supertypes, in declaration order. */
+  private def collectFields(owner: ClassDesc, visited: Set[ClassDesc])(implicit flix: Flix): Result[List[JavaField], JavaLookupError] = {
+    if (visited.contains(owner)) {
+      Ok(Nil)
+    } else {
+      flix.javaTypeProvider.lookupClass(owner).flatMap { clazz =>
+        val declared = clazz.declaredFields.filter(field => Modifier.isPublic(field.modifiers) && !isSynthetic(field.modifiers))
+        val parents = clazz.interfaces.map(_.erasure) ::: clazz.superClass.map(_.erasure).toList
+        Result.traverse(parents)(parent => collectFields(parent, visited + owner)).map(inherited => declared ::: inherited.flatten)
+      }
+    }
+  }
 
   /** Selects the best supported methods from `owner`, then retains the requested kind. */
   private def resolveMethods(owner: ClassDesc, name: String, arguments: List[JavaArgument], static: Boolean)(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] =
@@ -248,26 +305,32 @@ object JavaMemberResolver {
     }
   }
 
-  /** Returns public static methods, applying Java superclass inheritance and hiding. */
+  /** Returns public static methods named `name`, applying Java superclass inheritance and hiding. */
   private def staticMethodCandidates(owner: ClassDesc,
                                      name: String,
-                                     visited: Set[ClassDesc])(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] = {
+                                     visited: Set[ClassDesc])(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] =
+    staticMethodsWhere(owner, _.ref.name == name, visited)
+
+  /** Returns public static methods satisfying `keep`, applying Java superclass inheritance and hiding. */
+  private def staticMethodsWhere(owner: ClassDesc,
+                                 keep: JavaMethod => Boolean,
+                                 visited: Set[ClassDesc])(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] = {
     if (visited.contains(owner)) {
       Ok(Nil)
     } else {
       flix.javaTypeProvider.lookupClass(owner).flatMap { clazz =>
-        val namedStaticMethods = clazz.declaredMethods.filter { method =>
-          method.ref.name == name && Modifier.isStatic(method.modifiers)
+        val staticMethods = clazz.declaredMethods.filter { method =>
+          keep(method) && Modifier.isStatic(method.modifiers) && !isSynthetic(method.modifiers)
         }
-        val declared = namedStaticMethods.filter(method => Modifier.isPublic(method.modifiers))
+        val declared = staticMethods.filter(method => Modifier.isPublic(method.modifiers))
         if (Modifier.isInterface(clazz.modifiers)) {
           // Static interface methods are not inherited from superinterfaces.
           Ok(declared)
         } else clazz.superClass match {
           case None => Ok(declared)
           case Some(parent) =>
-            staticMethodCandidates(parent.erasure, name, visited + owner).map { inherited =>
-              val hidden = namedStaticMethods.map(methodKey).toSet
+            staticMethodsWhere(parent.erasure, keep, visited + owner).map { inherited =>
+              val hidden = staticMethods.map(methodKey).toSet
               declared ::: inherited.filterNot(method => hidden.contains(methodKey(method)))
             }
         }
@@ -701,14 +764,20 @@ object JavaMemberResolver {
   /** Returns whether `method` was generated as a bridge method. */
   private def isBridge(method: JavaMethod): Boolean = (method.modifiers & BridgeModifier) != 0
 
-  /** Returns whether `method` was generated by the compiler as a synthetic member. */
-  private def isSynthetic(method: JavaMethod): Boolean = (method.modifiers & SyntheticModifier) != 0
+  /** Returns whether the member with the given `modifiers` was generated by the compiler as a synthetic member. */
+  private def isSynthetic(modifiers: Int): Boolean = (modifiers & SyntheticModifier) != 0
 
   /** Returns whether an anonymous subclass in another package may override the instance method `method`. */
   private def isOverridable(method: JavaMethod): Boolean = {
     val modifiers = method.modifiers
     (Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers)) &&
-      !Modifier.isStatic(modifiers) && !Modifier.isFinal(modifiers) && !isBridge(method) && !isSynthetic(method)
+      !Modifier.isStatic(modifiers) && !Modifier.isFinal(modifiers) && !isBridge(method) && !isSynthetic(modifiers)
+  }
+
+  /** Returns whether `method` is a public instance method that is not compiler-generated. */
+  private def isPublicInstance(method: JavaMethod): Boolean = {
+    val modifiers = method.modifiers
+    Modifier.isPublic(modifiers) && !Modifier.isStatic(modifiers) && !isBridge(method) && !isSynthetic(modifiers)
   }
 
   /** Returns all typed argument descriptors, or `None` if any argument is `Null`. */

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaMemberResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaMemberResolver.scala
@@ -443,4 +443,81 @@ class TestJavaMemberResolver extends AnyFunSuite {
     } finally flix.javaTypeProvider.close()
   }
 
+  // --- instanceMethods / staticMethods / fields ---
+
+  test("instanceMethods.Class.IncludesInheritedAndFinal") {
+    implicit val flix: Flix = new Flix
+    try {
+      JavaMemberResolver.instanceMethods(ClassDesc.of("java.util.ArrayList")) match {
+        case Ok(methods) =>
+          val names = methods.map(_.ref.name).toSet
+          assert(Set("add", "size", "toString", "getClass", "wait").subsetOf(names))
+          assert(methods.forall(m => Modifier.isPublic(m.modifiers) && !Modifier.isStatic(m.modifiers)))
+          assert(!names.contains("clone") || methods.exists(m => m.ref.name == "clone" && m.ref.owner == ClassDesc.of("java.util.ArrayList")))
+        case Err(error) => fail(error.toString)
+      }
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("instanceMethods.Interface.IncludesObjectMethods") {
+    implicit val flix: Flix = new Flix
+    try {
+      JavaMemberResolver.instanceMethods(ClassDesc.of("java.lang.Runnable")) match {
+        case Ok(methods) =>
+          val names = methods.map(_.ref.name).toSet
+          assert(Set("run", "toString", "equals", "hashCode", "getClass").subsetOf(names))
+          assert(!names.contains("clone"))
+        case Err(error) => fail(error.toString)
+      }
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("instanceMethods.ArrayAndPrimitive") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaMemberResolver.instanceMethods(CD_String.arrayType()) == JavaMemberResolver.instanceMethods(CD_Object))
+      assert(JavaMemberResolver.instanceMethods(CD_int) == Ok(Nil))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("staticMethods.Class.InheritsFromSuperclassOnly") {
+    implicit val flix: Flix = new Flix
+    try {
+      // Integer declares valueOf and parseInt; ArrayList implements List, whose static `of` is not inherited.
+      JavaMemberResolver.staticMethods(ClassDesc.of("java.lang.Integer")) match {
+        case Ok(methods) =>
+          val names = methods.map(_.ref.name).toSet
+          assert(Set("valueOf", "parseInt").subsetOf(names))
+          assert(methods.forall(m => Modifier.isPublic(m.modifiers) && Modifier.isStatic(m.modifiers)))
+        case Err(error) => fail(error.toString)
+      }
+      // Timestamp inherits the static `UTC` of its superclass Date.
+      JavaMemberResolver.staticMethods(ClassDesc.of("java.sql.Timestamp")) match {
+        case Ok(methods) =>
+          val names = methods.map(_.ref.name).toSet
+          assert(names.contains("valueOf") && names.contains("UTC"))
+        case Err(error) => fail(error.toString)
+      }
+      assert(JavaMemberResolver.staticMethods(ClassDesc.of("java.util.ArrayList")).map(_.map(_.ref.name).contains("of")) == Ok(false))
+      assert(JavaMemberResolver.staticMethods(CD_int) == Ok(Nil))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("fields.IncludesInheritedFields") {
+    implicit val flix: Flix = new Flix
+    try {
+      // JarEntry inherits the constants of ZipEntry; ObjectOutputStream inherits the constants of ObjectStreamConstants.
+      assert(JavaMemberResolver.fields(ClassDesc.of("java.util.jar.JarEntry")).map(_.map(_.ref.name).contains("STORED")) == Ok(true))
+      assert(JavaMemberResolver.fields(ClassDesc.of("java.io.ObjectOutputStream")).map(_.map(_.ref.name).contains("STREAM_MAGIC")) == Ok(true))
+      JavaMemberResolver.fields(ClassDesc.of("java.awt.Point")) match {
+        case Ok(fields) =>
+          assert(fields.map(_.ref.name) == List("x", "y"))
+          assert(fields.forall(f => Modifier.isPublic(f.modifiers)))
+        case Err(error) => fail(error.toString)
+      }
+      assert(JavaMemberResolver.fields(CD_int) == Ok(Nil))
+      assert(JavaMemberResolver.fields(CD_String.arrayType()) == Ok(Nil))
+    } finally flix.javaTypeProvider.close()
+  }
+
 }


### PR DESCRIPTION
`TypeError.FieldNotFound` and the three LSP completers (`GetStaticFieldCompleter`, `InvokeStaticMethodCompleter`, `InvokeMethodCompleter`) were the last frontend code to load a class, via the `ClassDescs.load` shims left by earlier PRs. They now list members from class-file metadata.

**Changes**

- `JavaMemberResolver` gains three listing entry points that apply the same inheritance rules as reflection: `instanceMethods` (public instance methods including inherited ones; arrays expose `Object`'s methods, interfaces gain `Object`'s public methods), `staticMethods` (public static methods with superclass inheritance and hiding; static methods of superinterfaces are not inherited), and `fields` (public fields from the class, its superclasses, and superinterfaces, sorted by name). `overridableMethods` and the by-name static lookup share the new helpers.
- `Completion.FieldCompletion` and `MethodCompletion` wrap `JavaField` and `JavaMethod`. Method completions use the parameter names from the class file (#13186) and simple names of the erased parameter and return types, matching what the reflective `Parameter.getName` and `getSimpleName` produced.
- `FieldNotFound` lists available fields through `JavaMemberResolver.fields`.
- Removed `Type.getFlixType(Class[?])`, the last of the P1 shims, and every remaining "transitional" comment.

After this, `Class[?]` appears only in `JvmUtils`, `ClassDescs`, `JvmLoader`, `FlixClassLoader`, and the documentation annotations. `JvmLoader.findMethod` is the sole caller of `JvmUtils`; the follow-up cleanup PR removes it together with `ClassDescs.load` and `ClassDescs.of(Class)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3L1U3oBUhdk6DdhvPn9VM
