### PR TITLE
refactor: use JavaClasses descriptors in the frontend and typer

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -28,6 +28,7 @@ import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
+import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
 import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaLookupError, JavaMemberResolver, JavaTypes}
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
@@ -3560,26 +3561,26 @@ object Resolver {
   /**
     * Converts the class into a Flix type.
     */
-  private def flixifyType(clazz: ca.uwaterloo.flix.language.ast.jvm.JavaClass, loc: SourceLocation): UnkindedType = ClassDescs.binaryNameOf(clazz.desc) match {
-    case "java.math.BigDecimal" => UnkindedType.Cst(TypeConstructor.BigDecimal, loc)
-    case "java.math.BigInteger" => UnkindedType.Cst(TypeConstructor.BigInt, loc)
-    case "java.lang.String" => UnkindedType.Cst(TypeConstructor.Str, loc)
-    case "java.util.regex.Pattern" => UnkindedType.Cst(TypeConstructor.Regex, loc)
-    case "java.util.function.Function" => UnkindedType.mkIoArrow(UnkindedType.mkObject(loc), UnkindedType.mkObject(loc), loc)
-    case "java.util.function.Consumer" => UnkindedType.mkIoArrow(UnkindedType.mkObject(loc), UnkindedType.mkUnit(loc), loc)
-    case "java.util.function.Predicate" => UnkindedType.mkIoArrow(UnkindedType.mkObject(loc), UnkindedType.mkBool(loc), loc)
-    case "java.util.function.IntFunction" => UnkindedType.mkIoArrow(UnkindedType.mkInt32(loc), UnkindedType.mkObject(loc), loc)
-    case "java.util.function.IntConsumer" => UnkindedType.mkIoArrow(UnkindedType.mkInt32(loc), UnkindedType.mkUnit(loc), loc)
-    case "java.util.function.IntPredicate" => UnkindedType.mkIoArrow(UnkindedType.mkInt32(loc), UnkindedType.mkBool(loc), loc)
-    case "java.util.function.IntUnaryOperator" => UnkindedType.mkIoArrow(UnkindedType.mkInt32(loc), UnkindedType.mkInt32(loc), loc)
-    case "java.util.function.LongFunction" => UnkindedType.mkIoArrow(UnkindedType.mkInt64(loc), UnkindedType.mkObject(loc), loc)
-    case "java.util.function.LongConsumer" => UnkindedType.mkIoArrow(UnkindedType.mkInt64(loc), UnkindedType.mkUnit(loc), loc)
-    case "java.util.function.LongPredicate" => UnkindedType.mkIoArrow(UnkindedType.mkInt64(loc), UnkindedType.mkBool(loc), loc)
-    case "java.util.function.LongUnaryOperator" => UnkindedType.mkIoArrow(UnkindedType.mkInt64(loc), UnkindedType.mkInt64(loc), loc)
-    case "java.util.function.DoubleFunction" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkObject(loc), loc)
-    case "java.util.function.DoubleConsumer" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkUnit(loc), loc)
-    case "java.util.function.DoublePredicate" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkBool(loc), loc)
-    case "java.util.function.DoubleUnaryOperator" => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkFloat64(loc), loc)
+  private def flixifyType(clazz: ca.uwaterloo.flix.language.ast.jvm.JavaClass, loc: SourceLocation): UnkindedType = clazz.desc match {
+    case JavaClasses.BigDecimal => UnkindedType.Cst(TypeConstructor.BigDecimal, loc)
+    case JavaClasses.BigInteger => UnkindedType.Cst(TypeConstructor.BigInt, loc)
+    case JavaClasses.String => UnkindedType.Cst(TypeConstructor.Str, loc)
+    case JavaClasses.Regex => UnkindedType.Cst(TypeConstructor.Regex, loc)
+    case JavaClasses.ObjFunction => UnkindedType.mkIoArrow(UnkindedType.mkObject(loc), UnkindedType.mkObject(loc), loc)
+    case JavaClasses.ObjConsumer => UnkindedType.mkIoArrow(UnkindedType.mkObject(loc), UnkindedType.mkUnit(loc), loc)
+    case JavaClasses.ObjPredicate => UnkindedType.mkIoArrow(UnkindedType.mkObject(loc), UnkindedType.mkBool(loc), loc)
+    case JavaClasses.IntFunction => UnkindedType.mkIoArrow(UnkindedType.mkInt32(loc), UnkindedType.mkObject(loc), loc)
+    case JavaClasses.IntConsumer => UnkindedType.mkIoArrow(UnkindedType.mkInt32(loc), UnkindedType.mkUnit(loc), loc)
+    case JavaClasses.IntPredicate => UnkindedType.mkIoArrow(UnkindedType.mkInt32(loc), UnkindedType.mkBool(loc), loc)
+    case JavaClasses.IntUnaryOperator => UnkindedType.mkIoArrow(UnkindedType.mkInt32(loc), UnkindedType.mkInt32(loc), loc)
+    case JavaClasses.LongFunction => UnkindedType.mkIoArrow(UnkindedType.mkInt64(loc), UnkindedType.mkObject(loc), loc)
+    case JavaClasses.LongConsumer => UnkindedType.mkIoArrow(UnkindedType.mkInt64(loc), UnkindedType.mkUnit(loc), loc)
+    case JavaClasses.LongPredicate => UnkindedType.mkIoArrow(UnkindedType.mkInt64(loc), UnkindedType.mkBool(loc), loc)
+    case JavaClasses.LongUnaryOperator => UnkindedType.mkIoArrow(UnkindedType.mkInt64(loc), UnkindedType.mkInt64(loc), loc)
+    case JavaClasses.DoubleFunction => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkObject(loc), loc)
+    case JavaClasses.DoubleConsumer => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkUnit(loc), loc)
+    case JavaClasses.DoublePredicate => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkBool(loc), loc)
+    case JavaClasses.DoubleUnaryOperator => UnkindedType.mkIoArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkFloat64(loc), loc)
     case _ => UnkindedType.UnappliedNative(clazz.desc, clazz.typeParameters.length, loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -21,10 +21,11 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.CaseSymUse
 import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, JMethod, Modifiers, Mutability, RegionScope}
 import ca.uwaterloo.flix.language.ast.{Purity, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
+import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
 import ca.uwaterloo.flix.util.collection.{ListOps, MapOps, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
-import java.lang.constant.{ClassDesc, MethodTypeDesc}
+import java.lang.constant.MethodTypeDesc
 import scala.annotation.tailrec
 
 /**
@@ -50,7 +51,7 @@ object Simplifier {
   /** The `BigInteger.equals(Object)` method. */
   private val BigIntEqualsMethod: JMethod = {
     import java.lang.constant.ConstantDescs.*
-    JMethod(ClassDesc.of("java.math.BigInteger"), "equals", MethodTypeDesc.of(CD_boolean, CD_Object), isInterface = false)
+    JMethod(JavaClasses.BigInteger, "equals", MethodTypeDesc.of(CD_boolean, CD_Object), isInterface = false)
   }
 
   def run(root: MonoAst.Root)(implicit flix: Flix): SimplifiedAst.Root = flix.phase("Simplifier") {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JavaClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JavaClasses.scala
@@ -32,6 +32,7 @@ object JavaClasses {
   val BigDecimal: ClassDesc = ClassDesc.ofInternalName("java/math/BigDecimal")
   val BigInteger: ClassDesc = ClassDesc.ofInternalName("java/math/BigInteger")
   val CallSite: ClassDesc = CD_CallSite
+  val Cloneable: ClassDesc = ClassDesc.ofInternalName("java/lang/Cloneable")
   val ConcurrentLinkedQueue: ClassDesc = ClassDesc.ofInternalName("java/util/concurrent/ConcurrentLinkedQueue")
   val DoubleConsumer: ClassDesc = ClassDesc.ofInternalName("java/util/function/DoubleConsumer")
   val DoubleFunction: ClassDesc = ClassDesc.ofInternalName("java/util/function/DoubleFunction")
@@ -60,6 +61,7 @@ object JavaClasses {
   val Regex: ClassDesc = ClassDesc.ofInternalName("java/util/regex/Pattern")
   val ReentrantLock: ClassDesc = ClassDesc.ofInternalName("java/util/concurrent/locks/ReentrantLock")
   val Runnable: ClassDesc = ClassDesc.ofInternalName("java/lang/Runnable")
+  val Serializable: ClassDesc = ClassDesc.ofInternalName("java/io/Serializable")
   val String: ClassDesc = CD_String
   val StringBuilder: ClassDesc = ClassDesc.ofInternalName("java/lang/StringBuilder")
   val System: ClassDesc = ClassDesc.ofInternalName("java/lang/System")

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -30,6 +30,7 @@ import net.bytebuddy.dynamic.scaffold.MethodGraph
 import net.bytebuddy.pool.TypePool
 
 import java.lang.annotation.{Retention, RetentionPolicy}
+import java.lang.constant.ConstantDescs.CD_Object
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
 import java.lang.reflect.{GenericSignatureFormatError, MalformedParameterizedTypeException}
 import java.nio.file.{Files, Path}
@@ -245,7 +246,7 @@ final case class ByteBuddyJavaTypeProvider(
       case TypeDefinition.Sort.WILDCARD =>
         val upperBounds = tpe.getUpperBounds.asScala.toList.map(toType)
         val lowerBounds = tpe.getLowerBounds.asScala.toList.map(toType)
-        val erasure = upperBounds.headOption.map(_.erasure).getOrElse(ClassDesc.of("java.lang.Object"))
+        val erasure = upperBounds.headOption.map(_.erasure).getOrElse(CD_Object)
         JavaType.Wildcard(upperBounds, lowerBounds, erasure)
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
@@ -17,6 +17,7 @@ package ca.uwaterloo.flix.language.phase.typer.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod}
+import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
 import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.Ok
 
@@ -93,12 +94,6 @@ object JavaMemberResolver {
 
   /** The penalty added for each varargs conversion. */
   private val VarArgsCost = 0.001f
-
-  /** The descriptor of `java.lang.Cloneable`, a direct supertype of every array type. */
-  private val CloneableDesc = ClassDesc.of("java.lang.Cloneable")
-
-  /** The descriptor of `java.io.Serializable`, a direct supertype of every array type. */
-  private val SerializableDesc = ClassDesc.of("java.io.Serializable")
 
   /** The primitive types in the promotion order used by Commons Lang. */
   private val WideningPrimitives = List(CD_byte, CD_short, CD_char, CD_int, CD_long, CD_float, CD_double)
@@ -548,7 +543,7 @@ object JavaMemberResolver {
       Ok(true)
     } else if (source.isArray) {
       // Arrays have descriptor-defined supertypes and covariant reference components.
-      if (target == CD_Object || target == CloneableDesc || target == SerializableDesc) {
+      if (target == CD_Object || target == JavaClasses.Cloneable || target == JavaClasses.Serializable) {
         Ok(true)
       } else if (target.isArray) {
         (componentType(source), componentType(target)) match {


### PR DESCRIPTION
Replaces the remaining hard-coded Java class name strings outside the backend with the shared descriptors in `JavaClasses`.

- `Resolver.flixifyType` now matches the class descriptor directly against `JavaClasses` members instead of converting it to a binary name and matching 19 string literals.
- `Simplifier` builds the `BigInteger.equals` method from `JavaClasses.BigInteger`.
- `JavaMemberResolver` uses new `JavaClasses.Cloneable` and `JavaClasses.Serializable` entries in the array subtyping check instead of private descriptors.
- `ByteBuddyJavaTypeProvider` uses `CD_Object` as the wildcard erasure fallback.

No behaviour change: `ClassDesc` compares by descriptor, so the descriptor match is equivalent to the string match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoURc32vzKdJqEtNJkXtwd
