### PR TITLE
fix: make Java error messages consistent

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -870,10 +870,9 @@ object ResolutionError {
     *
     * @param name the class name.
     * @param ap   the anchor position.
-    * @param msg  the Java error message.
     * @param loc  the location of the class name.
     */
-  case class UndefinedJvmClass(name: Name.Ident, ap: AnchorPosition, msg: String, loc: SourceLocation) extends ResolutionError {
+  case class UndefinedJvmClass(name: Name.Ident, ap: AnchorPosition, loc: SourceLocation) extends ResolutionError {
     def code: ErrorCode = ErrorCode.E1792
 
     def summary: String = s"Undefined Java class: '$name'."
@@ -883,8 +882,6 @@ object ResolutionError {
       s""">> Undefined Java class '${red(name.name)}'.
          |
          |${highlight(loc, "undefined class", fmt)}
-         |
-         |$msg
          |""".stripMargin
     }
   }
@@ -908,17 +905,16 @@ object ResolutionError {
          |
          |${highlight(loc, "unknown import", fmt)}
          |
-         |$msg
-         |$nestedClassHint
+         |$msg$nestedClassHint
          |""".stripMargin
     }
 
     /**
-      * Returns a formatted string with helpful suggestions.
+      * Returns a hint on nested class syntax on its own line, or the empty string if the hint does not apply.
       */
     private def nestedClassHint: String = {
       if (raw".*\.[A-Z].*\.[A-Z].*".r matches name)
-        s"Static nested classes should be specified using '$$', e.g. java.util.Locale$$Builder"
+        s"\nStatic nested classes should be specified using '$$', e.g. java.util.Locale$$Builder"
       else
         ""
     }
@@ -938,7 +934,7 @@ object ResolutionError {
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Undefined static field '${red(field.name)}' in class '${cyan(ClassDescs.binaryNameOf(clazz))}'.
+      s""">> Undefined static field '${red(field.name)}' in class '${magenta(ClassDescs.binaryNameOf(clazz))}'.
          |
          |${highlight(loc, "field not found", fmt)}
          |""".stripMargin

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -4,7 +4,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.language.ast.jvm.JavaMethod
 import ca.uwaterloo.flix.language.ast.shared.SecurityContext
-import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type, TypedAst}
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
 import ca.uwaterloo.flix.language.fmt.FormatType
 import ca.uwaterloo.flix.util.{ClassDescs, Formatter}
@@ -468,15 +468,18 @@ object SafetyError {
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      val parameterTypes = (clazz :: method.ref.descriptor.parameterList().asScala.toList).map(formatJavaType)
-      val returnType = formatJavaType(method.ref.descriptor.returnType())
+      val thisParam = s"_this: ${ClassDescs.simpleNameOf(clazz)}"
+      val params = method.parameterNames.zip(method.ref.descriptor.parameterList().asScala).map {
+        case (name, desc) => s"$name: ${formatSourceType(desc)}"
+      }
+      val returnType = formatSourceType(method.ref.descriptor.returnType())
       s""">> Missing implementation of method '${red(method.ref.name)}' of '${magenta(ClassDescs.binaryNameOf(clazz))}'.
          |
          |${highlight(loc, "new object", fmt)}
          |
          |${underline("Explanation:")} Add a method with the following signature:
          |
-         |  def ${method.ref.name}(${parameterTypes.mkString(", ")}): $returnType
+         |  def ${method.ref.name}(${(thisParam :: params).mkString(", ")}): $returnType = ...
          |""".stripMargin
     }
   }
@@ -630,5 +633,18 @@ object SafetyError {
       Type.getFlixType(desc, 0).toString
     else
       ClassDescs.binaryNameOf(desc)
+  }
+
+  /**
+    * Returns the Java type `desc` as it would be written in the signature of a method
+    * in a `new` expression, e.g. `Int32`, `String`, `Object`, or `Array[Int32, IO]`.
+    */
+  private def formatSourceType(desc: ClassDesc): String = {
+    if (desc.isArray)
+      s"Array[${formatSourceType(desc.componentType())}, IO]"
+    else Type.getFlixType(desc, 0) match {
+      case Type.Cst(TypeConstructor.Native(d, _), _) => ClassDescs.simpleNameOf(d)
+      case tpe => tpe.toString
+    }
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -105,11 +105,11 @@ object TypeError {
   case class ConstructorNotFound(clazz: ClassDesc, tpes: List[Type], renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
     def code: ErrorCode = ErrorCode.E6025
 
-    def summary: String = s"Constructor not found: '${ClassDescs.binaryNameOf(clazz)}' with arguments (${tpes.mkString(", ")})."
+    def summary: String = s"Constructor not found: '${ClassDescs.binaryNameOf(clazz)}' with arguments (${formatTypes(tpes, Some(renv))})."
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Constructor not found: '${red(ClassDescs.binaryNameOf(clazz))}' with arguments (${cyan(tpes.mkString(", "))}).
+      s""">> Constructor not found: '${red(ClassDescs.binaryNameOf(clazz))}' with arguments (${cyan(formatTypes(tpes, Some(renv)))}).
          |
          |${highlight(loc, "cannot find constructor", fmt)}
          |
@@ -322,13 +322,15 @@ object TypeError {
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
       val availableFields = Type.descFromFlixType(tpe).toList.flatMap(desc => JavaMemberResolver.fields(desc).toOption.getOrElse(Nil))
+      val available = if (availableFields.isEmpty) "" else
+        s"""
+           |Available fields:
+           |${availableFields.map(f => s"  - ${formatField(f)}").mkString("\n")}
+           |""".stripMargin
       s""">> Field not found: '${red(fieldName.name)}' on type '${magenta(formatType(tpe))}'.
          |
          |${highlight(loc, "cannot find field", fmt)}
-         |
-         |Available fields:
-         |${availableFields.map(f => s"  - ${formatField(f)}").mkString("\n")}
-         |""".stripMargin
+         |$available""".stripMargin
     }
   }
 
@@ -460,7 +462,7 @@ object TypeError {
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Method not found: '${red(methodName.name)}' on type '${magenta(formatType(tpe))}' with arguments (${cyan(tpes.mkString(", "))}).
+      s""">> Method not found: '${red(methodName.name)}' on type '${magenta(formatType(tpe))}' with arguments (${cyan(formatTypes(tpes))}).
          |
          |${highlight(loc, "cannot find method", fmt)}
          |
@@ -910,14 +912,14 @@ object TypeError {
     * @param renv       the rigidity environment.
     * @param loc        the location where the error occurred.
     */
-  case class StaticMethodNotFound(clazz: ClassDesc, methodName: Name.Ident, tpes: List[Type], renv: RigidityEnv, loc: SourceLocation) extends TypeError {
+  case class StaticMethodNotFound(clazz: ClassDesc, methodName: Name.Ident, tpes: List[Type], renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
     def code: ErrorCode = ErrorCode.E6358
 
     def summary: String = s"Static method not found: '${methodName.name}' in class '${ClassDescs.binaryNameOf(clazz)}'."
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Static method not found: '${red(methodName.name)}' in class '${magenta(ClassDescs.binaryNameOf(clazz))}' with arguments (${cyan(tpes.mkString(", "))}).
+      s""">> Static method not found: '${red(methodName.name)}' in class '${magenta(ClassDescs.binaryNameOf(clazz))}' with arguments (${cyan(formatTypes(tpes, Some(renv)))}).
          |
          |${highlight(loc, "cannot find static method", fmt)}
          |
@@ -1113,6 +1115,13 @@ object TypeError {
   private def formatConstructor(clazz: ClassDesc, c: JavaMethod): String = {
     val params = c.ref.descriptor.parameterList().asScala.map(formatJavaType).mkString(", ")
     s"${ClassDescs.simpleNameOf(clazz)}($params)"
+  }
+
+  /**
+    * Returns the types `tpes` formatted as a comma-separated list.
+    */
+  private def formatTypes(tpes: List[Type], renv: Option[RigidityEnv] = None)(implicit flix: Flix): String = {
+    tpes.map(formatType(_, renv)).mkString(", ")
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1163,7 +1163,7 @@ object Resolver {
         case List(Resolution.JavaClass(clazz)) =>
           ResolvedAst.Expr.InstanceOf(e, clazz.desc, loc)
         case _ =>
-          val error = ResolutionError.UndefinedJvmClass(className, AnchorPosition.mkImportOrUseAnchor(ns0), "", loc)
+          val error = ResolutionError.UndefinedJvmClass(className, AnchorPosition.mkImportOrUseAnchor(ns0), loc)
           sctx.errors.add(error)
           ResolvedAst.Expr.Error(error)
       }


### PR DESCRIPTION
Tidies a handful of Java-related error messages so they follow the conventions in `errors/README.md` and agree with each other:

- `UndefinedJvmStaticField` colours the class name magenta like its sibling errors, instead of cyan.
- `UndefinedJvmClass` drops its `msg` parameter, which was always the empty string and produced a trailing blank line. `UndefinedJvmImport` only emits the nested-class hint when it applies, removing the same trailing blank line.
- `ConstructorNotFound`, `MethodNotFound` and `StaticMethodNotFound` format argument types with `formatType` instead of `Type.toString`, matching `FieldNotFound`.
- `NewObjectMissingMethod` suggests a valid Flix signature in the same shape as `NewObjectIllegalThisType` and `NewObjectMissingThisArg`. `new Runnable {}` now suggests `def run(_this: Runnable): Unit = ...` instead of `def run(java.lang.Runnable): Unit`.
- `FieldNotFound` omits the `Available fields:` section when the class has no public fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDECuZBVc6svSEm32AjVGc
