### PR TITLE
chore: remove unused commons-lang3 dependency

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -26,7 +26,6 @@ object flix extends ScalaModule {
     mvn"org.commonmark:commonmark:0.24.0",
     mvn"org.commonmark:commonmark-ext-gfm-tables:0.24.0",
     mvn"com.github.scopt::scopt:4.1.0",
-    mvn"org.apache.commons:commons-lang3:3.20.0",
     mvn"io.get-coursier::coursier:2.1.24",
     mvn"org.tomlj:tomlj:1.1.1",            // determines antlr version
     mvn"org.antlr:antlr4-runtime:4.11.1",


### PR DESCRIPTION
The last user of commons-lang3 (`ClassUtils`/`MethodUtils` in Java method resolution) was removed in #13180 when method resolution moved to descriptors. No source references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CvfCqYQcj11bN4f1QCNy5