### PR TITLE
refactor: move the Java helpers of Safety into JavaTypes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/jvm/JavaClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/jvm/JavaClass.scala
@@ -36,4 +36,8 @@ case class JavaClass(
   /** Returns whether this class-file type is an annotation. */
   def isAnnotation: Boolean = JavaModifiers.has(modifiers, JavaModifiers.ACC_ANNOTATION)
 
+  /** Returns whether this class declares a constructor without parameters that is not private. */
+  def hasNonPrivateZeroArgConstructor: Boolean =
+    declaredConstructors.exists(c => c.parameterTypes.isEmpty && !c.isPrivate)
+
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -3,7 +3,6 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.TypedAst.*
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
-import ca.uwaterloo.flix.language.ast.jvm.{JavaClass, JavaMethod, JavaType, JavaTypeVariable}
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps.*
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{ChangeSet, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
@@ -11,14 +10,14 @@ import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
 import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
-import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaMemberResolver, JavaTypes}
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaTypes
 import ca.uwaterloo.flix.language.phase.typer.{ConstraintGen, ConstraintSolver2}
 import ca.uwaterloo.flix.language.phase.unification.EqualityEnv
 import ca.uwaterloo.flix.util.collection.ListOps
-import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Result}
+import ca.uwaterloo.flix.util.ParOps
 
 import java.lang.constant.ClassDesc
-import java.lang.constant.ConstantDescs.{CD_Object, CD_String, CD_Throwable}
+import java.lang.constant.ConstantDescs.{CD_Object, CD_String}
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.CollectionHasAsScala
@@ -453,27 +452,27 @@ object Safety {
 
         // Allow casting one Java type to another if there is a subtype relationship.
         case (Type.Cst(TypeConstructor.Native(left, _), _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (isSubtype(left, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaTypes.isSubtype(left, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for String.
         case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (isSubtype(CD_String, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaTypes.isSubtype(CD_String, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for Regex.
         case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (isSubtype(JavaClasses.Regex, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaTypes.isSubtype(JavaClasses.Regex, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for BigInt.
         case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (isSubtype(JavaClasses.BigInteger, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaTypes.isSubtype(JavaClasses.BigInteger, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for BigDecimal.
         case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (isSubtype(JavaClasses.BigDecimal, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaTypes.isSubtype(JavaClasses.BigDecimal, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for Arrays.
         case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (isSubtype(CD_Object.arrayType(), right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaTypes.isSubtype(CD_Object.arrayType(), right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Disallow casting a type variable.
         case (src@Type.Var(_, _), _) =>
@@ -766,14 +765,10 @@ object Safety {
     * @param loc   the location of the catch parameter.
     */
   private def checkCatchClass(clazz: ClassDesc, loc: SourceLocation)(implicit sctx: SharedContext, flix: Flix): Unit = {
-    if (!isThrowable(clazz, loc)) {
+    if (!JavaTypes.isThrowable(clazz, loc)) {
       sctx.errors.add(IllegalCatchType(clazz, loc))
     }
   }
-
-  /** Returns `true` if `desc` is [[java.lang.Throwable]] or a subclass of it. */
-  private def isThrowable(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
-    isSubtype(desc, CD_Throwable, loc)
 
   /** Checks that the type of the argument to `throw` is [[java.lang.Throwable]] or a subclass. */
   private def checkThrow(exp: Expr)(implicit sctx: SharedContext, flix: Flix): Unit =
@@ -782,27 +777,9 @@ object Safety {
   /** Returns `true` if `tpe` is [[java.lang.Throwable]] or a subclass of it. */
   @tailrec
   private def isThrowableType(tpe0: Type)(implicit flix: Flix): Boolean = tpe0 match {
-    case Type.Cst(TypeConstructor.Native(desc, _), loc) => isThrowable(desc, loc)
+    case Type.Cst(TypeConstructor.Native(desc, _), loc) => JavaTypes.isThrowable(desc, loc)
     case Type.Alias(_, _, tpe, _) => isThrowableType(tpe)
     case _ => false
-  }
-
-  /**
-    * Returns `true` if the Java type `sub` is a subtype of the Java type `sup`.
-    *
-    * A primitive type is only a subtype of itself. Reference types, including arrays,
-    * are checked against the class-file metadata of the Java type provider.
-    */
-  private def isSubtype(sub: ClassDesc, sup: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean = {
-    if (sub.isPrimitive || sup.isPrimitive) {
-      sub == sup
-    } else {
-      JavaMemberResolver.isReferenceSubtype(sub, sup) match {
-        case Result.Ok(result) => result
-        case Result.Err(error) =>
-          throw InternalCompilerException(s"Java subtype check failed for '${sub.displayName()} <: ${sup.displayName()}': $error", loc)
-      }
-    }
   }
 
   /**
@@ -826,7 +803,7 @@ object Safety {
       val javaClass = JavaTypes.lookupClass(clazz, loc)
       // `clazz` must be an interface or have a non-private constructor without arguments
       // (unless user-defined constructors are provided).
-      if (!javaClass.isInterface && cs.isEmpty && !hasNonPrivateZeroArgConstructor(javaClass)) {
+      if (!javaClass.isInterface && cs.isEmpty && !javaClass.hasNonPrivateZeroArgConstructor) {
         sctx.errors.add(NewObjectMissingPublicZeroArgConstructor(clazz, loc))
       }
 
@@ -868,11 +845,11 @@ object Safety {
       val targs = tpe.typeArguments
       // The type parameters of `clazz` map to its type arguments; a missing argument falls back to Object.
       val substMap = javaClass.typeParameters.map(_.variable).zip(targs).toMap
-      val expectedMethods = overridableMethods(clazz, loc).map {
+      val expectedMethods = JavaTypes.overridableMethods(clazz, loc).map {
         case method =>
           val name = method.ref.name
-          val types = method.parameterTypes.map(resolveJavaType(_, substMap, loc))
-          val retTpe = resolveJavaType(method.returnType, substMap, loc)
+          val types = method.parameterTypes.map(JavaTypes.flixTypeOf(_, substMap, loc))
+          val retTpe = JavaTypes.flixTypeOf(method.returnType, substMap, loc)
           (method, name, types, retTpe)
       }.sortBy { case (_, name, types, _) => (name, types.length) }
 
@@ -897,7 +874,7 @@ object Safety {
       }
 
       // an unimplemented method is only a problem if it's abstract and isn't auto-implemented by Object
-      val missing = unimplemented.filter { case (method, _, _, _) => isAbstractMethod(method) && !isObjectMethod(method, loc) }
+      val missing = unimplemented.filter { case (method, _, _, _) => method.isAbstract && !JavaTypes.isObjectMethod(method, loc) }
       missing.foreach { case (method, _, _, _) => sctx.errors.add(NewObjectMissingMethod(clazz, method, loc)) }
       extra.foreach { case (ident, name, _, _) => sctx.errors.add(NewObjectUndefinedMethod(clazz, name, ident.loc)) }
 
@@ -905,46 +882,6 @@ object Safety {
       val controlEffecting = methods.filter(m => hasControlEffects(m.eff))
       controlEffecting.map(m => SafetyError.IllegalMethodEffect(m.eff, m.loc)).foreach(sctx.errors.add)
   }
-
-  /** Returns the methods of `clazz` that an anonymous subclass may override, or throws if its metadata cannot be read. */
-  private def overridableMethods(clazz: ClassDesc, loc: SourceLocation)(implicit flix: Flix): List[JavaMethod] =
-    JavaMemberResolver.overridableMethods(clazz) match {
-      case Result.Ok(methods) => methods
-      case Result.Err(error) => throw InternalCompilerException(s"Java method lookup failed for '${clazz.displayName()}': $error", loc)
-    }
-
-  /** Return `true` if `clazz` has a non-private constructor with zero arguments. */
-  private def hasNonPrivateZeroArgConstructor(clazz: JavaClass): Boolean =
-    clazz.declaredConstructors.exists(c => c.parameterTypes.isEmpty && !c.isPrivate)
-
-  /**
-    * Resolves the Java type `javaType` to a Flix [[Type]] using the given
-    * substitution of type variables. Falls back to the erased (Object-filled) type.
-    */
-  private def resolveJavaType(javaType: JavaType, substMap: Map[JavaTypeVariable, Type], loc: SourceLocation)(implicit flix: Flix): Type = javaType match {
-    case JavaType.Variable(variable, _) =>
-      substMap.getOrElse(variable, Type.mkObject(loc))
-    case JavaType.Parameterized(erasure, arguments) =>
-      val base = JavaTypes.flixTypeOf(erasure, loc)
-      val resolvedArgs = arguments.map(resolveJavaType(_, substMap, loc))
-      Type.mkApply(base, resolvedArgs, loc)
-    case JavaType.NonGeneric(erasure) =>
-      JavaTypes.instantiateWithObjectArgs(erasure, loc)
-    case JavaType.GenericArray(_, _) =>
-      Type.mkObject(loc)
-    case JavaType.Wildcard(_, _, _) =>
-      Type.mkObject(loc)
-  }
-
-  /** Return `true` if `m` is abstract. */
-  private def isAbstractMethod(m: JavaMethod): Boolean =
-    m.isAbstract
-
-  /** Returns `true` if `method` is or overrides a method declared by the Object class. */
-  private def isObjectMethod(method: JavaMethod, loc: SourceLocation)(implicit flix: Flix): Boolean =
-    JavaTypes.lookupClass(CD_Object, loc).declaredMethods.exists { m =>
-      m.ref.name == method.ref.name && m.ref.descriptor.parameterList() == method.ref.descriptor.parameterList()
-    }
 
   /** Returns `true` if `eff` includes control effects (e.g. Console). */
   private def hasControlEffects(eff: Type): Boolean = {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
@@ -16,13 +16,14 @@
 package ca.uwaterloo.flix.language.phase.typer.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.jvm.JavaClass
+import ca.uwaterloo.flix.language.ast.jvm.{JavaClass, JavaMethod, JavaType, JavaTypeVariable}
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Type, TypeConstructor}
 import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 
 import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.{CD_Object, CD_Throwable}
 
 /**
   * Builds Flix types from Java class descriptors using the class-file metadata of the Java type provider.
@@ -67,6 +68,64 @@ object JavaTypes {
   /** Like [[instantiateWithObjectArgs]] but uses fresh type variables instead of `Object`. */
   def instantiateWithFreshVars(desc: ClassDesc, scope: RegionScope, loc: SourceLocation)(implicit flix: Flix): Type =
     instantiate(desc, loc)(Type.freshVar(Kind.Star, loc)(scope, flix))
+
+  /**
+    * Returns the Flix type of the Java type `javaType` under the substitution `subst` of type variables.
+    *
+    * A type variable that is not in `subst`, a generic array, and a wildcard fall back to `Object`.
+    */
+  def flixTypeOf(javaType: JavaType, subst: Map[JavaTypeVariable, Type], loc: SourceLocation)(implicit flix: Flix): Type = javaType match {
+    case JavaType.Variable(variable, _) =>
+      subst.getOrElse(variable, Type.mkObject(loc))
+    case JavaType.Parameterized(erasure, arguments) =>
+      val base = flixTypeOf(erasure, loc)
+      val resolvedArgs = arguments.map(flixTypeOf(_, subst, loc))
+      Type.mkApply(base, resolvedArgs, loc)
+    case JavaType.NonGeneric(erasure) =>
+      instantiateWithObjectArgs(erasure, loc)
+    case JavaType.GenericArray(_, _) =>
+      Type.mkObject(loc)
+    case JavaType.Wildcard(_, _, _) =>
+      Type.mkObject(loc)
+  }
+
+  /**
+    * Returns `true` if the Java type `sub` is a subtype of the Java type `sup`, or throws an
+    * [[InternalCompilerException]] if their metadata cannot be read.
+    *
+    * A primitive type is only a subtype of itself. Reference types, including arrays, are checked
+    * against the class-file metadata of the Java type provider.
+    */
+  def isSubtype(sub: ClassDesc, sup: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean = {
+    if (sub.isPrimitive || sup.isPrimitive) {
+      sub == sup
+    } else {
+      JavaMemberResolver.isReferenceSubtype(sub, sup) match {
+        case Ok(result) => result
+        case Err(error) => throw InternalCompilerException(s"Java subtype check failed for '${sub.displayName()} <: ${sup.displayName()}': $error", loc)
+      }
+    }
+  }
+
+  /** Returns `true` if `desc` is `java.lang.Throwable` or a subclass of it. */
+  def isThrowable(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
+    isSubtype(desc, CD_Throwable, loc)
+
+  /**
+    * Returns the methods of `desc` that an anonymous subclass may override, or throws an
+    * [[InternalCompilerException]] if its metadata cannot be read.
+    */
+  def overridableMethods(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): List[JavaMethod] =
+    JavaMemberResolver.overridableMethods(desc) match {
+      case Ok(methods) => methods
+      case Err(error) => throw InternalCompilerException(s"Java method lookup failed for '${desc.displayName()}': $error", loc)
+    }
+
+  /** Returns `true` if `method` is or overrides a method declared by `java.lang.Object`. */
+  def isObjectMethod(method: JavaMethod, loc: SourceLocation)(implicit flix: Flix): Boolean =
+    lookupClass(CD_Object, loc).declaredMethods.exists { m =>
+      m.ref.name == method.ref.name && m.ref.descriptor.parameterList() == method.ref.descriptor.parameterList()
+    }
 
   /** Applies the Flix type of `desc` to one `mkArg` per type parameter of `desc`. */
   private def instantiate(desc: ClassDesc, loc: SourceLocation)(mkArg: => Type)(implicit flix: Flix): Type =

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.typer.jvm
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.jvm.{JavaType, JavaTypeVariable, JavaTypeVariableOwner}
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Type, TypeConstructor}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.lang.constant.ConstantDescs.*
+import java.lang.constant.ClassDesc
+
+class TestJavaTypes extends AnyFunSuite {
+
+  private val loc = SourceLocation.Unknown
+
+  test("isSubtype.ReferenceTypes") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaTypes.isSubtype(CD_String, CD_Object, loc))
+      assert(JavaTypes.isSubtype(CD_String, ClassDesc.of("java.lang.CharSequence"), loc))
+      assert(!JavaTypes.isSubtype(CD_Object, CD_String, loc))
+      assert(!JavaTypes.isSubtype(CD_String, CD_Integer, loc))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("isSubtype.PrimitiveAndArrayTypes") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaTypes.isSubtype(CD_int, CD_int, loc))
+      assert(!JavaTypes.isSubtype(CD_int, CD_long, loc))
+      assert(!JavaTypes.isSubtype(CD_int, CD_Object, loc))
+      assert(JavaTypes.isSubtype(CD_String.arrayType(), CD_Object, loc))
+      assert(JavaTypes.isSubtype(CD_String.arrayType(), CD_Object.arrayType(), loc))
+      assert(!JavaTypes.isSubtype(CD_int.arrayType(), CD_long.arrayType(), loc))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("isThrowable") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaTypes.isThrowable(CD_Throwable, loc))
+      assert(JavaTypes.isThrowable(ClassDesc.of("java.lang.RuntimeException"), loc))
+      assert(!JavaTypes.isThrowable(CD_String, loc))
+      assert(!JavaTypes.isThrowable(CD_int, loc))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("isObjectMethod") {
+    implicit val flix: Flix = new Flix
+    try {
+      // Comparator redeclares equals(Object), which Object also declares, but compare is Comparator's own.
+      val methods = JavaTypes.overridableMethods(ClassDesc.of("java.util.Comparator"), loc)
+      val equals = methods.find(_.ref.name == "equals").get
+      val compare = methods.find(_.ref.name == "compare").get
+      assert(JavaTypes.isObjectMethod(equals, loc))
+      assert(!JavaTypes.isObjectMethod(compare, loc))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("flixTypeOf.JavaType") {
+    implicit val flix: Flix = new Flix
+    try {
+      val list = ClassDesc.of("java.util.List")
+      val variable = JavaTypeVariable(JavaTypeVariableOwner.Class(list), "E")
+      val subst: Map[JavaTypeVariable, Type] = Map(variable -> Type.Str)
+      // A bound variable takes its substitution; an unbound one, a generic array, and a wildcard fall back to Object.
+      assert(JavaTypes.flixTypeOf(JavaType.Variable(variable, CD_Object), subst, loc) == Type.Str)
+      assert(JavaTypes.flixTypeOf(JavaType.Variable(variable, CD_Object), Map.empty, loc) == Type.mkObject(loc))
+      assert(JavaTypes.flixTypeOf(JavaType.GenericArray(JavaType.Variable(variable, CD_Object), CD_Object.arrayType()), subst, loc) == Type.mkObject(loc))
+      assert(JavaTypes.flixTypeOf(JavaType.Wildcard(Nil, Nil, CD_Object), subst, loc) == Type.mkObject(loc))
+      // Non-generic and parameterized types map to their Flix counterparts.
+      assert(JavaTypes.flixTypeOf(JavaType.NonGeneric(CD_String), subst, loc) == Type.Str)
+      assert(JavaTypes.flixTypeOf(JavaType.NonGeneric(CD_int), subst, loc) == Type.Int32)
+      val listOfStr = JavaTypes.flixTypeOf(JavaType.Parameterized(list, List(JavaType.Variable(variable, CD_Object))), subst, loc)
+      assert(listOfStr == Type.mkApply(Type.mkNative(list, 1, loc), List(Type.Str), loc))
+      listOfStr.typeConstructor match {
+        case Some(TypeConstructor.Native(desc, arity)) => assert(desc == list && arity == 1)
+        case other => fail(s"Unexpected type constructor: $other")
+      }
+    } finally flix.javaTypeProvider.close()
+  }
+
+}


### PR DESCRIPTION
Safety kept five private Java interop helpers next to its checks. They move to `JavaTypes`, beside the other descriptor-based helpers, so Safety is left with only the checks themselves.

**Changes**

- `JavaTypes` gains `isSubtype` (primitive-aware, over `JavaMemberResolver.isReferenceSubtype`), `isThrowable`, the `InternalCompilerException`-throwing `overridableMethods` wrapper, `isObjectMethod`, and the `JavaType`-to-Flix-type resolution as an overload `flixTypeOf(javaType, subst, loc)` alongside the descriptor version.
- `JavaClass.hasNonPrivateZeroArgConstructor` replaces Safety's private predicate.
- `isAbstractMethod` is inlined as `method.isAbstract`.
- Safety drops 63 net lines and the imports it no longer needs.

New `TestJavaTypes` covers subtyping for reference, primitive, and array types, `isThrowable`, `isObjectMethod`, and the generic resolution with bound and unbound variables.

This is the Safety-only part of the consolidation; `PatMatch2`'s copy of `isSubtype`, the `Type.getFlixType` / `descFromFlixType` move, and the error-formatting helpers follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3L1U3oBUhdk6DdhvPn9VM
