### PR TITLE
refactor: move the remaining Java type helpers into JavaTypes

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
@@ -18,12 +18,12 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
 import ca.uwaterloo.flix.language.ast.{Name, Type}
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
+import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaMemberResolver, JavaTypes}
 
 object InvokeMethodCompleter {
 
   def getCompletions(obj: Type, name: Name.Ident)(implicit flix: Flix): Iterable[MethodCompletion] = {
-    Type.descFromFlixType(obj) match {
+    JavaTypes.descriptorOf(obj) match {
       case None =>
         Nil
       case Some(desc) =>

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -21,12 +21,11 @@ import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{AssocTypeSymUse, TypeAliasSymUse}
 import ca.uwaterloo.flix.language.ast.shared.VarText.Absent
 import ca.uwaterloo.flix.language.fmt.{FormatOptions, FormatType}
-import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
 
 import java.lang.constant.ClassDesc
-import java.lang.constant.ConstantDescs.*
+import java.lang.constant.ConstantDescs.CD_Object
 import java.util.Objects
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedSet
@@ -1305,62 +1304,6 @@ object Type {
     case Type.JvmToType(_, _) => false
     case Type.JvmToEff(_, _) => false
     case Type.UnresolvedJvmType(_, _) => false
-  }
-
-  /**
-    * Returns the Flix Type of the Java class `desc` whose element class has `arity` type parameters.
-    *
-    * Arrays are returned with the [[Type.IO]] region. Since an array class has no type parameters
-    * of its own, `arity` is the number of type parameters of its (innermost) element class.
-    *
-    * Returns a [[TypeConstructor.Native]] of `desc` if nothing more specific is found. The `arity`
-    * is only evaluated in that case, so callers may compute it lazily.
-    */
-  def getFlixType(desc: ClassDesc, arity: => Int): Type = desc match {
-    case CD_boolean => Type.Bool
-    case CD_byte => Type.Int8
-    case CD_short => Type.Int16
-    case CD_int => Type.Int32
-    case CD_long => Type.Int64
-    case CD_char => Type.Char
-    case CD_float => Type.Float32
-    case CD_double => Type.Float64
-    case CD_void => Type.Unit
-    case CD_String => Type.Str
-    case JavaClasses.BigDecimal => Type.BigDecimal
-    case JavaClasses.BigInteger => Type.BigInt
-    case JavaClasses.Regex => Type.Regex
-    case _ if desc.isArray =>
-      val elmType = getFlixType(desc.componentType(), arity)
-      Type.mkArray(elmType, Type.IO, SourceLocation.Unknown)
-    case _ => Type.mkNative(desc, arity, SourceLocation.Unknown)
-  }
-
-  /**
-    * Returns the descriptor of the Java class of `tpe`, if it exists.
-    *
-    * Almost the inverse function of [[getFlixType]], but arrays and unit returns None.
-    */
-  def descFromFlixType(tpe: Type): Option[ClassDesc] = tpe match {
-    case Type.Bool => Some(CD_boolean)
-    case Type.Int8 => Some(CD_byte)
-    case Type.Int16 => Some(CD_short)
-    case Type.Int32 => Some(CD_int)
-    case Type.Int64 => Some(CD_long)
-    case Type.Char => Some(CD_char)
-    case Type.Float32 => Some(CD_float)
-    case Type.Float64 => Some(CD_double)
-    case Type.Cst(TypeConstructor.BigDecimal, _) => Some(JavaClasses.BigDecimal)
-    case Type.Cst(TypeConstructor.BigInt, _) => Some(JavaClasses.BigInteger)
-    case Type.Cst(TypeConstructor.Str, _) => Some(CD_String)
-    case Type.Cst(TypeConstructor.Regex, _) => Some(JavaClasses.Regex)
-    case Type.Cst(TypeConstructor.Native(desc, _), _) => Some(desc)
-    case _ =>
-      // Peel off type applications (e.g., ArrayList[String]) and check the base type.
-      tpe.baseType match {
-        case Type.Cst(TypeConstructor.Native(desc, _), _) => Some(desc)
-        case _ => None
-      }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -7,6 +7,7 @@ import ca.uwaterloo.flix.language.ast.shared.SecurityContext
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
 import ca.uwaterloo.flix.language.fmt.FormatType
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaTypes
 import ca.uwaterloo.flix.util.{ClassDescs, Formatter}
 
 import java.lang.constant.ClassDesc
@@ -104,7 +105,7 @@ object SafetyError {
          |${highlight(loc, "impossible cast", fmt)}
          |
          |From: ${red(FormatType.formatType(from))}
-         |To  : ${red(formatJavaType(to))}
+         |To  : ${red(JavaTypes.formatType(to))}
          |
          |${underline("Explanation:")} A checked cast can only be used between Java types.
          |""".stripMargin
@@ -156,7 +157,7 @@ object SafetyError {
          |
          |${highlight(loc, "impossible cast", fmt)}
          |
-         |From: ${red(formatJavaType(from))}
+         |From: ${red(JavaTypes.formatType(from))}
          |To  : ${red(FormatType.formatType(to))}
          |
          |${underline("Explanation:")} A checked cast can only be used between Java types.
@@ -626,15 +627,6 @@ object SafetyError {
     }
   }
 
-
-  /** Returns the string representation of the Java type `desc`. */
-  private def formatJavaType(desc: ClassDesc): String = {
-    if (desc.isPrimitive || desc.isArray)
-      Type.getFlixType(desc, 0).toString
-    else
-      ClassDescs.binaryNameOf(desc)
-  }
-
   /**
     * Returns the Java type `desc` as it would be written in the signature of a method
     * in a `new` expression, e.g. `Int32`, `String`, `Object`, or `Array[Int32, IO]`.
@@ -642,7 +634,7 @@ object SafetyError {
   private def formatSourceType(desc: ClassDesc): String = {
     if (desc.isArray)
       s"Array[${formatSourceType(desc.componentType())}, IO]"
-    else Type.getFlixType(desc, 0) match {
+    else JavaTypes.flixTypeOf(desc, 0) match {
       case Type.Cst(TypeConstructor.Native(d, _), _) => ClassDescs.simpleNameOf(d)
       case tpe => tpe.toString
     }

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod}
 import ca.uwaterloo.flix.language.ast.shared.{Denotation, EffSymOrRigidVar, SymbolSet}
 import ca.uwaterloo.flix.language.fmt.FormatType.formatType
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
+import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaMemberResolver, JavaTypes}
 import ca.uwaterloo.flix.util.{ClassDescs, Formatter, Grammar}
 
 import java.lang.constant.ClassDesc
@@ -321,7 +321,7 @@ object TypeError {
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      val availableFields = Type.descFromFlixType(tpe).toList.flatMap(desc => JavaMemberResolver.fields(desc).toOption.getOrElse(Nil))
+      val availableFields = JavaTypes.descriptorOf(tpe).toList.flatMap(desc => JavaMemberResolver.fields(desc).toOption.getOrElse(Nil))
       val available = if (availableFields.isEmpty) "" else
         s"""
            |Available fields:
@@ -1113,7 +1113,7 @@ object TypeError {
     * Returns a formatted string representation of a Java constructor.
     */
   private def formatConstructor(clazz: ClassDesc, c: JavaMethod): String = {
-    val params = c.ref.descriptor.parameterList().asScala.map(formatJavaType).mkString(", ")
+    val params = c.ref.descriptor.parameterList().asScala.map(JavaTypes.formatType).mkString(", ")
     s"${ClassDescs.simpleNameOf(clazz)}($params)"
   }
 
@@ -1128,17 +1128,7 @@ object TypeError {
     * Returns a formatted string representation of a Java field.
     */
   private def formatField(f: JavaField): String = {
-    s"${f.ref.name}: ${formatJavaType(f.ref.descriptor)}"
-  }
-
-  /**
-    * Returns the Flix-style string representation of the Java type `desc`.
-    */
-  private def formatJavaType(desc: ClassDesc): String = {
-    if (desc.isPrimitive || desc.isArray)
-      Type.getFlixType(desc, 0).toString
-    else
-      ClassDescs.binaryNameOf(desc)
+    s"${f.ref.name}: ${JavaTypes.formatType(f.ref.descriptor)}"
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
@@ -24,10 +24,9 @@ import ca.uwaterloo.flix.language.ast.shared.Constant
 import ca.uwaterloo.flix.language.ast.shared.SymUse.CaseSymUse
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.PatMatchError
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
-import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Result}
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaTypes
+import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
-import java.lang.constant.ClassDesc
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -592,7 +591,7 @@ object PatMatch2 {
     var precedingRules: List[TypedAst.CatchRule] = Nil
     for (rule <- rules) {
       // Check if any preceding rule's class is a superclass of (or equal to) this rule's class.
-      precedingRules.find(prev => isSubtype(rule.clazz, prev.clazz, rule.loc)) match {
+      precedingRules.find(prev => JavaTypes.isSubtype(rule.clazz, prev.clazz, rule.loc)) match {
         case Some(coveringRule) =>
           sctx.errors.add(PatMatchError.RedundantCatchRule(coveringRule.loc, rule.loc))
         case None => ()
@@ -600,13 +599,6 @@ object PatMatch2 {
       precedingRules = precedingRules :+ rule
     }
   }
-
-  /** Returns `true` if the Java class `sub` is a subtype of `sup`, or throws if their metadata cannot be read. */
-  private def isSubtype(sub: ClassDesc, sup: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
-    JavaMemberResolver.isReferenceSubtype(sub, sup) match {
-      case Result.Ok(result) => result
-      case Result.Err(error) => throw InternalCompilerException(s"Java subtype check failed for '${sub.displayName()} <: ${sup.displayName()}': $error", loc)
-    }
 
   // ─────────────────────────────────────────────────────────────
   //  Section 3: Run / Visitors

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -831,7 +831,7 @@ object Safety {
         case JvmMethod(_, ident, fparams, _, _, _, methodLoc) =>
           val firstParam = fparams.head
           firstParam.tpe match {
-            case t if Type.descFromFlixType(Type.eraseAliases(t)).contains(clazz) =>
+            case t if JavaTypes.descriptorOf(Type.eraseAliases(t)).contains(clazz) =>
               ()
             case Type.Unit =>
               // Unit arguments are likely inserted by the compiler.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -27,7 +27,6 @@ import ca.uwaterloo.flix.language.phase.unification.Substitution
 import ca.uwaterloo.flix.util.collection.{ListOps, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, Subeffecting}
 
-import java.lang.constant.ClassDesc
 
 /**
   * This phase generates a list of type constraints, which include
@@ -926,7 +925,7 @@ object ConstraintGen {
         // --------------------------------------------------------
         // Γ ⊢ new k(e₁ ...) : k \ JvmToEff[ι]
         val baseEff = Type.JvmToEff(jvar, loc)
-        val clazzTpe = mkConstructorType(clazz, loc)
+        val clazzTpe = JavaTypes.instantiateWithFreshVars(clazz, scope, loc)
         val (tpes, effs) = exps.map(visitExp).unzip
         c.unifyType(jvar, Type.UnresolvedJvmType(Type.JvmMember.JvmConstructor(clazz, tpes), loc), loc)
         c.unifyType(evar, Type.mkUnion(baseEff :: effs, loc), loc)
@@ -939,7 +938,7 @@ object ConstraintGen {
         // --------------------------------------------------------
         // Γ ⊢ super(e₁ ...) : k \ JvmToEff[ι]
         val baseEff = Type.JvmToEff(jvar, loc)
-        val clazzTpe = mkConstructorType(clazz, loc)
+        val clazzTpe = JavaTypes.instantiateWithFreshVars(clazz, scope, loc)
         val (tpes, effs) = exps.map(visitExp).unzip
         c.unifyType(jvar, Type.UnresolvedJvmType(Type.JvmMember.JvmConstructor(clazz, tpes), loc), loc)
         c.unifyType(evar, Type.mkUnion(baseEff :: effs, loc), loc)
@@ -999,7 +998,7 @@ object ConstraintGen {
         (resTpe, resEff)
 
       case Expr.PutField(field, clazz, exp1, exp2, loc) =>
-        val fieldType = getJavaFieldType(field, loc)
+        val fieldType = JavaTypes.instantiateWithObjectArgs(field.ref.descriptor, loc)
         val classType = JavaTypes.instantiateWithObjectArgs(clazz, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
@@ -1011,7 +1010,7 @@ object ConstraintGen {
 
       case Expr.GetStaticField(field, tvar, loc) =>
         val isFinal = field.isFinal
-        val fieldType = getJavaFieldType(field, loc)
+        val fieldType = JavaTypes.instantiateWithObjectArgs(field.ref.descriptor, loc)
         val fieldReadEff = if (isFinal) Type.Pure else Type.IO
         c.unifyType(tvar, fieldType, loc)
         val resTpe = tvar
@@ -1020,7 +1019,7 @@ object ConstraintGen {
 
       case Expr.PutStaticField(field, exp, loc) =>
         val (valueTyp, eff) = visitExp(exp)
-        c.expectType(expected = getJavaFieldType(field, loc), actual = valueTyp, exp.loc)
+        c.expectType(expected = JavaTypes.instantiateWithObjectArgs(field.ref.descriptor, loc), actual = valueTyp, exp.loc)
         val resTpe = Type.Unit
         val resEff = Type.mkUnion(eff, Type.IO, loc)
         (resTpe, resEff)
@@ -1273,10 +1272,6 @@ object ConstraintGen {
       (patTpe, tpe, eff)
   }
 
-  /** Returns the Flix type of the erased descriptor of `field`. */
-  private def getJavaFieldType(field: JavaField, loc: SourceLocation)(implicit flix: Flix): Type =
-    JavaTypes.instantiateWithObjectArgs(field.ref.descriptor, loc)
-
   /**
     * Generates constraints for the given catch rule.
     *
@@ -1471,10 +1466,6 @@ object ConstraintGen {
     val regionOpt = struct.tparams.lastOption.map(region => substMap(region.sym))
     (instantiatedFields.toMap, tpe, regionOpt)
   }
-
-  /** Builds the result type for a constructor call, using fresh type variables for generic classes. */
-  private def mkConstructorType(clazz: ClassDesc, loc: SourceLocation)(implicit scope: RegionScope, flix: Flix): Type =
-    JavaTypes.instantiateWithFreshVars(clazz, scope, loc)
 
   /** Returns `true` if `exp` is a JVM interop invocation (constructor, method, or static method). */
   private def isJvmInvoke(exp: KindedAst.Expr): Boolean = exp match {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
@@ -19,11 +19,12 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.jvm.{JavaClass, JavaMethod, JavaType, JavaTypeVariable}
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Type, TypeConstructor}
-import ca.uwaterloo.flix.util.InternalCompilerException
+import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
+import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 
 import java.lang.constant.ClassDesc
-import java.lang.constant.ConstantDescs.{CD_Object, CD_Throwable}
+import java.lang.constant.ConstantDescs.*
 
 /**
   * Builds Flix types from Java class descriptors using the class-file metadata of the Java type provider.
@@ -55,7 +56,70 @@ object JavaTypes {
     * type parameters of the class (or of the element class of an array).
     */
   def flixTypeOf(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Type =
-    Type.getFlixType(desc, typeParameterCount(elementTypeOf(desc), loc))
+    flixTypeOf(desc, typeParameterCount(elementTypeOf(desc), loc))
+
+  /**
+    * Returns the Flix type of the Java class `desc` whose element class has `arity` type parameters.
+    *
+    * Arrays are returned with the [[Type.IO]] region. Since an array class has no type parameters
+    * of its own, `arity` is the number of type parameters of its (innermost) element class.
+    *
+    * Returns a [[TypeConstructor.Native]] of `desc` if nothing more specific is found. The `arity`
+    * is only evaluated in that case, so callers may compute it lazily.
+    */
+  def flixTypeOf(desc: ClassDesc, arity: => Int): Type = desc match {
+    case CD_boolean => Type.Bool
+    case CD_byte => Type.Int8
+    case CD_short => Type.Int16
+    case CD_int => Type.Int32
+    case CD_long => Type.Int64
+    case CD_char => Type.Char
+    case CD_float => Type.Float32
+    case CD_double => Type.Float64
+    case CD_void => Type.Unit
+    case CD_String => Type.Str
+    case JavaClasses.BigDecimal => Type.BigDecimal
+    case JavaClasses.BigInteger => Type.BigInt
+    case JavaClasses.Regex => Type.Regex
+    case _ if desc.isArray =>
+      val elmType = flixTypeOf(desc.componentType(), arity)
+      Type.mkArray(elmType, Type.IO, SourceLocation.Unknown)
+    case _ => Type.mkNative(desc, arity, SourceLocation.Unknown)
+  }
+
+  /**
+    * Returns the descriptor of the Java class of `tpe`, if it exists.
+    *
+    * Almost the inverse of `flixTypeOf(desc, arity)`, but arrays and `Unit` return `None`.
+    */
+  def descriptorOf(tpe: Type): Option[ClassDesc] = tpe match {
+    case Type.Bool => Some(CD_boolean)
+    case Type.Int8 => Some(CD_byte)
+    case Type.Int16 => Some(CD_short)
+    case Type.Int32 => Some(CD_int)
+    case Type.Int64 => Some(CD_long)
+    case Type.Char => Some(CD_char)
+    case Type.Float32 => Some(CD_float)
+    case Type.Float64 => Some(CD_double)
+    case Type.Cst(TypeConstructor.BigDecimal, _) => Some(JavaClasses.BigDecimal)
+    case Type.Cst(TypeConstructor.BigInt, _) => Some(JavaClasses.BigInteger)
+    case Type.Cst(TypeConstructor.Str, _) => Some(CD_String)
+    case Type.Cst(TypeConstructor.Regex, _) => Some(JavaClasses.Regex)
+    case Type.Cst(TypeConstructor.Native(desc, _), _) => Some(desc)
+    case _ =>
+      // Peel off type applications (e.g., ArrayList[String]) and check the base type.
+      tpe.baseType match {
+        case Type.Cst(TypeConstructor.Native(desc, _), _) => Some(desc)
+        case _ => None
+      }
+  }
+
+  /**
+    * Returns the string representation of the Java type `desc` used in error messages: a primitive
+    * or array type is shown as its Flix type and a class by its binary name.
+    */
+  def formatType(desc: ClassDesc): String =
+    if (desc.isPrimitive || desc.isArray) flixTypeOf(desc, 0).toString else ClassDescs.binaryNameOf(desc)
 
   /**
     * Returns the fully-applied Flix type of the Java class `desc`, with `Object` type arguments for a generic class.

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
@@ -94,4 +94,38 @@ class TestJavaTypes extends AnyFunSuite {
     } finally flix.javaTypeProvider.close()
   }
 
+  test("flixTypeOf.Descriptor") {
+    val list = ClassDesc.of("java.util.List")
+    assert(JavaTypes.flixTypeOf(CD_int, 0) == Type.Int32)
+    assert(JavaTypes.flixTypeOf(CD_void, 0) == Type.Unit)
+    assert(JavaTypes.flixTypeOf(CD_String, 0) == Type.Str)
+    assert(JavaTypes.flixTypeOf(ClassDesc.of("java.math.BigInteger"), 0) == Type.BigInt)
+    assert(JavaTypes.flixTypeOf(list, 1) == Type.mkNative(list, 1, loc))
+    // The arity is only evaluated for a native type, so a special class never triggers it.
+    var evaluated = false
+    assert(JavaTypes.flixTypeOf(CD_String, { evaluated = true; 0 }) == Type.Str)
+    assert(!evaluated)
+    assert(JavaTypes.flixTypeOf(list, { evaluated = true; 1 }) == Type.mkNative(list, 1, loc))
+    assert(evaluated)
+    // An array of a generic class carries the arity of its element class.
+    assert(JavaTypes.flixTypeOf(list.arrayType(), 1) == Type.mkArray(Type.mkNative(list, 1, loc), Type.IO, loc))
+  }
+
+  test("descriptorOf") {
+    val list = ClassDesc.of("java.util.List")
+    assert(JavaTypes.descriptorOf(Type.Int32) == Some(CD_int))
+    assert(JavaTypes.descriptorOf(Type.Str) == Some(CD_String))
+    assert(JavaTypes.descriptorOf(Type.mkNative(list, 1, loc)) == Some(list))
+    assert(JavaTypes.descriptorOf(Type.mkApply(Type.mkNative(list, 1, loc), List(Type.Str), loc)) == Some(list))
+    assert(JavaTypes.descriptorOf(Type.Unit) == None)
+    assert(JavaTypes.descriptorOf(Type.mkArray(Type.Int32, Type.IO, loc)) == None)
+  }
+
+  test("formatType") {
+    assert(JavaTypes.formatType(CD_int) == "Int32")
+    assert(JavaTypes.formatType(CD_String) == "java.lang.String")
+    assert(JavaTypes.formatType(ClassDesc.of("java.util.Map$Entry")) == "java.util.Map$Entry")
+    assert(JavaTypes.formatType(CD_int.arrayType()) == Type.mkArray(Type.Int32, Type.IO, loc).toString)
+  }
+
 }


### PR DESCRIPTION
Completes the consolidation of descriptor-to-type conversion started in #13201. Every place that mapped between a `ClassDesc` and a Flix type now goes through `JavaTypes`.

**Changes**

- `Type.getFlixType(desc, arity)` and `Type.descFromFlixType` become `JavaTypes.flixTypeOf(desc, arity)` and `JavaTypes.descriptorOf`. `Type` no longer imports the backend's `JavaClasses` and keeps only `mkNative`, `mkObject`, and `JvmMember`.
- The identical `formatJavaType` helpers in `TypeError` and `SafetyError` become one `JavaTypes.formatType`; `SafetyError.formatSourceType` uses `JavaTypes` as well.
- `PatMatch2` uses `JavaTypes.isSubtype` and drops its private copy.
- ConstraintGen's one-line `getJavaFieldType` and `mkConstructorType` wrappers are inlined at their call sites.

`TestJavaTypes` gains cases for `flixTypeOf` (including that the by-name arity is only evaluated for native types), `descriptorOf`, and `formatType`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3L1U3oBUhdk6DdhvPn9VM
