### PR TITLE
refactor: share the Java boxing table between the lowering phases

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -27,11 +27,11 @@ import ca.uwaterloo.flix.language.ast.shared.{BoundBy, Constant, Decreasing, Den
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoAst, Name, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization.Context
 import ca.uwaterloo.flix.language.phase.monomorph.Symbols.{Defs, Enums, Types}
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
+import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaBoxing, JavaMemberResolver}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, Result}
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListOps, Nel}
 
-import java.lang.constant.{ClassDesc, MethodTypeDesc}
+import java.lang.constant.ClassDesc
 import scala.jdk.CollectionConverters.*
 
 /**
@@ -431,7 +431,7 @@ object Lowering {
 
     case TypedAst.Expr.InstanceOf(exp, clazz, loc) =>
       val e = lowerExp(exp)
-      if (isPrimType(e.tpe)) {
+      if (JavaBoxing.isPrimitive(e.tpe)) {
         // If it's a primitive type, evaluate the expression but return false
         MonoAst.Expr.Stm(List(e), MonoAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc), Type.Bool, e.eff, loc)
       } else {
@@ -516,8 +516,8 @@ object Lowering {
       val javaParamTypes = method.ref.descriptor.parameterList().asScala.toList
       val boxedArgs = es.zip(javaParamTypes).map { case (arg, paramType) => boxIfNecessary(arg, paramType) }
       val javaReturnType = method.ref.descriptor.returnType()
-      val needsUnbox = isPrimType(t) && !javaReturnType.isPrimitive
-      val invokeType = if (needsUnbox) boxedWrapperType(t, loc) else t
+      val needsUnbox = JavaBoxing.isPrimitive(t) && !javaReturnType.isPrimitive
+      val invokeType = if (needsUnbox) JavaBoxing.boxedType(t, loc) else t
       val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeMethod(mkJMethod(method, loc)), e :: boxedArgs, invokeType, eff, loc)
       unboxIfNecessary(invoke, t, javaReturnType)
 
@@ -538,8 +538,8 @@ object Lowering {
       val javaParamTypes = method.ref.descriptor.parameterList().asScala.toList
       val boxedArgs = es.zip(javaParamTypes).map { case (arg, paramType) => boxIfNecessary(arg, paramType) }
       val javaReturnType = method.ref.descriptor.returnType()
-      val needsUnbox = isPrimType(t) && !javaReturnType.isPrimitive
-      val invokeType = if (needsUnbox) boxedWrapperType(t, loc) else t
+      val needsUnbox = JavaBoxing.isPrimitive(t) && !javaReturnType.isPrimitive
+      val invokeType = if (needsUnbox) JavaBoxing.boxedType(t, loc) else t
       val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeStaticMethod(mkJMethod(method, loc)), boxedArgs, invokeType, eff, loc)
       unboxIfNecessary(invoke, t, javaReturnType)
 
@@ -985,35 +985,11 @@ object Lowering {
       case (Type.Int64, Type.Int64) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
       case (Type.Float32, Type.Float32) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
       case (Type.Float64, Type.Float64) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (x, y) if !isPrimType(x) && !isPrimType(y) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
+      case (x, y) if !JavaBoxing.isPrimitive(x) && !JavaBoxing.isPrimitive(y) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
       case (x, y) =>
         val crash = MonoAst.Expr.ApplyAtomic(AtomicOp.CastError(erasedString(x), erasedString(y)), Nil, tpe, eff, loc)
         MonoAst.Expr.Stm(List(exp), crash, tpe, eff, loc)
     }
-  }
-
-  /**
-    * Returns `true` if `tpe` is a primitive type.
-    *
-    * N.B.: `tpe` must be normalized.
-    */
-  private def isPrimType(tpe: Type): Boolean = tpe match {
-    case Type.Char => true
-    case Type.Bool => true
-    case Type.Int8 => true
-    case Type.Int16 => true
-    case Type.Int32 => true
-    case Type.Int64 => true
-    case Type.Float32 => true
-    case Type.Float64 => true
-    case Type.Cst(_, _) => false
-    case Type.Apply(_, _, _) => false
-    case Type.Var(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.Alias(_, _, _, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.AssocType(_, _, _, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.JvmToType(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.JvmToEff(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.UnresolvedJvmType(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
   }
 
   /**
@@ -1041,67 +1017,6 @@ object Lowering {
   }
 
   /**
-    * Returns the `valueOf` boxing method for a Flix primitive type.
-    * This is the same mechanism javac uses to implement autoboxing.
-    */
-  private def javaBoxMethod(tpe: Type): JMethod = {
-    import java.lang.constant.ConstantDescs.*
-    def valueOf(box: ClassDesc, prim: ClassDesc): JMethod =
-      JMethod(box, "valueOf", MethodTypeDesc.of(box, prim), isInterface = false)
-    tpe match {
-      case Type.Bool => valueOf(CD_Boolean, CD_boolean)
-      case Type.Char => valueOf(CD_Character, CD_char)
-      case Type.Int8 => valueOf(CD_Byte, CD_byte)
-      case Type.Int16 => valueOf(CD_Short, CD_short)
-      case Type.Int32 => valueOf(CD_Integer, CD_int)
-      case Type.Int64 => valueOf(CD_Long, CD_long)
-      case Type.Float32 => valueOf(CD_Float, CD_float)
-      case Type.Float64 => valueOf(CD_Double, CD_double)
-      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
-    }
-  }
-
-  /**
-    * Returns the unboxing method (e.g., `intValue`) for a Flix primitive type.
-    * This is the same mechanism javac uses to implement auto-unboxing.
-    */
-  private def javaUnboxMethod(tpe: Type): JMethod = {
-    import java.lang.constant.ConstantDescs.*
-    def unbox(box: ClassDesc, name: String, prim: ClassDesc): JMethod =
-      JMethod(box, name, MethodTypeDesc.of(prim), isInterface = false)
-    tpe match {
-      case Type.Bool => unbox(CD_Boolean, "booleanValue", CD_boolean)
-      case Type.Char => unbox(CD_Character, "charValue", CD_char)
-      case Type.Int8 => unbox(CD_Byte, "byteValue", CD_byte)
-      case Type.Int16 => unbox(CD_Short, "shortValue", CD_short)
-      case Type.Int32 => unbox(CD_Integer, "intValue", CD_int)
-      case Type.Int64 => unbox(CD_Long, "longValue", CD_long)
-      case Type.Float32 => unbox(CD_Float, "floatValue", CD_float)
-      case Type.Float64 => unbox(CD_Double, "doubleValue", CD_double)
-      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
-    }
-  }
-
-  /**
-    * Returns the Flix Type for the Java wrapper class of a primitive type.
-    * E.g., `Bool` -> `Native(java.lang.Boolean)`, `Int32` -> `Native(java.lang.Integer)`.
-    */
-  private def boxedWrapperType(tpe: Type, loc: SourceLocation): Type = {
-    import java.lang.constant.ConstantDescs.*
-    tpe match {
-      case Type.Bool => Type.mkNative(CD_Boolean, 0, loc)
-      case Type.Char => Type.mkNative(CD_Character, 0, loc)
-      case Type.Int8 => Type.mkNative(CD_Byte, 0, loc)
-      case Type.Int16 => Type.mkNative(CD_Short, 0, loc)
-      case Type.Int32 => Type.mkNative(CD_Integer, 0, loc)
-      case Type.Int64 => Type.mkNative(CD_Long, 0, loc)
-      case Type.Float32 => Type.mkNative(CD_Float, 0, loc)
-      case Type.Float64 => Type.mkNative(CD_Double, 0, loc)
-      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
-    }
-  }
-
-  /**
     * Returns the [[JMethod]] of `method`.
     *
     * Whether the owner of `method` is an interface is read from its class metadata,
@@ -1122,11 +1037,11 @@ object Lowering {
     */
   private def boxIfNecessary(arg: MonoAst.Expr, expectedParamType: ClassDesc): MonoAst.Expr = {
     val actualArgType = arg.tpe
-    if (isPrimType(actualArgType) && !expectedParamType.isPrimitive) {
+    if (JavaBoxing.isPrimitive(actualArgType) && !expectedParamType.isPrimitive) {
       MonoAst.Expr.ApplyAtomic(
-        AtomicOp.InvokeStaticMethod(javaBoxMethod(actualArgType)),
+        AtomicOp.InvokeStaticMethod(JavaBoxing.boxMethod(actualArgType)),
         List(arg),
-        boxedWrapperType(actualArgType, arg.loc),
+        JavaBoxing.boxedType(actualArgType, arg.loc),
         arg.eff,
         arg.loc.asSynthetic
       )
@@ -1139,9 +1054,9 @@ object Lowering {
     * `Int32` but the actual Java return type is `Object` (erased), so the result is unboxed via `intValue()`.
     */
   private def unboxIfNecessary(expr: MonoAst.Expr, expectedReturnType: Type, actualReturnType: ClassDesc): MonoAst.Expr = {
-    if (isPrimType(expectedReturnType) && !actualReturnType.isPrimitive) {
+    if (JavaBoxing.isPrimitive(expectedReturnType) && !actualReturnType.isPrimitive) {
       MonoAst.Expr.ApplyAtomic(
-        AtomicOp.InvokeMethod(javaUnboxMethod(expectedReturnType)),
+        AtomicOp.InvokeMethod(JavaBoxing.unboxMethod(expectedReturnType)),
         List(expr),
         expectedReturnType,
         expr.eff,

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -25,11 +25,11 @@ import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.phase.monomorph2.Specialize.*
 import ca.uwaterloo.flix.language.phase.monomorph2.Symbols.{Defs, Enums, Types}
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaMemberResolver
+import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaBoxing, JavaMemberResolver}
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListOps, Nel}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException, Result}
 
-import java.lang.constant.{ClassDesc, MethodTypeDesc}
+import java.lang.constant.ClassDesc
 import scala.jdk.CollectionConverters.*
 
 /**
@@ -435,7 +435,7 @@ private[monomorph2] object SpecializeAndLower {
     case TypedAst.Expr.InstanceOf(exp, clazz, loc) =>
       // Primitives never satisfy an instanceof check: evaluate for side effects and return false.
       val e = visitExp(exp, env0, subst)
-      if (isPrimType(e.tpe)) {
+      if (JavaBoxing.isPrimitive(e.tpe)) {
         // If it's a primitive type, evaluate the expression but return false
         MonoAst.Expr.Stm(List(e), MonoAst.Expr.Cst(Constant.Bool(false), Type.Bool, loc), Type.Bool, e.eff, loc)
       } else {
@@ -1061,36 +1061,12 @@ private[monomorph2] object SpecializeAndLower {
       case (Type.Int64, Type.Int64) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
       case (Type.Float32, Type.Float32) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
       case (Type.Float64, Type.Float64) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
-      case (x, y) if !isPrimType(x) && !isPrimType(y) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
+      case (x, y) if !JavaBoxing.isPrimitive(x) && !JavaBoxing.isPrimitive(y) => MonoAst.Expr.Cast(exp, tpe, eff, loc)
 
       case (x, y) =>
         val crash = MonoAst.Expr.ApplyAtomic(AtomicOp.CastError(prettyPrintErasedType(x), prettyPrintErasedType(y)), Nil, tpe, eff, loc)
         MonoAst.Expr.Stm(List(exp), crash, tpe, eff, loc)
     }
-  }
-
-  /**
-    * Returns `true` if `tpe` is a primitive type.
-    *
-    * N.B.: `tpe` must be normalized.
-    */
-  private def isPrimType(tpe: Type): Boolean = tpe match {
-    case Type.Char => true
-    case Type.Bool => true
-    case Type.Int8 => true
-    case Type.Int16 => true
-    case Type.Int32 => true
-    case Type.Int64 => true
-    case Type.Float32 => true
-    case Type.Float64 => true
-    case Type.Cst(_, _) => false
-    case Type.Apply(_, _, _) => false
-    case Type.Var(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.Alias(_, _, _, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.AssocType(_, _, _, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.JvmToType(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.JvmToEff(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-    case Type.UnresolvedJvmType(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
   }
 
   /**
@@ -1135,67 +1111,6 @@ private[monomorph2] object SpecializeAndLower {
   }
 
   /**
-    * Returns the `valueOf` boxing method for a Flix primitive type.
-    * This is the same mechanism javac uses to implement autoboxing.
-    */
-  private def javaBoxMethod(tpe: Type): JMethod = {
-    import java.lang.constant.ConstantDescs.*
-    def valueOf(box: ClassDesc, prim: ClassDesc): JMethod =
-      JMethod(box, "valueOf", MethodTypeDesc.of(box, prim), isInterface = false)
-    tpe match {
-      case Type.Bool => valueOf(CD_Boolean, CD_boolean)
-      case Type.Char => valueOf(CD_Character, CD_char)
-      case Type.Int8 => valueOf(CD_Byte, CD_byte)
-      case Type.Int16 => valueOf(CD_Short, CD_short)
-      case Type.Int32 => valueOf(CD_Integer, CD_int)
-      case Type.Int64 => valueOf(CD_Long, CD_long)
-      case Type.Float32 => valueOf(CD_Float, CD_float)
-      case Type.Float64 => valueOf(CD_Double, CD_double)
-      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
-    }
-  }
-
-  /**
-    * Returns the unboxing method (e.g., `intValue`) for a Flix primitive type.
-    * This is the same mechanism javac uses to implement auto-unboxing.
-    */
-  private def javaUnboxMethod(tpe: Type): JMethod = {
-    import java.lang.constant.ConstantDescs.*
-    def unbox(box: ClassDesc, name: String, prim: ClassDesc): JMethod =
-      JMethod(box, name, MethodTypeDesc.of(prim), isInterface = false)
-    tpe match {
-      case Type.Bool => unbox(CD_Boolean, "booleanValue", CD_boolean)
-      case Type.Char => unbox(CD_Character, "charValue", CD_char)
-      case Type.Int8 => unbox(CD_Byte, "byteValue", CD_byte)
-      case Type.Int16 => unbox(CD_Short, "shortValue", CD_short)
-      case Type.Int32 => unbox(CD_Integer, "intValue", CD_int)
-      case Type.Int64 => unbox(CD_Long, "longValue", CD_long)
-      case Type.Float32 => unbox(CD_Float, "floatValue", CD_float)
-      case Type.Float64 => unbox(CD_Double, "doubleValue", CD_double)
-      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
-    }
-  }
-
-  /**
-    * Returns the Flix Type for the Java wrapper class of a primitive type.
-    * E.g., `Bool` -> `Native(java.lang.Boolean)`, `Int32` -> `Native(java.lang.Integer)`.
-    */
-  private def boxedWrapperType(tpe: Type, loc: SourceLocation): Type = {
-    import java.lang.constant.ConstantDescs.*
-    tpe match {
-      case Type.Bool => Type.mkNative(CD_Boolean, 0, loc)
-      case Type.Char => Type.mkNative(CD_Character, 0, loc)
-      case Type.Int8 => Type.mkNative(CD_Byte, 0, loc)
-      case Type.Int16 => Type.mkNative(CD_Short, 0, loc)
-      case Type.Int32 => Type.mkNative(CD_Integer, 0, loc)
-      case Type.Int64 => Type.mkNative(CD_Long, 0, loc)
-      case Type.Float32 => Type.mkNative(CD_Float, 0, loc)
-      case Type.Float64 => Type.mkNative(CD_Double, 0, loc)
-      case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
-    }
-  }
-
-  /**
     * Returns the [[JMethod]] of `method`.
     *
     * Whether the owner of `method` is an interface is read from its class metadata,
@@ -1216,11 +1131,11 @@ private[monomorph2] object SpecializeAndLower {
     */
   private def boxIfNecessary(arg: MonoAst.Expr, expectedParamType: ClassDesc): MonoAst.Expr = {
     val actualArgType = arg.tpe
-    if (isPrimType(actualArgType) && !expectedParamType.isPrimitive) {
+    if (JavaBoxing.isPrimitive(actualArgType) && !expectedParamType.isPrimitive) {
       MonoAst.Expr.ApplyAtomic(
-        AtomicOp.InvokeStaticMethod(javaBoxMethod(actualArgType)),
+        AtomicOp.InvokeStaticMethod(JavaBoxing.boxMethod(actualArgType)),
         List(arg),
-        boxedWrapperType(actualArgType, arg.loc),
+        JavaBoxing.boxedType(actualArgType, arg.loc),
         arg.eff,
         arg.loc.asSynthetic
       )
@@ -1245,9 +1160,9 @@ private[monomorph2] object SpecializeAndLower {
     * `Int32` but the actual Java return type is `Object` (erased), so the result is unboxed via `intValue()`.
     */
   private def unboxIfNecessary(expr: MonoAst.Expr, expectedReturnType: Type, actualReturnType: ClassDesc): MonoAst.Expr = {
-    if (isPrimType(expectedReturnType) && !actualReturnType.isPrimitive) {
+    if (JavaBoxing.isPrimitive(expectedReturnType) && !actualReturnType.isPrimitive) {
       MonoAst.Expr.ApplyAtomic(
-        AtomicOp.InvokeMethod(javaUnboxMethod(expectedReturnType)),
+        AtomicOp.InvokeMethod(JavaBoxing.unboxMethod(expectedReturnType)),
         List(expr),
         expectedReturnType,
         expr.eff,
@@ -1262,8 +1177,8 @@ private[monomorph2] object SpecializeAndLower {
   private def mkJavaInvoke(method: JavaMethod, receiver: List[MonoAst.Expr], args: List[MonoAst.Expr], t: Type, eff: Type, loc: SourceLocation, mkOp: JavaMethod => AtomicOp): MonoAst.Expr = {
     val boxedArgs = ListOps.zip(args, method.ref.descriptor.parameterList().asScala.toList).map { case (arg, paramType) => boxIfNecessary(arg, paramType) }
     val javaReturnType = method.ref.descriptor.returnType()
-    val needsUnbox = isPrimType(t) && !javaReturnType.isPrimitive
-    val invokeType = if (needsUnbox) boxedWrapperType(t, loc) else t
+    val needsUnbox = JavaBoxing.isPrimitive(t) && !javaReturnType.isPrimitive
+    val invokeType = if (needsUnbox) JavaBoxing.boxedType(t, loc) else t
     val invoke = MonoAst.Expr.ApplyAtomic(mkOp(method), receiver ++ boxedArgs, invokeType, eff, loc)
     unboxIfNecessary(invoke, t, javaReturnType)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaBoxing.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaBoxing.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.typer.jvm
+
+import ca.uwaterloo.flix.language.ast.shared.JMethod
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Type}
+import ca.uwaterloo.flix.util.InternalCompilerException
+
+import java.lang.constant.ConstantDescs.*
+import java.lang.constant.{ClassDesc, MethodTypeDesc}
+
+/**
+  * Boxing and unboxing of the Flix primitive types to and from their Java wrapper classes.
+  *
+  * The lowering phases use the same mechanism as javac: `Integer.valueOf(int)` boxes an `Int32`
+  * and `Integer.intValue()` unboxes it.
+  */
+object JavaBoxing {
+
+  /**
+    * Returns `true` if `tpe` is a primitive type.
+    *
+    * N.B.: `tpe` must be normalized.
+    */
+  def isPrimitive(tpe: Type): Boolean = tpe match {
+    case Type.Char => true
+    case Type.Bool => true
+    case Type.Int8 => true
+    case Type.Int16 => true
+    case Type.Int32 => true
+    case Type.Int64 => true
+    case Type.Float32 => true
+    case Type.Float64 => true
+    case Type.Cst(_, _) => false
+    case Type.Apply(_, _, _) => false
+    case Type.Var(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
+    case Type.Alias(_, _, _, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
+    case Type.AssocType(_, _, _, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
+    case Type.JvmToType(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
+    case Type.JvmToEff(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
+    case Type.UnresolvedJvmType(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
+  }
+
+  /** Returns the `valueOf` method that boxes the primitive type `tpe`, e.g. `Integer.valueOf(int)` for `Int32`. */
+  def boxMethod(tpe: Type): JMethod = {
+    val wrapper = wrapperOf(tpe)
+    JMethod(wrapper.box, "valueOf", MethodTypeDesc.of(wrapper.box, wrapper.prim), isInterface = false)
+  }
+
+  /** Returns the method that unboxes the wrapper of the primitive type `tpe`, e.g. `Integer.intValue()` for `Int32`. */
+  def unboxMethod(tpe: Type): JMethod = {
+    val wrapper = wrapperOf(tpe)
+    JMethod(wrapper.box, wrapper.unboxName, MethodTypeDesc.of(wrapper.prim), isInterface = false)
+  }
+
+  /** Returns the native type of the wrapper class of the primitive type `tpe`, e.g. `java.lang.Integer` for `Int32`. */
+  def boxedType(tpe: Type, loc: SourceLocation): Type =
+    Type.mkNative(wrapperOf(tpe).box, 0, loc)
+
+  /** The Java wrapper class `box` of a primitive type `prim` and the name of the method that unboxes it. */
+  private case class Wrapper(box: ClassDesc, prim: ClassDesc, unboxName: String)
+
+  /** Returns the wrapper of the primitive type `tpe`, or throws if `tpe` is not a primitive type. */
+  private def wrapperOf(tpe: Type): Wrapper = tpe match {
+    case Type.Bool => Wrapper(CD_Boolean, CD_boolean, "booleanValue")
+    case Type.Char => Wrapper(CD_Character, CD_char, "charValue")
+    case Type.Int8 => Wrapper(CD_Byte, CD_byte, "byteValue")
+    case Type.Int16 => Wrapper(CD_Short, CD_short, "shortValue")
+    case Type.Int32 => Wrapper(CD_Integer, CD_int, "intValue")
+    case Type.Int64 => Wrapper(CD_Long, CD_long, "longValue")
+    case Type.Float32 => Wrapper(CD_Float, CD_float, "floatValue")
+    case Type.Float64 => Wrapper(CD_Double, CD_double, "doubleValue")
+    case _ => throw InternalCompilerException(s"Unexpected non-primitive type '$tpe'", tpe.loc)
+  }
+
+}

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaBoxing.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaBoxing.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.typer.jvm
+
+import ca.uwaterloo.flix.language.ast.shared.JMethod
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Type}
+import ca.uwaterloo.flix.util.InternalCompilerException
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.lang.constant.ConstantDescs.*
+import java.lang.constant.MethodTypeDesc
+
+class TestJavaBoxing extends AnyFunSuite {
+
+  private val loc = SourceLocation.Unknown
+
+  test("isPrimitive") {
+    assert(JavaBoxing.isPrimitive(Type.Bool))
+    assert(JavaBoxing.isPrimitive(Type.Int32))
+    assert(JavaBoxing.isPrimitive(Type.Float64))
+    assert(!JavaBoxing.isPrimitive(Type.Str))
+    assert(!JavaBoxing.isPrimitive(Type.Unit))
+    assert(!JavaBoxing.isPrimitive(Type.mkObject(loc)))
+    assert(!JavaBoxing.isPrimitive(Type.mkArray(Type.Int32, Type.IO, loc)))
+  }
+
+  test("boxMethod") {
+    assert(JavaBoxing.boxMethod(Type.Int32) == JMethod(CD_Integer, "valueOf", MethodTypeDesc.of(CD_Integer, CD_int), isInterface = false))
+    assert(JavaBoxing.boxMethod(Type.Bool) == JMethod(CD_Boolean, "valueOf", MethodTypeDesc.of(CD_Boolean, CD_boolean), isInterface = false))
+    assert(JavaBoxing.boxMethod(Type.Char) == JMethod(CD_Character, "valueOf", MethodTypeDesc.of(CD_Character, CD_char), isInterface = false))
+    assert(JavaBoxing.boxMethod(Type.Float64) == JMethod(CD_Double, "valueOf", MethodTypeDesc.of(CD_Double, CD_double), isInterface = false))
+    assertThrows[InternalCompilerException](JavaBoxing.boxMethod(Type.Str))
+  }
+
+  test("unboxMethod") {
+    assert(JavaBoxing.unboxMethod(Type.Int32) == JMethod(CD_Integer, "intValue", MethodTypeDesc.of(CD_int), isInterface = false))
+    assert(JavaBoxing.unboxMethod(Type.Bool) == JMethod(CD_Boolean, "booleanValue", MethodTypeDesc.of(CD_boolean), isInterface = false))
+    assert(JavaBoxing.unboxMethod(Type.Int64) == JMethod(CD_Long, "longValue", MethodTypeDesc.of(CD_long), isInterface = false))
+    assert(JavaBoxing.unboxMethod(Type.Float32) == JMethod(CD_Float, "floatValue", MethodTypeDesc.of(CD_float), isInterface = false))
+    assertThrows[InternalCompilerException](JavaBoxing.unboxMethod(Type.Unit))
+  }
+
+  test("boxedType") {
+    assert(JavaBoxing.boxedType(Type.Int32, loc) == Type.mkNative(CD_Integer, 0, loc))
+    assert(JavaBoxing.boxedType(Type.Int8, loc) == Type.mkNative(CD_Byte, 0, loc))
+    assert(JavaBoxing.boxedType(Type.Int16, loc) == Type.mkNative(CD_Short, 0, loc))
+    assertThrows[InternalCompilerException](JavaBoxing.boxedType(Type.Str, loc))
+  }
+
+}


### PR DESCRIPTION
Lowering and SpecializeAndLower carried byte-identical copies of `isPrimType`, `javaBoxMethod`, `javaUnboxMethod`, and `boxedWrapperType`. They become `JavaBoxing.isPrimitive`, `boxMethod`, `unboxMethod`, and `boxedType` in `phase.typer.jvm`, backed by one table from primitive type to wrapper class, primitive descriptor, and unboxing method name instead of three parallel eight-way matches.

The `MonoAst`-building wrappers (`boxIfNecessary`, `unboxIfNecessary`, `mkJMethod`, `mkJavaInvoke`) stay in the lowering phases, so the typer package does not depend on the lowering AST. Each lowering loses 85 lines. No behavior change: the generated `valueOf` and `xValue` invocations are the same.

`TestJavaBoxing` covers the four functions, including the primitive-only precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3L1U3oBUhdk6DdhvPn9VM
