### PR TITLE
fix: render Java types consistently in error messages

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.errors
 
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, TraitUsageKind}
-import ca.uwaterloo.flix.language.ast.{Kind, Name, SourceLocation, Symbol, TypedAst, UnkindedType}
+import ca.uwaterloo.flix.language.ast.{Kind, Name, SourceLocation, Symbol, TypedAst}
 import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
 import ca.uwaterloo.flix.util.{ClassDescs, Formatter, Grammar}
@@ -204,19 +204,28 @@ object ResolutionError {
   }
 
   /**
-    * Illegal Non-Java Type Error.
+    * An error raised to indicate that a `new` expression names a type that is not a Java class or interface.
     *
-    * @param tpe the illegal type.
-    * @param loc the location where the error occurred.
+    * @param loc the location of the type.
     */
-  case class IllegalNonJavaType(tpe: UnkindedType, loc: SourceLocation) extends ResolutionError {
+  case class IllegalNonJavaType(loc: SourceLocation) extends ResolutionError {
     def code: ErrorCode = ErrorCode.E9623
 
-    def summary: String = "Unexpected non-Java type. Expected class or interface type."
+    // The type as written in the source, if it fits on a single line.
+    private val name: Option[String] = loc.text
+
+    def summary: String = name match {
+      case Some(t) => s"Unexpected non-Java type: '$t'. Expected a Java class or interface."
+      case None => "Unexpected non-Java type. Expected a Java class or interface."
+    }
 
     def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import fmt.*
-      s""">> Unexpected non-Java type: '${red(tpe.toString)}'.
+      val headline = name match {
+        case Some(t) => s">> Unexpected non-Java type: '${red(t)}'."
+        case None => ">> Unexpected non-Java type."
+      }
+      s"""$headline
          |
          |${highlight(loc, "unexpected type", fmt)}
          |

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatTypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatTypeConstructor.scala
@@ -71,8 +71,8 @@ object FormatTypeConstructor {
     case TypeConstructor.RestrictableEnum(sym, _) => sym.name
 
     // JVM types
-    case TypeConstructor.Native(desc, _) => ClassDescs.simpleNameOf(desc)
-    case TypeConstructor.JvmConstructor(constructor) => s"Constructor(${constructor.ref.owner.displayName()})"
+    case TypeConstructor.Native(desc, _) => ClassDescs.binaryNameOf(desc)
+    case TypeConstructor.JvmConstructor(constructor) => s"Constructor(${ClassDescs.binaryNameOf(constructor.ref.owner)})"
     case TypeConstructor.JvmMethod(method, _) => s"Method(${method.ref.name})"
     case TypeConstructor.JvmField(field) => s"Field(${field.ref.name})"
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1705,7 +1705,9 @@ object Resolver {
             }
         }
       case None =>
-        val err = ResolutionError.IllegalNonJavaType(resolveType(tpe, Some(Kind.Star), Wildness.ForbidWild, scp0, taenv, ns0, root), loc)
+        // Resolve the type anyway so that errors inside it (e.g. undefined names) are reported.
+        resolveType(tpe, Some(Kind.Star), Wildness.ForbidWild, scp0, taenv, ns0, root)
+        val err = ResolutionError.IllegalNonJavaType(tpe.loc)
         sctx.errors.add(err)
         ResolvedAst.Expr.Error(err)
     }
@@ -1754,12 +1756,12 @@ object Resolver {
                     sctx.errors.add(err)
                     ResolvedAst.Expr.Error(err)
                   case None =>
-                    val err = ResolutionError.IllegalNonJavaType(t, t.loc)
+                    val err = ResolutionError.IllegalNonJavaType(t.loc)
                     sctx.errors.add(err)
                     ResolvedAst.Expr.Error(err)
                 }
               case _ =>
-                val err = ResolutionError.IllegalNonJavaType(t, t.loc)
+                val err = ResolutionError.IllegalNonJavaType(t.loc)
                 sctx.errors.add(err)
                 ResolvedAst.Expr.Error(err)
             }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
@@ -115,11 +115,12 @@ object JavaTypes {
   }
 
   /**
-    * Returns the string representation of the Java type `desc` used in error messages: a primitive
-    * or array type is shown as its Flix type and a class by its binary name.
+    * Returns the string representation of the Java type `desc` used in error messages: a primitive,
+    * an array, or a class with a Flix counterpart (e.g. `String` or `BigInt`) is shown as its Flix
+    * type, and any other class by its binary name.
     */
   def formatType(desc: ClassDesc): String =
-    if (desc.isPrimitive || desc.isArray) flixTypeOf(desc, 0).toString else ClassDescs.binaryNameOf(desc)
+    flixTypeOf(desc, 0).toString
 
   /**
     * Returns the fully-applied Flix type of the Java class `desc`, with `Object` type arguments for a generic class.

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase.typer.jvm
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.jvm.{JavaType, JavaTypeVariable, JavaTypeVariableOwner}
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.lang.constant.ConstantDescs.*
@@ -123,7 +124,8 @@ class TestJavaTypes extends AnyFunSuite {
 
   test("formatType") {
     assert(JavaTypes.formatType(CD_int) == "Int32")
-    assert(JavaTypes.formatType(CD_String) == "java.lang.String")
+    assert(JavaTypes.formatType(CD_String) == "String")
+    assert(JavaTypes.formatType(JavaClasses.BigInteger) == "BigInt")
     assert(JavaTypes.formatType(ClassDesc.of("java.util.Map$Entry")) == "java.util.Map$Entry")
     assert(JavaTypes.formatType(CD_int.arrayType()) == Type.mkArray(Type.Int32, Type.IO, loc).toString)
   }


### PR DESCRIPTION
Follow-up to #13199 and #13203. Fixes the remaining inconsistencies in how Java types are rendered in error messages:

- `IllegalNonJavaType` printed the raw `UnkindedType` AST, e.g. `Unexpected non-Java type: 'Cst(Int32,foo.flix:5:17)'`. It now names the type as written in the source: `'Int32'`, `'T'`, or `'Option[Int32]'`. The type is still resolved at the first call site so that errors inside it, such as undefined names, are still reported.
- `FormatTypeConstructor` printed `Native` types with the simple name while `DisplayType` uses the binary name, so an `OverlappingInstances` error on a Java type said `'ArrayList'` where every other error says `'java.util.ArrayList'`. It now uses the binary name, and its `JvmConstructor` case goes through `ClassDescs` instead of `displayName()`.
- `JavaTypes.formatType` only mapped primitives and arrays to Flix types, so a method signature showed `java.lang.String` and `java.math.BigInteger` where the Flix formatter says `String` and `BigInt`. It now routes every descriptor through `flixTypeOf`. As a side effect, the constructor list in `ConstructorNotFound` reads `File(String)` rather than `File(java.lang.String)`.

`TestJavaTypes` is updated for the new `String` expectation and gains a `BigInt` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDECuZBVc6svSEm32AjVGc
