### PR TITLE
refactor: move FlixError into its own class generator

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassConstants.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassConstants.scala
@@ -16,42 +16,13 @@
 
 package ca.uwaterloo.flix.language.phase.jvm
 
-import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, InstanceMethod, InterfaceMethod, StaticMethod}
-import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
 import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoidDescriptor}
-import org.objectweb.asm.MethodVisitor
 
-import java.lang.constant.ClassDesc
 import java.lang.constant.ConstantDescs.{CD_boolean, CD_int}
 
+/** The well-known members of the Java classes referenced by the backend. */
 object ClassConstants {
-
-  // Flix Constants.
-
-  object FlixError {
-
-    val Desc: ClassDesc = Mangle.mkDesc(Mangle.DevFlixRuntime, Mangle.mkClassName("FlixError"))
-
-    val Constructor: ConstructorMethod = ConstructorMethod(Desc, List(JavaClasses.String))
-
-    def genByteCode()(implicit flix: Flix): Array[Byte] = {
-      val cm = ClassMaker.mkAbstractClass(Desc, JavaClasses.Error)
-      cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
-      cm.closeClassMaker()
-    }
-
-    private def constructorIns(implicit mv: MethodVisitor): Unit = {
-      thisLoad()
-      ALOAD(1)
-      invokeConstructor(JavaClasses.Error, mkVoidDescriptor(JavaClasses.String))
-      RETURN()
-    }
-
-  }
-
-  // Java Constants.
 
   object BigDecimal {
     val Constructor: ConstructorMethod = ClassMaker.ConstructorMethod(JavaClasses.BigDecimal, List(JavaClasses.String))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{BytecodeAst, SimpleType, SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugNoOp
-import ca.uwaterloo.flix.language.phase.jvm.classes.{GenAbstractArrow, GenArrow, GenCastError, GenEffectCall, GenExtTag, GenExtTagged, GenFrame, GenFrames, GenFramesCons, GenFramesNil, GenGlobal, GenHandler, GenHoleError, GenLazy, GenMain, GenMatchError, GenNamespace, GenNullaryTag, GenRecord, GenRecordEmpty, GenRecordExtend, GenRegion, GenReifiedSourceLocation, GenResult, GenResumption, GenResumptionCons, GenResumptionNil, GenResumptionWrapper, GenStruct, GenSuspension, GenTag, GenTagged, GenThunk, GenTuple, GenUncaughtExceptionHandler, GenUnhandledEffectError, GenUnit, GenValue}
+import ca.uwaterloo.flix.language.phase.jvm.classes.{GenAbstractArrow, GenArrow, GenCastError, GenEffectCall, GenExtTag, GenExtTagged, GenFlixError, GenFrame, GenFrames, GenFramesCons, GenFramesNil, GenGlobal, GenHandler, GenHoleError, GenLazy, GenMain, GenMatchError, GenNamespace, GenNullaryTag, GenRecord, GenRecordEmpty, GenRecordExtend, GenRegion, GenReifiedSourceLocation, GenResult, GenResumption, GenResumptionCons, GenResumptionNil, GenResumptionWrapper, GenStruct, GenSuspension, GenTag, GenTagged, GenThunk, GenTuple, GenUncaughtExceptionHandler, GenUnhandledEffectError, GenUnit, GenValue}
 import ca.uwaterloo.flix.util.{ClassDescs, InternalCompilerException}
 
 import java.lang.constant.ClassDesc
@@ -88,7 +88,7 @@ object CodeGen {
 
     val unitClass = List(JvmClass(GenUnit.Desc, GenUnit.genByteCode()))
 
-    val flixErrorClass = List(JvmClass(ClassConstants.FlixError.Desc, ClassConstants.FlixError.genByteCode()))
+    val flixErrorClass = List(JvmClass(GenFlixError.Desc, GenFlixError.genByteCode()))
     val rslClass = List(JvmClass(GenReifiedSourceLocation.Desc, GenReifiedSourceLocation.genByteCode()))
     val holeErrorClass = List(JvmClass(GenHoleError.Desc, GenHoleError.genByteCode()))
     val matchErrorClass = List(JvmClass(GenMatchError.Desc, GenMatchError.genByteCode()))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenCastError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenCastError.scala
@@ -36,7 +36,7 @@ object GenCastError {
   val Desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("CastError"))
 
   def genByteCode()(implicit flix: Flix): Array[Byte] = {
-    val cm = ClassMaker.mkClass(this.Desc, IsFinal, superClass = ClassConstants.FlixError.Desc)
+    val cm = ClassMaker.mkClass(this.Desc, IsFinal, superClass = GenFlixError.Desc)
 
     cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
 
@@ -59,7 +59,7 @@ object GenCastError {
       INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
       INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
       INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-      INVOKESPECIAL(ClassConstants.FlixError.Constructor)
+      INVOKESPECIAL(GenFlixError.Constructor)
       RETURN()
     }))
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFlixError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenFlixError.scala
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2025 Jonathan Lindegaard Starup
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm.classes
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.ConstructorMethod
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.IsPublic
+import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
+import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
+import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.mkVoidDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.{ClassMaker, JavaClasses, Mangle}
+import org.objectweb.asm.MethodVisitor
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The abstract `FlixError` class, which the generated `HoleError`, `MatchError`, `CastError`,
+  * and `UnhandledEffectError` classes extend.
+  */
+object GenFlixError {
+
+  /** The JVM class descriptor for the generated `FlixError` class. */
+  val Desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("FlixError"))
+
+  val Constructor: ConstructorMethod = ConstructorMethod(Desc, List(JavaClasses.String))
+
+  def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkAbstractClass(Desc, JavaClasses.Error)
+    cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
+    cm.closeClassMaker()
+  }
+
+  private def constructorIns(implicit mv: MethodVisitor): Unit = {
+    thisLoad()
+    ALOAD(1)
+    invokeConstructor(JavaClasses.Error, mkVoidDescriptor(JavaClasses.String))
+    RETURN()
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenHoleError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenHoleError.scala
@@ -37,7 +37,7 @@ object GenHoleError {
   val Desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("HoleError"))
 
   def genByteCode()(implicit flix: Flix): Array[Byte] = {
-    val cm = ClassMaker.mkClass(this.Desc, IsFinal, ClassConstants.FlixError.Desc)
+    val cm = ClassMaker.mkClass(this.Desc, IsFinal, GenFlixError.Desc)
 
     cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
     // These fields allow external equality checking.
@@ -71,7 +71,7 @@ object GenHoleError {
         INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
         INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
         INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-        INVOKESPECIAL(ClassConstants.FlixError.Constructor)
+        INVOKESPECIAL(GenFlixError.Constructor)
         // save the arguments locally
         thisLoad()
         hole.load()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenMatchError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenMatchError.scala
@@ -37,7 +37,7 @@ object GenMatchError {
   val Desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("MatchError"))
 
   def genByteCode()(implicit flix: Flix): Array[Byte] = {
-    val cm = ClassMaker.mkClass(this.Desc, IsFinal, superClass = ClassConstants.FlixError.Desc)
+    val cm = ClassMaker.mkClass(this.Desc, IsFinal, superClass = GenFlixError.Desc)
 
     cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
     // This field allows external equality checking.
@@ -61,7 +61,7 @@ object GenMatchError {
     INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
     INVOKEVIRTUAL(ClassConstants.StringBuilder.AppendStringMethod)
     INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-    INVOKESPECIAL(ClassConstants.FlixError.Constructor)
+    INVOKESPECIAL(GenFlixError.Constructor)
     // save argument locally
     thisLoad()
     ALOAD(1)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnhandledEffectError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenUnhandledEffectError.scala
@@ -38,7 +38,7 @@ object GenUnhandledEffectError {
   val Desc: ClassDesc = mkDesc(DevFlixRuntime, Mangle.mkClassName("UnhandledEffectError"))
 
   def genByteCode()(implicit flix: Flix): Array[Byte] = {
-    val cm = ClassMaker.mkClass(this.Desc, IsFinal, superClass = ClassConstants.FlixError.Desc)
+    val cm = ClassMaker.mkClass(this.Desc, IsFinal, superClass = GenFlixError.Desc)
 
     cm.mkConstructor(Constructor, IsPublic, constructorIns(_))
     // This field allows external equality checking.
@@ -78,7 +78,7 @@ object GenUnhandledEffectError {
       INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
       appendString()
       INVOKEVIRTUAL(ClassConstants.Object.ToStringMethod)
-      INVOKESPECIAL(ClassConstants.FlixError.Constructor)
+      INVOKESPECIAL(GenFlixError.Constructor)
       // save arguments locally
       thisLoad()
       suspension.load()


### PR DESCRIPTION
The generated `FlixError` class lived inside `ClassConstants`, next to the well-known members of JDK classes, and was the only entry there that generates bytecode. It now has its own generator in `classes/GenFlixError`, matching the four error classes that extend it (`HoleError`, `MatchError`, `CastError`, `UnhandledEffectError`).

`ClassConstants` keeps only JDK member references and gains a one-line doc saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGqoj6qH3MTP4rgPuvQnD1
