### PR TITLE
perf: compute Java class metadata outside the cache lock

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -108,15 +108,34 @@ final case class ByteBuddyJavaTypeProvider(
 
   /** Returns `Ok` with metadata for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
   override def lookupClass(desc: ClassDesc): Result[JavaClass, JavaLookupError] =
-    classCache.computeIfAbsent(desc, d => lookupClassDirect(d))
+    cached(classCache, desc)(lookupClassDirect)
 
   /** Returns `Ok` with the virtual method graph for `desc`, or `Err` if the descriptor is unsupported, missing, or invalid. */
   override def virtualMethods(desc: ClassDesc): Result[List[JavaMethod], JavaLookupError] =
-    virtualMethodsCache.computeIfAbsent(desc, d => virtualMethodsDirect(d))
+    cached(virtualMethodsCache, desc)(virtualMethodsDirect)
 
   /** Returns `Ok` with the subtype result, or `Err` if either descriptor is unsupported, missing, or invalid. */
   override def isSubtype(subtype: ClassDesc, supertype: ClassDesc): Result[Boolean, JavaLookupError] =
-    subtypeCache.computeIfAbsent((subtype, supertype), key => isSubtypeDirect(key._1, key._2))
+    cached(subtypeCache, (subtype, supertype))(key => isSubtypeDirect(key._1, key._2))
+
+  /**
+    * Returns the value cached for `key`, computing it with `compute` and caching it on a miss.
+    *
+    * The computation deliberately runs outside the lock of the map. A miss parses a class file or compiles a
+    * method graph, and `computeIfAbsent` would hold the lock of the hash bin for that duration, blocking every
+    * other thread that needs the same or a colliding key. Two threads may therefore compute the same value
+    * concurrently; the first value stored wins and the values are immutable, so the duplicate work is harmless.
+    */
+  private def cached[K, V <: AnyRef](cache: ConcurrentHashMap[K, V], key: K)(compute: K => V): V = {
+    val hit = cache.get(key)
+    if (hit != null) {
+      hit
+    } else {
+      val computed = compute(key)
+      val prior = cache.putIfAbsent(key, computed)
+      if (prior != null) prior else computed
+    }
+  }
 
   /** Closes the underlying class-file locator and its owned resources. */
   override def close(): Unit = locator.close()


### PR DESCRIPTION
Replaces `computeIfAbsent` in the three caches of `ByteBuddyJavaTypeProvider` with a get-then-put helper. A cache miss parses a class file or compiles a virtual method graph (65 to 600 µs), and `computeIfAbsent` held the lock of the hash bin for that duration, blocking every other thread that needed the same or a colliding key. The values are immutable, so two threads may compute the same value concurrently and the first value stored wins.

Motivation: with `--par`, every typer thread starts by resolving the same core classes on a cold provider. Instrumentation showed method-resolution thread time tripling under 10 threads compared to a warm provider, with the virtual-method cache accounting for most of the blocked time.

Measurements so far are mixed. `Xperf --frontend --par --n 20` showed the Typer phase at 402/419 ms with this change versus 449/463 ms without, in two alternating rounds. A driver-based A/B with 20 iterations per variant showed no difference. Treat the gain as unconfirmed until re-measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvaX7cU1y5ij2MaE4DLAHe