### PR TITLE
refactor: carry the interface flag on Java method references

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/jvm/JavaMethodRef.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/jvm/JavaMethodRef.scala
@@ -17,5 +17,9 @@ package ca.uwaterloo.flix.language.ast.jvm
 
 import java.lang.constant.{ClassDesc, MethodTypeDesc}
 
-/** A nominal, descriptor-based reference to a Java method or constructor. */
-case class JavaMethodRef(owner: ClassDesc, name: String, descriptor: MethodTypeDesc)
+/**
+  * A nominal, descriptor-based reference to a Java method or constructor.
+  *
+  * `isInterface` holds whether `owner` is an interface; the JVM distinguishes interface method references.
+  */
+case class JavaMethodRef(owner: ClassDesc, name: String, descriptor: MethodTypeDesc, isInterface: Boolean)

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/JMethod.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/JMethod.scala
@@ -21,9 +21,9 @@ import java.lang.constant.{ClassDesc, MethodTypeDesc}
 
 object JMethod {
 
-  /** Returns the [[JMethod]] of the given class-file method metadata, whose owner is an interface iff `isInterface`. */
-  def of(method: JavaMethod, isInterface: Boolean): JMethod =
-    JMethod(method.ref.owner, method.ref.name, method.ref.descriptor, isInterface)
+  /** Returns the [[JMethod]] of the given class-file method metadata. */
+  def of(method: JavaMethod): JMethod =
+    JMethod(method.ref.owner, method.ref.name, method.ref.descriptor, method.ref.isInterface)
 
 }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -518,7 +518,7 @@ object Lowering {
       val javaReturnType = method.ref.descriptor.returnType()
       val needsUnbox = JavaBoxing.isPrimitive(t) && !javaReturnType.isPrimitive
       val invokeType = if (needsUnbox) JavaBoxing.boxedType(t, loc) else t
-      val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeMethod(mkJMethod(method, loc)), e :: boxedArgs, invokeType, eff, loc)
+      val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeMethod(JMethod.of(method)), e :: boxedArgs, invokeType, eff, loc)
       unboxIfNecessary(invoke, t, javaReturnType)
 
     case TypedAst.Expr.InvokeSuperMethod(method, exps, tpe, eff, loc) =>
@@ -526,7 +526,7 @@ object Lowering {
       val t = lowerType(tpe)
       (lctx.sym, lctx.thisRef) match {
         case (Some(sym), Some(thisRef)) =>
-          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(sym, mkJMethod(method, loc)), thisRef :: es, t, eff, loc)
+          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(sym, JMethod.of(method)), thisRef :: es, t, eff, loc)
         case _ =>
           throw InternalCompilerException("InvokeSuperMethod outside NewObject context", loc)
       }
@@ -540,7 +540,7 @@ object Lowering {
       val javaReturnType = method.ref.descriptor.returnType()
       val needsUnbox = JavaBoxing.isPrimitive(t) && !javaReturnType.isPrimitive
       val invokeType = if (needsUnbox) JavaBoxing.boxedType(t, loc) else t
-      val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeStaticMethod(mkJMethod(method, loc)), boxedArgs, invokeType, eff, loc)
+      val invoke = MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeStaticMethod(JMethod.of(method)), boxedArgs, invokeType, eff, loc)
       unboxIfNecessary(invoke, t, javaReturnType)
 
     case TypedAst.Expr.GetField(field, exp, tpe, eff, loc) =>
@@ -687,7 +687,7 @@ object Lowering {
         case Some(m) => boxIfNecessary(e0, m.ref.descriptor.returnType())
         case None => e0
       }
-      MonoAst.JvmMethod(ann, ident, fs, e, e.tpe, eff, overridden.map(mkJMethod(_, loc)), loc)
+      MonoAst.JvmMethod(ann, ident, fs, e, e.tpe, eff, overridden.map(JMethod.of), loc)
   }
 
   /**
@@ -1014,20 +1014,6 @@ object Lowering {
     case Type.JvmToType(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
     case Type.JvmToEff(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
     case Type.UnresolvedJvmType(_, _) => throw InternalCompilerException(s"Unexpected type '$tpe'", tpe.loc)
-  }
-
-  /**
-    * Returns the [[JMethod]] of `method`.
-    *
-    * Whether the owner of `method` is an interface is read from its class metadata,
-    * since the JVM distinguishes interface method invocations.
-    */
-  private def mkJMethod(method: JavaMethod, loc: SourceLocation)(implicit flix: Flix): JMethod = {
-    val owner = method.ref.owner
-    flix.javaTypeProvider.lookupClass(owner) match {
-      case Result.Ok(clazz) => JMethod.of(method, isInterface = clazz.isInterface)
-      case Result.Err(error) => throw InternalCompilerException(s"Java class lookup failed for '${ClassDescs.binaryNameOf(owner)}': $error", loc)
-    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -514,14 +514,14 @@ private[monomorph2] object SpecializeAndLower {
       val e = visitExp(exp, env0, subst)
       val es = exps.map(visitExp(_, env0, subst))
       val t = visitType(tpe, subst)
-      mkJavaInvoke(method, List(e), es, t, subst(eff), loc, m => AtomicOp.InvokeMethod(mkJMethod(m, loc)))
+      mkJavaInvoke(method, List(e), es, t, subst(eff), loc, m => AtomicOp.InvokeMethod(JMethod.of(m)))
 
     case TypedAst.Expr.InvokeSuperMethod(method, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp(_, env0, subst))
       val t = visitType(tpe, subst)
       (lctx.sym, lctx.thisRef) match {
         case (Some(sym), Some(thisRef)) =>
-          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(sym, mkJMethod(method, loc)), thisRef :: es, t, subst(eff), loc)
+          MonoAst.Expr.ApplyAtomic(AtomicOp.InvokeSuperMethod(sym, JMethod.of(method)), thisRef :: es, t, subst(eff), loc)
 
         case _ =>
           throw InternalCompilerException("InvokeSuperMethod outside NewObject context", loc)
@@ -530,7 +530,7 @@ private[monomorph2] object SpecializeAndLower {
     case TypedAst.Expr.InvokeStaticMethod(method, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp(_, env0, subst))
       val t = visitType(tpe, subst)
-      mkJavaInvoke(method, Nil, es, t, subst(eff), loc, m => AtomicOp.InvokeStaticMethod(mkJMethod(m, loc)))
+      mkJavaInvoke(method, Nil, es, t, subst(eff), loc, m => AtomicOp.InvokeStaticMethod(JMethod.of(m)))
 
     case TypedAst.Expr.GetField(field, exp, tpe, eff, loc) =>
       val e = visitExp(exp, env0, subst)
@@ -579,7 +579,7 @@ private[monomorph2] object SpecializeAndLower {
             case Some(m) => boxIfNecessary(e0, m.ref.descriptor.returnType())
             case None => e0
           }
-          MonoAst.JvmMethod(mAnn, mIdent, fs, e, e.tpe, subst(mEff), overridden.map(mkJMethod(_, mLoc)), mLoc)
+          MonoAst.JvmMethod(mAnn, mIdent, fs, e, e.tpe, subst(mEff), overridden.map(JMethod.of), mLoc)
       }
       val t = visitType(tpe, subst)
       MonoAst.Expr.NewObject(freshSym, clazz, t, subst(eff), cs, ms, loc)
@@ -1108,20 +1108,6 @@ private[monomorph2] object SpecializeAndLower {
     case Type.Cst(TypeConstructor.Float32, _) => "JvmFloat32"
     case Type.Cst(TypeConstructor.Float64, _) => "JvmFloat64"
     case _                                    => "JvmObject"
-  }
-
-  /**
-    * Returns the [[JMethod]] of `method`.
-    *
-    * Whether the owner of `method` is an interface is read from its class metadata,
-    * since the JVM distinguishes interface method invocations.
-    */
-  private def mkJMethod(method: JavaMethod, loc: SourceLocation)(implicit flix: Flix): JMethod = {
-    val owner = method.ref.owner
-    flix.javaTypeProvider.lookupClass(owner) match {
-      case Result.Ok(clazz) => JMethod.of(method, isInterface = clazz.isInterface)
-      case Result.Err(error) => throw InternalCompilerException(s"Java class lookup failed for '${ClassDescs.binaryNameOf(owner)}': $error", loc)
-    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/ByteBuddyJavaTypeProvider.scala
@@ -215,10 +215,12 @@ final case class ByteBuddyJavaTypeProvider(
   /** Converts a Byte Buddy method description to its nominal class-file reference. */
   private def toMethodRef(method: MethodDescription): JavaMethodRef = {
     val defined = method.asDefined()
+    val owner = defined.getDeclaringType
     JavaMethodRef(
-      owner = toClassDesc(defined.getDeclaringType.asErasure()),
+      owner = toClassDesc(owner.asErasure()),
       name = defined.getInternalName,
-      descriptor = MethodTypeDesc.ofDescriptor(defined.getDescriptor)
+      descriptor = MethodTypeDesc.ofDescriptor(defined.getDescriptor),
+      isInterface = owner.isInterface
     )
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -215,4 +215,29 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
     } finally provider.close()
   }
 
+  test("lookupClass.MethodRef.IsInterface") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
+      def sizeIsInterface(desc: ClassDesc) =
+        provider.lookupClass(desc).map(_.declaredMethods.find(_.ref.name == "size").map(_.ref.isInterface))
+
+      assert(sizeIsInterface(ClassDesc.of("java.util.List")) == Ok(Some(true)))
+      assert(sizeIsInterface(ClassDesc.of("java.util.ArrayList")) == Ok(Some(false)))
+    } finally provider.close()
+  }
+
+  test("virtualMethods.MethodRef.IsInterfaceOfDeclaringType") {
+    val provider = ByteBuddyJavaTypeProvider.platform()
+    try {
+      // `ArrayList` inherits the default method `stream` from the interface `Collection`.
+      provider.virtualMethods(ClassDesc.of("java.util.ArrayList")) match {
+        case Ok(methods) =>
+          val stream = methods.find(m => m.ref.name == "stream" && m.ref.descriptor.parameterCount() == 0)
+          assert(stream.map(_.ref.owner) == Some(ClassDesc.of("java.util.Collection")))
+          assert(stream.map(_.ref.isInterface) == Some(true))
+        case Err(error) => fail(error.toString)
+      }
+    } finally provider.close()
+  }
+
 }


### PR DESCRIPTION
The JVM distinguishes interface method references, so the lowerings need to know whether the owner of a resolved method is an interface. Both lowering phases used to look the owner class up again just to read that flag.

The class-file provider already knows the declaring type when it converts a method, so `JavaMethodRef` now carries `isInterface`, `JMethod.of` reads it from the reference, and the duplicated lookup helper is gone from both `Lowering` and `SpecializeAndLower`.

Two provider tests cover the flag: declared methods of an interface versus a class, and a default method inherited by a class still reporting its interface owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGqoj6qH3MTP4rgPuvQnD1
