### PR TITLE
feat: add native-image CI smoke test

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -46,8 +46,3 @@ jobs:
           ../out/flix-native check
           ../out/flix-native build-fatjar
           java -jar artifact/hello.jar | grep -q 'Hello World!'
-      - name: Upload native image
-        uses: actions/upload-artifact@v4
-        with:
-          name: flix-native-${{ runner.os }}
-          path: out/flix-native

--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   build-native-image-and-smoke-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Check out master
@@ -36,10 +37,9 @@ jobs:
         run: ./mill flix.assembly
       - name: Build native image
         # The native-image configuration ships inside the JAR under META-INF/native-image/dev.flix/flix.
-        timeout-minutes: 20
-        run: native-image -jar out/flix/assembly.dest/out.jar -o out/flix-native
+        # -Ob selects the quick build mode, which roughly halves build time at the cost of run-time performance.
+        run: native-image -Ob -jar out/flix/assembly.dest/out.jar -o out/flix-native
       - name: Smoke test on a hello world project
-        timeout-minutes: 5
         run: |
           mkdir hello && cd hello
           ../out/flix-native init

--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -1,0 +1,53 @@
+name: Native Image
+
+on: [ pull_request, merge_group ]
+
+permissions:
+  contents: read
+
+# Cancel previous runs if the PR is updated
+concurrency:
+  cancel-in-progress: true
+  group: native-image-${{ github.ref }}
+
+jobs:
+  build-native-image-and-smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out master
+        uses: actions/checkout@v5
+      - name: Install GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          distribution: 'graalvm-community'
+          java-version: '25'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache Mill and Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.cache/mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('build.mill', '.mill-version') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
+      - name: Build fat JAR
+        run: ./mill flix.assembly
+      - name: Build native image
+        # The native-image configuration ships inside the JAR under META-INF/native-image/dev.flix/flix.
+        timeout-minutes: 20
+        run: native-image -jar out/flix/assembly.dest/out.jar -o out/flix-native
+      - name: Smoke test on a hello world project
+        timeout-minutes: 5
+        run: |
+          mkdir hello && cd hello
+          ../out/flix-native init
+          ../out/flix-native check
+          ../out/flix-native build-fatjar
+          java -jar artifact/hello.jar | grep -q 'Hello World!'
+      - name: Upload native image
+        uses: actions/upload-artifact@v4
+        with:
+          name: flix-native-${{ runner.os }}
+          path: out/flix-native

--- a/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
+++ b/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
@@ -3,6 +3,10 @@
 # native-image discovers this file automatically when the Flix JAR is on its class path,
 # so `native-image -jar flix.jar` needs no additional flags.
 #
+# The accompanying reachability-metadata.json lists the resources read through LocalResource
+# (standard library, ClassList.txt, primitive effect tables, documentation assets) and the
+# reflection Byte Buddy needs to resolve the JVM version.
+#
 # --no-fallback
 #   Fail the build instead of silently producing a JVM-backed fallback image.
 #

--- a/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
+++ b/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
@@ -1,0 +1,23 @@
+# GraalVM native-image configuration for the Flix compiler.
+#
+# native-image discovers this file automatically when the Flix JAR is on its class path,
+# so `native-image -jar flix.jar` needs no additional flags.
+#
+# --no-fallback
+#   Fail the build instead of silently producing a JVM-backed fallback image.
+#
+# --initialize-at-build-time=net.bytebuddy
+#   Byte Buddy resolves the class-file version of the running VM in a static initializer,
+#   which fails inside a native image. Initializing it at build time avoids the probe.
+#
+# -H:IncludeResources=...
+#   The type checker reads JDK class files through ByteBuddyJavaTypeProvider using
+#   ClassLoader.getResourceAsStream. Inside a native image no class loader can serve JDK
+#   class files, so they are bundled as resources. The dev/flix entry covers the
+#   dev.flix.runtime.Global mock class that ExternalJarLoader serves as a system resource.
+#   The option is experimental, hence the surrounding unlock/lock pair.
+Args = --no-fallback \
+       --initialize-at-build-time=net.bytebuddy \
+       -H:+UnlockExperimentalVMOptions \
+       -H:IncludeResources=(java|javax|jdk|sun|com/sun|org/w3c|org/xml|dev/flix)/.*\\.class \
+       -H:-UnlockExperimentalVMOptions

--- a/main/src/resources/META-INF/native-image/dev.flix/flix/reachability-metadata.json
+++ b/main/src/resources/META-INF/native-image/dev.flix/flix/reachability-metadata.json
@@ -1,5 +1,4 @@
 {
-  "comment": "Resources read via LocalResource (standard library, ClassList.txt, primitive effect tables, documentation assets) and the reflection Byte Buddy needs to resolve the JVM version.",
   "resources": [
     { "glob": "src/**" },
     { "glob": "doc/**" },

--- a/main/src/resources/META-INF/native-image/dev.flix/flix/reachability-metadata.json
+++ b/main/src/resources/META-INF/native-image/dev.flix/flix/reachability-metadata.json
@@ -1,0 +1,12 @@
+{
+  "comment": "Resources read via LocalResource (standard library, ClassList.txt, primitive effect tables, documentation assets) and the reflection Byte Buddy needs to resolve the JVM version.",
+  "resources": [
+    { "glob": "src/**" },
+    { "glob": "doc/**" },
+    { "glob": "benchmark/**" }
+  ],
+  "reflection": [
+    { "type": "java.lang.Runtime", "allDeclaredMethods": true },
+    { "type": "java.lang.Runtime$Version", "allDeclaredMethods": true }
+  ]
+}


### PR DESCRIPTION
Adds a CI job that builds the Flix compiler into a GraalVM native image and runs it on a hello world project.

## What is added

- `.github/workflows/native-image.yaml`: installs GraalVM CE 25, builds the fat JAR with Mill, runs `native-image -jar` on it, then in a fresh directory runs `flix init`, `flix check`, `flix build-fatjar`, and executes the produced JAR with `java -jar`, asserting it prints `Hello World!`.
- `META-INF/native-image/dev.flix/flix/native-image.properties` and `reachability-metadata.json` under `main/src/resources`: native-image picks these up from the JAR automatically, so no flags are needed on the command line. They
  - bundle the resources read through `LocalResource` (standard library, `ClassList.txt`, primitive effect tables, doc assets),
  - initialize Byte Buddy at image build time, since its JVM-version probe fails inside an image, and
  - include the JDK class files as resources, because `ByteBuddyJavaTypeProvider` reads class bytes via `getResourceAsStream` and no class loader can serve JDK class files inside an image.

## Scope and known limitations

- Only compile-only commands work in the image: `check`, `build`, `build-classes`, `build-jar`, `build-fatjar`, `doc`. The `run`, `test`, and `repl` commands load generated bytecode in-process through `FlixClassLoader.defineClass`, which native-image refuses. See follow-up 2 below.
- `lsp` needs lsp4j proxy and reflection metadata that is not part of this PR.
- The image is around 260 MB, of which roughly 200 MB is the bundled JDK class files. Reading them from a JDK on disk at run time instead would shrink the image but requires a code change in the type provider.
- `-H:IncludeResources` is an experimental native-image option and is wrapped in an unlock/lock pair in the properties file.
- The workflow runs on every pull request like the other checks. If the added minutes are unwelcome it can be moved to `merge_group` or a nightly schedule.

## Follow-ups

1. Experiment with Mill's built-in `NativeImageModule` so `./mill flix.nativeImage` replaces the raw `native-image -jar` call.
2. Detect the native image via the `org.graalvm.nativeimage.imagecode` system property and print a helpful message for `run`, `test`, `repl`, and the other commands that load generated bytecode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLYNr3zsG9cgR6jsvB9gzb
