### PR TITLE
refactor: extract Java subtyping into JavaHierarchy

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaHierarchy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaHierarchy.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.typer.jvm
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
+import ca.uwaterloo.flix.util.Result
+import ca.uwaterloo.flix.util.Result.Ok
+
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.CD_Object
+
+/**
+  * Subtyping of Java types, read from the class-file metadata of the Java type provider.
+  */
+object JavaHierarchy {
+
+  /**
+    * Returns `Ok(true)` if the Java type `sub` is a subtype of the Java type `sup`, `Ok(false)` if it
+    * is not, or `Err` if the nominal hierarchy metadata cannot be read.
+    *
+    * A primitive type is only a subtype of itself. Arrays follow the rules of Java: every array is a
+    * subtype of `Object`, `Cloneable`, and `Serializable`, reference components are covariant, and
+    * primitive components must be identical. Nominal reference types are delegated to the
+    * [[JavaTypeProvider]] since array descriptors have no class-file metadata of their own.
+    *
+    *   - `String` is a subtype of `CharSequence`.
+    *   - `String[]` is a subtype of `Object`, `Cloneable`, `Serializable`, and `Object[]`.
+    *   - `int[]` is not a subtype of `long[]` because primitive array components must be identical.
+    */
+  def isSubtype(sub: ClassDesc, sup: ClassDesc)(implicit flix: Flix): Result[Boolean, JavaLookupError] = {
+    if (sub == sup) {
+      // Every type is a subtype of itself.
+      Ok(true)
+    } else if (sub.isPrimitive || sup.isPrimitive) {
+      // A primitive type is only a subtype of itself.
+      Ok(false)
+    } else if (sub.isArray) {
+      // Arrays have descriptor-defined supertypes and covariant reference components.
+      if (sup == CD_Object || sup == JavaClasses.Cloneable || sup == JavaClasses.Serializable) {
+        Ok(true)
+      } else if (sup.isArray) {
+        isSubtype(sub.componentType(), sup.componentType())
+      } else {
+        Ok(false)
+      }
+    } else if (sup.isArray) {
+      // A non-array reference type is never a subtype of an array type.
+      Ok(false)
+    } else {
+      // All remaining cases are nominal reference relationships read from class-file metadata.
+      flix.javaTypeProvider.isSubtype(sub, sup)
+    }
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaMemberResolver.scala
@@ -17,7 +17,6 @@ package ca.uwaterloo.flix.language.phase.typer.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod}
-import ca.uwaterloo.flix.language.phase.jvm.JavaClasses
 import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.Ok
 
@@ -515,53 +514,14 @@ object JavaMemberResolver {
       if (parameter.isPrimitive) Ok(isWideningPrimitive(source, parameter))
       else boxed(source) match {
         case None => Ok(false)
-        case Some(boxedSource) => isReferenceSubtype(boxedSource, parameter)
+        case Some(boxedSource) => JavaHierarchy.isSubtype(boxedSource, parameter)
       }
     case Typed(source) if parameter.isPrimitive =>
       unboxed(source) match {
         case None => Ok(false)
         case Some(unboxedSource) => Ok(unboxedSource == parameter || isWideningPrimitive(unboxedSource, parameter))
       }
-    case Typed(source) => isReferenceSubtype(source, parameter)
-  }
-
-  /**
-    * Tests reference subtyping, including Java's special array subtype rules.
-    *
-    * Nominal reference types are delegated to the configured `JavaTypeProvider`; array relationships are computed
-    * directly because array descriptors do not have class-file metadata of their own.
-    *
-    *   - `String` is a subtype of `CharSequence`.
-    *   - `String[]` is a subtype of `Object`, `Cloneable`, `Serializable`, and `Object[]`.
-    *   - `int[]` is not a subtype of `long[]` because primitive array components must be identical.
-    *
-    * Returns `Ok(true)` for a subtype, `Ok(false)` otherwise, or `Err` if nominal hierarchy metadata is missing.
-    */
-  def isReferenceSubtype(source: ClassDesc, target: ClassDesc)(implicit flix: Flix): Result[Boolean, JavaLookupError] = {
-    if (source == target) {
-      // Every reference type is a subtype of itself.
-      Ok(true)
-    } else if (source.isArray) {
-      // Arrays have descriptor-defined supertypes and covariant reference components.
-      if (target == CD_Object || target == JavaClasses.Cloneable || target == JavaClasses.Serializable) {
-        Ok(true)
-      } else if (target.isArray) {
-        (componentType(source), componentType(target)) match {
-          case (Some(sourceComponent), Some(targetComponent)) if sourceComponent.isPrimitive || targetComponent.isPrimitive =>
-            Ok(sourceComponent == targetComponent)
-          case (Some(sourceComponent), Some(targetComponent)) => isReferenceSubtype(sourceComponent, targetComponent)
-          case _ => Ok(false)
-        }
-      } else {
-        Ok(false)
-      }
-    } else if (target.isArray) {
-      // A non-array reference type is never a subtype of an array type.
-      Ok(false)
-    } else {
-      // All remaining cases are nominal reference relationships read from class-file metadata.
-      flix.javaTypeProvider.isSubtype(source, target)
-    }
+    case Typed(source) => JavaHierarchy.isSubtype(source, parameter)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
@@ -158,19 +158,13 @@ object JavaTypes {
     * Returns `true` if the Java type `sub` is a subtype of the Java type `sup`, or throws an
     * [[InternalCompilerException]] if their metadata cannot be read.
     *
-    * A primitive type is only a subtype of itself. Reference types, including arrays, are checked
-    * against the class-file metadata of the Java type provider.
+    * See [[JavaHierarchy.isSubtype]] for the subtyping rules.
     */
-  def isSubtype(sub: ClassDesc, sup: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean = {
-    if (sub.isPrimitive || sup.isPrimitive) {
-      sub == sup
-    } else {
-      JavaMemberResolver.isReferenceSubtype(sub, sup) match {
-        case Ok(result) => result
-        case Err(error) => throw InternalCompilerException(s"Java subtype check failed for '${ClassDescs.binaryNameOf(sub)} <: ${ClassDescs.binaryNameOf(sup)}': $error", loc)
-      }
+  def isSubtype(sub: ClassDesc, sup: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
+    JavaHierarchy.isSubtype(sub, sup) match {
+      case Ok(result) => result
+      case Err(error) => throw InternalCompilerException(s"Java subtype check failed for '${ClassDescs.binaryNameOf(sub)} <: ${ClassDescs.binaryNameOf(sup)}': $error", loc)
     }
-  }
 
   /** Returns `true` if `desc` is `java.lang.Throwable` or a subclass of it. */
   def isThrowable(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaHierarchy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaHierarchy.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.typer.jvm
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.typer.jvm.JavaLookupError.MissingClass
+import ca.uwaterloo.flix.util.Result.{Err, Ok}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.*
+
+class TestJavaHierarchy extends AnyFunSuite {
+
+  test("isSubtype.ReferenceTypes") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaHierarchy.isSubtype(CD_String, CD_Object) == Ok(true))
+      assert(JavaHierarchy.isSubtype(CD_String, ClassDesc.of("java.lang.CharSequence")) == Ok(true))
+      assert(JavaHierarchy.isSubtype(CD_Object, CD_String) == Ok(false))
+      assert(JavaHierarchy.isSubtype(CD_String, CD_Integer) == Ok(false))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("isSubtype.PrimitiveTypes") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaHierarchy.isSubtype(CD_int, CD_int) == Ok(true))
+      assert(JavaHierarchy.isSubtype(CD_int, CD_long) == Ok(false))
+      assert(JavaHierarchy.isSubtype(CD_int, CD_Object) == Ok(false))
+      assert(JavaHierarchy.isSubtype(CD_Integer, CD_int) == Ok(false))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("isSubtype.ArrayTypes") {
+    implicit val flix: Flix = new Flix
+    try {
+      val cloneable = ClassDesc.of("java.lang.Cloneable")
+      val serializable = ClassDesc.of("java.io.Serializable")
+      assert(JavaHierarchy.isSubtype(CD_String.arrayType(), CD_Object) == Ok(true))
+      assert(JavaHierarchy.isSubtype(CD_String.arrayType(), cloneable) == Ok(true))
+      assert(JavaHierarchy.isSubtype(CD_String.arrayType(), serializable) == Ok(true))
+      assert(JavaHierarchy.isSubtype(CD_String.arrayType(), CD_Object.arrayType()) == Ok(true))
+      assert(JavaHierarchy.isSubtype(CD_int.arrayType(), CD_Object) == Ok(true))
+      assert(JavaHierarchy.isSubtype(CD_int.arrayType(), CD_int.arrayType()) == Ok(true))
+      assert(JavaHierarchy.isSubtype(CD_int.arrayType(), CD_long.arrayType()) == Ok(false))
+      assert(JavaHierarchy.isSubtype(CD_int.arrayType(), CD_Object.arrayType()) == Ok(false))
+      assert(JavaHierarchy.isSubtype(CD_Object.arrayType(), CD_String.arrayType()) == Ok(false))
+      assert(JavaHierarchy.isSubtype(CD_Object, CD_Object.arrayType()) == Ok(false))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("isSubtype.ReportsMissingClass") {
+    implicit val flix: Flix = new Flix
+    try {
+      val missing = ClassDesc.of("java.lang.DoesNotExist")
+      assert(JavaHierarchy.isSubtype(missing, CD_Object) == Err(MissingClass(missing)))
+    } finally flix.javaTypeProvider.close()
+  }
+
+}

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
@@ -28,28 +28,6 @@ class TestJavaTypes extends AnyFunSuite {
 
   private val loc = SourceLocation.Unknown
 
-  test("isSubtype.ReferenceTypes") {
-    implicit val flix: Flix = new Flix
-    try {
-      assert(JavaTypes.isSubtype(CD_String, CD_Object, loc))
-      assert(JavaTypes.isSubtype(CD_String, ClassDesc.of("java.lang.CharSequence"), loc))
-      assert(!JavaTypes.isSubtype(CD_Object, CD_String, loc))
-      assert(!JavaTypes.isSubtype(CD_String, CD_Integer, loc))
-    } finally flix.javaTypeProvider.close()
-  }
-
-  test("isSubtype.PrimitiveAndArrayTypes") {
-    implicit val flix: Flix = new Flix
-    try {
-      assert(JavaTypes.isSubtype(CD_int, CD_int, loc))
-      assert(!JavaTypes.isSubtype(CD_int, CD_long, loc))
-      assert(!JavaTypes.isSubtype(CD_int, CD_Object, loc))
-      assert(JavaTypes.isSubtype(CD_String.arrayType(), CD_Object, loc))
-      assert(JavaTypes.isSubtype(CD_String.arrayType(), CD_Object.arrayType(), loc))
-      assert(!JavaTypes.isSubtype(CD_int.arrayType(), CD_long.arrayType(), loc))
-    } finally flix.javaTypeProvider.close()
-  }
-
   test("isThrowable") {
     implicit val flix: Flix = new Flix
     try {


### PR DESCRIPTION
Whether `String[]` is a `Cloneable` is a hierarchy question, not an overload resolution question, yet the array-aware subtype check lived in `JavaMemberResolver` and was public only so that `JavaTypes.isSubtype` could wrap it.

`JavaHierarchy.isSubtype` now owns the check, covering primitives, arrays, and nominal reference types in one Result-returning function. The resolver and the throwing `JavaTypes.isSubtype` wrapper both call it; `JavaTypes` keeps only the error-to-exception adaptation. The primitive handling that used to be split between the two callers is folded into the recursion, so `int[] <: long[]` falls out of the same rule as `int <: long`.

The subtyping tests move to `TestJavaHierarchy` and gain the `Cloneable`/`Serializable`, primitive-array, and missing-class cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGqoj6qH3MTP4rgPuvQnD1
