### PR TITLE
refactor: split the throwing Java lookups out of JavaTypes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/jvm/JavaMetadata.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/JavaMetadata.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.jvm
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.SourceLocation
+import ca.uwaterloo.flix.language.ast.jvm.{JavaClass, JavaMethod}
+import ca.uwaterloo.flix.util.InternalCompilerException
+import ca.uwaterloo.flix.util.Result.{Err, Ok}
+
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.{CD_Object, CD_Throwable}
+
+/**
+  * Java class-file metadata queries for the phases that run after the Resolver.
+  *
+  * The Resolver reports a class whose metadata cannot be read as a compilation error, so a class that
+  * reaches a later phase has already been read once. A failure here is therefore a compiler bug, and
+  * every query throws an [[InternalCompilerException]] at the given location instead of returning a
+  * `Result`.
+  */
+object JavaMetadata {
+
+  /** Returns the class metadata of `desc`. */
+  def lookupClass(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): JavaClass =
+    flix.javaTypeProvider.lookupClass(desc) match {
+      case Ok(clazz) => clazz
+      case Err(error) => throw InternalCompilerException(s"Java class lookup failed for '${ClassDescs.binaryNameOf(desc)}': $error", loc)
+    }
+
+  /**
+    * Returns `true` if the Java type `sub` is a subtype of the Java type `sup`.
+    *
+    * See [[JavaHierarchy.isSubtype]] for the subtyping rules.
+    */
+  def isSubtype(sub: ClassDesc, sup: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
+    JavaHierarchy.isSubtype(sub, sup) match {
+      case Ok(result) => result
+      case Err(error) => throw InternalCompilerException(s"Java subtype check failed for '${ClassDescs.binaryNameOf(sub)} <: ${ClassDescs.binaryNameOf(sup)}': $error", loc)
+    }
+
+  /** Returns `true` if `desc` is `java.lang.Throwable` or a subclass of it. */
+  def isThrowable(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
+    isSubtype(desc, CD_Throwable, loc)
+
+  /**
+    * Returns the methods of `desc` that an anonymous subclass may override.
+    *
+    * See [[JavaMemberResolver.overridableMethods]] for which methods qualify.
+    */
+  def overridableMethods(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): List[JavaMethod] =
+    JavaMemberResolver.overridableMethods(desc) match {
+      case Ok(methods) => methods
+      case Err(error) => throw InternalCompilerException(s"Java method lookup failed for '${ClassDescs.binaryNameOf(desc)}': $error", loc)
+    }
+
+  /** Returns `true` if `method` is or overrides a method declared by `java.lang.Object`. */
+  def isObjectMethod(method: JavaMethod, loc: SourceLocation)(implicit flix: Flix): Boolean =
+    lookupClass(CD_Object, loc).declaredMethods.exists { m =>
+      m.ref.name == method.ref.name && m.ref.descriptor.parameterList() == method.ref.descriptor.parameterList()
+    }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch2.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.ast.shared.Constant
 import ca.uwaterloo.flix.language.ast.shared.SymUse.CaseSymUse
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.PatMatchError
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaTypes
+import ca.uwaterloo.flix.language.jvm.JavaMetadata
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -591,7 +591,7 @@ object PatMatch2 {
     var precedingRules: List[TypedAst.CatchRule] = Nil
     for (rule <- rules) {
       // Check if any preceding rule's class is a superclass of (or equal to) this rule's class.
-      precedingRules.find(prev => JavaTypes.isSubtype(rule.clazz, prev.clazz, rule.loc)) match {
+      precedingRules.find(prev => JavaMetadata.isSubtype(rule.clazz, prev.clazz, rule.loc)) match {
         case Some(coveringRule) =>
           sctx.errors.add(PatMatchError.RedundantCatchRule(coveringRule.loc, rule.loc))
         case None => ()

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -28,8 +28,7 @@ import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
-import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaClasses, JavaLookupError, JavaMemberResolver}
-import ca.uwaterloo.flix.language.phase.typer.jvm.JavaTypes
+import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaClasses, JavaLookupError, JavaMemberResolver, JavaMetadata}
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
 
@@ -1744,7 +1743,7 @@ object Resolver {
             val cs = constructors.map(visitJvmConstructor(_, superScp))
             val ms = methods.map(visitJvmMethod(_, superScp))
             val anonClassSym = Symbol.mkFreshAnonClassSym(loc);
-            val clazz = JClass(desc, JavaTypes.lookupClass(desc, loc).isInterface)
+            val clazz = JClass(desc, JavaMetadata.lookupClass(desc, loc).isInterface)
             ResolvedAst.Expr.NewObject(anonClassSym, clazz, targs, cs, ms, loc)
           case None =>
             erased match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -9,7 +9,7 @@ import ca.uwaterloo.flix.language.ast.{ChangeSet, RigidityEnv, SourceLocation, S
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
-import ca.uwaterloo.flix.language.jvm.JavaClasses
+import ca.uwaterloo.flix.language.jvm.{JavaClasses, JavaMetadata}
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaTypes
 import ca.uwaterloo.flix.language.phase.typer.{ConstraintGen, ConstraintSolver2}
 import ca.uwaterloo.flix.language.phase.unification.EqualityEnv
@@ -452,27 +452,27 @@ object Safety {
 
         // Allow casting one Java type to another if there is a subtype relationship.
         case (Type.Cst(TypeConstructor.Native(left, _), _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (JavaTypes.isSubtype(left, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaMetadata.isSubtype(left, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for String.
         case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (JavaTypes.isSubtype(CD_String, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaMetadata.isSubtype(CD_String, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for Regex.
         case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (JavaTypes.isSubtype(JavaClasses.Regex, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaMetadata.isSubtype(JavaClasses.Regex, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for BigInt.
         case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (JavaTypes.isSubtype(JavaClasses.BigInteger, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaMetadata.isSubtype(JavaClasses.BigInteger, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for BigDecimal.
         case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (JavaTypes.isSubtype(JavaClasses.BigDecimal, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaMetadata.isSubtype(JavaClasses.BigDecimal, right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for Arrays.
         case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right, _), _)) =>
-          if (JavaTypes.isSubtype(CD_Object.arrayType(), right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
+          if (JavaMetadata.isSubtype(CD_Object.arrayType(), right, loc)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Disallow casting a type variable.
         case (src@Type.Var(_, _), _) =>
@@ -765,7 +765,7 @@ object Safety {
     * @param loc   the location of the catch parameter.
     */
   private def checkCatchClass(clazz: ClassDesc, loc: SourceLocation)(implicit sctx: SharedContext, flix: Flix): Unit = {
-    if (!JavaTypes.isThrowable(clazz, loc)) {
+    if (!JavaMetadata.isThrowable(clazz, loc)) {
       sctx.errors.add(IllegalCatchType(clazz, loc))
     }
   }
@@ -777,7 +777,7 @@ object Safety {
   /** Returns `true` if `tpe` is [[java.lang.Throwable]] or a subclass of it. */
   @tailrec
   private def isThrowableType(tpe0: Type)(implicit flix: Flix): Boolean = tpe0 match {
-    case Type.Cst(TypeConstructor.Native(desc, _), loc) => JavaTypes.isThrowable(desc, loc)
+    case Type.Cst(TypeConstructor.Native(desc, _), loc) => JavaMetadata.isThrowable(desc, loc)
     case Type.Alias(_, _, tpe, _) => isThrowableType(tpe)
     case _ => false
   }
@@ -800,7 +800,7 @@ object Safety {
     case Expr.NewObject(_, clazz0, tpe0, _, cs, methods, loc) =>
       val tpe = Type.eraseAliases(tpe0)
       val clazz = clazz0.desc
-      val javaClass = JavaTypes.lookupClass(clazz, loc)
+      val javaClass = JavaMetadata.lookupClass(clazz, loc)
       // `clazz` must be an interface or have a non-private constructor without arguments
       // (unless user-defined constructors are provided).
       if (!javaClass.isInterface && cs.isEmpty && !javaClass.hasNonPrivateZeroArgConstructor) {
@@ -845,7 +845,7 @@ object Safety {
       val targs = tpe.typeArguments
       // The type parameters of `clazz` map to its type arguments; a missing argument falls back to Object.
       val substMap = javaClass.typeParameters.map(_.variable).zip(targs).toMap
-      val expectedMethods = JavaTypes.overridableMethods(clazz, loc).map {
+      val expectedMethods = JavaMetadata.overridableMethods(clazz, loc).map {
         case method =>
           val name = method.ref.name
           val types = method.parameterTypes.map(JavaTypes.flixTypeOf(_, substMap, loc))
@@ -874,7 +874,7 @@ object Safety {
       }
 
       // an unimplemented method is only a problem if it's abstract and isn't auto-implemented by Object
-      val missing = unimplemented.filter { case (method, _, _, _) => method.isAbstract && !JavaTypes.isObjectMethod(method, loc) }
+      val missing = unimplemented.filter { case (method, _, _, _) => method.isAbstract && !JavaMetadata.isObjectMethod(method, loc) }
       missing.foreach { case (method, _, _, _) => sctx.errors.add(NewObjectMissingMethod(clazz, method, loc)) }
       extra.foreach { case (ident, name, _, _) => sctx.errors.add(NewObjectUndefinedMethod(clazz, name, ident.loc)) }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.Type.JvmMember
 import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod, JavaType, JavaTypeParameter, JavaTypeVariable}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
 import ca.uwaterloo.flix.language.ast.shared.{AssocTypeDef, RegionScope}
-import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaArgument, JavaClasses, JavaMemberResolver}
+import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaArgument, JavaClasses, JavaMemberResolver, JavaMetadata}
 import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaTypes, PrimitiveEffects}
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, Substitution}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
@@ -501,7 +501,7 @@ object TypeReduction2 {
     */
   private def classTypeParametersOf(method: JavaMethod, owner: ClassDesc, loc: SourceLocation)(implicit flix: Flix): List[JavaTypeParameter] =
     if (method.isStatic || !owner.isClassOrInterface) Nil
-    else JavaTypes.lookupClass(owner, loc).typeParameters
+    else JavaMetadata.lookupClass(owner, loc).typeParameters
 
   /**
     * Instantiates a resolved Java method: creates fresh type variables for method-level
@@ -614,7 +614,7 @@ object TypeReduction2 {
             val fiTypeArgs: Map[String, Type] =
               mapping.argParam.map(_ -> flixArg).toMap ++
               mapping.retParam.map(_ -> flixRet).toMap
-            val interfaceParamNames = JavaTypes.lookupClass(pt.erasure, loc).typeParameters.map(_.variable.name)
+            val interfaceParamNames = JavaMetadata.lookupClass(pt.erasure, loc).typeParameters.map(_.variable.name)
             interfaceParamNames.zip(pt.arguments).flatMap {
               case (ifParamName, javaTypeArg) =>
                 resolveToTypeVariable(javaTypeArg).flatMap { methodTv =>

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
@@ -16,12 +16,10 @@
 package ca.uwaterloo.flix.language.phase.typer.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.jvm.{JavaClass, JavaMethod, JavaType, JavaTypeVariable}
+import ca.uwaterloo.flix.language.ast.jvm.{JavaType, JavaTypeVariable}
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Type, TypeConstructor}
-import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaClasses, JavaHierarchy, JavaMemberResolver}
-import ca.uwaterloo.flix.util.InternalCompilerException
-import ca.uwaterloo.flix.util.Result.{Err, Ok}
+import ca.uwaterloo.flix.language.jvm.{JavaClasses, JavaMetadata}
 
 import java.lang.constant.ClassDesc
 import java.lang.constant.ConstantDescs.*
@@ -33,20 +31,13 @@ import java.lang.constant.ConstantDescs.*
   */
 object JavaTypes {
 
-  /** Returns the class metadata of `desc`, or throws an [[InternalCompilerException]] if it cannot be read. */
-  def lookupClass(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): JavaClass =
-    flix.javaTypeProvider.lookupClass(desc) match {
-      case Ok(clazz) => clazz
-      case Err(error) => throw InternalCompilerException(s"Java class lookup failed for '${ClassDescs.binaryNameOf(desc)}': $error", loc)
-    }
-
   /**
     * Returns the number of type parameters of the class `desc`.
     *
     * Primitive and array types have no type parameters.
     */
-  def typeParameterCount(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Int =
-    if (desc.isClassOrInterface) lookupClass(desc, loc).typeParameters.length else 0
+  private def typeParameterCount(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Int =
+    if (desc.isClassOrInterface) JavaMetadata.lookupClass(desc, loc).typeParameters.length else 0
 
   /**
     * Returns the Flix type of the Java class `desc`.
@@ -153,38 +144,6 @@ object JavaTypes {
     case JavaType.Wildcard(_, _, _) =>
       Type.mkObject(loc)
   }
-
-  /**
-    * Returns `true` if the Java type `sub` is a subtype of the Java type `sup`, or throws an
-    * [[InternalCompilerException]] if their metadata cannot be read.
-    *
-    * See [[JavaHierarchy.isSubtype]] for the subtyping rules.
-    */
-  def isSubtype(sub: ClassDesc, sup: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
-    JavaHierarchy.isSubtype(sub, sup) match {
-      case Ok(result) => result
-      case Err(error) => throw InternalCompilerException(s"Java subtype check failed for '${ClassDescs.binaryNameOf(sub)} <: ${ClassDescs.binaryNameOf(sup)}': $error", loc)
-    }
-
-  /** Returns `true` if `desc` is `java.lang.Throwable` or a subclass of it. */
-  def isThrowable(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean =
-    isSubtype(desc, CD_Throwable, loc)
-
-  /**
-    * Returns the methods of `desc` that an anonymous subclass may override, or throws an
-    * [[InternalCompilerException]] if its metadata cannot be read.
-    */
-  def overridableMethods(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): List[JavaMethod] =
-    JavaMemberResolver.overridableMethods(desc) match {
-      case Ok(methods) => methods
-      case Err(error) => throw InternalCompilerException(s"Java method lookup failed for '${ClassDescs.binaryNameOf(desc)}': $error", loc)
-    }
-
-  /** Returns `true` if `method` is or overrides a method declared by `java.lang.Object`. */
-  def isObjectMethod(method: JavaMethod, loc: SourceLocation)(implicit flix: Flix): Boolean =
-    lookupClass(CD_Object, loc).declaredMethods.exists { m =>
-      m.ref.name == method.ref.name && m.ref.descriptor.parameterList() == method.ref.descriptor.parameterList()
-    }
 
   /** Applies the Flix type of `desc` to one `mkArg` per type parameter of `desc`. */
   private def instantiate(desc: ClassDesc, loc: SourceLocation)(mkArg: => Type)(implicit flix: Flix): Type =

--- a/main/test/ca/uwaterloo/flix/language/jvm/TestJavaMetadata.scala
+++ b/main/test/ca/uwaterloo/flix/language/jvm/TestJavaMetadata.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.jvm
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.SourceLocation
+import ca.uwaterloo.flix.util.InternalCompilerException
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.lang.constant.ClassDesc
+import java.lang.constant.ConstantDescs.*
+
+class TestJavaMetadata extends AnyFunSuite {
+
+  private val loc = SourceLocation.Unknown
+
+  test("lookupClass") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaMetadata.lookupClass(CD_String, loc).desc == CD_String)
+      assert(JavaMetadata.lookupClass(ClassDesc.of("java.util.List"), loc).isInterface)
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("lookupClass.ThrowsOnMissingClass") {
+    implicit val flix: Flix = new Flix
+    try {
+      intercept[InternalCompilerException](JavaMetadata.lookupClass(ClassDesc.of("java.lang.DoesNotExist"), loc))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("isSubtype") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaMetadata.isSubtype(CD_String, CD_Object, loc))
+      assert(!JavaMetadata.isSubtype(CD_Object, CD_String, loc))
+      intercept[InternalCompilerException](JavaMetadata.isSubtype(ClassDesc.of("java.lang.DoesNotExist"), CD_Object, loc))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("isThrowable") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaMetadata.isThrowable(CD_Throwable, loc))
+      assert(JavaMetadata.isThrowable(ClassDesc.of("java.lang.RuntimeException"), loc))
+      assert(!JavaMetadata.isThrowable(CD_String, loc))
+      assert(!JavaMetadata.isThrowable(CD_int, loc))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("isObjectMethod") {
+    implicit val flix: Flix = new Flix
+    try {
+      // Comparator redeclares equals(Object), which Object also declares, but compare is Comparator's own.
+      val methods = JavaMetadata.overridableMethods(ClassDesc.of("java.util.Comparator"), loc)
+      val equals = methods.find(_.ref.name == "equals").get
+      val compare = methods.find(_.ref.name == "compare").get
+      assert(JavaMetadata.isObjectMethod(equals, loc))
+      assert(!JavaMetadata.isObjectMethod(compare, loc))
+    } finally flix.javaTypeProvider.close()
+  }
+
+}

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
@@ -28,28 +28,6 @@ class TestJavaTypes extends AnyFunSuite {
 
   private val loc = SourceLocation.Unknown
 
-  test("isThrowable") {
-    implicit val flix: Flix = new Flix
-    try {
-      assert(JavaTypes.isThrowable(CD_Throwable, loc))
-      assert(JavaTypes.isThrowable(ClassDesc.of("java.lang.RuntimeException"), loc))
-      assert(!JavaTypes.isThrowable(CD_String, loc))
-      assert(!JavaTypes.isThrowable(CD_int, loc))
-    } finally flix.javaTypeProvider.close()
-  }
-
-  test("isObjectMethod") {
-    implicit val flix: Flix = new Flix
-    try {
-      // Comparator redeclares equals(Object), which Object also declares, but compare is Comparator's own.
-      val methods = JavaTypes.overridableMethods(ClassDesc.of("java.util.Comparator"), loc)
-      val equals = methods.find(_.ref.name == "equals").get
-      val compare = methods.find(_.ref.name == "compare").get
-      assert(JavaTypes.isObjectMethod(equals, loc))
-      assert(!JavaTypes.isObjectMethod(compare, loc))
-    } finally flix.javaTypeProvider.close()
-  }
-
   test("flixTypeOf.JavaType") {
     implicit val flix: Flix = new Flix
     try {


### PR DESCRIPTION
Second half of the package move started in #13212.

`JavaTypes` is documented as building Flix types from Java class descriptors, but half of its methods were adapters that only turn a lookup `Result` into an `InternalCompilerException`: class lookup, subtyping, the throwable check, overridable methods, and the object-method check. None of them mention a Flix type.

They now live in `language.jvm.JavaMetadata`, next to the queries they adapt, with a doc explaining why throwing is the right policy after the Resolver has validated every class. The Resolver, Safety, PatMatch2, and TypeReduction2 call the facade directly; PatMatch2 and the Resolver no longer import `JavaTypes` at all. `JavaTypes` keeps only the conversions, and its type-parameter count helper becomes private since nothing else used it.

The tests for the adapters move to `TestJavaMetadata` and gain class-lookup and missing-class error cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGqoj6qH3MTP4rgPuvQnD1
