### PR TITLE
chore: build the native image with Mill's NativeImageModule

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -33,16 +33,16 @@ jobs:
           key: ${{ runner.os }}-mill-${{ hashFiles('build.mill', '.mill-version') }}
           restore-keys: |
             ${{ runner.os }}-mill-
-      - name: Build fat JAR
-        run: ./mill flix.assembly
       - name: Build native image
-        # The native-image configuration ships inside the JAR under META-INF/native-image/dev.flix/flix.
-        # -Ob selects the quick build mode, which roughly halves build time at the cost of run-time performance.
-        run: native-image -Ob -jar out/flix/assembly.dest/out.jar -o out/flix-native
+        # setup-graalvm exports GRAALVM_HOME, which Mill uses to locate native-image.
+        # NATIVE_IMAGE_QUICK selects -Ob (quick build mode), see build.mill.
+        env:
+          NATIVE_IMAGE_QUICK: '1'
+        run: ./mill flix.nativeImage
       - name: Smoke test on a hello world project
         run: |
           mkdir hello && cd hello
-          ../out/flix-native init
-          ../out/flix-native check
-          ../out/flix-native build-fatjar
+          ../out/flix/nativeImage.dest/native-executable init
+          ../out/flix/nativeImage.dest/native-executable check
+          ../out/flix/nativeImage.dest/native-executable build-fatjar
           java -jar artifact/hello.jar | grep -q 'Hello World!'

--- a/build.mill
+++ b/build.mill
@@ -1,10 +1,11 @@
 package build
 
 import mill.*
+import mill.javalib.NativeImageModule
 import mill.scalalib.*
 import mill.scalalib.Assembly.*
 
-object flix extends ScalaModule {
+object flix extends ScalaModule with NativeImageModule {
 
   def scalaVersion = "2.13.18"
 
@@ -115,6 +116,26 @@ object flix extends ScalaModule {
     def testSandboxWorkingDir = false
     def testParallelism = false
     def forkEnv = super.forkEnv() ++ Task.env
+  }
+
+  // ── Native Image ────────────────────────────────────────
+  //
+  // Run: GRAALVM_HOME=/path/to/graalvm ./mill flix.nativeImage
+  //
+  // Produces out/flix/nativeImage.dest/native-executable. Mill reads GRAALVM_HOME
+  // from the daemon's environment, so run `./mill shutdown` first if the daemon
+  // was started without it. Set NATIVE_IMAGE_QUICK=1 to build with -Ob (quick
+  // build mode) for faster iteration at the cost of run-time performance.
+  //
+  // The native-image configuration ships in
+  // main/src/resources/META-INF/native-image/dev.flix/flix, so Mill's automatic
+  // inclusion of every file under the resource roots is disabled.
+
+  def nativeIncludedResources = Seq.empty[String]
+
+  def nativeImageOptions = Task {
+    val quick = if (Task.env.contains("NATIVE_IMAGE_QUICK")) Seq("-Ob") else Seq.empty
+    super.nativeImageOptions() ++ quick
   }
 
   // ── Custom Tasks ────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #13210. Replaces the raw `native-image -jar` call in the Native Image workflow with Mill's built-in `NativeImageModule`, so the native binary can be built locally with a single command:

```
GRAALVM_HOME=/path/to/graalvm ./mill flix.nativeImage
```

## What changes

- `build.mill`: `flix` now mixes in `mill.javalib.NativeImageModule`.
  - Mill's automatic inclusion of every file under the resource roots is disabled (`nativeIncludedResources`), because the configuration already ships in `META-INF/native-image/dev.flix/flix`. The automatic list was a 67 KB `-H:IncludeResources` option that also pulled in test sources.
  - `nativeImageOptions` adds `-Ob` (quick build mode) when `NATIVE_IMAGE_QUICK` is set in the environment, which the workflow uses.
- `.github/workflows/native-image.yaml`: the fat JAR step and the direct `native-image` call are replaced by `./mill flix.nativeImage`. The smoke test now runs `out/flix/nativeImage.dest/native-executable`.

## Notes

- Mill locates `native-image` through `GRAALVM_HOME`, which `graalvm/setup-graalvm` exports. The module's `jvmVersion` is deliberately left alone so the compiler is still built and tested on the regular JDK.
- Mill reads `GRAALVM_HOME` from its daemon's environment, so a daemon started without it needs `./mill shutdown` first. This is documented in `build.mill`.
- Mill also downloads the GraalVM reachability-metadata repository and passes configuration directories for matching dependencies (gson, commons-compress, zstd-jni and others). This is extra network traffic in CI but harmless.
- The image is built from the full run classpath rather than the fat JAR, so the assembly exclusion rules do not apply. Locally the binary is about 10 MB larger than the JAR-based one and passes the same smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLYNr3zsG9cgR6jsvB9gzb
