### PR TITLE
refactor: reuse the JavaTypes conversions in TypeReduction2

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -848,8 +848,8 @@ object Safety {
       val expectedMethods = JavaMetadata.overridableMethods(clazz, loc).map {
         case method =>
           val name = method.ref.name
-          val types = method.parameterTypes.map(JavaTypes.flixTypeOf(_, substMap, loc))
-          val retTpe = JavaTypes.flixTypeOf(method.returnType, substMap, loc)
+          val types = method.parameterTypes.map(JavaTypes.flixTypeOf(_, substMap, loc)(Type.mkObject(loc)))
+          val retTpe = JavaTypes.flixTypeOf(method.returnType, substMap, loc)(Type.mkObject(loc))
           (method, name, types, retTpe)
       }.sortBy { case (_, name, types, _) => (name, types.length) }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -146,7 +146,7 @@ object TypeReduction2 {
           val (reducedTpes, css) = tpes.map(reduce(_)).unzip
           val cs = css.flatten
           lookupConstructor(clazz, reducedTpes, loc) match {
-            case JavaConstructorResolution.Resolved(constructor) =>
+            case JavaResolution.Resolved(constructor) =>
               progress.markProgress()
               (Type.Cst(TypeConstructor.JvmConstructor(constructor), loc), cs)
             case _ => (unresolved, cs)
@@ -155,7 +155,7 @@ object TypeReduction2 {
         case JvmMember.JvmField(_, tpe, name) =>
           val (reducedTpe, cs) = reduce(tpe)
           lookupField(reducedTpe, name.name, loc) match {
-            case JavaFieldResolution.Resolved(field) =>
+            case JavaResolution.Resolved(field) =>
               progress.markProgress()
               (Type.Cst(TypeConstructor.JvmField(field), loc), cs)
             case _ => (unresolved, cs)
@@ -166,7 +166,7 @@ object TypeReduction2 {
           val (reducedTpes, css) = tpes.map(reduce(_)).unzip
           val cs = cs0 ::: css.flatten
           lookupMethod(reducedTpe, name.name, reducedTpes, loc) match {
-            case JavaMethodResolution.Resolved(method) =>
+            case JavaResolution.Resolved(method) =>
               val classTypeParameters = classTypeParametersOf(method, getJavaTypeDesc(reducedTpe), loc)
               val classTypeArgs = extractClassTypeArgs(classTypeParameters, reducedTpe, scope, loc)
               val (tpe, cs0) = instantiateMethod(method, classTypeParameters, classTypeArgs, reducedTpes, scope, loc)
@@ -179,7 +179,7 @@ object TypeReduction2 {
           val (reducedTpes, css) = tpes.map(reduce(_)).unzip
           val cs = css.flatten
           lookupStaticMethod(clazz, name.name, reducedTpes, loc) match {
-            case JavaMethodResolution.Resolved(method) =>
+            case JavaResolution.Resolved(method) =>
               // Class type parameters are not in scope for static methods.
               val (tpe, cs0) = instantiateMethod(method, Nil, Nil, reducedTpes, scope, loc)
               progress.markProgress()
@@ -190,16 +190,16 @@ object TypeReduction2 {
   }
 
   /** Tries to find a constructor of `owner` that takes arguments of type `ts`. */
-  private def lookupConstructor(owner: ClassDesc, ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaConstructorResolution = {
+  private def lookupConstructor(owner: ClassDesc, ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaResolution[JavaMethod] = {
     val typesAreKnown = ts.forall(isKnown)
-    if (!typesAreKnown) return JavaConstructorResolution.UnresolvedTypes
+    if (!typesAreKnown) return JavaResolution.UnresolvedTypes
 
     val arguments = ts.map(getJavaArgument)
     JavaMemberResolver.constructors(owner, arguments) match {
       // The resolver returns every constructor tied for the best match, in class-file declaration order.
       // We deterministically pick the first one.
-      case Ok(constructor :: _) => JavaConstructorResolution.Resolved(constructor)
-      case Ok(Nil) => JavaConstructorResolution.NotFound
+      case Ok(constructor :: _) => JavaResolution.Resolved(constructor)
+      case Ok(Nil) => JavaResolution.NotFound
       case Err(error) =>
         val query = s"${ClassDescs.binaryNameOf(owner)}(${arguments.mkString(", ")})"
         throw InternalCompilerException(s"Java constructor lookup failed for '$query': $error", loc)
@@ -207,30 +207,30 @@ object TypeReduction2 {
   }
 
   /** Tries to find a method of `thisObj` that takes arguments of type `ts`. */
-  private def lookupMethod(thisObj: Type, methodName: String, ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaMethodResolution = {
+  private def lookupMethod(thisObj: Type, methodName: String, ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaResolution[JavaMethod] = {
     val typesAreKnown = isKnown(thisObj) && ts.forall(isKnown)
-    if (!typesAreKnown) return JavaMethodResolution.UnresolvedTypes
+    if (!typesAreKnown) return JavaResolution.UnresolvedTypes
 
     // Rigid type variables and other non-Java types fall back to Object.
     retrieveMethod(getJavaTypeDesc(thisObj), methodName, ts, static = false, loc)
   }
 
   /** Tries to find a static method of `owner` that takes arguments of type `ts`. */
-  private def lookupStaticMethod(owner: ClassDesc, methodName: String, ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaMethodResolution = {
+  private def lookupStaticMethod(owner: ClassDesc, methodName: String, ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaResolution[JavaMethod] = {
     val typesAreKnown = ts.forall(isKnown)
-    if (!typesAreKnown) return JavaMethodResolution.UnresolvedTypes
+    if (!typesAreKnown) return JavaResolution.UnresolvedTypes
 
     retrieveMethod(owner, methodName, ts, static = true, loc)
   }
 
   /** Tries to find a static/dynamic method of `owner` that takes arguments of type `ts`. */
-  private def retrieveMethod(owner: ClassDesc, methodName: String, ts: List[Type], static: Boolean, loc: SourceLocation)(implicit flix: Flix): JavaMethodResolution = {
+  private def retrieveMethod(owner: ClassDesc, methodName: String, ts: List[Type], static: Boolean, loc: SourceLocation)(implicit flix: Flix): JavaResolution[JavaMethod] = {
     val arguments = ts.map(getJavaArgument)
     JavaMemberResolver.methods(owner, methodName, arguments, static) match {
       // The resolver returns every method tied for the best match in a deterministic order.
       // We pick the first one.
-      case Ok(method :: _) => JavaMethodResolution.Resolved(method)
-      case Ok(Nil) => JavaMethodResolution.NotFound
+      case Ok(method :: _) => JavaResolution.Resolved(method)
+      case Ok(Nil) => JavaResolution.NotFound
       case Err(error) =>
         val kind = if (static) "static" else "instance"
         val query = s"$kind ${ClassDescs.binaryNameOf(owner)}.$methodName(${arguments.mkString(", ")})"
@@ -244,29 +244,13 @@ object TypeReduction2 {
     case _ => JavaArgument.Typed(getJavaTypeDesc(tpe))
   }
 
-  /** Returns the Java class descriptor corresponding to the given non-null Flix `tpe`. */
-  private def getJavaTypeDesc(tpe: Type): ClassDesc = tpe match {
-    case Type.Bool => CD_boolean
-    case Type.Int8 => CD_byte
-    case Type.Int16 => CD_short
-    case Type.Int32 => CD_int
-    case Type.Int64 => CD_long
-    case Type.Char => CD_char
-    case Type.Float32 => CD_float
-    case Type.Float64 => CD_double
-    case Type.Cst(TypeConstructor.BigDecimal, _) => JavaClasses.BigDecimal
-    case Type.Cst(TypeConstructor.BigInt, _) => JavaClasses.BigInteger
-    case Type.Cst(TypeConstructor.Str, _) => CD_String
-    case Type.Cst(TypeConstructor.Regex, _) => JavaClasses.Regex
-    case Type.Cst(TypeConstructor.Native(desc, _), _) => desc
-
-    // Parameterized Java types erase to their native base type.
-    case Type.Apply(_, _, _) if isNativeBase(tpe) =>
-      tpe.baseType match {
-        case Type.Cst(TypeConstructor.Native(desc, _), _) => desc
-        case _ => CD_Object
-      }
-
+  /**
+    * Returns the erased Java class descriptor of the given non-null Flix `tpe`, as used for member lookup.
+    *
+    * Types with a Java counterpart (see [[JavaTypes.descriptorOf]]) erase to it. Arrays and vectors erase
+    * to Java arrays, functions to their Java functional interfaces, and every other type to `Object`.
+    */
+  private def getJavaTypeDesc(tpe: Type): ClassDesc = JavaTypes.descriptorOf(tpe).getOrElse(tpe match {
     // Arrays and vectors erase to Java arrays. A null element type falls back to Object.
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Array, _), elmType, _), _, _) =>
       getJavaArrayTypeDesc(elmType)
@@ -277,7 +261,7 @@ object TypeReduction2 {
     case Type.Apply(Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Arrow(2), _), _, _), varArg, _), varRet, _) =>
       lookupFunIF(varArg, varRet).map(_.desc).getOrElse(CD_Object)
     case _ => CD_Object
-  }
+  })
 
   /** Returns the Java array descriptor for an array or vector element type. */
   private def getJavaArrayTypeDesc(elmType: Type): ClassDesc = elmType match {
@@ -286,14 +270,14 @@ object TypeReduction2 {
   }
 
   /** Tries to find a field of `thisObj` with the name `fieldName`. */
-  private def lookupField(thisObj: Type, fieldName: String, loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaFieldResolution = {
+  private def lookupField(thisObj: Type, fieldName: String, loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaResolution[JavaField] = {
     val typeIsKnown = isKnown(thisObj)
-    if (!typeIsKnown) return JavaFieldResolution.UnresolvedTypes
+    if (!typeIsKnown) return JavaResolution.UnresolvedTypes
 
     val owner = getJavaTypeDesc(thisObj)
     JavaMemberResolver.field(owner, fieldName, static = false) match {
-      case Ok(Some(field)) => JavaFieldResolution.Resolved(field)
-      case Ok(None) => JavaFieldResolution.NotFound
+      case Ok(Some(field)) => JavaResolution.Resolved(field)
+      case Ok(None) => JavaResolution.NotFound
       case Err(error) =>
         val query = s"${ClassDescs.binaryNameOf(owner)}.$fieldName"
         throw InternalCompilerException(s"Java field lookup failed for '$query': $error", loc)
@@ -322,63 +306,23 @@ object TypeReduction2 {
     case Type.AssocType(_, _, _, _) => false
   }
 
-  /** A lookup result of a Java field. */
-  private sealed trait JavaFieldResolution
+  /** A lookup result of a Java member of type `A`: a field, a constructor, or a method. */
+  private sealed trait JavaResolution[+A]
 
-  private object JavaFieldResolution {
+  private object JavaResolution {
 
-    /** One matching field. */
-    case class Resolved(field: JavaField) extends JavaFieldResolution
+    /** One matching member. */
+    case class Resolved[A](member: A) extends JavaResolution[A]
 
-    /** No matching field. */
-    case object NotFound extends JavaFieldResolution
+    /** No matching member. */
+    case object NotFound extends JavaResolution[Nothing]
 
     /**
-      * The types used for the lookup are not resolved enough to decide on a field.
+      * The types used for the lookup are not resolved enough to decide on a member.
       *
       * This happens if they contain e.g., type variables or associated types.
       */
-    case object UnresolvedTypes extends JavaFieldResolution
-
-  }
-
-  /** A lookup result of a Java constructor. */
-  private sealed trait JavaConstructorResolution
-
-  private object JavaConstructorResolution {
-
-    /** One matching constructor. */
-    case class Resolved(constructor: JavaMethod) extends JavaConstructorResolution
-
-    /** No matching constructor. */
-    case object NotFound extends JavaConstructorResolution
-
-    /**
-      * The types used for the lookup are not resolved enough to decide on a constructor.
-      *
-      * This happens if they contain e.g., type variables or associated types.
-      */
-    case object UnresolvedTypes extends JavaConstructorResolution
-
-  }
-
-  /** A lookup result of a Java method. */
-  private sealed trait JavaMethodResolution
-
-  private object JavaMethodResolution {
-
-    /** One matching method. */
-    case class Resolved(method: JavaMethod) extends JavaMethodResolution
-
-    /** No matching method. */
-    case object NotFound extends JavaMethodResolution
-
-    /**
-      * The types used for the lookup are not resolved enough to decide on a method.
-      *
-      * This happens if they contain e.g., type variables or associated types.
-      */
-    case object UnresolvedTypes extends JavaMethodResolution
+    case object UnresolvedTypes extends JavaResolution[Nothing]
 
   }
 
@@ -393,7 +337,8 @@ object TypeReduction2 {
   /**
     * Resolves the return type of `method`, using generic type information when available.
     *
-    * Delegates to `resolveGenericType` which handles every kind of [[JavaType]].
+    * A parameterized return type is resolved by [[JavaTypes.flixTypeOf]] with a fresh type variable
+    * for every position that is not bound by the receiver or the method.
     *
     * Example 1: `ArrayList[String].get(int)` -- the generic return type is `E`.
     * The receiver `ArrayList[String]` maps `E -> String`, so the result is `String`.
@@ -417,60 +362,12 @@ object TypeReduction2 {
       case returnType: JavaType.Parameterized =>
         // Parameterized return type (e.g., Set<K> from HashMap.keySet()).
         // Resolve type arguments using the substitution map.
-        resolveGenericType(returnType, substMap, scope, loc)
+        JavaTypes.flixTypeOf(returnType, substMap, loc)(Type.freshVar(Kind.Star, loc)(scope, flix))
       case returnType =>
         // Other return types (non-generic, generic arrays, etc.).
         // Use erased return type with fresh vars for backward compatibility.
         JavaTypes.instantiateWithFreshVars(returnType.erasure, scope, loc)
     }
-  }
-
-  /**
-    * Resolves the Java `genericType` to a Flix [[Type]] using the given type variable substitution map.
-    *
-    * Handles every kind of [[JavaType]]:
-    *   - `Variable`: look up in substMap; fall back to a fresh type variable
-    *   - `Parameterized`: resolve the erased class + recursively resolve the type arguments
-    *   - `Wildcard`: resolve the upper bound if it is a type variable; otherwise a fresh type variable
-    *   - `GenericArray`: recursively resolve the component type, wrap in Array
-    *   - `NonGeneric`: use `JavaTypes.instantiateWithFreshVars`
-    */
-  private def resolveGenericType(genericType: JavaType, substMap: Map[JavaTypeVariable, Type],
-    scope: RegionScope, loc: SourceLocation)(implicit flix: Flix): Type = genericType match {
-    case JavaType.Variable(variable, _) =>
-      // Look up the type variable in the substitution map.
-      // If not found (e.g., receiver has type variable args that were filtered out),
-      // use a fresh variable so the result can unify with the expected type.
-      substMap.getOrElse(variable, Type.freshVar(Kind.Star, loc)(scope, flix))
-
-    case JavaType.Parameterized(erasure, arguments) =>
-      // Resolve parameterized types like Set<K>, Map.Entry<K,V>, Iterator<E>, etc.
-      val base = JavaTypes.flixTypeOf(erasure, loc)
-      val typeArgs = arguments.map(resolveGenericType(_, substMap, scope, loc))
-      if (typeArgs.nonEmpty)
-        Type.mkApply(base, typeArgs, loc)
-      else
-        base
-
-    case JavaType.Wildcard(upperBounds, _, _) =>
-      // Resolve wildcard types like "? extends K" or "? super V".
-      // Use the upper bound if it references a type variable (e.g., "? extends R"),
-      // otherwise use a fresh type variable to avoid premature erasure to Object.
-      upperBounds match {
-        case (variable: JavaType.Variable) :: _ =>
-          resolveGenericType(variable, substMap, scope, loc)
-        case _ =>
-          Type.freshVar(Kind.Star, loc)(scope, flix)
-      }
-
-    case JavaType.GenericArray(component, _) =>
-      // Resolve generic array types like "T[]".
-      val componentType = resolveGenericType(component, substMap, scope, loc)
-      Type.mkArray(componentType, Type.IO, loc)
-
-    case JavaType.NonGeneric(erasure) =>
-      // Plain class (non-generic or raw). Convert directly.
-      JavaTypes.instantiateWithFreshVars(erasure, scope, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
@@ -128,21 +128,30 @@ object JavaTypes {
   /**
     * Returns the Flix type of the Java type `javaType` under the substitution `subst` of type variables.
     *
-    * A type variable that is not in `subst`, a generic array, and a wildcard fall back to `Object`.
+    * `fallback` is evaluated once for every position that has no Flix counterpart: a type variable that
+    * is not in `subst`, a wildcard whose upper bound is not a type variable, and each type argument of a
+    * raw generic class. Pass `Object` in ground-type contexts and a fresh type variable where the result
+    * takes part in unification.
+    *
+    *   - A wildcard `? extends T` resolves to the resolution of `T`.
+    *   - A generic array `T[]` resolves to a Flix array of the resolution of `T` in the `IO` region.
     */
-  def flixTypeOf(javaType: JavaType, subst: Map[JavaTypeVariable, Type], loc: SourceLocation)(implicit flix: Flix): Type = javaType match {
+  def flixTypeOf(javaType: JavaType, subst: Map[JavaTypeVariable, Type], loc: SourceLocation)(fallback: => Type)(implicit flix: Flix): Type = javaType match {
     case JavaType.Variable(variable, _) =>
-      subst.getOrElse(variable, Type.mkObject(loc))
+      subst.getOrElse(variable, fallback)
     case JavaType.Parameterized(erasure, arguments) =>
       val base = flixTypeOf(erasure, loc)
-      val resolvedArgs = arguments.map(flixTypeOf(_, subst, loc))
+      val resolvedArgs = arguments.map(flixTypeOf(_, subst, loc)(fallback))
       Type.mkApply(base, resolvedArgs, loc)
     case JavaType.NonGeneric(erasure) =>
-      instantiateWithObjectArgs(erasure, loc)
-    case JavaType.GenericArray(_, _) =>
-      Type.mkObject(loc)
-    case JavaType.Wildcard(_, _, _) =>
-      Type.mkObject(loc)
+      instantiate(erasure, loc)(fallback)
+    case JavaType.GenericArray(component, _) =>
+      Type.mkArray(flixTypeOf(component, subst, loc)(fallback), Type.IO, loc)
+    case JavaType.Wildcard(upperBounds, _, _) =>
+      upperBounds match {
+        case (variable: JavaType.Variable) :: _ => flixTypeOf(variable, subst, loc)(fallback)
+        case _ => fallback
+      }
   }
 
   /** Applies the Flix type of `desc` to one `mkArg` per type parameter of `desc`. */

--- a/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/typer/jvm/TestJavaTypes.scala
@@ -34,16 +34,29 @@ class TestJavaTypes extends AnyFunSuite {
       val list = ClassDesc.of("java.util.List")
       val variable = JavaTypeVariable(JavaTypeVariableOwner.Class(list), "E")
       val subst: Map[JavaTypeVariable, Type] = Map(variable -> Type.Str)
-      // A bound variable takes its substitution; an unbound one, a generic array, and a wildcard fall back to Object.
-      assert(JavaTypes.flixTypeOf(JavaType.Variable(variable, CD_Object), subst, loc) == Type.Str)
-      assert(JavaTypes.flixTypeOf(JavaType.Variable(variable, CD_Object), Map.empty, loc) == Type.mkObject(loc))
-      assert(JavaTypes.flixTypeOf(JavaType.GenericArray(JavaType.Variable(variable, CD_Object), CD_Object.arrayType()), subst, loc) == Type.mkObject(loc))
-      assert(JavaTypes.flixTypeOf(JavaType.Wildcard(Nil, Nil, CD_Object), subst, loc) == Type.mkObject(loc))
+      val obj = Type.mkObject(loc)
+      // A bound variable takes its substitution; an unbound one and an unbounded wildcard take the fallback.
+      assert(JavaTypes.flixTypeOf(JavaType.Variable(variable, CD_Object), subst, loc)(obj) == Type.Str)
+      assert(JavaTypes.flixTypeOf(JavaType.Variable(variable, CD_Object), Map.empty, loc)(obj) == obj)
+      assert(JavaTypes.flixTypeOf(JavaType.Wildcard(Nil, Nil, CD_Object), subst, loc)(obj) == obj)
+      // A wildcard bounded by a variable and a generic array resolve through the variable.
+      assert(JavaTypes.flixTypeOf(JavaType.Wildcard(List(JavaType.Variable(variable, CD_Object)), Nil, CD_Object), subst, loc)(obj) == Type.Str)
+      assert(JavaTypes.flixTypeOf(JavaType.GenericArray(JavaType.Variable(variable, CD_Object), CD_Object.arrayType()), subst, loc)(obj) == Type.mkArray(Type.Str, Type.IO, loc))
       // Non-generic and parameterized types map to their Flix counterparts.
-      assert(JavaTypes.flixTypeOf(JavaType.NonGeneric(CD_String), subst, loc) == Type.Str)
-      assert(JavaTypes.flixTypeOf(JavaType.NonGeneric(CD_int), subst, loc) == Type.Int32)
-      val listOfStr = JavaTypes.flixTypeOf(JavaType.Parameterized(list, List(JavaType.Variable(variable, CD_Object))), subst, loc)
+      assert(JavaTypes.flixTypeOf(JavaType.NonGeneric(CD_String), subst, loc)(obj) == Type.Str)
+      assert(JavaTypes.flixTypeOf(JavaType.NonGeneric(CD_int), subst, loc)(obj) == Type.Int32)
+      val listOfStr = JavaTypes.flixTypeOf(JavaType.Parameterized(list, List(JavaType.Variable(variable, CD_Object))), subst, loc)(obj)
       assert(listOfStr == Type.mkApply(Type.mkNative(list, 1, loc), List(Type.Str), loc))
+      // The fallback is evaluated once per unbound position, so each can receive its own fresh variable.
+      var evaluations = 0
+      val rawList = JavaTypes.flixTypeOf(JavaType.NonGeneric(list), subst, loc)({ evaluations += 1; obj })
+      val map = ClassDesc.of("java.util.Map")
+      val k = JavaType.Variable(JavaTypeVariable(JavaTypeVariableOwner.Class(map), "K"), CD_Object)
+      val v = JavaType.Variable(JavaTypeVariable(JavaTypeVariableOwner.Class(map), "V"), CD_Object)
+      val mapOfUnbound = JavaTypes.flixTypeOf(JavaType.Parameterized(map, List(k, v)), subst, loc)({ evaluations += 1; obj })
+      assert(rawList == Type.mkApply(Type.mkNative(list, 1, loc), List(obj), loc))
+      assert(mapOfUnbound == Type.mkApply(Type.mkNative(map, 2, loc), List(obj, obj), loc))
+      assert(evaluations == 3)
       listOfStr.typeConstructor match {
         case Some(TypeConstructor.Native(desc, arity)) => assert(desc == list && arity == 1)
         case other => fail(s"Unexpected type constructor: $other")


### PR DESCRIPTION
`TypeReduction2` carried its own copies of two conversions that `JavaTypes` already provides: the erased descriptor of a Flix type, which repeated the primitive table of `descriptorOf`, and a resolver from generic Java types to Flix types, which differed from `flixTypeOf` only in its fallbacks. It also declared three identical result ADTs for field, constructor, and method lookup.

- The lookup descriptor now builds on `descriptorOf` and adds only the array, vector, and function cases.
- `JavaTypes.flixTypeOf` takes the fallback as a by-name argument, evaluated once per unbound position, so Safety passes `Object` and the typer passes a fresh type variable. The private resolver in `TypeReduction2` is gone.
- The three result ADTs collapse into one generic `JavaResolution[A]`.

Unifying the resolvers changes what Safety expects of an anonymous class in two cases: a generic array `T[]` now converts to a Flix array (matching how a non-generic `String[]` already converts, and matching the `Object[]` descriptor the backend emits either way), and a wildcard `? extends T` resolves to `T` instead of `Object`. Nothing in the test suite depended on the old forms.

The `flixTypeOf` test covers the new cases and checks that the fallback is evaluated once per position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGqoj6qH3MTP4rgPuvQnD1
