### PR TITLE
chore: trim the JDK class files bundled in the native image

### DIFF
--- a/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
+++ b/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
@@ -17,11 +17,15 @@
 # -H:IncludeResources=...
 #   The type checker reads JDK class files through ByteBuddyJavaTypeProvider using
 #   ClassLoader.getResourceAsStream. Inside a native image no class loader can serve JDK
-#   class files, so they are bundled as resources. The dev/flix entry covers the
-#   dev.flix.runtime.Global mock class that ExternalJarLoader serves as a system resource.
+#   class files, so they are bundled as resources. Only the public java and javax packages
+#   are included, plus com.sun.net.httpserver which the standard library imports; the
+#   internal sun and jdk packages are left out because they add well over 100 MB (locale
+#   data, graphics and security implementation classes) and Flix code should not depend
+#   on them. The dev/flix entry covers the dev.flix.runtime.Global mock class that
+#   ExternalJarLoader serves as a system resource.
 #   The option is experimental, hence the surrounding unlock/lock pair.
 Args = --no-fallback \
        --initialize-at-build-time=net.bytebuddy \
        -H:+UnlockExperimentalVMOptions \
-       -H:IncludeResources=(java|javax|jdk|sun|com/sun|org/w3c|org/xml|dev/flix)/.*\\.class \
+       -H:IncludeResources=(java|javax|com/sun/net/httpserver|dev/flix)/.*\\.class \
        -H:-UnlockExperimentalVMOptions


### PR DESCRIPTION
Follow-up to #13210. Trims the regex that bundles JDK class files into the native image.

## Why

The type checker reads JDK class files through `ByteBuddyJavaTypeProvider`, and inside a native image they have to be bundled as resources. The original regex included the internal `sun`, `jdk`, and `com/sun` packages across every module, which pulled in about 30,000 class files: locale data, graphics, security, and javac implementation classes that Flix code should never reference.

## What changes

The regex now covers the public `java` and `javax` packages plus `com.sun.net.httpserver`, which the standard library's Net module imports. The `dev/flix` entry for the runtime mock class is unchanged.

| | Before | After |
|---|---|---|
| Bundled class files | 30,287 | 8,487 |
| Image heap | 208 MB | 85 MB |
| Binary size | 259 MB | 137 MB |

The remaining size is machine code (51 MB) and the normal image heap; the JDK class files are now about 33 MB of it.

## Trade-off

Flix code that imports an internal class such as `sun.misc.Unsafe` will fail to resolve in the native build, while the JVM build still accepts it. Supporting such imports would mean reading the JDK's `jmods` at run time instead of bundling, which is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLYNr3zsG9cgR6jsvB9gzb
