### PR TITLE
feat: explain why run and test are unsupported in the native build

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -41,8 +41,14 @@ jobs:
         run: ./mill flix.nativeImage
       - name: Smoke test on a hello world project
         run: |
+          flix="$PWD/out/flix/nativeImage.dest/native-executable"
           mkdir hello && cd hello
-          ../out/flix/nativeImage.dest/native-executable init
-          ../out/flix/nativeImage.dest/native-executable check
-          ../out/flix/nativeImage.dest/native-executable build-fatjar
+          "$flix" init
+          "$flix" check
+          "$flix" build-fatjar
           java -jar artifact/hello.jar | grep -q 'Hello World!'
+          # Commands that load the compiled program into the JVM must fail with an explanation.
+          if "$flix" run > run.log 2>&1; then echo "expected 'run' to fail"; exit 1; fi
+          grep -q 'unsupported in the native build' run.log
+          if "$flix" lsp > lsp.log 2>&1 < /dev/null; then echo "expected 'lsp' to fail"; exit 1; fi
+          grep -q 'not yet supported in the native build' lsp.log

--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -49,6 +49,6 @@ jobs:
           java -jar artifact/hello.jar | grep -q 'Hello World!'
           # Commands that load the compiled program into the JVM must fail with an explanation.
           if "$flix" run > run.log 2>&1; then echo "expected 'run' to fail"; exit 1; fi
-          grep -q 'unsupported in the native build' run.log
+          grep -q 'not supported in the native image' run.log
           if "$flix" lsp > lsp.log 2>&1 < /dev/null; then echo "expected 'lsp' to fail"; exit 1; fi
-          grep -q 'not yet supported in the native build' lsp.log
+          grep -q 'not supported in the native image' lsp.log

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -122,7 +122,7 @@ object Main {
         case Command.None =>
           // check if the --listen flag was passed.
           if (cmdOpts.listen.nonEmpty) {
-            requireJvmLoader("The '--listen' server")
+            featureNotSupportedInNativeImage()
             SocketServer.listen(cmdOpts.listen.get)
             System.exit(0)
           }
@@ -159,7 +159,7 @@ object Main {
 
           // check if we should start a REPL
           if (cmdOpts.files.isEmpty) {
-            requireJvmLoader("The REPL")
+            featureNotSupportedInNativeImage()
             Bootstrap.bootstrap(cwd, options.githubToken) match {
               case Result.Ok(bootstrap) =>
                 val shell = new Shell(bootstrap, options)
@@ -172,7 +172,7 @@ object Main {
           }
 
           // running the given files loads the compiled program into the JVM.
-          requireJvmLoader("Running a Flix program")
+          featureNotSupportedInNativeImage()
 
           // configure Flix and add the paths.
           val flix = new Flix()
@@ -347,7 +347,7 @@ object Main {
             println("The 'run' command does not support file arguments.")
             System.exit(1)
           }
-          requireJvmLoader("The 'run' command")
+          featureNotSupportedInNativeImage()
           exitOnResult {
             Bootstrap.bootstrap(cwd, options.githubToken).flatMap { bootstrap =>
               val flix = new Flix().setFormatter(formatter)
@@ -357,7 +357,7 @@ object Main {
           }
 
         case Command.Test =>
-          requireJvmLoader("The 'test' command")
+          featureNotSupportedInNativeImage()
           if (cmdOpts.files.isEmpty) {
             exitOnResult {
               Bootstrap.bootstrap(cwd, options.githubToken).flatMap { bootstrap =>
@@ -383,7 +383,7 @@ object Main {
             println("The 'repl' command does not support file arguments.")
             System.exit(1)
           }
-          requireJvmLoader("The REPL")
+          featureNotSupportedInNativeImage()
           Bootstrap.bootstrap(cwd, options.githubToken) match {
             case Result.Ok(bootstrap) =>
               val shell = new Shell(bootstrap, options)
@@ -399,11 +399,8 @@ object Main {
             println("The 'lsp' command does not support file arguments.")
             System.exit(1)
           }
-          if (NativeImage.isRuntime) {
-            // lsp4j needs reflection metadata that the native image does not include yet.
-            println("The 'lsp' command is not yet supported in the native build of Flix. Use 'lsp-vscode <port>' or the JAR distribution of Flix instead.")
-            System.exit(1)
-          }
+          // lsp4j needs reflection metadata that the native image does not include yet.
+          featureNotSupportedInNativeImage()
           LspServer.run(options)
           System.exit(0)
 
@@ -831,20 +828,23 @@ object Main {
   }
 
   /**
-    * Exits with code 0 on success, or prints the error and exits with code 1 on failure.
+    * Exits with an explanatory message if running inside a GraalVM native image.
     */
-  /**
-    * Exits with an explanatory message if the running JVM cannot load compiled Flix programs.
-    *
-    * `action` names what was attempted, e.g. "The 'run' command"; see [[JvmLoader.isSupported]].
-    */
-  private def requireJvmLoader(action: String): Unit = {
-    if (!JvmLoader.isSupported) {
-      println(JvmLoader.unsupportedMessage(action))
+  private def featureNotSupportedInNativeImage(): Unit = {
+    if (NativeImage.GraalEnabled) {
+      val msg =
+        """This action is not supported in the native image.
+          |
+          |You must run the flix.jar in the JVM for this action.
+          |""".stripMargin
+      println(msg)
       System.exit(1)
     }
   }
 
+  /**
+    * Exits with code 0 on success, or prints the error and exits with code 1 on failure.
+    */
   private def exitOnResult[T](result: Result[T, BootstrapError])(implicit formatter: Formatter): Unit = {
     result match {
       case Result.Ok(_) => System.exit(0)

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -122,6 +122,7 @@ object Main {
         case Command.None =>
           // check if the --listen flag was passed.
           if (cmdOpts.listen.nonEmpty) {
+            requireJvmLoader("The '--listen' server")
             SocketServer.listen(cmdOpts.listen.get)
             System.exit(0)
           }
@@ -158,6 +159,7 @@ object Main {
 
           // check if we should start a REPL
           if (cmdOpts.files.isEmpty) {
+            requireJvmLoader("The REPL")
             Bootstrap.bootstrap(cwd, options.githubToken) match {
               case Result.Ok(bootstrap) =>
                 val shell = new Shell(bootstrap, options)
@@ -168,6 +170,9 @@ object Main {
                 System.exit(1)
             }
           }
+
+          // running the given files loads the compiled program into the JVM.
+          requireJvmLoader("Running a Flix program")
 
           // configure Flix and add the paths.
           val flix = new Flix()
@@ -342,6 +347,7 @@ object Main {
             println("The 'run' command does not support file arguments.")
             System.exit(1)
           }
+          requireJvmLoader("The 'run' command")
           exitOnResult {
             Bootstrap.bootstrap(cwd, options.githubToken).flatMap { bootstrap =>
               val flix = new Flix().setFormatter(formatter)
@@ -351,6 +357,7 @@ object Main {
           }
 
         case Command.Test =>
+          requireJvmLoader("The 'test' command")
           if (cmdOpts.files.isEmpty) {
             exitOnResult {
               Bootstrap.bootstrap(cwd, options.githubToken).flatMap { bootstrap =>
@@ -376,6 +383,7 @@ object Main {
             println("The 'repl' command does not support file arguments.")
             System.exit(1)
           }
+          requireJvmLoader("The REPL")
           Bootstrap.bootstrap(cwd, options.githubToken) match {
             case Result.Ok(bootstrap) =>
               val shell = new Shell(bootstrap, options)
@@ -389,6 +397,11 @@ object Main {
         case Command.PlainLsp =>
           if (cmdOpts.files.nonEmpty) {
             println("The 'lsp' command does not support file arguments.")
+            System.exit(1)
+          }
+          if (NativeImage.isRuntime) {
+            // lsp4j needs reflection metadata that the native image does not include yet.
+            println("The 'lsp' command is not yet supported in the native build of Flix. Use 'lsp-vscode <port>' or the JAR distribution of Flix instead.")
             System.exit(1)
           }
           LspServer.run(options)
@@ -820,6 +833,18 @@ object Main {
   /**
     * Exits with code 0 on success, or prints the error and exits with code 1 on failure.
     */
+  /**
+    * Exits with an explanatory message if the running JVM cannot load compiled Flix programs.
+    *
+    * `action` names what was attempted, e.g. "The 'run' command"; see [[JvmLoader.isSupported]].
+    */
+  private def requireJvmLoader(action: String): Unit = {
+    if (!JvmLoader.isSupported) {
+      println(JvmLoader.unsupportedMessage(action))
+      System.exit(1)
+    }
+  }
+
   private def exitOnResult[T](result: Result[T, BootstrapError])(implicit formatter: Formatter): Unit = {
     result match {
       case Result.Ok(_) => System.exit(0)

--- a/main/src/ca/uwaterloo/flix/runtime/JvmLoader.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/JvmLoader.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.jvm.ClassDescs
 import ca.uwaterloo.flix.language.phase.jvm.JvmClass
 import ca.uwaterloo.flix.util.collection.MapOps
-import ca.uwaterloo.flix.util.InternalCompilerException
+import ca.uwaterloo.flix.util.{InternalCompilerException, NativeImage}
 
 import java.lang.constant.ClassDesc
 import java.lang.reflect.{InvocationTargetException, Method}
@@ -36,14 +36,40 @@ import java.lang.reflect.{InvocationTargetException, Method}
 object JvmLoader {
 
   /**
+    * `true` if the running JVM can load compiled Flix programs.
+    *
+    * A GraalVM native image refuses `ClassLoader.defineClass` at run time, so a program compiled
+    * inside the image cannot be loaded into it. Callers should check this before [[load]] and
+    * explain the limitation to the user; [[load]] itself throws if called regardless.
+    */
+  val isSupported: Boolean = !NativeImage.isRuntime
+
+  /**
+    * Returns a message explaining that `action` (e.g. "The 'run' command") cannot load compiled
+    * programs because [[isSupported]] is `false`.
+    */
+  def unsupportedMessage(action: String): String =
+    s"$action is unsupported in the native build of Flix because it loads the compiled program into the running JVM, which a native image cannot do. Use the JAR distribution of Flix instead, or build a JAR with 'build-fatjar' and run it with 'java -jar'."
+
+  /**
     * Loads the classes of `result` into a fresh class loader and returns reflected handles to `main` and the tests.
     *
     * The class loader falls back to `result.flix.jarLoader` for classes from external JARs.
     *
+    * Throws [[UnsupportedOperationException]] if [[isSupported]] is `false`.
+    *
     * A failure to load (or to find an entry point) is a compiler bug and is reported via [[CrashHandler]].
     * Exceptions thrown by the *program* itself, when `main` or a test is invoked, are not caught here.
     */
-  def load(result: CompilationResult): LoadedProgram = try {
+  def load(result: CompilationResult): LoadedProgram = {
+    if (!isSupported) {
+      throw new UnsupportedOperationException(unsupportedMessage("Loading a compiled program"))
+    }
+    loadUnchecked(result)
+  }
+
+  /** Loads `result` without checking [[isSupported]]; see [[load]]. */
+  private def loadUnchecked(result: CompilationResult): LoadedProgram = try {
     implicit val flix: Flix = result.flix
     val root = result.root
 

--- a/main/src/ca/uwaterloo/flix/runtime/JvmLoader.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/JvmLoader.scala
@@ -36,58 +36,43 @@ import java.lang.reflect.{InvocationTargetException, Method}
 object JvmLoader {
 
   /**
-    * `true` if the running JVM can load compiled Flix programs.
-    *
-    * A GraalVM native image refuses `ClassLoader.defineClass` at run time, so a program compiled
-    * inside the image cannot be loaded into it. Callers should check this before [[load]] and
-    * explain the limitation to the user; [[load]] itself throws if called regardless.
-    */
-  val isSupported: Boolean = !NativeImage.isRuntime
-
-  /**
-    * Returns a message explaining that `action` (e.g. "The 'run' command") cannot load compiled
-    * programs because [[isSupported]] is `false`.
-    */
-  def unsupportedMessage(action: String): String =
-    s"$action is unsupported in the native build of Flix because it loads the compiled program into the running JVM, which a native image cannot do. Use the JAR distribution of Flix instead, or build a JAR with 'build-fatjar' and run it with 'java -jar'."
-
-  /**
     * Loads the classes of `result` into a fresh class loader and returns reflected handles to `main` and the tests.
     *
     * The class loader falls back to `result.flix.jarLoader` for classes from external JARs.
     *
-    * Throws [[UnsupportedOperationException]] if [[isSupported]] is `false`.
+    * Throws [[UnsupportedOperationException]] if running inside a GraalVM native image, which
+    * refuses `ClassLoader.defineClass` at run time.
     *
     * A failure to load (or to find an entry point) is a compiler bug and is reported via [[CrashHandler]].
     * Exceptions thrown by the *program* itself, when `main` or a test is invoked, are not caught here.
     */
   def load(result: CompilationResult): LoadedProgram = {
-    if (!isSupported) {
-      throw new UnsupportedOperationException(unsupportedMessage("Loading a compiled program"))
-    }
-    loadUnchecked(result)
-  }
-
-  /** Loads `result` without checking [[isSupported]]; see [[load]]. */
-  private def loadUnchecked(result: CompilationResult): LoadedProgram = try {
-    implicit val flix: Flix = result.flix
-    val root = result.root
-
-    // Load each class into the JVM in a fresh class loader.
-    implicit val loadedClasses: Map[ClassDesc, Class[?]] = loadAll(root.classes.values, flix.jarLoader)
-
-    val tests = MapOps.mapValuesWithKey(root.tests) {
-      case (sym, defn) => TestFn(sym, defn.isSkip, wrapTest(loadMethod(defn.className, defn.methodName)))
-    }
-    val main = root.main.map {
-      case defn => wrapMain(loadMethod(defn.className, defn.methodName))
+    // A native image refuses ClassLoader.defineClass, so bail out before the crash handler below.
+    if (NativeImage.GraalEnabled) {
+      val msg = "Loading a compiled program is not supported in the native image. You must run the flix.jar in the JVM for this action."
+      throw new UnsupportedOperationException(msg)
     }
 
-    LoadedProgram(main, tests)
-  } catch {
-    case ex: Throwable =>
-      CrashHandler.handleCrash(ex)(result.flix)
-      throw ex
+    try {
+      implicit val flix: Flix = result.flix
+      val root = result.root
+
+      // Load each class into the JVM in a fresh class loader.
+      implicit val loadedClasses: Map[ClassDesc, Class[?]] = loadAll(root.classes.values, flix.jarLoader)
+
+      val tests = MapOps.mapValuesWithKey(root.tests) {
+        case (sym, defn) => TestFn(sym, defn.isSkip, wrapTest(loadMethod(defn.className, defn.methodName)))
+      }
+      val main = root.main.map {
+        case defn => wrapMain(loadMethod(defn.className, defn.methodName))
+      }
+
+      LoadedProgram(main, tests)
+    } catch {
+      case ex: Throwable =>
+        CrashHandler.handleCrash(ex)(result.flix)
+        throw ex
+    }
   }
 
   /** Wraps the reflected test `method` (of type `Unit -> t`) into a thunk. */

--- a/main/src/ca/uwaterloo/flix/util/NativeImage.scala
+++ b/main/src/ca/uwaterloo/flix/util/NativeImage.scala
@@ -24,8 +24,7 @@ object NativeImage {
     * `true` if the compiler is running inside a GraalVM native image.
     *
     * A native image sets the system property `org.graalvm.nativeimage.imagecode` to `"runtime"`.
-    * The property is `"buildtime"` while the image is being built and absent on a regular JVM.
     */
-  val isRuntime: Boolean = System.getProperty("org.graalvm.nativeimage.imagecode") == "runtime"
+  val GraalEnabled: Boolean = System.getProperty("org.graalvm.nativeimage.imagecode") == "runtime"
 
 }

--- a/main/src/ca/uwaterloo/flix/util/NativeImage.scala
+++ b/main/src/ca/uwaterloo/flix/util/NativeImage.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.util
+
+/**
+  * Detects whether the compiler is running inside a GraalVM native image.
+  */
+object NativeImage {
+
+  /**
+    * `true` if the compiler is running inside a GraalVM native image.
+    *
+    * A native image sets the system property `org.graalvm.nativeimage.imagecode` to `"runtime"`.
+    * The property is `"buildtime"` while the image is being built and absent on a regular JVM.
+    */
+  val isRuntime: Boolean = System.getProperty("org.graalvm.nativeimage.imagecode") == "runtime"
+
+}


### PR DESCRIPTION
Follow-up to #13210. In the native build, the commands that load the compiled program into the JVM currently die inside `JvmLoader.load` with a crash report that asks the user to file a compiler bug. This PR makes them fail fast with an explanation instead.

## What changes

- `util/NativeImage.scala`: `isRuntime` reads the `org.graalvm.nativeimage.imagecode` system property, which a native image sets to `runtime`. The property is absent on a regular JVM, so nothing changes for the JAR distribution.
- `JvmLoader`: gains `isSupported` and `unsupportedMessage`, and `load` throws `UnsupportedOperationException` with that message before anything reaches `CrashHandler`. This covers callers that bypass `Main`, such as `Bootstrap`, `Shell`, `SocketServer`, and embedders.
- `Main`: a `requireJvmLoader` helper guards every path that ends in `JvmLoader.load`, before any compilation happens: `run`, `test` in both forms, `repl`, the REPL started by a bare `flix`, running a file directly, and `--listen`. The message is:

  > The 'run' command is unsupported in the native build of Flix because it loads the compiled program into the running JVM, which a native image cannot do. Use the JAR distribution of Flix instead, or build a JAR with 'build-fatjar' and run it with 'java -jar'.

- `lsp` gets its own, weaker message, because its limitation is temporary: lsp4j needs reflection metadata that the image does not include yet. It points at `lsp-vscode`, which works in the image, since it uses plain sockets and AST-based JSON.
- The Native Image workflow now asserts that `run` and `lsp` fail with these messages, alongside the existing checks that `check` and `build-fatjar` succeed.

## Not guarded

`check`, `build`, `build-classes`, `build-jar`, `build-fatjar`, `doc`, and `lsp-vscode` all work in the image and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLYNr3zsG9cgR6jsvB9gzb
