### PR TITLE
refactor: name anonymous classes by descriptor

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/JvmAst.scala
@@ -119,7 +119,7 @@ object JvmAst {
 
   case class StructField(sym: Symbol.StructFieldSym, tpe: SimpleType, loc: SourceLocation)
 
-  case class AnonClass(name: String, clazz: JClass, tpe: SimpleType, constructors: List[JvmConstructor], methods: List[JvmMethod], superMethods: List[JMethod], loc: SourceLocation)
+  case class AnonClass(sym: Symbol.AnonClassSym, clazz: JClass, tpe: SimpleType, constructors: List[JvmConstructor], methods: List[JvmMethod], superMethods: List[JMethod], loc: SourceLocation)
 
   case class JvmConstructor(exp: Expr, tpe: SimpleType, purity: Purity, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -987,11 +987,6 @@ object Symbol {
   final class AnonClassSym(val id: Int, val loc: SourceLocation) extends Symbol with Locatable {
 
     /**
-      * Returns the name of `this` symbol.
-      */
-    def name: String = s"Anon$$${id}"
-
-    /**
       * Returns `true` if this symbol is equal to `that` symbol.
       */
     override def equals(obj: Any): Boolean = obj match {
@@ -1006,8 +1001,10 @@ object Symbol {
 
     /**
       * Human-readable representation.
+      *
+      * Note: This is not the name of the generated class. Use `GenAnonymousClasses.desc` for that.
       */
-    override def toString: String = name
+    override def toString: String = s"Anon$$$id"
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -126,7 +126,7 @@ object Reducer {
 
       case ErasedAst.Expr.ApplyAtomic(op, exps, tpe, purity, loc) =>
         op match {
-          case AtomicOp.InvokeSuperMethod(sym, method) => ctx.addSuperMethod(sym.name, method)
+          case AtomicOp.InvokeSuperMethod(sym, method) => ctx.addSuperMethod(sym, method)
           case _ => ()
         }
         val es = exps.map(visitExpr)
@@ -225,7 +225,7 @@ object Reducer {
             val c = visitExpr(clo)
             JvmAst.JvmMethod(ann, ident, fparams.map(visitFormalParam), c, retTpe, methPurity, javaSig, methLoc)
         }
-        ctx.addAnonClass(JvmAst.AnonClass(sym.name, clazz, tpe, cs, specs, Nil, loc))
+        ctx.addAnonClass(JvmAst.AnonClass(sym, clazz, tpe, cs, specs, Nil, loc))
 
         JvmAst.Expr.NewObject(sym, clazz, tpe, purity, cs, specs, loc)
 
@@ -317,20 +317,20 @@ object Reducer {
     /** Collects all types encountered in def expressions (used as a set via `ConcurrentHashMap`). */
     private val defTypes: ConcurrentHashMap[SimpleType, Unit] = new ConcurrentHashMap()
 
-    /** Maps anonymous class names to the super methods they invoke, so the backend can generate `invokespecial` bridge methods. */
-    private val superMethods: ConcurrentHashMap[(String, JMethod), Unit] = new ConcurrentHashMap()
+    /** Maps anonymous classes to the super methods they invoke, so the backend can generate `invokespecial` bridge methods. */
+    private val superMethods: ConcurrentHashMap[(Symbol.AnonClassSym, JMethod), Unit] = new ConcurrentHashMap()
 
     def addAnonClass(clazz: JvmAst.AnonClass): Unit =
       anonClasses.add(clazz)
 
-    def getAnonClasses: List[JvmAst.AnonClass] =
-      anonClasses.asScala.toList.map(ac => ac.copy(superMethods = getSuperMethods(ac.name)))
+    def getAnonClasses: List[JvmAst.AnonClass] = {
+      // Group the super methods by class once, so that each class costs a single lookup.
+      val methodsOf = superMethods.keySet.asScala.groupMap(_._1)(_._2)
+      anonClasses.asScala.toList.map(ac => ac.copy(superMethods = methodsOf.getOrElse(ac.sym, Nil).toList))
+    }
 
-    def addSuperMethod(className: String, method: JMethod): Unit =
-      superMethods.putIfAbsent((className, method), ())
-
-    def getSuperMethods(className: String): List[JMethod] =
-      superMethods.keySet.asScala.collect { case (cn, m) if cn == className => m }.toList
+    def addSuperMethod(sym: Symbol.AnonClassSym, method: JMethod): Unit =
+      superMethods.putIfAbsent((sym, method), ())
 
     def addDefType(tpe: SimpleType): Unit =
       defTypes.putIfAbsent(tpe, ())

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -324,9 +324,23 @@ object Reducer {
       anonClasses.add(clazz)
 
     def getAnonClasses: List[JvmAst.AnonClass] = {
-      // Group the super methods by class once, so that each class costs a single lookup.
-      val methodsOf = superMethods.keySet.asScala.groupMap(_._1)(_._2)
-      anonClasses.asScala.toList.map(ac => ac.copy(superMethods = methodsOf.getOrElse(ac.sym, Nil).toList))
+      // Group the super methods by the anonymous class that invokes them. We do this
+      // once, up front, so that attaching them below costs a single lookup per class.
+      val methodsOf = mutable.Map.empty[Symbol.AnonClassSym, mutable.ArrayBuffer[JMethod]]
+      for ((sym, method) <- superMethods.keySet.asScala) {
+        val methods = methodsOf.getOrElseUpdate(sym, mutable.ArrayBuffer.empty)
+        methods += method
+      }
+
+      // Attach the super methods of each anonymous class. A class that invokes none
+      // already has the empty list it was constructed with.
+      anonClasses.asScala.toList.map {
+        anonClass =>
+          methodsOf.get(anonClass.sym) match {
+            case None => anonClass
+            case Some(methods) => anonClass.copy(superMethods = methods.toList)
+          }
+      }
     }
 
     def addSuperMethod(sym: Symbol.AnonClassSym, method: JMethod): Unit =

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/CodeGen.scala
@@ -85,7 +85,7 @@ object CodeGen {
 
     val lazyClasses = getLazyTypesOf(allTypes).map(tpe => JvmClass(GenLazy.desc(tpe), GenLazy.genByteCode(tpe))).toList
 
-    val anonClasses = GenAnonymousClasses.gen(root.anonClasses.distinctBy(_.name))
+    val anonClasses = GenAnonymousClasses.gen(root.anonClasses.distinctBy(_.sym))
 
     val unitClass = List(JvmClass(GenUnit.Desc, GenUnit.genByteCode()))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.shared.{JConstructor, JMethod}
-import ca.uwaterloo.flix.language.ast.{AtomicOp, SimpleType}
+import ca.uwaterloo.flix.language.ast.{AtomicOp, SimpleType, Symbol}
 import ca.uwaterloo.flix.language.ast.JvmAst.*
 import ca.uwaterloo.flix.language.jvm.JavaClasses
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
@@ -36,10 +36,27 @@ import scala.jdk.CollectionConverters.*
 /** Generates bytecode for anonymous classes (created through NewObject). */
 object GenAnonymousClasses {
 
+  /**
+    * Returns the descriptor of the anonymous class `Anon$Id` of `sym`.
+    *
+    * Unlike defs and effects, an anonymous class has no enclosing namespace,
+    * so it is placed in the root package.
+    */
+  def desc(sym: Symbol.AnonClassSym): ClassDesc =
+    Mangle.mkDesc(Mangle.RootPackage, Mangle.mkClassName("Anon", sym.id.toString))
+
+  /**
+    * Returns the name of the bridge method through which `method` is called on the superclass.
+    *
+    * A Java method name is always a valid JVM name, so it needs no mangling.
+    */
+  def bridgeName(method: JMethod): String =
+    "super" + Flix.Delimiter + method.name
+
   /** Returns the generated classes of `objs`. */
   def gen(objs: List[AnonClass])(implicit root: Root, flix: Flix): List[JvmClass] = {
     for (obj <- objs) yield {
-      val className = ClassDesc.ofInternalName(obj.name)
+      val className = desc(obj.sym)
       JvmClass(className, genByteCode(className, obj))
     }
   }
@@ -92,8 +109,7 @@ object GenAnonymousClasses {
     // Generate bridge methods for super method calls.
     val superMethods = obj.superMethods
     for (method <- superMethods) {
-      val bridgeName = s"super$$${method.name}"
-      cm.mkMethod(Nil, ClassMaker.InstanceMethod(className, bridgeName, method.descriptor), IsPublic, NotFinal, superBridgeIns(superClass, method)(_))
+      cm.mkMethod(Nil, ClassMaker.InstanceMethod(className, bridgeName(method), method.descriptor), IsPublic, NotFinal, superBridgeIns(superClass, method)(_))
     }
 
     cm.closeClassMaker()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -894,7 +894,7 @@ object GenExpression {
 
         // Evaluate the receiver object.
         compileExpr(receiver)
-        val anonClassInternalName = sym.name.replace('.', '/')
+        val anonClassInternalName = internalNameOf(GenAnonymousClasses.desc(sym))
         mv.visitTypeInsn(Opcodes.CHECKCAST, anonClassInternalName)
 
         // Evaluate and cast each argument.
@@ -904,8 +904,7 @@ object GenExpression {
         }
 
         // Call the bridge method super$methodName on the anonymous class.
-        val bridgeName = s"super$$${method.name}"
-        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, anonClassInternalName, bridgeName, method.descriptor.descriptorString(), false)
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, anonClassInternalName, GenAnonymousClasses.bridgeName(method), method.descriptor.descriptorString(), false)
 
         // If the method is void, put a unit on top of the stack
         if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
@@ -1561,7 +1560,7 @@ object GenExpression {
 
     case Expr.NewObject(sym, _, _, _, constructors, methods, _) =>
       val methodExps = methods.map(_.exp)
-      val className = sym.name
+      val className = internalNameOf(GenAnonymousClasses.desc(sym))
       mv.visitTypeInsn(Opcodes.NEW, className)
       mv.visitInsn(Opcodes.DUP)
 


### PR DESCRIPTION
Anonymous classes were the only kind of generated class without a symbol-to-descriptor function. Their name lived as a raw string on `AnonClassSym`, and the backend turned it into a JVM internal name three different ways:

- `ClassDesc.ofInternalName(obj.name)` in `GenAnonymousClasses`
- `sym.name.replace('.', '/')` in `GenExpression`, a no-op since the name is unqualified
- `sym.name` used raw for `NEW`, `INVOKESPECIAL` and `PUTFIELD`

The string was also the join key between the collected class list and the bridge methods each class needs, keyed by `String` in the Reducer's shared context.

This adds `GenAnonymousClasses.desc`, mirroring `defnDesc` and `effectDesc`, and carries the symbol on `JvmAst.AnonClass` instead of the name. The Reducer keys its super-method table by symbol, and both `GenExpression` sites go through `internalNameOf`. `AnonClassSym.name` is removed, so the string now exists only inside `toString` and cannot be mistaken for a JVM name again.

Two adjacent cleanups in the same code:

- The duplicated `super$` bridge-method name is extracted into `GenAnonymousClasses.bridgeName`. It was spelled out in both `GenAnonymousClasses` and `GenExpression`.
- `getAnonClasses` grouped the super methods once instead of scanning the whole key set per anonymous class, which was quadratic in programs with many of them.

Generated class names and bridge-method names are unchanged. Anonymous classes still land in the root package as `Anon$<id>`, now built through `Mangle` like every other generated class, so the delimiter is the shared constant rather than a literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CvfCqYQcj11bN4f1QCNy5