### PR TITLE
refactor: derive the Flix runtime class names from one descriptor

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.shared.{AvailableClasses, Input, SecurityContext, Source}
 import ca.uwaterloo.flix.language.dbg.AstPrinter
 import ca.uwaterloo.flix.language.fmt.FormatOptions
-import ca.uwaterloo.flix.language.jvm.{ByteBuddyJavaTypeProvider, JavaTypeProvider}
+import ca.uwaterloo.flix.language.jvm.{ByteBuddyJavaTypeProvider, ExternalJarLoader, JavaTypeProvider}
 import ca.uwaterloo.flix.language.phase.*
 import ca.uwaterloo.flix.language.phase.jvm.CodeGen
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization

--- a/main/src/ca/uwaterloo/flix/language/jvm/ExternalJarLoader.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/ExternalJarLoader.scala
@@ -13,9 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ca.uwaterloo.flix.util
+package ca.uwaterloo.flix.language.jvm
 
 import java.net.{URL, URLClassLoader}
+
+object ExternalJarLoader {
+
+  /** The binary name of the `Global` class, i.e. `dev.flix.runtime.Global`. */
+  private val GlobalBinaryName: String = ClassDescs.binaryNameOf(FlixClasses.Global)
+
+  /** The class file name of the `Global` class, i.e. `dev/flix/runtime/Global.class`. */
+  private val GlobalClassFileName: String = ClassDescs.classFileNameOf(FlixClasses.Global)
+
+  /** The prefix shared by the binary names of the test classes, i.e. `dev.flix.test.`. */
+  private val TestBinaryNamePrefix: String = FlixClasses.TestPackage.mkString("", ".", ".")
+
+  /** The prefix shared by the class file names of the test classes, i.e. `dev/flix/test/`. */
+  private val TestClassFileNamePrefix: String = FlixClasses.TestPackage.mkString("", "/", "/")
+
+}
 
 /**
   * A class loader to which JARs can be added dynamically.
@@ -24,6 +40,9 @@ import java.net.{URL, URLClassLoader}
   * (otherwise compiled Flix code has access to all classes within the compiler)
   */
 class ExternalJarLoader extends URLClassLoader(Array.empty, ClassLoader.getPlatformClassLoader) {
+
+  import ExternalJarLoader.*
+
   /**
     * Adds the URL to the class loader.
     */
@@ -37,13 +56,13 @@ class ExternalJarLoader extends URLClassLoader(Array.empty, ClassLoader.getPlatf
       super.findClass(name)
     } catch {
       case e: ClassNotFoundException =>
-        // Special case for dev.flix.runtime.Global
+        // Special case for the Global class.
         // This is never used at runtime, but we need to be able to load it at compile
         // time in order to check method signatures
-        if (name == "dev.flix.runtime.Global")
+        if (name == GlobalBinaryName)
           super.findSystemClass(name)
         // Special case for testing to allow us to load test classes
-        else if (name.startsWith(("dev.flix.test.")))
+        else if (name.startsWith(TestBinaryNamePrefix))
           super.findSystemClass(name)
         else
           throw e
@@ -55,7 +74,7 @@ class ExternalJarLoader extends URLClassLoader(Array.empty, ClassLoader.getPlatf
     val resource = super.findResource(name)
     if (resource != null) {
       resource
-    } else if (name == "dev/flix/runtime/Global.class" || name.startsWith("dev/flix/test/")) {
+    } else if (name == GlobalClassFileName || name.startsWith(TestClassFileNamePrefix)) {
       ClassLoader.getSystemResource(name)
     } else {
       null

--- a/main/src/ca/uwaterloo/flix/language/jvm/FlixClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/FlixClasses.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.jvm
+
+import java.lang.constant.ClassDesc
+
+/**
+  * The packages and [[ClassDesc]]s of the Flix classes that the compiler refers to by name.
+  *
+  * The classes and interfaces of the JDK live in [[JavaClasses]].
+  */
+object FlixClasses {
+
+  /** The `dev.flix.runtime` package, which holds the classes of the Flix runtime. */
+  val RuntimePackage: List[String] = List("dev", "flix", "runtime")
+
+  /** The `dev.flix.test` package, which holds the Java classes used by the test suite. */
+  val TestPackage: List[String] = List("dev", "flix", "test")
+
+  /**
+    * The `dev.flix.runtime.Global` class, which holds the global id counter and the
+    * command line arguments.
+    *
+    * The compiler generates this class, but `main/src/dev/flix/runtime/Global.java` provides
+    * a mock of it so that its method signatures can be checked at compile time.
+    */
+  val Global: ClassDesc = ClassDesc.of(RuntimePackage.mkString("."), "Global")
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
@@ -18,6 +18,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.jvm.FlixClasses
 
 import java.lang.constant.ClassDesc
 import java.lang.constant.ConstantDescs.{CD_boolean, CD_byte, CD_char, CD_double, CD_float, CD_int, CD_long, CD_short}
@@ -31,7 +32,7 @@ object Mangle {
   val RootPackage: List[String] = Nil
 
   /** The `dev.flix.runtime` package of the Flix runtime classes. */
-  val DevFlixRuntime: List[String] = List("dev", "flix", "runtime")
+  val DevFlixRuntime: List[String] = FlixClasses.RuntimePackage
 
   /** Returns the [[ClassDesc]] of the class `name` in the package `pkg`. */
   def mkDesc(pkg: List[String], name: String): ClassDesc = {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenGlobal.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenGlobal.scala
@@ -17,13 +17,12 @@
 package ca.uwaterloo.flix.language.phase.jvm.classes
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.jvm.JavaClasses
+import ca.uwaterloo.flix.language.jvm.{FlixClasses, JavaClasses}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.NotVolatile
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{ConstructorMethod, StaticConstructorMethod, StaticField, StaticMethod}
 import ca.uwaterloo.flix.language.phase.jvm.Instructions.*
-import ca.uwaterloo.flix.language.phase.jvm.Mangle.{DevFlixRuntime, mkDesc}
 import ca.uwaterloo.flix.language.phase.jvm.MethodTypeDescs.{mkDescriptor, mkVoidDescriptor}
 import ca.uwaterloo.flix.language.phase.jvm.{ClassConstants, ClassMaker, MethodTypeDescs}
 import org.objectweb.asm.{MethodVisitor, Opcodes}
@@ -36,9 +35,12 @@ import java.lang.constant.{ClassDesc, MethodTypeDesc}
   */
 object GenGlobal {
 
-  /** "Global" is fixed in source code, so it should not be mangled and `$` suffixed. */
-  /** The JVM class descriptor for the generated `Global` class. */
-  val Desc: ClassDesc = mkDesc(DevFlixRuntime, "Global")
+  /**
+    * The JVM class descriptor for the generated `Global` class.
+    *
+    * The name is fixed in source code, so it is neither mangled nor `$` suffixed.
+    */
+  val Desc: ClassDesc = FlixClasses.Global
 
   def genByteCode()(implicit flix: Flix): Array[Byte] = {
     val cm = ClassMaker.mkClass(this.Desc, IsFinal)


### PR DESCRIPTION
This is item 4 from the ad-hoc JVM name survey.

`ExternalJarLoader` spelled `dev.flix.runtime.Global` twice, once as a binary name at `findClass` and once as a class file path at `findResource`. It spelled the `dev.flix.test` package twice in the same two forms. A descriptor for the Global class already existed as `GenGlobal.Desc`, so the loader held a third and fourth spelling of names the backend already knew, with nothing keeping them in sync.

Adds `FlixClasses`, sitting alongside `JavaClasses` in `language.jvm`, holding the two Flix packages and the Global descriptor. It is deliberately separate from `JavaClasses`, which is scoped to the JDK, and from `CompilerConstants`, which holds scalar and path constants rather than class descriptors.

`GenGlobal` and `Mangle.DevFlixRuntime` now derive from it, so the runtime package has one definition instead of two. The loader derives all four of its strings through the existing `ClassDescs` helpers.

`ExternalJarLoader` moves from `util` into `language.jvm` so it can reach those constants. It is entirely a JVM class-loading concern, and `language.jvm` is where the JVM naming and metadata layer has been collecting. This keeps `util` from gaining a dependency on the JVM layer, which is the direction the recent moves of `ClassDescs` and `JavaClasses` were going.

No behavior change. The four derived strings are identical to the literals they replace, and `GenGlobal.Desc` is the same descriptor as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CvfCqYQcj11bN4f1QCNy5