### PR TITLE
fix: enable https in the native image so Maven dependencies download

### DIFF
--- a/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
+++ b/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
@@ -24,7 +24,12 @@
 #   on them. The dev/flix entry covers the dev.flix.runtime.Global mock class that
 #   ExternalJarLoader serves as a system resource.
 #   The option is experimental, hence the surrounding unlock/lock pair.
+#
+# --enable-url-protocols=https
+#   A native image supports no URL protocols by default. Coursier needs https to download
+#   the Maven dependencies declared in a project's flix.toml.
 Args = --no-fallback \
+       --enable-url-protocols=https \
        --initialize-at-build-time=net.bytebuddy \
        -H:+UnlockExperimentalVMOptions \
        -H:IncludeResources=(java|javax|com/sun/net/httpserver|dev/flix)/.*\\.class \


### PR DESCRIPTION
A native image supports no URL protocols unless they are declared at build time. Coursier therefore failed to download every Maven dependency declared in a project's `flix.toml`:

```
Error downloading org.lwjgl:lwjgl-opengl:3.4.1
  download error: Caught java.net.MalformedURLException (Accessing a URL protocol
  that was not enabled. The URL protocol https is supported but not enabled by
  default. It must be enabled by adding the --enable-url-protocols=https option
  to the native-image command.)
```

Adding `--enable-url-protocols=https` to the checked-in Native Image configuration fixes it.

## How it was found

Building the `ababup1192/flix_game_engine` community project, which declares five LWJGL dependencies, with a native image. The project failed after 0.06 seconds. The existing smoke test could not catch this because the hello world project it builds has no dependencies.

## Verification

With the `lib/` directory deleted so the download runs for real, dependency resolution now completes:

```
  Adding `org.lwjgl:lwjgl-opengl' (v3.4.1).
  ...
Dependency resolution completed.
```

`magnus-madsen/bibblitz`, which has no Maven dependencies, still builds a fat JAR in 1.75 s.

Note that `flix_game_engine` still does not build for two further reasons, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLYNr3zsG9cgR6jsvB9gzb