### PR TITLE
fix: restore the JDK packages bundled in the native image

### DIFF
--- a/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
+++ b/main/src/resources/META-INF/native-image/dev.flix/flix/native-image.properties
@@ -17,12 +17,21 @@
 # -H:IncludeResources=...
 #   The type checker reads JDK class files through ByteBuddyJavaTypeProvider using
 #   ClassLoader.getResourceAsStream. Inside a native image no class loader can serve JDK
-#   class files, so they are bundled as resources. Only the public java and javax packages
-#   are included, plus com.sun.net.httpserver which the standard library imports; the
-#   internal sun and jdk packages are left out because they add well over 100 MB (locale
-#   data, graphics and security implementation classes) and Flix code should not depend
-#   on them. The dev/flix entry covers the dev.flix.runtime.Global mock class that
-#   ExternalJarLoader serves as a system resource.
+#   class files, so they are bundled as resources. Every package a program may refer to must
+#   be present: resolving a class also resolves its supertypes and member types, so
+#   restricting this to java and javax breaks projects that use, for example,
+#   com.sun.management.ThreadMXBean, whose resolution reaches sun.management.spi. The
+#   dev/flix entry covers the dev.flix.runtime.Global mock class that ExternalJarLoader
+#   serves as a system resource.
+#
+# -H:ExcludeResources=...
+#   Trims the trees that cannot appear in the signature of a Java class a Flix program can
+#   name: the Graal compiler embedded in the image, the JDK development tools, the
+#   Serviceability Agent, and the locale and text resource bundles, which hold data rather
+#   than API, and the bundled Xerces and Xalan implementation, which no public signature
+#   names. The XML interfaces themselves stay: org.w3c.dom.Node is reachable from the
+#   image metadata API in java.desktop. This mirrors the packages that ClassList.scala
+#   already filters out.
 #   The option is experimental, hence the surrounding unlock/lock pair.
 #
 # --enable-url-protocols=https
@@ -32,5 +41,6 @@ Args = --no-fallback \
        --enable-url-protocols=https \
        --initialize-at-build-time=net.bytebuddy \
        -H:+UnlockExperimentalVMOptions \
-       -H:IncludeResources=(java|javax|com/sun/net/httpserver|dev/flix)/.*\\.class \
+       -H:IncludeResources=(java|javax|jdk|sun|com/sun|org/w3c|org/xml|dev/flix)/.*\\.class \
+       -H:ExcludeResources=(jdk/graal|jdk/javadoc|jdk/jpackage|jdk/jshell|jdk/tools|com/sun/tools|com/sun/org|com/sun/xml|sun/jvm/hotspot|sun/util/resources|sun/text/resources)/.*\\.class \
        -H:-UnlockExperimentalVMOptions


### PR DESCRIPTION
Reverts the regex trim from #13216, which broke projects that refer to JDK packages outside `java` and `javax`, and replaces it with a targeted exclusion list.

## The problem

Resolving a Java class also resolves its supertypes and member types, so the class files the type checker needs are not limited to what a project imports directly. The `ababup1192/flix_game_engine` community project imports `com.sun.management.ThreadMXBean` to measure allocation, and resolving it reaches `sun.management.spi.PlatformMBeanProvider$PlatformComponent`. With those packages excluded the compiler did not report an error, it crashed:

```
net.bytebuddy.pool.TypePool$Resolution$NoSuchTypeException: Cannot resolve type
description for sun.management.spi.PlatformMBeanProvider$PlatformComponent
```

When I made #13216 I described the trade-off as affecting only code that imports internal classes directly. That was wrong: it fires on transitive resolution a user does not control, and the failure mode is a crash rather than a diagnostic.

## What this does instead

The include list goes back to the full set, and an exclusion list drops the trees that cannot appear in the signature of a class a Flix program can name. Sizes are uncompressed class files across the JDK modules in the image:

| Excluded | Size | Why it cannot be referenced |
| --- | --- | --- |
| `jdk/graal` | 22.2 MB | The Graal compiler embedded in the image |
| `sun/util/resources` | 20.5 MB | Locale resource bundles: data, not API |
| `com/sun/tools` | 10.5 MB | javac and javadoc internals |
| `com/sun/org`, `com/sun/xml` | 9.4 MB | The bundled Xerces and Xalan implementation |
| `sun/text/resources` | 5.8 MB | Text and locale data |
| `sun/jvm/hotspot` | 3.6 MB | The Serviceability Agent debugger |
| `jdk/javadoc`, `jdk/jpackage`, `jdk/jshell`, `jdk/tools` | 5.1 MB | JDK development tools |

This mirrors the packages `ClassList.scala` already filters out when generating its own list.

The XML interfaces themselves are kept. Dropping `org/w3c` was tried and breaks the engine: `org.w3c.dom.Node` is reachable from the image metadata API in `java.desktop`. Only the implementation under `com/sun/org` is dropped, and a program importing `javax.xml.parsers.DocumentBuilderFactory` still type checks.

| | Size | Bundled resources |
| --- | --- | --- |
| Before #13216 | 269 MB | 30,287 |
| This PR | 186 MB | 18,806 |
| #13216, broken | 137 MB | 8,487 |

## Verification

- The `NoSuchTypeException` is gone and `ababup1192/flix_game_engine` builds a fat JAR byte-for-byte the size of the one the JVM produces.
- `magnus-madsen/bibblitz` builds in 1.9 s.
- The CI smoke test passes, including the `run` guard.
- A program importing `javax.xml.parsers` type checks.

Reading the JDK's `jmods` at run time would remove the bundling altogether and is still the better long-term fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLYNr3zsG9cgR6jsvB9gzb
