### PR TITLE
fix: resolve Java classes from dependencies in a native image

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.shared.{AvailableClasses, Input, SecurityContext, Source}
 import ca.uwaterloo.flix.language.dbg.AstPrinter
 import ca.uwaterloo.flix.language.fmt.FormatOptions
-import ca.uwaterloo.flix.language.jvm.{ByteBuddyJavaTypeProvider, ExternalJarLoader, JavaTypeProvider}
+import ca.uwaterloo.flix.language.jvm.{ByteBuddyJavaTypeProvider, ExternalJarLoader, JavaTypeProvider, MutableClassPathLocator}
 import ca.uwaterloo.flix.language.phase.*
 import ca.uwaterloo.flix.language.phase.jvm.CodeGen
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization
@@ -199,8 +199,16 @@ class Flix {
     */
   val jarLoader = new ExternalJarLoader
 
+  /**
+    * The class files of the JARs added with [[addJar]].
+    *
+    * Read directly rather than through [[jarLoader]]: a class loader constructed at run time
+    * cannot serve resources inside a GraalVM native image.
+    */
+  private val jarClassPath = new MutableClassPathLocator
+
   /** The descriptor-based Java metadata provider owned by this compiler instance. */
-  val javaTypeProvider: JavaTypeProvider = ByteBuddyJavaTypeProvider.fromClassLoader(jarLoader)
+  val javaTypeProvider: JavaTypeProvider = ByteBuddyJavaTypeProvider.fromMutableClassPath(jarClassPath, jarLoader)
 
   /**
     * Adds Flix source code from a file on the filesystem.
@@ -379,6 +387,7 @@ class Flix {
       case Result.Ok(()) =>
         val p1 = p.normalize()
         jarLoader.addURL(p1.toUri.toURL)
+        jarClassPath.addPath(p1)
         extendKnownJavaClassesAndInterfaces(p1)
         this
     }

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.shared.{AvailableClasses, Input, SecurityContext, Source}
 import ca.uwaterloo.flix.language.dbg.AstPrinter
 import ca.uwaterloo.flix.language.fmt.FormatOptions
-import ca.uwaterloo.flix.language.jvm.{ByteBuddyJavaTypeProvider, ExternalJarLoader, JavaTypeProvider, MutableClassPathLocator}
+import ca.uwaterloo.flix.language.jvm.{ByteBuddyJavaTypeProvider, DependencyClassPath, ExternalJarLoader, JavaTypeProvider}
 import ca.uwaterloo.flix.language.phase.*
 import ca.uwaterloo.flix.language.phase.jvm.CodeGen
 import ca.uwaterloo.flix.language.phase.monomorph.Specialization
@@ -205,10 +205,10 @@ class Flix {
     * Read directly rather than through [[jarLoader]]: a class loader constructed at run time
     * cannot serve resources inside a GraalVM native image.
     */
-  private val jarClassPath = new MutableClassPathLocator
+  private val dependencyClassPath = new DependencyClassPath
 
   /** The descriptor-based Java metadata provider owned by this compiler instance. */
-  val javaTypeProvider: JavaTypeProvider = ByteBuddyJavaTypeProvider.fromMutableClassPath(jarClassPath, jarLoader)
+  val javaTypeProvider: JavaTypeProvider = ByteBuddyJavaTypeProvider.fromDependencyClassPath(dependencyClassPath, jarLoader)
 
   /**
     * Adds Flix source code from a file on the filesystem.
@@ -387,7 +387,7 @@ class Flix {
       case Result.Ok(()) =>
         val p1 = p.normalize()
         jarLoader.addURL(p1.toUri.toURL)
-        jarClassPath.addPath(p1)
+        dependencyClassPath.addPath(p1)
         extendKnownJavaClassesAndInterfaces(p1)
         this
     }

--- a/main/src/ca/uwaterloo/flix/language/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/ByteBuddyJavaTypeProvider.scala
@@ -73,6 +73,20 @@ object ByteBuddyJavaTypeProvider {
     fromLocators(locators)
   }
 
+  /**
+    * Returns a provider that reads `entries` directly, falling back to `loader` and the JDK platform.
+    *
+    * `entries` is consulted first because a class loader constructed at run time cannot serve
+    * resources inside a GraalVM native image. `loader` is still consulted for the class files the
+    * compiler provides itself, such as `dev.flix.runtime.Global`.
+    */
+  def fromMutableClassPath(entries: MutableClassPathLocator, loader: ClassLoader): ByteBuddyJavaTypeProvider =
+    fromLocators(List(
+      entries,
+      ClassFileLocator.ForClassLoader.of(loader),
+      ClassFileLocator.ForClassLoader.ofPlatformLoader()
+    ))
+
   /** Returns a provider backed by the given locators in lookup order. */
   private def fromLocators(locators: List[ClassFileLocator]): ByteBuddyJavaTypeProvider = {
     val locator = new ClassFileLocator.Compound(locators.asJava)

--- a/main/src/ca/uwaterloo/flix/language/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/ByteBuddyJavaTypeProvider.scala
@@ -62,15 +62,15 @@ object ByteBuddyJavaTypeProvider {
   }
 
   /**
-    * Returns a provider that reads `entries` directly, falling back to `loader` and the JDK platform.
+    * Returns a provider that reads `deps` directly, falling back to `loader` and the JDK platform.
     *
-    * `entries` is consulted first because a class loader constructed at run time cannot serve
+    * `deps` is consulted first because a class loader constructed at run time cannot serve
     * resources inside a GraalVM native image. `loader` is still consulted for the class files the
     * compiler provides itself, such as `dev.flix.runtime.Global`.
     */
-  def fromMutableClassPath(entries: MutableClassPathLocator, loader: ClassLoader): ByteBuddyJavaTypeProvider =
+  def fromDependencyClassPath(deps: DependencyClassPath, loader: ClassLoader): ByteBuddyJavaTypeProvider =
     fromLocators(List(
-      entries,
+      deps,
       ClassFileLocator.ForClassLoader.of(loader),
       ClassFileLocator.ForClassLoader.ofPlatformLoader()
     ))

--- a/main/src/ca/uwaterloo/flix/language/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/ByteBuddyJavaTypeProvider.scala
@@ -43,18 +43,6 @@ object ByteBuddyJavaTypeProvider {
   def platform(): ByteBuddyJavaTypeProvider =
     fromLocators(List(ClassFileLocator.ForClassLoader.ofPlatformLoader()))
 
-  /** Returns a provider that reads resources visible to `loader` without loading classes; `null` denotes the bootstrap loader. */
-  def fromClassLoader(loader: ClassLoader): ByteBuddyJavaTypeProvider = {
-    val locator = if (loader == null) {
-      // The JVM represents the bootstrap class loader with null.
-      ClassFileLocator.ForClassLoader.ofBootLoader()
-    } else {
-      // A non-null loader exposes application or user-provided class-path resources.
-      ClassFileLocator.ForClassLoader.of(loader)
-    }
-    fromLocators(List(locator))
-  }
-
   /** Returns a provider for JARs and class directories, with running-JVM multi-release entries and optional platform fallback. */
   def fromClassPath(entries: List[Path], includePlatform: Boolean = true): ByteBuddyJavaTypeProvider = {
     val version = ClassFileVersion.ofThisVm()

--- a/main/src/ca/uwaterloo/flix/language/jvm/DependencyClassPath.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/DependencyClassPath.scala
@@ -22,7 +22,8 @@ import java.nio.file.{Files, Path}
 import scala.collection.mutable
 
 /**
-  * A [[ClassFileLocator]] that reads class files from a growing set of JARs and directories.
+  * The class path of a project's dependencies: a [[ClassFileLocator]] that reads class files
+  * from a growing set of JARs and class directories.
   *
   * Entries are read directly from the archive rather than through a [[ClassLoader]]. A class
   * loader constructed at run time cannot serve resources inside a GraalVM native image, which
@@ -34,7 +35,7 @@ import scala.collection.mutable
   * [[locate]] is then called from the worker threads, which are created afterwards, so the
   * entries are safely published to them.
   */
-final class MutableClassPathLocator extends ClassFileLocator {
+final class DependencyClassPath extends ClassFileLocator {
 
   /**
     * The locators to consult, in order.

--- a/main/src/ca/uwaterloo/flix/language/jvm/MutableClassPathLocator.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/MutableClassPathLocator.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.jvm
+
+import net.bytebuddy.ClassFileVersion
+import net.bytebuddy.dynamic.ClassFileLocator
+
+import java.nio.file.{Files, Path}
+import scala.collection.mutable
+
+/**
+  * A [[ClassFileLocator]] that reads class files from a growing set of JARs and directories.
+  *
+  * Entries are read directly from the archive rather than through a [[ClassLoader]]. A class
+  * loader constructed at run time cannot serve resources inside a GraalVM native image, which
+  * would make every class from a project's dependencies unresolvable.
+  *
+  * Entries are consulted in the order they were added.
+  *
+  * [[addPath]] is called while the compiler is being configured, before compilation starts.
+  * [[locate]] is then called from the worker threads, which are created afterwards, so the
+  * entries are safely published to them.
+  */
+final class MutableClassPathLocator extends ClassFileLocator {
+
+  /**
+    * The locators to consult, in order.
+    */
+  private val locators = mutable.ArrayBuffer.empty[ClassFileLocator]
+
+  /**
+    * Adds the JAR or class directory at `path`.
+    *
+    * Throws [[java.io.IOException]] if `path` cannot be opened.
+    */
+  def addPath(path: Path): Unit = {
+    val version = ClassFileVersion.ofThisVm()
+    val locator =
+      if (Files.isDirectory(path)) ClassFileLocator.ForFolder.of(path.toFile, version)
+      else ClassFileLocator.ForJarFile.of(path.toFile, version)
+    locators += locator
+  }
+
+  /**
+    * Returns the class file of `name` from the first entry that has it.
+    */
+  override def locate(name: String): ClassFileLocator.Resolution = {
+    val it = locators.iterator
+    while (it.hasNext) {
+      val resolution = it.next().locate(name)
+      if (resolution.isResolved) {
+        return resolution
+      }
+    }
+    new ClassFileLocator.Resolution.Illegal(name)
+  }
+
+  /**
+    * Closes every entry.
+    */
+  override def close(): Unit = {
+    locators.foreach(_.close())
+    locators.clear()
+  }
+
+}


### PR DESCRIPTION
A native image of the compiler cannot type check any project that has Java dependencies. Every import of a class from a Maven or JAR dependency fails:

```
-- Resolution Error [E1803] --------------------------- src/render_gl/Audio.flix
>> Undefined Java class 'org.lwjgl.openal.AL10'.
   The class 'org.lwjgl.openal.AL10' was not found on the class path.
```

Building `ababup1192/flix_game_engine` this way produced 1155 errors.

## Cause

`Flix` built its `JavaTypeProvider` from `jarLoader`, an `ExternalJarLoader` that receives dependency JARs at run time through `addURL`. Byte Buddy then reads class files with `ClassLoader.getResourceAsStream`. Inside a native image a class loader constructed at run time cannot serve resources from a JAR:

| | Native image | JVM |
| --- | --- | --- |
| `new URLClassLoader(jar).getResourceAsStream("org/lwjgl/openal/AL10.class")` | `null` | 59169 bytes |
| `new ZipFile(jar).getInputStream(entry)` | 59169 bytes | 59169 bytes |

## The fix

`MutableClassPathLocator` reads the added JARs directly with Byte Buddy's `ForJarFile`, which is ordinary file I/O and works in an image. `Flix` registers each path as `addJar` is called.

The locator sits first in a chain of three. Lookups fall through to `jarLoader` and then to the platform loader, so nothing that worked before changes: `ExternalJarLoader` still serves the class files the compiler provides itself, such as `dev.flix.runtime.Global` and the `dev.flix.test.*` classes used by the test suite. An earlier revision of this branch dropped that fallback and 330 tests failed, which is why the chain keeps it.

Writes to the locator are single-threaded: `addJar` runs while the compiler is configured, and the worker pool is created afterwards in `initThreadPool`, which safely publishes the entries to the threads that call `locate`.

## Verification

- `ababup1192/flix_game_engine` builds a fat JAR of 2,367,337 bytes, the same size the JVM produces, in 4.2 s against 5.3 s on the JVM.
- `magnus-madsen/bibblitz` builds in 1.9 s.
- The CI smoke test passes, including the `run` guard.
- The full test suite passes: 16689 tests.

The CI smoke test could not have caught this, because the hello world project it builds has no dependencies. A regression test needs a project with at least one Maven dependency.

Fixes #13224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLYNr3zsG9cgR6jsvB9gzb
