### PR TITLE
fix: print annotation classes with their simple name

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/JvmAstPrinter.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.dbg.printer
 import ca.uwaterloo.flix.language.ast.JvmAst.Expr
 import ca.uwaterloo.flix.language.ast.{JvmAst, Symbol}
 import ca.uwaterloo.flix.language.dbg.DocAst
+import ca.uwaterloo.flix.language.jvm.ClassDescs
 import ca.uwaterloo.flix.util.collection.MapOps
 
 object JvmAstPrinter {
@@ -94,6 +95,6 @@ object JvmAstPrinter {
   /** Returns the [[DocAst.JvmMethod]] representation of `method`. */
   private def printJvmMethod(method: JvmAst.JvmMethod): DocAst.JvmMethod = method match {
     case JvmAst.JvmMethod(ann, ident, fparams, exp, tpe, _, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
+      DocAst.JvmMethod(ann.map(a => ClassDescs.simpleNameOf(a.clazz)), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.dbg.printer
 import ca.uwaterloo.flix.language.ast.LiftedAst.Expr.*
 import ca.uwaterloo.flix.language.ast.{LiftedAst, Symbol}
 import ca.uwaterloo.flix.language.dbg.DocAst
+import ca.uwaterloo.flix.language.jvm.ClassDescs
 import ca.uwaterloo.flix.util.collection.MapOps
 
 object LiftedAstPrinter {
@@ -76,7 +77,7 @@ object LiftedAstPrinter {
       }
       val ms = methods.map {
         case LiftedAst.JvmMethod(ann, ident, fparams, clo, retTpe, _, _, _) =>
-          DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.map(printFormalParam), print(clo), SimpleTypePrinter.print(retTpe))
+          DocAst.JvmMethod(ann.map(a => ClassDescs.simpleNameOf(a.clazz)), ident, fparams.map(printFormalParam), print(clo), SimpleTypePrinter.print(retTpe))
       }
       DocAst.Expr.NewObject(sym, DocAst.Expr.javaClassName(clazz.desc), SimpleTypePrinter.print(tpe), cs, ms)
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -3,6 +3,7 @@ package ca.uwaterloo.flix.language.dbg.printer
 import ca.uwaterloo.flix.language.ast.{MonoAst, Symbol}
 import ca.uwaterloo.flix.language.ast.MonoAst.{Expr, ExtPattern, ExtTagPattern, Pattern}
 import ca.uwaterloo.flix.language.dbg.DocAst
+import ca.uwaterloo.flix.language.jvm.ClassDescs
 
 object MonoAstPrinter {
 
@@ -55,7 +56,7 @@ object MonoAstPrinter {
   /** Returns the [[DocAst.JvmMethod]] representation of `method`. */
   private def printJvmMethod(method: MonoAst.JvmMethod): DocAst.JvmMethod = method match {
     case MonoAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
+      DocAst.JvmMethod(ann.map(a => ClassDescs.simpleNameOf(a.clazz)), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
   }
 
   /** Returns the [[DocAst]] representation of `rule`. */

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.dbg.printer
 import ca.uwaterloo.flix.language.ast.ReducedAst.Expr
 import ca.uwaterloo.flix.language.ast.{ReducedAst, Symbol}
 import ca.uwaterloo.flix.language.dbg.DocAst
+import ca.uwaterloo.flix.language.jvm.ClassDescs
 import ca.uwaterloo.flix.util.collection.MapOps
 
 object ReducedAstPrinter {
@@ -100,6 +101,6 @@ object ReducedAstPrinter {
     */
   private def printJvmMethod(method: ReducedAst.JvmMethod): DocAst.JvmMethod = method match {
     case ReducedAst.JvmMethod(ann, ident, fparams, exp, tpe, _, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
+      DocAst.JvmMethod(ann.map(a => ClassDescs.simpleNameOf(a.clazz)), ident, fparams map printFormalParam, print(exp), SimpleTypePrinter.print(tpe))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.dbg.printer
 import ca.uwaterloo.flix.language.ast.SimplifiedAst.Expr.*
 import ca.uwaterloo.flix.language.ast.{SimplifiedAst, Symbol}
 import ca.uwaterloo.flix.language.dbg.DocAst
+import ca.uwaterloo.flix.language.jvm.ClassDescs
 import ca.uwaterloo.flix.util.collection.MapOps
 
 object SimplifiedAstPrinter {
@@ -81,7 +82,7 @@ object SimplifiedAstPrinter {
       }
       val ms = methods.map {
         case SimplifiedAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _, _) =>
-          DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.map(printFormalParam), print(exp), SimpleTypePrinter.print(retTpe))
+          DocAst.JvmMethod(ann.map(a => ClassDescs.simpleNameOf(a.clazz)), ident, fparams.map(printFormalParam), print(exp), SimpleTypePrinter.print(retTpe))
       }
       DocAst.Expr.NewObject(sym, DocAst.Expr.javaClassName(clazz.desc), SimpleTypePrinter.print(tpe), cs, ms)
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -6,6 +6,7 @@ import ca.uwaterloo.flix.language.ast.shared.SymUse.{DefSymUse, LocalDefSymUse, 
 import ca.uwaterloo.flix.language.ast.shared.{JConstructor, JField}
 import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
 import ca.uwaterloo.flix.language.dbg.DocAst
+import ca.uwaterloo.flix.language.jvm.ClassDescs
 
 object TypedAstPrinter {
 
@@ -120,7 +121,7 @@ object TypedAstPrinter {
     */
   private def printJvmMethod(method: TypedAst.JvmMethod): DocAst.JvmMethod = method match {
     case TypedAst.JvmMethod(ann, ident, fparams, exp, retTpe, _, _) =>
-      DocAst.JvmMethod(ann.map(_.clazz.displayName()), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
+      DocAst.JvmMethod(ann.map(a => ClassDescs.simpleNameOf(a.clazz)), ident, fparams.toList.map(printFormalParam), print(exp), TypePrinter.print(retTpe))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/runtime/FlixClassLoader.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/FlixClassLoader.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable
 /**
   * A custom class loader to load generated class files.
   *
-  * @param classes   A map from internal names (strings) to JvmClasses.
+  * @param classes   A map from binary names (strings) to JvmClasses.
   * @param jarLoader The class loader used to resolve classes from external JARs.
   *
   * We pass the platform class loader as the parent to avoid it delegating to the system classloader
@@ -40,13 +40,13 @@ class FlixClassLoader(classes: Map[String, JvmClass], jarLoader: ClassLoader) ex
     * Finds the class with the given binary `name`.
     */
   override def loadClass(name: String): Class[?] = try {
-    // Lookup the internal name in the cache to see if the class was already defined.
+    // Lookup the binary name in the cache to see if the class was already defined.
     cache.get(name) match {
       case None =>
         // Case 1: The class was not defined. Lookup the bytecode.
         classes.get(name) match {
           case None =>
-            // Case 1.1: The internal name does not exist. Try the external JAR loader.
+            // Case 1.1: The binary name does not exist. Try the external JAR loader.
             try {
               val clazz = jarLoader.loadClass(name)
               cache.put(name, clazz)
@@ -59,7 +59,7 @@ class FlixClassLoader(classes: Map[String, JvmClass], jarLoader: ClassLoader) ex
                 clazz
             }
           case Some(jvmClass) =>
-            // Case 1.2: The internal name was found. Define the class using its byte code.
+            // Case 1.2: The binary name was found. Define the class using its byte code.
             val clazz = defineClass(name, jvmClass.bytecode, 0, jvmClass.bytecode.length)
             // Store it in the cache.
             cache.put(name, clazz)


### PR DESCRIPTION
Two small follow-ups to the `ClassDesc` migration.

**Annotation classes in the AST printers.** All six AST printers (`TypedAstPrinter`, `MonoAstPrinter`, `LiftedAstPrinter`, `SimplifiedAstPrinter`, `ReducedAstPrinter`, `JvmAstPrinter`) printed annotation classes with `ClassDesc.displayName()`, which returns the dollar-separated unqualified name — so a nested annotation class showed up as `Outer$Ann`. They now go through the existing `ClassDescs.simpleNameOf` helper, which strips the enclosing class and any local-class digits. Debug output only.

**Comments in `FlixClassLoader`.** The `classes` map is built in `JvmLoader` with `ClassDescs.binaryNameOf`, and lookups go through `loadClass(binaryName)`, but four comments described the keys as internal names. Renamed to "binary name". Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CvfCqYQcj11bN4f1QCNy5