### PR TITLE
fix: decide varargs wrapping from the resolved parameter type

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -657,18 +657,15 @@ object TypeReconstruction {
       val normalArgs = es.take(declaredArity - 1)
       val varArgExprs = es.drop(declaredArity - 1)
 
-      // Check if a single trailing arg is already a Vector/Array (from ...{} syntax).
+      // A single trailing argument is the varargs array itself if it is assignable to the array parameter.
+      // Otherwise it is an element, e.g. a `Vector[Int32]` passed for `T...` (erased to `Object[]`).
       val alreadyWrapped = varArgExprs match {
-        case single :: Nil => single.tpe.baseType match {
-          case Type.Cst(TypeConstructor.Vector, _) => true
-          case Type.Cst(TypeConstructor.Array, _) => true
-          case _ => false
-        }
+        case single :: Nil => JavaTypes.isVarArgsArray(single.tpe, descriptor.parameterType(declaredArity - 1), loc)
         case _ => false
       }
 
       if (alreadyWrapped) {
-        // Already a vector/array, no wrapping needed.
+        // Already the varargs array, no wrapping needed.
         es
       } else {
         // Case 2: Individual varargs arguments. Wrap them into a VectorLit.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -21,13 +21,12 @@ import ca.uwaterloo.flix.language.ast.Type.JvmMember
 import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod, JavaType, JavaTypeParameter, JavaTypeVariable}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
 import ca.uwaterloo.flix.language.ast.shared.{AssocTypeDef, RegionScope}
-import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaArgument, JavaClasses, JavaMemberResolver, JavaMetadata}
+import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaArgument, JavaMemberResolver, JavaMetadata}
 import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaTypes, PrimitiveEffects}
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, Substitution}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
-import java.lang.constant.ConstantDescs.*
 import java.lang.constant.ClassDesc
 import scala.annotation.tailrec
 
@@ -167,7 +166,7 @@ object TypeReduction2 {
           val cs = cs0 ::: css.flatten
           lookupMethod(reducedTpe, name.name, reducedTpes, loc) match {
             case JavaResolution.Resolved(method) =>
-              val classTypeParameters = classTypeParametersOf(method, getJavaTypeDesc(reducedTpe), loc)
+              val classTypeParameters = classTypeParametersOf(method, JavaTypes.erasedDescriptorOf(reducedTpe), loc)
               val classTypeArgs = extractClassTypeArgs(classTypeParameters, reducedTpe, scope, loc)
               val (tpe, cs0) = instantiateMethod(method, classTypeParameters, classTypeArgs, reducedTpes, scope, loc)
               progress.markProgress()
@@ -212,7 +211,7 @@ object TypeReduction2 {
     if (!typesAreKnown) return JavaResolution.UnresolvedTypes
 
     // Rigid type variables and other non-Java types fall back to Object.
-    retrieveMethod(getJavaTypeDesc(thisObj), methodName, ts, static = false, loc)
+    retrieveMethod(JavaTypes.erasedDescriptorOf(thisObj), methodName, ts, static = false, loc)
   }
 
   /** Tries to find a static method of `owner` that takes arguments of type `ts`. */
@@ -241,32 +240,7 @@ object TypeReduction2 {
   /** Returns the descriptor-based Java argument corresponding to the given Flix `tpe`. */
   private def getJavaArgument(tpe: Type): JavaArgument = tpe match {
     case Type.Cst(TypeConstructor.Null, _) => JavaArgument.Null
-    case _ => JavaArgument.Typed(getJavaTypeDesc(tpe))
-  }
-
-  /**
-    * Returns the erased Java class descriptor of the given non-null Flix `tpe`, as used for member lookup.
-    *
-    * Types with a Java counterpart (see [[JavaTypes.descriptorOf]]) erase to it. Arrays and vectors erase
-    * to Java arrays, functions to their Java functional interfaces, and every other type to `Object`.
-    */
-  private def getJavaTypeDesc(tpe: Type): ClassDesc = JavaTypes.descriptorOf(tpe).getOrElse(tpe match {
-    // Arrays and vectors erase to Java arrays. A null element type falls back to Object.
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Array, _), elmType, _), _, _) =>
-      getJavaArrayTypeDesc(elmType)
-    case Type.Apply(Type.Cst(TypeConstructor.Vector, _), elmType, _) =>
-      getJavaArrayTypeDesc(elmType)
-
-    // Functions map to the same Java functional interfaces as the reflective path.
-    case Type.Apply(Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Arrow(2), _), _, _), varArg, _), varRet, _) =>
-      lookupFunIF(varArg, varRet).map(_.desc).getOrElse(CD_Object)
-    case _ => CD_Object
-  })
-
-  /** Returns the Java array descriptor for an array or vector element type. */
-  private def getJavaArrayTypeDesc(elmType: Type): ClassDesc = elmType match {
-    case Type.Cst(TypeConstructor.Null, _) => CD_Object.arrayType()
-    case _ => getJavaTypeDesc(elmType).arrayType()
+    case _ => JavaArgument.Typed(JavaTypes.erasedDescriptorOf(tpe))
   }
 
   /** Tries to find a field of `thisObj` with the name `fieldName`. */
@@ -274,7 +248,7 @@ object TypeReduction2 {
     val typeIsKnown = isKnown(thisObj)
     if (!typeIsKnown) return JavaResolution.UnresolvedTypes
 
-    val owner = getJavaTypeDesc(thisObj)
+    val owner = JavaTypes.erasedDescriptorOf(thisObj)
     JavaMemberResolver.field(owner, fieldName, static = false) match {
       case Ok(Some(field)) => JavaResolution.Resolved(field)
       case Ok(None) => JavaResolution.NotFound
@@ -449,15 +423,22 @@ object TypeReduction2 {
             }
           case pt: JavaType.Parameterized =>
             mkParamTypeConstraints(pt, argType, substMap, loc)
-          case JavaType.GenericArray(component, _) =>
-            // For varargs/array params (e.g., T[] in Stream.of(T...)), emit a constraint
-            // linking the component type variable to the Flix array/vector element type.
-            (component, argType.typeArguments) match {
-              case (JavaType.Variable(variable, _), elmType :: _) =>
-                substMap.get(variable).map { expectedType =>
-                  TypeConstraint.Equality(expectedType, elmType,
-                    TypeConstraint.Provenance.Match(expectedType, elmType, loc))
-                }.toList
+          case JavaType.GenericArray(component, erasure) =>
+            // A generic array parameter such as `T[]` in `Stream.of(T...)`. The argument instantiates `T`
+            // with its element type if it is passed as the array, and with its own type if it is a single
+            // element that is expanded into the array (see `JavaTypes.isVarArgsArray`). Further expanded
+            // arguments are not zipped with a parameter and leave `T` unconstrained.
+            component match {
+              case JavaType.Variable(variable, _) =>
+                substMap.get(variable).toList.flatMap { expectedType =>
+                  val actualType =
+                    if (JavaTypes.isVarArgsArray(argType, erasure, loc)) argType.typeArguments.headOption
+                    else Some(argType)
+                  actualType.map { tpe =>
+                    TypeConstraint.Equality(expectedType, tpe,
+                      TypeConstraint.Provenance.Match(expectedType, tpe, loc))
+                  }
+                }
               case _ => Nil
             }
           case _ => None
@@ -489,12 +470,12 @@ object TypeReduction2 {
     * Handles two cases:
     *
     * 1. **Arrow types** (Flix functions passed as Java functional interfaces):
-    *    Uses `lookupFunIF` to determine which Arrow component (arg/ret) maps to
+    *    Uses `JavaTypes.lookupFunIF` to determine which Arrow component (arg/ret) maps to
     *    which interface type param, then constrains the method's type variable
     *    against that component.
     *
     *    Example: `IntStream.mapToObj(IntFunction<? extends R>)` with arg `Int32 -> Object \ IO`:
-    *    - `lookupFunIF` maps `IntFunction` to `FunIFMapping(retParam = Some("R"))`
+    *    - `JavaTypes.lookupFunIF` maps `IntFunction` to `FunIFMapping(retParam = Some("R"))`
     *    - The interface param `R` corresponds to the Arrow return type `Object`
     *    - The wildcard `? extends R` resolves to method type variable `R`
     *    - Emits constraint: `?r ~ Object`
@@ -506,7 +487,7 @@ object TypeReduction2 {
     substMap: Map[JavaTypeVariable, Type], loc: SourceLocation)(implicit flix: Flix): List[TypeConstraint] = {
     argType match {
       case Type.Apply(Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Arrow(2), _), _, _), flixArg, _), flixRet, _) =>
-        lookupFunIF(flixArg, flixRet) match {
+        JavaTypes.lookupFunIF(flixArg, flixRet) match {
           case Some(mapping) =>
             val fiTypeArgs: Map[String, Type] =
               mapping.argParam.map(_ -> flixArg).toMap ++
@@ -543,54 +524,5 @@ object TypeReduction2 {
       upperBounds.collectFirst { case JavaType.Variable(variable, _) => variable }
         .orElse(lowerBounds.collectFirst { case JavaType.Variable(variable, _) => variable })
     case _ => None
-  }
-
-  /**
-    * Maps a Flix Arrow type to its Java functional interface.
-    * `argParam`/`retParam` name the interface type param that corresponds
-    * to the Arrow's argument/return type (None for primitive-specialized
-    * interfaces like IntConsumer that have no type params).
-    */
-  private case class FunIFMapping(
-    desc: ClassDesc,
-    argParam: Option[String],
-    retParam: Option[String]
-  )
-
-  /** Looks up the Java functional interface for a Flix Arrow with the given arg and ret types. */
-  private def lookupFunIF(argType: Type, retType: Type): Option[FunIFMapping] = {
-    import TypeConstructor.*
-    (argType, retType) match {
-      case (Type.Cst(Int32, _), Type.Cst(Unit, _)) =>
-        Some(FunIFMapping(JavaClasses.IntConsumer, None, None))
-      case (Type.Cst(Int32, _), Type.Cst(Bool, _)) =>
-        Some(FunIFMapping(JavaClasses.IntPredicate, None, None))
-      case (Type.Cst(Int32, _), Type.Cst(Int32, _)) =>
-        Some(FunIFMapping(JavaClasses.IntUnaryOperator, None, None))
-      case (Type.Cst(Int32, _), _) =>
-        Some(FunIFMapping(JavaClasses.IntFunction, None, Some("R")))
-      case (Type.Cst(Int64, _), Type.Cst(Unit, _)) =>
-        Some(FunIFMapping(JavaClasses.LongConsumer, None, None))
-      case (Type.Cst(Int64, _), Type.Cst(Bool, _)) =>
-        Some(FunIFMapping(JavaClasses.LongPredicate, None, None))
-      case (Type.Cst(Int64, _), Type.Cst(Int64, _)) =>
-        Some(FunIFMapping(JavaClasses.LongUnaryOperator, None, None))
-      case (Type.Cst(Int64, _), _) =>
-        Some(FunIFMapping(JavaClasses.LongFunction, None, Some("R")))
-      case (Type.Cst(Float64, _), Type.Cst(Unit, _)) =>
-        Some(FunIFMapping(JavaClasses.DoubleConsumer, None, None))
-      case (Type.Cst(Float64, _), Type.Cst(Bool, _)) =>
-        Some(FunIFMapping(JavaClasses.DoublePredicate, None, None))
-      case (Type.Cst(Float64, _), Type.Cst(Float64, _)) =>
-        Some(FunIFMapping(JavaClasses.DoubleUnaryOperator, None, None))
-      case (Type.Cst(Float64, _), _) =>
-        Some(FunIFMapping(JavaClasses.DoubleFunction, None, Some("R")))
-      case (_, Type.Cst(Unit, _)) =>
-        Some(FunIFMapping(JavaClasses.ObjConsumer, Some("T"), None))
-      case (_, Type.Cst(Bool, _)) =>
-        Some(FunIFMapping(JavaClasses.ObjPredicate, Some("T"), None))
-      case (_, _) =>
-        Some(FunIFMapping(JavaClasses.ObjFunction, Some("T"), Some("R")))
-    }
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/jvm/JavaTypes.scala
@@ -106,6 +106,49 @@ object JavaTypes {
   }
 
   /**
+    * Returns the erased Java class descriptor of the non-null Flix type `tpe`, as used for member lookup.
+    *
+    * Types with a Java counterpart (see [[descriptorOf]]) erase to it. Arrays and vectors erase to Java
+    * arrays, functions to their Java functional interfaces (see [[lookupFunIF]]), and every other type,
+    * including type variables, to `Object`.
+    */
+  def erasedDescriptorOf(tpe: Type): ClassDesc = descriptorOf(tpe).getOrElse(tpe match {
+    // Arrays and vectors erase to Java arrays. A null element type falls back to Object.
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Array, _), elmType, _), _, _) =>
+      erasedArrayDescriptorOf(elmType)
+    case Type.Apply(Type.Cst(TypeConstructor.Vector, _), elmType, _) =>
+      erasedArrayDescriptorOf(elmType)
+
+    // Functions map to the same Java functional interfaces as the reflective path.
+    case Type.Apply(Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Arrow(2), _), _, _), varArg, _), varRet, _) =>
+      lookupFunIF(varArg, varRet).map(_.desc).getOrElse(CD_Object)
+    case _ => CD_Object
+  })
+
+  /** Returns the Java array descriptor for an array or vector element type. */
+  private def erasedArrayDescriptorOf(elmType: Type): ClassDesc = elmType match {
+    case Type.Cst(TypeConstructor.Null, _) => CD_Object.arrayType()
+    case _ => erasedDescriptorOf(elmType).arrayType()
+  }
+
+  /**
+    * Returns `true` if an argument of type `tpe` for the varargs parameter `paramDesc` is the varargs array
+    * itself, and `false` if it is a single element that must be wrapped in an array.
+    *
+    * The decision mirrors the applicability check of [[ca.uwaterloo.flix.language.jvm.JavaMemberResolver]]:
+    * an argument that is assignable to the array parameter is passed directly, and only an argument that is
+    * not assignable is expanded. `null` is assignable to every array type and is passed as the array.
+    *
+    *   - `Vector[String]` for `String...` is the array.
+    *   - `String` for `String...` is an element.
+    *   - `Vector[Int32]` for `T...`, which erases to `Object[]`, is an element since `int[]` is not an `Object[]`.
+    */
+  def isVarArgsArray(tpe: Type, paramDesc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Boolean = tpe match {
+    case Type.Cst(TypeConstructor.Null, _) => true
+    case _ => JavaMetadata.isSubtype(erasedDescriptorOf(tpe), paramDesc, loc)
+  }
+
+  /**
     * Returns the string representation of the Java type `desc` used in error messages: a primitive,
     * an array, or a class with a Flix counterpart (e.g. `String` or `BigInt`) is shown as its Flix
     * type, and any other class by its binary name.
@@ -164,5 +207,54 @@ object JavaTypes {
   /** Returns the innermost element type of the array `desc`, or `desc` itself if it is not an array. */
   private def elementTypeOf(desc: ClassDesc): ClassDesc =
     if (desc.isArray) elementTypeOf(desc.componentType()) else desc
+
+  /**
+    * Maps a Flix Arrow type to its Java functional interface.
+    * `argParam`/`retParam` name the interface type param that corresponds
+    * to the Arrow's argument/return type (None for primitive-specialized
+    * interfaces like IntConsumer that have no type params).
+    */
+  case class FunIFMapping(
+    desc: ClassDesc,
+    argParam: Option[String],
+    retParam: Option[String]
+  )
+
+  /** Looks up the Java functional interface for a Flix Arrow with the given arg and ret types. */
+  def lookupFunIF(argType: Type, retType: Type): Option[FunIFMapping] = {
+    import TypeConstructor.*
+    (argType, retType) match {
+      case (Type.Cst(Int32, _), Type.Cst(Unit, _)) =>
+        Some(FunIFMapping(JavaClasses.IntConsumer, None, None))
+      case (Type.Cst(Int32, _), Type.Cst(Bool, _)) =>
+        Some(FunIFMapping(JavaClasses.IntPredicate, None, None))
+      case (Type.Cst(Int32, _), Type.Cst(Int32, _)) =>
+        Some(FunIFMapping(JavaClasses.IntUnaryOperator, None, None))
+      case (Type.Cst(Int32, _), _) =>
+        Some(FunIFMapping(JavaClasses.IntFunction, None, Some("R")))
+      case (Type.Cst(Int64, _), Type.Cst(Unit, _)) =>
+        Some(FunIFMapping(JavaClasses.LongConsumer, None, None))
+      case (Type.Cst(Int64, _), Type.Cst(Bool, _)) =>
+        Some(FunIFMapping(JavaClasses.LongPredicate, None, None))
+      case (Type.Cst(Int64, _), Type.Cst(Int64, _)) =>
+        Some(FunIFMapping(JavaClasses.LongUnaryOperator, None, None))
+      case (Type.Cst(Int64, _), _) =>
+        Some(FunIFMapping(JavaClasses.LongFunction, None, Some("R")))
+      case (Type.Cst(Float64, _), Type.Cst(Unit, _)) =>
+        Some(FunIFMapping(JavaClasses.DoubleConsumer, None, None))
+      case (Type.Cst(Float64, _), Type.Cst(Bool, _)) =>
+        Some(FunIFMapping(JavaClasses.DoublePredicate, None, None))
+      case (Type.Cst(Float64, _), Type.Cst(Float64, _)) =>
+        Some(FunIFMapping(JavaClasses.DoubleUnaryOperator, None, None))
+      case (Type.Cst(Float64, _), _) =>
+        Some(FunIFMapping(JavaClasses.DoubleFunction, None, Some("R")))
+      case (_, Type.Cst(Unit, _)) =>
+        Some(FunIFMapping(JavaClasses.ObjConsumer, Some("T"), None))
+      case (_, Type.Cst(Bool, _)) =>
+        Some(FunIFMapping(JavaClasses.ObjPredicate, Some("T"), None))
+      case (_, _) =>
+        Some(FunIFMapping(JavaClasses.ObjFunction, Some("T"), Some("R")))
+    }
+  }
 
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.VarArgs.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.VarArgs.flix
@@ -1,6 +1,8 @@
 mod Test.Exp.Jvm.InvokeStaticMethod.VarArgs {
 
     import java.nio.file.Path
+    import java.util.Arrays
+    import java.util.{List => JList}
 
     use Assert.assertEq;
 
@@ -27,5 +29,23 @@ mod Test.Exp.Jvm.InvokeStaticMethod.VarArgs {
         // Explicit varargs vector
         let p = Path.of("hello", Vector#{"foo", "bar.txt"});
         assertEq(expected = "bar.txt", p.getFileName().toString())
+
+    @Test
+    def testInvokeVarArgs05(): Unit \ Assert + IO =
+        // A primitive array is not an Object[], so it is a single element of the generic varargs `T...`
+        let l = Arrays.asList(Vector#{1, 2});
+        assertEq(expected = 1, l.size())
+
+    @Test
+    def testInvokeVarArgs06(): Unit \ Assert + IO =
+        // The element instantiates `T`, so the list holds vectors
+        let l: JList[Vector[Int32]] = Arrays.asList(Vector#{1, 2});
+        assertEq(expected = 1, l.size())
+
+    @Test
+    def testInvokeVarArgs07(): Unit \ Assert + IO =
+        // Several primitive arrays are wrapped into one array of arrays
+        let l = Arrays.asList(Vector#{1, 2}, Vector#{3});
+        assertEq(expected = 2, l.size())
 
 }


### PR DESCRIPTION
## Summary

`TypeReconstruction.getArgumentsWithVarArgs` decided whether a single trailing argument was the varargs array or an element to wrap by asking whether the argument *is a Vector or Array*. That is the wrong question: what matters is whether the argument is assignable to the array parameter, which is what `JavaMemberResolver` already used to decide that the method applies.

The two disagreed for a primitive array passed to a generic varargs parameter:

```flix
Arrays.asList(Vector#{1, 2})
```

The resolver correctly treats the `int[]` as a single element of `T...` (erased `Object[]`), since `int[]` is not an `Object[]`. Reconstruction then passed the `int[]` straight through as the array, and the program failed at runtime with

```
ClassCastException: class [I cannot be cast to class [Ljava.lang.Object;
```

The typer had the same blind spot: it always instantiated `T` with the vector's element type, giving the call the type `List[Int32]` although the value is a one-element list holding an `int[]`.

## Changes

- `JavaTypes.isVarArgsArray` decides from the erased argument type and the array parameter, mirroring the resolver: an assignable argument (including `null`) is the array, anything else is an element.
- `TypeReconstruction` uses it instead of the Vector/Array check.
- `TypeReduction2.mkArgConstraints` uses it for generic array parameters: `T` is instantiated with the element type when the array is passed, and with the argument's own type when a single element is expanded. Previously a single non-array element left `T` unconstrained.
- The erasure helper (`getJavaTypeDesc`) and the functional-interface table (`lookupFunIF`) move from `TypeReduction2` into `JavaTypes` as `erasedDescriptorOf` and `lookupFunIF`, so both phases share one definition. No behaviour change in the move.
- Tests in `Test.Exp.Jvm.InvokeStaticMethod.VarArgs` cover the single primitive array, its type, and several primitive arrays.

## Out of scope

Two neighbouring failures exist on master and are unaffected by this change:

- `Stream.of(1, 2)` expands primitive elements into a `Vector[Int32]`, which is an `int[]` where the `Object[]` parameter needs boxed elements, and fails with the same `ClassCastException`.
- Reading a `Vector[Int32]` back through a generic return type, e.g. `ArrayList[Vector[Int32]].get(0)`, fails verification because no cast to `int[]` is emitted.

Part of the overload-resolution redesign discussed separately; this fix stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013R3jvCiqAtLvLCcntyBhfy
