### PR TITLE
refactor: add an option-returning ClassDescs.ofBinaryName

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/jvm/ClassDescs.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/ClassDescs.scala
@@ -20,6 +20,18 @@ import java.lang.constant.ClassDesc
 object ClassDescs {
 
   /**
+    * Returns the descriptor of the class or interface with the binary `name`,
+    * e.g. `java.lang.String` or `java.util.Map$Entry`.
+    *
+    * Returns `None` if `name` is not a valid binary name.
+    */
+  def ofBinaryName(name: String): Option[ClassDesc] = try {
+    Some(ClassDesc.of(name))
+  } catch {
+    case _: IllegalArgumentException => None
+  }
+
+  /**
     * Returns the JVM internal name of the class, interface, or array descriptor `desc`,
     * e.g. `java/lang/String` or `[Ljava/lang/String;`.
     */

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3316,13 +3316,7 @@ object Resolver {
       ResolutionError.UndefinedJvmImport(className, AnchorPosition.mkImportOrUseAnchor(ns0), message, loc)
 
     // A name that is not a valid binary class name has no descriptor.
-    val desc = try {
-      Some(ClassDesc.of(className))
-    } catch {
-      case _: IllegalArgumentException => None
-    }
-
-    desc match {
+    ClassDescs.ofBinaryName(className) match {
       case None => Result.Err(undefined(s"'$className' is not a valid class name."))
       case Some(d) => flix.javaTypeProvider.lookupClass(d) match {
         case Result.Ok(clazz) => Result.Ok(clazz)


### PR DESCRIPTION
`Resolver.lookupJvmClass` wrapped `ClassDesc.of` in a `try`/`catch` on `IllegalArgumentException` purely to test whether the imported name is a valid binary name, then converted the result back to an `Option`:

```scala
val desc = try {
  Some(ClassDesc.of(className))
} catch {
  case _: IllegalArgumentException => None
}

desc match { ... }
```

The `className` comes straight from a user's `import`, so an ill-formed name is ordinary input rather than an exceptional condition. This moves the conversion behind `ClassDescs.ofBinaryName`, which returns an `Option`, and the call site now matches on it directly.

The three other `ClassDesc.of` calls, in `PrimitiveEffects`, parse compiler-owned JSON resources where a malformed name is an internal error, so they keep throwing and are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CvfCqYQcj11bN4f1QCNy5