### PR TITLE
fix: reserve a Case prefix for nullary enum case classes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNullaryTag.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/classes/GenNullaryTag.scala
@@ -29,15 +29,22 @@ import org.objectweb.asm.MethodVisitor
 import java.lang.constant.ClassDesc
 
 /**
-  * The class of a nullary enum case, e.g. `Color$Red` for `case Red` of `enum Color`.
+  * The class of a nullary enum case, e.g. `Case$Color$Red` for `case Red` of `enum Color`.
   *
   * A nullary case carries no values, so the class has a single instance held in
   * [[SingletonField]].
   */
 object GenNullaryTag {
 
+  /**
+    * Returns the descriptor of the class of the case `name` of the enum `enumName`.
+    *
+    * The `Case` prefix is reserved: it keeps the enum and case names, which are chosen
+    * by the user, from colliding with the generated classes that share this package,
+    * e.g. `Tag$Obj`, `Struct$Obj`, or `RecordExtend$Obj`.
+    */
   def desc(enumName: String, name: String): ClassDesc =
-    mkDesc(RootPackage, Mangle.mkClassName(enumName, name))
+    mkDesc(RootPackage, Mangle.mkClassName("Case", List(enumName, name)))
 
   def genByteCode(enumName: String, name: String, ordinal: Int)(implicit flix: Flix): Array[Byte] = {
     val d = desc(enumName, name)


### PR DESCRIPTION
`GenNullaryTag` named the class of a nullary case `<EnumName>$<CaseName>` in the root package, where **both halves are chosen by the user**. That package also holds the generated structural classes, whose names are built from the erased type names in `Mangle.erasedName` — `Bool`, `Char`, `Int8`, `Int16`, `Int32`, `Int64`, `Float32`, `Float64`, `Obj`. Every one of those is a legal enum case name, and every family prefix (`Tag`, `Struct`, `ExtTag`, `RecordExtend`, …) is a legal enum name. So a user enum could take the name of a generated class and trip the duplicate-name check in `CodeGen`.

`enum Tag { case Obj }` alone was enough, since the standard library already emits `Tag$Obj` — no other user code required:

```
ca.uwaterloo.flix.util.InternalCompilerException: Duplicate JVM class names: Tag$Obj (unknown:1:1)
```

Confirmed the same for `enum Tag { case Int64 }`, `enum Struct { case Obj }`, `enum ExtTag { case Obj }`, `enum RecordExtend { case Obj }`, and for an `enum Eff` whose case names an effect in the same namespace.

This prefixes the class name with `Case`, matching the `Def`, `Clo`, and `Eff` prefixes the def, closure, and effect classes already carry, so user-chosen names can no longer occupy a generated one. A nullary case of `enum Color` is now `Case$Color$Red`.

All six cases above now compile and run; the structural classes are unchanged.

### Not covered here

A module named `Main` still collides with the generated entry-point class, since `GenMain.Desc` and `GenNamespace.desc(List("Main"))` both produce `Main`. That needs its own fix and is left for a follow-up, along with moving these classes into their enum's namespace package (they are still in the root package, mangled as `Case$A$dotB$dotColor$Red`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CvfCqYQcj11bN4f1QCNy5