### PR TITLE
fix: report unresolvable Java supertypes as lookup errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/jvm/ByteBuddyJavaTypeProvider.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/ByteBuddyJavaTypeProvider.scala
@@ -144,17 +144,19 @@ final case class ByteBuddyJavaTypeProvider(
 
   /** Computes [[lookupClass]] without consulting the cache. */
   private def lookupClassDirect(desc: ClassDesc): Result[JavaClass, JavaLookupError] =
-    resolve(desc).map(toClass)
+    guarded(desc)(resolve(desc).map(toClass))
 
   /** Computes [[virtualMethods]] without consulting the cache. */
   private def virtualMethodsDirect(desc: ClassDesc): Result[List[JavaMethod], JavaLookupError] =
-    resolve(desc).map { tpe =>
-      MethodGraph.Compiler.Default.forJavaHierarchy().compile(tpe: TypeDefinition).listNodes().asScala
-        .map(_.getRepresentative)
-        .filter(_.isVirtual)
-        .map(toMethod)
-        .toList
-        .sortBy(m => (m.ref.name, m.ref.descriptor.descriptorString()))
+    guarded(desc) {
+      resolve(desc).map { tpe =>
+        MethodGraph.Compiler.Default.forJavaHierarchy().compile(tpe: TypeDefinition).listNodes().asScala
+          .map(_.getRepresentative)
+          .filter(_.isVirtual)
+          .map(toMethod)
+          .toList
+          .sortBy(m => (m.ref.name, m.ref.descriptor.descriptorString()))
+      }
     }
 
   /** Computes [[isSubtype]] without consulting the cache. */
@@ -162,28 +164,46 @@ final case class ByteBuddyJavaTypeProvider(
     if (subtype == supertype) {
       Ok(true)
     } else {
-      resolve(subtype).flatMap { sub =>
-        resolve(supertype).map(sup => sub.isAssignableTo(sup))
+      guarded(subtype) {
+        resolve(subtype).flatMap { sub =>
+          resolve(supertype).map(sup => sub.isAssignableTo(sup))
+        }
       }
     }
   }
 
-  /** Returns `Ok` with the resolved type, or `Err` if `desc` is unsupported, missing, or invalid. */
+  /**
+    * Returns `Ok` with the resolved type, or `Err` if `desc` is unsupported or missing.
+    *
+    * Must be called within [[guarded]], which turns the exceptions of a malformed class file into errors.
+    */
   private def resolve(desc: ClassDesc): Result[TypeDescription, JavaLookupError] = {
     if (!desc.isClassOrInterface) {
       Err(UnsupportedDescriptor(desc))
     } else {
-      try {
-        val resolution = pool.describe(ClassDescs.binaryNameOf(desc))
-        if (resolution.isResolved) Ok(resolution.resolve()) else Err(MissingClass(desc))
-      } catch {
-        case ex: GenericSignatureFormatError => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: MalformedParameterizedTypeException => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: IllegalArgumentException => Err(InvalidClass(desc, exceptionMessage(ex)))
-        case ex: IllegalStateException => Err(InvalidClass(desc, exceptionMessage(ex)))
-      }
+      val resolution = pool.describe(ClassDescs.binaryNameOf(desc))
+      if (resolution.isResolved) Ok(resolution.resolve()) else Err(MissingClass(desc))
     }
   }
+
+  /**
+    * Runs `query`, a metadata query about `desc`, turning the exceptions thrown by Byte Buddy into errors.
+    *
+    * The type pool resolves the types that a class file refers to lazily. A missing supertype therefore only
+    * surfaces, as a [[TypePool.Resolution.NoSuchTypeException]], once a query reaches it, e.g. while compiling
+    * the method graph of `desc` or while walking its hierarchy for a subtype check. Every other exception means
+    * that a class file is malformed.
+    */
+  private def guarded[A](desc: ClassDesc)(query: => Result[A, JavaLookupError]): Result[A, JavaLookupError] =
+    try {
+      query
+    } catch {
+      case ex: TypePool.Resolution.NoSuchTypeException => Err(MissingClass(ClassDesc.of(ex.getName)))
+      case ex: GenericSignatureFormatError => Err(InvalidClass(desc, exceptionMessage(ex)))
+      case ex: MalformedParameterizedTypeException => Err(InvalidClass(desc, exceptionMessage(ex)))
+      case ex: IllegalArgumentException => Err(InvalidClass(desc, exceptionMessage(ex)))
+      case ex: IllegalStateException => Err(InvalidClass(desc, exceptionMessage(ex)))
+    }
 
   /** Converts a Byte Buddy type description to Java class-file metadata. */
   private def toClass(tpe: TypeDescription): JavaClass = {

--- a/main/src/ca/uwaterloo/flix/language/jvm/JavaLookupError.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/JavaLookupError.scala
@@ -20,6 +20,13 @@ import java.lang.constant.ClassDesc
 /** An error encountered while looking up Java class-file metadata. */
 sealed trait JavaLookupError {
   def desc: ClassDesc
+
+  /** Returns a sentence that explains this error to the user. */
+  def explanation: String = this match {
+    case JavaLookupError.InvalidClass(desc, message) => s"The class file of '${ClassDescs.binaryNameOf(desc)}' could not be read: $message"
+    case JavaLookupError.MissingClass(desc) => s"The class '${ClassDescs.binaryNameOf(desc)}' was not found on the class path."
+    case JavaLookupError.UnsupportedDescriptor(desc) => s"'${ClassDescs.binaryNameOf(desc)}' does not denote a class or interface."
+  }
 }
 
 object JavaLookupError {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -28,7 +28,7 @@ import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
-import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaClasses, JavaLookupError, JavaMemberResolver, JavaMetadata}
+import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaClasses, JavaMemberResolver, JavaMetadata}
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
 
@@ -3320,9 +3320,7 @@ object Resolver {
       case None => Result.Err(undefined(s"'$className' is not a valid class name."))
       case Some(d) => flix.javaTypeProvider.lookupClass(d) match {
         case Result.Ok(clazz) => Result.Ok(clazz)
-        case Result.Err(JavaLookupError.MissingClass(_)) => Result.Err(undefined(s"The class '$className' was not found on the class path."))
-        case Result.Err(JavaLookupError.InvalidClass(_, message)) => Result.Err(undefined(s"The class file of '$className' could not be read: $message"))
-        case Result.Err(JavaLookupError.UnsupportedDescriptor(_)) => Result.Err(undefined(s"'$className' does not denote a class or interface."))
+        case Result.Err(error) => Result.Err(undefined(error.explanation))
       }
     }
   }

--- a/main/test/ca/uwaterloo/flix/language/jvm/TestByteBuddyJavaTypeProvider.scala
+++ b/main/test/ca/uwaterloo/flix/language/jvm/TestByteBuddyJavaTypeProvider.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.language.ast.jvm.JavaTypeVariable
 import ca.uwaterloo.flix.language.ast.jvm.JavaTypeVariableOwner.Class
 import ca.uwaterloo.flix.language.jvm.JavaLookupError.{InvalidClass, MissingClass, UnsupportedDescriptor}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
+import net.bytebuddy.ByteBuddy
 import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.pool.TypePool
 import org.scalatest.funsuite.AnyFunSuite
@@ -238,6 +239,51 @@ class TestByteBuddyJavaTypeProvider extends AnyFunSuite {
         case Err(error) => fail(error.toString)
       }
     } finally provider.close()
+  }
+
+  test("lookupClass.SucceedsWithMissingSuperclass") {
+    val (provider, derived, base) = providerWithMissingSuperclass()
+    try {
+      // Reading a class file does not read the class files of its supertypes.
+      provider.lookupClass(derived) match {
+        case Ok(clazz) => assert(clazz.superClass.map(_.erasure) == Some(base))
+        case Err(error) => fail(error.toString)
+      }
+    } finally provider.close()
+  }
+
+  test("virtualMethods.ReportsMissingSuperclass") {
+    val (provider, derived, base) = providerWithMissingSuperclass()
+    try {
+      assert(provider.virtualMethods(derived) == Err(MissingClass(base)))
+    } finally provider.close()
+  }
+
+  test("isSubtype.ReportsMissingSuperclass") {
+    val (provider, derived, base) = providerWithMissingSuperclass()
+    try {
+      assert(provider.isSubtype(derived, ClassDesc.of("java.io.Serializable")) == Err(MissingClass(base)))
+    } finally provider.close()
+  }
+
+  /**
+    * Returns a provider whose class path holds the class `Derived extends Base` but not `Base`, together with the
+    * descriptors of `Derived` and `Base`.
+    */
+  private def providerWithMissingSuperclass(): (ByteBuddyJavaTypeProvider, ClassDesc, ClassDesc) = {
+    val base = new ByteBuddy().subclass(classOf[Object]).name("dev.flix.prototype.Base").make()
+    val derived = new ByteBuddy().subclass(base.getTypeDescription).name("dev.flix.prototype.Derived").make()
+    val locator = new ClassFileLocator.Compound(
+      ClassFileLocator.Simple.of(derived.getTypeDescription.getName, derived.getBytes),
+      ClassFileLocator.ForClassLoader.ofPlatformLoader()
+    )
+    val pool = new TypePool.Default.WithLazyResolution(
+      new TypePool.CacheProvider.Simple(),
+      locator,
+      TypePool.Default.ReaderMode.FAST
+    )
+    val provider = ByteBuddyJavaTypeProvider(locator, pool)
+    (provider, ClassDesc.of(derived.getTypeDescription.getName), ClassDesc.of(base.getTypeDescription.getName))
   }
 
 }


### PR DESCRIPTION
First of two PRs replacing #13217, which bundled this with the validation that depends on it.

## Problem

Byte Buddy's type pool resolves the types that a class file refers to lazily. A supertype that is missing from the class path therefore only surfaces once a query reaches it, which happens while compiling a method graph or while walking the hierarchy for a subtype check. Neither call was inside the `try` that turns class-file failures into a `Result`, so the exception escaped the type provider, passed the `Result`-based error handling of every caller, and left the compiler as a raw stack trace with no source location and not even the "this is a bug" banner:

```
net.bytebuddy.pool.TypePool$Resolution$NoSuchTypeException: Cannot resolve type description for B
	at net.bytebuddy.pool.TypePool$Resolution$Illegal.resolve(TypePool.java:198)
	...
	at ca.uwaterloo.flix.language.jvm.ByteBuddyJavaTypeProvider.virtualMethodsDirect
```

Reproducible with a two-class JAR whose second class is deleted, calling a method on the class whose superclass is gone.

## Fix

Every query now runs inside `guarded`, which turns `NoSuchTypeException` into `MissingClass` naming the class Byte Buddy could not resolve, and the exceptions of a malformed class file into `InvalidClass`. The failure becomes an ordinary error result, so the existing callers report it through their normal paths instead of crashing.

Resolution stays lazy: reading a class file still does not read its supertypes, so `lookupClass` keeps succeeding for a class whose supertype is missing, and only the queries that actually need the hierarchy fail. A test pins this, since the next PR relies on it.

Also folds the wording of the three lookup failures into `JavaLookupError.explanation`, so it lives next to the errors rather than being spelled out at the call site. The Resolver's import messages now read from it and are unchanged: for every name that reaches that branch the binary name equals what the user wrote, and a name that is not a valid binary name is rejected earlier.

## Follow-up

The next PR uses this to validate supertypes and member signatures so that the failure is reported as a diagnostic rather than an internal compiler error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGqoj6qH3MTP4rgPuvQnD1
