### PR TITLE
fix: report Java classes that cannot be read as compilation errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -78,6 +78,7 @@ object ErrorCode {
   case object E1896 extends ErrorCode
   case object E1907 extends ErrorCode
   case object E1914 extends ErrorCode
+  case object E1925 extends ErrorCode
   case object E1952 extends ErrorCode
   case object E1960 extends ErrorCode
   case object E2018 extends ErrorCode
@@ -209,6 +210,7 @@ object ErrorCode {
   case object E6218 extends ErrorCode
   case object E6221 extends ErrorCode
   case object E6247 extends ErrorCode
+  case object E6258 extends ErrorCode
   case object E6285 extends ErrorCode
   case object E6289 extends ErrorCode
   case object E6358 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.errors
 
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, TraitUsageKind}
 import ca.uwaterloo.flix.language.ast.{Kind, Name, SourceLocation, Symbol, TypedAst}
-import ca.uwaterloo.flix.language.jvm.ClassDescs
+import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaLookupError}
 import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
 import ca.uwaterloo.flix.util.{Formatter, Grammar}
@@ -947,6 +947,29 @@ object ResolutionError {
       s""">> Undefined static field '${red(field.name)}' in class '${magenta(ClassDescs.binaryNameOf(clazz))}'.
          |
          |${highlight(loc, "field not found", fmt)}
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * An error raised to indicate that a Java class needed to resolve a Java class or member cannot be read.
+    *
+    * @param query what was being resolved, e.g. `the class 'java.util.List'` or `the static field 'java.lang.Math.PI'`.
+    * @param error the class-file metadata error, which names the class that cannot be read.
+    * @param loc   the location of the class or member.
+    */
+  case class UnreadableJvmClass(query: String, error: JavaLookupError, loc: SourceLocation) extends ResolutionError {
+    def code: ErrorCode = ErrorCode.E1925
+
+    def summary: String = s"Unable to read the Java class '${ClassDescs.binaryNameOf(error.desc)}' while resolving $query."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Unable to read the Java class '${red(ClassDescs.binaryNameOf(error.desc))}' while resolving $query.
+         |
+         |${highlight(loc, "unreadable Java class", fmt)}
+         |
+         |${error.explanation}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.errors
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaMemberResolver}
+import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaLookupError, JavaMemberResolver}
 import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.TypedAst
@@ -303,6 +303,29 @@ object TypeError {
          |  ${cyan(formatType(recordType, Some(renv)))}
          |
          |contains the extra label '${red(label.name)}' of type '${cyan(formatType(labelType, Some(renv)))}'.
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * An error raised to indicate that a Java class needed to resolve a Java member cannot be read.
+    *
+    * @param query the member being resolved, e.g. `the method 'java.util.List.of(String)'`.
+    * @param error the class-file metadata error, which names the class that cannot be read.
+    * @param loc   the location of the member access.
+    */
+  case class UnreadableJvmClass(query: String, error: JavaLookupError, loc: SourceLocation) extends TypeError {
+    def code: ErrorCode = ErrorCode.E6258
+
+    def summary: String = s"Unable to read the Java class '${ClassDescs.binaryNameOf(error.desc)}' while resolving $query."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Unable to read the Java class '${red(ClassDescs.binaryNameOf(error.desc))}' while resolving $query.
+         |
+         |${highlight(loc, "unreadable Java class", fmt)}
+         |
+         |${error.explanation}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/jvm/JavaHierarchy.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/JavaHierarchy.scala
@@ -17,15 +17,43 @@ package ca.uwaterloo.flix.language.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.util.Result
-import ca.uwaterloo.flix.util.Result.Ok
+import ca.uwaterloo.flix.util.Result.{Err, Ok}
 
 import java.lang.constant.ClassDesc
 import java.lang.constant.ConstantDescs.CD_Object
+import scala.annotation.tailrec
 
 /**
-  * Subtyping of Java types, read from the class-file metadata of the Java type provider.
+  * Subtyping and supertypes of Java types, read from the class-file metadata of the Java type provider.
   */
 object JavaHierarchy {
+
+  /**
+    * Returns `Ok` with the transitive supertypes of the class or interface `desc`, or `Err` if the metadata of
+    * `desc` or of one of its supertypes cannot be read.
+    *
+    * The supertypes are the erased superclasses and superinterfaces of `desc`, excluding `desc` itself. The
+    * result is empty for `Object` and for an interface without superinterfaces.
+    *
+    * Reading a class file does not read the class files it refers to, so a class whose metadata can be read
+    * may still have a supertype whose metadata cannot. Callers use this query to check that every supertype
+    * of a class can be read before the class takes part in member resolution or subtype checks.
+    */
+  def supertypes(desc: ClassDesc)(implicit flix: Flix): Result[Set[ClassDesc], JavaLookupError] = {
+    @tailrec
+    def visit(pending: List[ClassDesc], visited: Set[ClassDesc]): Result[Set[ClassDesc], JavaLookupError] = pending match {
+      case Nil => Ok(visited - desc)
+      case d :: rest if visited.contains(d) => visit(rest, visited)
+      case d :: rest => flix.javaTypeProvider.lookupClass(d) match {
+        case Ok(clazz) =>
+          val parents = clazz.superClass.map(_.erasure).toList ::: clazz.interfaces.map(_.erasure)
+          visit(parents ::: rest, visited + d)
+        case Err(error) => Err(error)
+      }
+    }
+
+    visit(List(desc), Set.empty)
+  }
 
   /**
     * Returns `Ok(true)` if the Java type `sub` is a subtype of the Java type `sup`, `Ok(false)` if it

--- a/main/src/ca/uwaterloo/flix/language/jvm/JavaMemberResolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/JavaMemberResolver.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod}
+import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod, JavaType}
 import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.Ok
 
@@ -114,24 +114,32 @@ object JavaMemberResolver {
     case (primitive, wrapper) => wrapper -> primitive
   }
 
+  /*
+   * Every member returned by `constructors`, `methods`, `field`, and `overridableMethods` has a readable
+   * signature (see `readableSignatures`). Consumers can therefore convert the signature to Flix types and
+   * check subtyping on those types without a metadata lookup failing.
+   */
+
   /** Returns `Ok` with every tied best public constructor, or `Err` if class metadata cannot be read. */
   def constructors(owner: ClassDesc, arguments: List[JavaArgument])(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] =
     flix.javaTypeProvider.lookupClass(owner).flatMap { clazz =>
       val candidates = clazz.declaredConstructors.filter(_.isPublic)
       best(candidates, arguments).map(_.filterNot(usesUnsupportedUnboxing(arguments, _)))
-    }
+    }.flatMap(readableSignatures)
 
   /** Returns `Ok` with every tied best public method, including the existing `Object` fallback. */
   def methods(owner: ClassDesc, name: String, arguments: List[JavaArgument], static: Boolean)(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] =
     resolveMethods(owner, name, arguments, static).flatMap {
       case result if result.nonEmpty || owner == CD_Object => Ok(result)
       case _ => resolveMethods(CD_Object, name, arguments, static)
-    }
+    }.flatMap(readableSignatures)
 
   /** Returns `Ok` with the selected public field, or `Err` if class metadata cannot be read. */
   def field(owner: ClassDesc, name: String, static: Boolean)(implicit flix: Flix): Result[Option[JavaField], JavaLookupError] = {
     if (owner.isClassOrInterface) {
-      findField(owner, name, Set.empty).map(_.filter(f => f.isStatic == static))
+      findField(owner, name, Set.empty).map(_.filter(f => f.isStatic == static)).flatMap { selected =>
+        Result.traverseOpt(selected)(field => readableTypes(List(field.fieldType)).map(_ => field))
+      }
     } else {
       Ok(None)
     }
@@ -154,7 +162,7 @@ object JavaMemberResolver {
     * method has type `(T) -> T` where `T` is the type parameter of `UnaryOperator`.
     */
   def overridableMethods(owner: ClassDesc)(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] =
-    virtualMethodsWhere(owner, isOverridable)
+    virtualMethodsWhere(owner, isOverridable).flatMap(readableSignatures)
 
   /**
     * Returns `Ok` with the public instance methods of `owner`, including inherited methods, or `Err` if class
@@ -699,6 +707,34 @@ object JavaMemberResolver {
       case None => findFieldIn(rest, name, visited)
     }
   }
+
+  /**
+    * Returns `Ok(methods)` if the signature of every method in `methods` can be read, or `Err` for the first
+    * class that cannot.
+    *
+    * The signature of a method can be read if every class that occurs in its parameter and return types, and
+    * every supertype of such a class, can be read. Consumers convert these types to Flix types and resolve
+    * members and subtyping on them, which would otherwise fail on a class that is missing from the class path.
+    */
+  private def readableSignatures(methods: List[JavaMethod])(implicit flix: Flix): Result[List[JavaMethod], JavaLookupError] =
+    readableTypes(methods.flatMap(method => method.returnType :: method.parameterTypes)).map(_ => methods)
+
+  /** Returns `Ok` if every class that occurs in `types`, and every supertype of such a class, can be read. */
+  private def readableTypes(types: List[JavaType])(implicit flix: Flix): Result[Unit, JavaLookupError] =
+    Result.traverse(types.flatMap(classesOf).distinct)(JavaHierarchy.supertypes).map(_ => ())
+
+  /** Returns the classes and interfaces that occur in `tpe`, with an array represented by its element class. */
+  private def classesOf(tpe: JavaType): List[ClassDesc] = tpe match {
+    case JavaType.GenericArray(component, _) => classesOf(component)
+    case JavaType.NonGeneric(erasure) => List(elementType(erasure)).filter(_.isClassOrInterface)
+    case JavaType.Parameterized(erasure, arguments) => elementType(erasure) :: arguments.flatMap(classesOf)
+    case JavaType.Variable(_, erasure) => List(elementType(erasure)).filter(_.isClassOrInterface)
+    case JavaType.Wildcard(upperBounds, lowerBounds, _) => (upperBounds ::: lowerBounds).flatMap(classesOf)
+  }
+
+  /** Returns the innermost element descriptor of an array, or `desc` itself for a non-array descriptor. */
+  private def elementType(desc: ClassDesc): ClassDesc =
+    if (desc.isArray) elementType(desc.componentType()) else desc
 
   /** Returns the erased parameter descriptors that participate in overload resolution. */
   private def erasedParameters(method: JavaMethod): List[ClassDesc] = method.ref.descriptor.parameterList().asScala.toList

--- a/main/src/ca/uwaterloo/flix/language/jvm/JavaMetadata.scala
+++ b/main/src/ca/uwaterloo/flix/language/jvm/JavaMetadata.scala
@@ -27,10 +27,12 @@ import java.lang.constant.ConstantDescs.{CD_Object, CD_Throwable}
 /**
   * Java class-file metadata queries for the phases that run after the Resolver.
   *
-  * The Resolver reports a class whose metadata cannot be read as a compilation error, so a class that
-  * reaches a later phase has already been read once. A failure here is therefore a compiler bug, and
-  * every query throws an [[InternalCompilerException]] at the given location instead of returning a
-  * `Result`.
+  * A class whose metadata cannot be read is reported as a compilation error before it reaches these
+  * phases: the Resolver checks every class it resolves along with its supertypes (see
+  * [[JavaHierarchy.supertypes]]), and [[JavaMemberResolver]] checks the signature of every member it
+  * resolves. Every class that occurs in a Flix type, or in the signature of a resolved member, has
+  * therefore been read once along with its supertypes. A failure here is a compiler bug, and every
+  * query throws an [[InternalCompilerException]] at the given location instead of returning a `Result`.
   */
 object JavaMetadata {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -28,7 +28,7 @@ import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, *}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.errors.ResolutionError.*
-import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaClasses, JavaMemberResolver, JavaMetadata}
+import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaClasses, JavaHierarchy, JavaLookupError, JavaMemberResolver, JavaMetadata}
 import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps, MapOps, Nel}
 
@@ -820,9 +820,15 @@ object Resolver {
                 val error = ResolutionError.UndefinedJvmStaticField(owner, fieldName, loc)
                 sctx.errors.add(error)
                 return ResolvedAst.Expr.Error(error)
-              case Result.Err(error) =>
+              case Result.Err(error: JavaLookupError.UnsupportedDescriptor) =>
                 val query = s"${ClassDescs.binaryNameOf(owner)}.${fieldName.name}"
                 throw InternalCompilerException(s"Java field lookup failed for '$query': $error", loc)
+              case Result.Err(error) =>
+                // The type of the field, or a supertype of it, cannot be read.
+                val query = s"the static field '${ClassDescs.binaryNameOf(owner)}.${fieldName.name}'"
+                val err = ResolutionError.UnreadableJvmClass(query, error, loc)
+                sctx.errors.add(err)
+                return ResolvedAst.Expr.Error(err)
             }
           case _ =>
           // Fallthrough to below.
@@ -1738,13 +1744,19 @@ object Resolver {
         val erased = UnkindedType.eraseAliases(t)
         getNativeDescFromType(erased) match {
           case Some(desc) =>
-            val targs = erased.typeArguments
-            val superScp = scp0.withSuperClass(Some(desc)).withSuperTargs(targs)
-            val cs = constructors.map(visitJvmConstructor(_, superScp))
-            val ms = methods.map(visitJvmMethod(_, superScp))
-            val anonClassSym = Symbol.mkFreshAnonClassSym(loc);
-            val clazz = JClass(desc, JavaMetadata.lookupClass(desc, loc).isInterface)
-            ResolvedAst.Expr.NewObject(anonClassSym, clazz, targs, cs, ms, loc)
+            checkOverridableMethods(desc, loc) match {
+              case None =>
+                val targs = erased.typeArguments
+                val superScp = scp0.withSuperClass(Some(desc)).withSuperTargs(targs)
+                val cs = constructors.map(visitJvmConstructor(_, superScp))
+                val ms = methods.map(visitJvmMethod(_, superScp))
+                val anonClassSym = Symbol.mkFreshAnonClassSym(loc);
+                val clazz = JClass(desc, JavaMetadata.lookupClass(desc, loc).isInterface)
+                ResolvedAst.Expr.NewObject(anonClassSym, clazz, targs, cs, ms, loc)
+              case Some(err) =>
+                sctx.errors.add(err)
+                ResolvedAst.Expr.Error(err)
+            }
           case None =>
             erased match {
               case _: UnkindedType.Error =>
@@ -3310,6 +3322,10 @@ object Resolver {
 
   /**
     * Returns the class metadata for the given `className`, read from its class file.
+    *
+    * Fails with [[UndefinedJvmImport]] if the class cannot be read, and with [[UnreadableJvmClass]] if one of its
+    * supertypes cannot be read. The latter lets the later phases resolve the members of the class and check its
+    * subtyping without a metadata lookup failing (see [[JavaMetadata]]).
     */
   private def lookupJvmClass(className: String, ns0: Name.NName, loc: SourceLocation)(implicit flix: Flix): Result[ca.uwaterloo.flix.language.ast.jvm.JavaClass, ResolutionError] = {
     def undefined(message: String): ResolutionError =
@@ -3319,11 +3335,30 @@ object Resolver {
     ClassDescs.ofBinaryName(className) match {
       case None => Result.Err(undefined(s"'$className' is not a valid class name."))
       case Some(d) => flix.javaTypeProvider.lookupClass(d) match {
-        case Result.Ok(clazz) => Result.Ok(clazz)
+        case Result.Ok(clazz) => JavaHierarchy.supertypes(d) match {
+          case Result.Ok(_) => Result.Ok(clazz)
+          case Result.Err(error) => Result.Err(ResolutionError.UnreadableJvmClass(s"the class '$className'", error, loc))
+        }
         case Result.Err(error) => Result.Err(undefined(error.explanation))
       }
     }
   }
+
+  /**
+    * Returns an error if the methods of the class or interface `desc` that an anonymous class may override
+    * cannot all be read, and `None` otherwise.
+    *
+    * The Safety phase compares the methods of an anonymous class against the overridable methods of `desc`,
+    * which requires their signatures to be readable (see [[JavaMemberResolver.overridableMethods]]).
+    */
+  private def checkOverridableMethods(desc: ClassDesc, loc: SourceLocation)(implicit flix: Flix): Option[ResolutionError] =
+    JavaMemberResolver.overridableMethods(desc) match {
+      case Result.Ok(_) => None
+      case Result.Err(error: JavaLookupError.UnsupportedDescriptor) =>
+        throw InternalCompilerException(s"Java method lookup failed for '${ClassDescs.binaryNameOf(desc)}': $error", loc)
+      case Result.Err(error) =>
+        Some(ResolutionError.UnreadableJvmClass(s"the methods of '${ClassDescs.binaryNameOf(desc)}'", error, loc))
+    }
 
   /**
     * Returns the class metadata for the given `className`, falling back to the imported classes in scope.
@@ -3422,7 +3457,7 @@ object Resolver {
   /**
     * Resolves the given uses and imports.
     *
-    * A use or import that cannot be resolved is reported ([[UndefinedUse]] or [[UndefinedJvmImport]])
+    * A use or import that cannot be resolved is reported ([[UndefinedUse]], [[UndefinedJvmImport]], or [[UnreadableJvmClass]])
     * and dropped, so that names it would have brought into scope are simply undefined.
     */
   private def resolveUsesAndImports(usesAndImports0: List[NamedAst.UseOrImport], ns: Name.NName, root: NamedAst.Root)(implicit sctx: SharedContext, flix: Flix): List[UseOrImport] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -366,12 +366,23 @@ object ConstraintSolverInterface {
 
   /**
     * Creates an appropriate error from the unresolved Jvm member.
+    *
+    * A member that is unresolved because the class-file metadata it needs cannot be read is reported as
+    * [[TypeError.UnreadableJvmClass]]. Every other unresolved member is reported as not found.
     */
-  private def mkErrorFromUnresolvedJvmMember(member: Type.JvmMember, renv: RigidityEnv, subst: SubstitutionTree, loc: SourceLocation)(implicit flix: Flix): TypeError = member match {
-    case JvmMember.JvmConstructor(clazz, tpes) => TypeError.ConstructorNotFound(clazz, tpes.map(subst.apply), renv, loc)
-    case JvmMember.JvmField(base, tpe, name) => TypeError.FieldNotFound(base, name, subst(tpe), loc)
-    case JvmMember.JvmMethod(tpe, name, tpes) => TypeError.MethodNotFound(name, subst(tpe), tpes.map(subst.apply), loc)
-    case JvmMember.JvmStaticMethod(clazz, name, tpes) => TypeError.StaticMethodNotFound(clazz, name, tpes.map(subst.apply), renv, loc)
+  private def mkErrorFromUnresolvedJvmMember(member0: Type.JvmMember, renv: RigidityEnv, subst: SubstitutionTree, loc: SourceLocation)(implicit flix: Flix): TypeError = {
+    val member = member0.map(subst.apply)
+    // The lookup is repeated in the top-level region scope. A type variable of an inner region is
+    // flexible there, so a member that depends on it is not known and is reported as not found.
+    TypeReduction2.unreadableClassOf(member, loc)(RegionScope.Top, renv, flix) match {
+      case Some((query, error)) => TypeError.UnreadableJvmClass(query, error, loc)
+      case None => member match {
+        case JvmMember.JvmConstructor(clazz, tpes) => TypeError.ConstructorNotFound(clazz, tpes, renv, loc)
+        case JvmMember.JvmField(base, tpe, name) => TypeError.FieldNotFound(base, name, tpe, loc)
+        case JvmMember.JvmMethod(tpe, name, tpes) => TypeError.MethodNotFound(name, tpe, tpes, loc)
+        case JvmMember.JvmStaticMethod(clazz, name, tpes) => TypeError.StaticMethodNotFound(clazz, name, tpes, renv, loc)
+      }
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.Type.JvmMember
 import ca.uwaterloo.flix.language.ast.jvm.{JavaField, JavaMethod, JavaType, JavaTypeParameter, JavaTypeVariable}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
 import ca.uwaterloo.flix.language.ast.shared.{AssocTypeDef, RegionScope}
-import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaArgument, JavaMemberResolver, JavaMetadata}
+import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaArgument, JavaLookupError, JavaMemberResolver, JavaMetadata}
 import ca.uwaterloo.flix.language.phase.typer.jvm.{JavaTypes, PrimitiveEffects}
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, Substitution}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
@@ -188,6 +188,26 @@ object TypeReduction2 {
       }
   }
 
+  /**
+    * Returns the class-file metadata error that prevents the Java member `member` from being resolved, together
+    * with a description of the member, or `None` if `member` is unresolved for another reason: no member matches,
+    * or the types of the lookup are not known yet.
+    *
+    * The constraint solver uses this to explain a Java member that is still unresolved once solving has finished.
+    */
+  def unreadableClassOf(member: JvmMember, loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): Option[(String, JavaLookupError)] = {
+    val resolution = member.map(Type.eraseAliases) match {
+      case JvmMember.JvmConstructor(clazz, tpes) => lookupConstructor(clazz, tpes, loc)
+      case JvmMember.JvmField(_, tpe, name) => lookupField(tpe, name.name, loc)
+      case JvmMember.JvmMethod(tpe, name, tpes) => lookupMethod(tpe, name.name, tpes, loc)
+      case JvmMember.JvmStaticMethod(clazz, name, tpes) => lookupStaticMethod(clazz, name.name, tpes, loc)
+    }
+    resolution match {
+      case JavaResolution.Unreadable(query, error) => Some((query, error))
+      case _ => None
+    }
+  }
+
   /** Tries to find a constructor of `owner` that takes arguments of type `ts`. */
   private def lookupConstructor(owner: ClassDesc, ts: List[Type], loc: SourceLocation)(implicit scope: RegionScope, renv: RigidityEnv, flix: Flix): JavaResolution[JavaMethod] = {
     val typesAreKnown = ts.forall(isKnown)
@@ -200,8 +220,8 @@ object TypeReduction2 {
       case Ok(constructor :: _) => JavaResolution.Resolved(constructor)
       case Ok(Nil) => JavaResolution.NotFound
       case Err(error) =>
-        val query = s"${ClassDescs.binaryNameOf(owner)}(${arguments.mkString(", ")})"
-        throw InternalCompilerException(s"Java constructor lookup failed for '$query': $error", loc)
+        val query = s"the constructor '${ClassDescs.binaryNameOf(owner)}(${formatArguments(arguments)})'"
+        unreadable(query, error, loc)
     }
   }
 
@@ -231,11 +251,17 @@ object TypeReduction2 {
       case Ok(method :: _) => JavaResolution.Resolved(method)
       case Ok(Nil) => JavaResolution.NotFound
       case Err(error) =>
-        val kind = if (static) "static" else "instance"
-        val query = s"$kind ${ClassDescs.binaryNameOf(owner)}.$methodName(${arguments.mkString(", ")})"
-        throw InternalCompilerException(s"Java method lookup failed for '$query': $error", loc)
+        val kind = if (static) "static method" else "method"
+        val query = s"the $kind '${ClassDescs.binaryNameOf(owner)}.$methodName(${formatArguments(arguments)})'"
+        unreadable(query, error, loc)
     }
   }
+
+  /** Returns the arguments of a member lookup as they are shown to the user. */
+  private def formatArguments(arguments: List[JavaArgument]): String = arguments.map {
+    case JavaArgument.Typed(desc) => JavaTypes.formatType(desc)
+    case JavaArgument.Null => "null"
+  }.mkString(", ")
 
   /** Returns the descriptor-based Java argument corresponding to the given Flix `tpe`. */
   private def getJavaArgument(tpe: Type): JavaArgument = tpe match {
@@ -252,10 +278,19 @@ object TypeReduction2 {
     JavaMemberResolver.field(owner, fieldName, static = false) match {
       case Ok(Some(field)) => JavaResolution.Resolved(field)
       case Ok(None) => JavaResolution.NotFound
-      case Err(error) =>
-        val query = s"${ClassDescs.binaryNameOf(owner)}.$fieldName"
-        throw InternalCompilerException(s"Java field lookup failed for '$query': $error", loc)
+      case Err(error) => unreadable(s"the field '${ClassDescs.binaryNameOf(owner)}.$fieldName'", error, loc)
     }
+  }
+
+  /**
+    * Returns the resolution of a member lookup for `query` that failed with `error`.
+    *
+    * A class that is missing from the class path, or whose class file is malformed, is a user error that leaves
+    * the member unresolved. A descriptor that does not denote a class or interface is a compiler bug.
+    */
+  private def unreadable(query: String, error: JavaLookupError, loc: SourceLocation): JavaResolution[Nothing] = error match {
+    case JavaLookupError.UnsupportedDescriptor(_) => throw InternalCompilerException(s"Java member lookup failed for $query: $error", loc)
+    case _ => JavaResolution.Unreadable(query, error)
   }
 
   /**
@@ -290,6 +325,15 @@ object TypeReduction2 {
 
     /** No matching member. */
     case object NotFound extends JavaResolution[Nothing]
+
+    /**
+      * The class-file metadata needed to resolve the member cannot be read.
+      *
+      * `query` describes the member, e.g. `the method 'java.util.List.of(String)'`, and `error` names the class.
+      * The member stays unresolved, like a member that is [[NotFound]]; the constraint solver obtains the error
+      * from [[unreadableClassOf]] when it reports the leftover constraint.
+      */
+    case class Unreadable(query: String, error: JavaLookupError) extends JavaResolution[Nothing]
 
     /**
       * The types used for the lookup are not resolved enough to decide on a member.

--- a/main/test/ca/uwaterloo/flix/language/jvm/TestJavaHierarchy.scala
+++ b/main/test/ca/uwaterloo/flix/language/jvm/TestJavaHierarchy.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.jvm.JavaLookupError.MissingClass
+import ca.uwaterloo.flix.language.jvm.JavaLookupError.{MissingClass, UnsupportedDescriptor}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -68,6 +68,56 @@ class TestJavaHierarchy extends AnyFunSuite {
     try {
       val missing = ClassDesc.of("java.lang.DoesNotExist")
       assert(JavaHierarchy.isSubtype(missing, CD_Object) == Err(MissingClass(missing)))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("supertypes.Class") {
+    implicit val flix: Flix = new Flix
+    try {
+      val arrayList = ClassDesc.of("java.util.ArrayList")
+      JavaHierarchy.supertypes(arrayList) match {
+        case Ok(supertypes) =>
+          assert(!supertypes.contains(arrayList))
+          assert(supertypes.contains(ClassDesc.of("java.util.AbstractList")))
+          assert(supertypes.contains(ClassDesc.of("java.util.List")))
+          assert(supertypes.contains(ClassDesc.of("java.util.Collection")))
+          assert(supertypes.contains(ClassDesc.of("java.lang.Iterable")))
+          assert(supertypes.contains(ClassDesc.of("java.io.Serializable")))
+          assert(supertypes.contains(CD_Object))
+        case Err(error) => fail(error.toString)
+      }
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("supertypes.Interface") {
+    implicit val flix: Flix = new Flix
+    try {
+      // An interface has no superclass, and `Iterable` has no superinterfaces.
+      assert(JavaHierarchy.supertypes(ClassDesc.of("java.lang.Iterable")) == Ok(Set.empty))
+      assert(JavaHierarchy.supertypes(ClassDesc.of("java.util.Collection")) == Ok(Set(ClassDesc.of("java.lang.Iterable"))))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("supertypes.Object") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaHierarchy.supertypes(CD_Object) == Ok(Set.empty))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("supertypes.ReportsMissingClass") {
+    implicit val flix: Flix = new Flix
+    try {
+      val missing = ClassDesc.of("java.lang.DoesNotExist")
+      assert(JavaHierarchy.supertypes(missing) == Err(MissingClass(missing)))
+    } finally flix.javaTypeProvider.close()
+  }
+
+  test("supertypes.ReportsUnsupportedDescriptor") {
+    implicit val flix: Flix = new Flix
+    try {
+      assert(JavaHierarchy.supertypes(CD_int) == Err(UnsupportedDescriptor(CD_int)))
+      assert(JavaHierarchy.supertypes(CD_String.arrayType()) == Err(UnsupportedDescriptor(CD_String.arrayType())))
     } finally flix.javaTypeProvider.close()
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestJavaClassPath.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestJavaClassPath.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Flix Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase
+
+import ca.uwaterloo.flix.TestUtils
+import ca.uwaterloo.flix.api.{CompilerConstants, Flix}
+import ca.uwaterloo.flix.language.CompilationMessage
+import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.errors.{ResolutionError, TypeError}
+import ca.uwaterloo.flix.util.Options
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.description.modifier.{Ownership, Visibility}
+import net.bytebuddy.implementation.StubMethod
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.file.{Files, Path}
+
+/**
+  * Tests the diagnostics for Java classes that cannot be read from the class path.
+  *
+  * The tests compile against a JAR that refers to a class it does not contain, as happens when a
+  * dependency of a user JAR is not on the class path.
+  */
+class TestJavaClassPath extends AnyFunSuite with TestUtils {
+
+  /** The class that the JAR refers to but does not contain. */
+  private val Missing = "dev.flix.classpath.Missing"
+
+  /**
+    * A JAR with the following classes, generated once for the suite. `Missing` is left out of it.
+    *
+    *   - `class SubclassOfMissing extends Missing`
+    *   - `class Factory { static Missing make(); static int accept(Missing m); Missing get(); Missing field; static Missing FIELD; }`
+    *   - `interface Producer { Missing produce(); }`
+    */
+  private lazy val jar: Path = {
+    val missing = new ByteBuddy().subclass(classOf[Object]).name(Missing).make()
+    val missingType = missing.getTypeDescription
+
+    val subclassOfMissing = new ByteBuddy().subclass(missingType).name("dev.flix.classpath.SubclassOfMissing").make()
+
+    val factory = new ByteBuddy().subclass(classOf[Object]).name("dev.flix.classpath.Factory")
+      .defineMethod("make", missingType, Visibility.PUBLIC, Ownership.STATIC).intercept(StubMethod.INSTANCE)
+      .defineMethod("accept", classOf[Int], Visibility.PUBLIC, Ownership.STATIC).withParameters(missingType).intercept(StubMethod.INSTANCE)
+      .defineMethod("get", missingType, Visibility.PUBLIC).intercept(StubMethod.INSTANCE)
+      .defineField("field", missingType, Visibility.PUBLIC)
+      .defineField("FIELD", missingType, Visibility.PUBLIC, Ownership.STATIC)
+      .make()
+
+    val producer = new ByteBuddy().makeInterface().name("dev.flix.classpath.Producer")
+      .defineMethod("produce", missingType, Visibility.PUBLIC).withoutCode()
+      .make()
+
+    val path = Files.createTempFile("flix-test-classpath", ".jar")
+    path.toFile.deleteOnExit()
+    subclassOfMissing.include(factory, producer).toJar(path.toFile)
+    path
+  }
+
+  /** Compiles `input` against the JAR. */
+  private def checkWithJar(input: String): (Option[TypedAst.Root], List[CompilationMessage]) =
+    new Flix().setOptions(Options.TestWithLibNix).addJar(jar).addVirtualPath(CompilerConstants.VirtualTestFile, input).check()
+
+  test("UnreadableJvmClass.Import.MissingSuperclass") {
+    val input =
+      """
+        |import dev.flix.classpath.SubclassOfMissing
+        |
+        |def f(): Unit \ IO = { let _ = new SubclassOfMissing(); () }
+      """.stripMargin
+    expectError[ResolutionError.UnreadableJvmClass](checkWithJar(input))
+  }
+
+  test("UnreadableJvmClass.StaticField.MissingType") {
+    val input =
+      """
+        |import dev.flix.classpath.Factory
+        |
+        |def f(): Unit \ IO = { let _ = Factory.FIELD; () }
+      """.stripMargin
+    expectError[ResolutionError.UnreadableJvmClass](checkWithJar(input))
+  }
+
+  test("UnreadableJvmClass.NewObject.MissingMethodType") {
+    val input =
+      """
+        |import dev.flix.classpath.Producer
+        |
+        |def f(): Producer \ IO = new Producer { def produce(_this: Producer): Int32 = 1 }
+      """.stripMargin
+    expectError[ResolutionError.UnreadableJvmClass](checkWithJar(input))
+  }
+
+  test("UnreadableJvmClass.StaticMethod.MissingReturnType") {
+    val input =
+      """
+        |import dev.flix.classpath.Factory
+        |
+        |def f(): Unit \ IO = { let _ = Factory.make(); () }
+      """.stripMargin
+    expectError[TypeError.UnreadableJvmClass](checkWithJar(input))
+  }
+
+  test("UnreadableJvmClass.StaticMethod.MissingParameterType") {
+    val input =
+      """
+        |import dev.flix.classpath.Factory
+        |
+        |def f(): Int32 \ IO = Factory.accept("hello")
+      """.stripMargin
+    expectError[TypeError.UnreadableJvmClass](checkWithJar(input))
+  }
+
+  test("UnreadableJvmClass.Method.MissingReturnType") {
+    val input =
+      """
+        |import dev.flix.classpath.Factory
+        |
+        |def f(): Unit \ IO = { let _ = new Factory().get(); () }
+      """.stripMargin
+    expectError[TypeError.UnreadableJvmClass](checkWithJar(input))
+  }
+
+  test("UnreadableJvmClass.Field.MissingType") {
+    val input =
+      """
+        |import dev.flix.classpath.Factory
+        |
+        |def f(): Unit \ IO = { let factory = new Factory(); let _ = factory.field; () }
+      """.stripMargin
+    expectError[TypeError.UnreadableJvmClass](checkWithJar(input))
+  }
+
+}


### PR DESCRIPTION
Second of two PRs replacing #13217. **Stacked on #13231**, so review that one first; the diff here excludes it and GitHub will retarget this to `master` once it merges.

## Problem

A user JAR may refer to classes that are not on the class path, for example when a transitive dependency of the JAR is missing.

`JavaMetadata` documents that a class reaching a phase after the Resolver has already been read once, which is why its queries throw an internal compiler error rather than returning a `Result`. That invariant was not true. The Resolver read the class file of the imported class and nothing else: not its supertypes, and not the classes named in the signatures of its members. A method whose return type is a missing class therefore crashed the compiler:

```
Java class lookup failed for 'B': MissingClass(ClassDesc[B])
  at JavaMetadata$.lookupClass(JavaMetadata.scala:41)
  at JavaTypes$.typeParameterCount(JavaTypes.scala:40)
  at TypeReduction2$.resolveMethodReturnType(TypeReduction2.scala:369)
```

## Fix

Rather than weaken the facade, this makes its claim true, so that every class occurring in a Flix type or in the signature of a resolved member has been read along with its supertypes. Validation happens at the two points where a class enters the compiler.

- `JavaHierarchy.supertypes` returns the transitive supertypes of a class, or the first one that cannot be read.
- The **Resolver** checks the supertypes of every class it resolves, and the overridable methods of the class of an anonymous object, which the Safety phase later compares against. A static field whose type cannot be read is reported instead of crashing.
- `JavaMemberResolver` checks that the signature of every member returned by `constructors`, `methods`, `field`, and `overridableMethods` can be read, and fails the lookup otherwise.
- `TypeReduction2` treats such a failed lookup like a member that does not exist, and `ConstraintSolverInterface` asks it for the reason when it reports the leftover constraint. So no new constraint variant or solver plumbing is needed, and the user sees the cause instead of a misleading `MethodNotFound`.

Both entry points report the same concept, as `ResolutionError.UnreadableJvmClass` and `TypeError.UnreadableJvmClass`:

```
>> Unable to read the Java class 'B' while resolving the static method 'A.make()'.

3 |     let b = A.make();
                ^^^^^^^^
                unreadable Java class

The class 'B' was not found on the class path.
```

The follow-on "Unable to unify 't0' and 'JvmToType(j0)'" error that appears after any unresolved Java member is pre-existing and unchanged.

## Tests

`TestJavaClassPath` generates a JAR with Byte Buddy that refers to a class it does not contain, and covers all seven paths: import with a missing superclass, static field, anonymous object, static and instance methods with a missing return type, a static method with a missing parameter type, and an instance field. `TestJavaHierarchy` gains unit tests for `supertypes`.

## Performance

`Xperf --frontend --par --n 50`, two runs per side with the order alternated, measured on the combined change. Best 163.5k and 161.7k lines/s on master against 164.7k and 158.6k on the branch, medians within 1% on the second pair. The first pair favoured master and the second favoured the branch, so the difference is noise. The supertype checks hit the type provider's existing class cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGqoj6qH3MTP4rgPuvQnD1
