### PR TITLE
fix: emit primitive widening for Java call arguments

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -845,10 +845,7 @@ object GenExpression {
         mv.visitTypeInsn(Opcodes.NEW, declaration)
         // Duplicate the reference since the first argument for a constructor call is the reference to the object
         mv.visitInsn(Opcodes.DUP)
-        for ((arg, argType) <- exps.zip(constructor.descriptor.parameterList.asScala)) {
-          compileExpr(arg)
-          if (!argType.isPrimitive) mv.visitTypeInsn(Opcodes.CHECKCAST, internalNameOf(argType))
-        }
+        compileJavaArgs(exps, constructor.descriptor)
 
         // Call the constructor
         mv.visitMethodInsn(Opcodes.INVOKESPECIAL, declaration, ClassMaker.ConstructorMethodName, constructor.descriptor.descriptorString(), false)
@@ -868,10 +865,7 @@ object GenExpression {
         val declaration = internalNameOf(method.owner)
         mv.visitTypeInsn(Opcodes.CHECKCAST, declaration)
 
-        for ((arg, argType) <- args.zip(method.descriptor.parameterList.asScala)) {
-          compileExpr(arg)
-          if (!argType.isPrimitive) mv.visitTypeInsn(Opcodes.CHECKCAST, internalNameOf(argType))
-        }
+        compileJavaArgs(args, method.descriptor)
 
         // Check if we are invoking an interface or class.
         if (method.isInterface) {
@@ -897,11 +891,8 @@ object GenExpression {
         val anonClassInternalName = internalNameOf(GenAnonymousClasses.desc(sym))
         mv.visitTypeInsn(Opcodes.CHECKCAST, anonClassInternalName)
 
-        // Evaluate and cast each argument.
-        for ((arg, argType) <- args.zip(method.descriptor.parameterList.asScala)) {
-          compileExpr(arg)
-          if (!argType.isPrimitive) mv.visitTypeInsn(Opcodes.CHECKCAST, internalNameOf(argType))
-        }
+        // Evaluate and convert each argument.
+        compileJavaArgs(args, method.descriptor)
 
         // Call the bridge method super$methodName on the anonymous class.
         mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, anonClassInternalName, GenAnonymousClasses.bridgeName(method), method.descriptor.descriptorString(), false)
@@ -914,10 +905,7 @@ object GenExpression {
       case AtomicOp.InvokeStaticMethod(method) =>
         // Add source line number for debugging (can fail when calling unsafe java methods)
         addLoc(loc)
-        for ((arg, argType) <- exps.zip(method.descriptor.parameterList.asScala)) {
-          compileExpr(arg)
-          if (!argType.isPrimitive) mv.visitTypeInsn(Opcodes.CHECKCAST, internalNameOf(argType))
-        }
+        compileJavaArgs(exps, method.descriptor)
         val declaration = internalNameOf(method.owner)
         mv.visitMethodInsn(Opcodes.INVOKESTATIC, declaration, method.name, method.descriptor.descriptorString(), method.isInterface)
         if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
@@ -1569,10 +1557,7 @@ object GenExpression {
         constructors.head.exp match {
           case Expr.ApplyAtomic(AtomicOp.InvokeSuperConstructor(constructor), superArgs, _, _, _) =>
             // Super-only: compile args and call parameterized <init>
-            for ((arg, argType) <- superArgs.zip(constructor.descriptor.parameterList.asScala)) {
-              compileExpr(arg)
-              if (!argType.isPrimitive) mv.visitTypeInsn(Opcodes.CHECKCAST, internalNameOf(argType))
-            }
+            compileJavaArgs(superArgs, constructor.descriptor)
             mv.visitMethodInsn(Opcodes.INVOKESPECIAL, className, ClassMaker.ConstructorMethodName, constructor.descriptor.descriptorString(), false)
           case _ => throw InternalCompilerException(s"Unexpected non-super constructor body.", constructors.head.loc)
         }
@@ -1591,6 +1576,22 @@ object GenExpression {
 
   private def getStructType(struct: Struct): List[ClassDesc] = {
     TypeDescs.structFields(struct)
+  }
+
+  /**
+    * Compiles the arguments `args` of a Java call and converts each to its parameter type in `descriptor`.
+    *
+    * A reference parameter receives a `CHECKCAST`. A primitive parameter receives the widening primitive
+    * conversion from the erased type of the argument, e.g. `I2L` for an `Int32` argument to a `long` parameter.
+    * Overload resolution admits no other conversion, so the erased argument type is either the parameter type
+    * itself or a primitive that widens to it.
+    */
+  private def compileJavaArgs(args: List[Expr], descriptor: MethodTypeDesc)(implicit mv: MethodVisitor, ctx: MethodContext, root: Root, flix: Flix): Unit = {
+    for ((arg, paramType) <- args.zip(descriptor.parameterList.asScala)) {
+      compileExpr(arg)
+      if (paramType.isPrimitive) xWidenPrimitive(TypeDescs.toClassDesc(arg.tpe), paramType)
+      else CHECKCAST(paramType)
+    }
   }
 
   private def compileIsTag(ordinal: Int, exp: Expr)(implicit mv: MethodVisitor, ctx: MethodContext, root: Root, flix: Flix): Unit = {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Instructions.scala
@@ -311,6 +311,30 @@ object Instructions {
   def isCategory2(tpe: ClassDesc): Boolean =
     tpe == ConstantDescs.CD_long || tpe == ConstantDescs.CD_double
 
+  /**
+    * Emits the widening primitive conversion (JLS §5.1.2) from `from` to `to`, or nothing if the two are equal.
+    *
+    * `byte`, `short`, and `char` are `int` on the operand stack, so widening among them and to `int` emits no
+    * instruction. Every other widening is one conversion instruction, e.g. `I2L` for `int` to `long`.
+    *
+    * Any other pair is not a widening primitive conversion and is therefore a compiler bug.
+    */
+  def xWidenPrimitive(from: ClassDesc, to: ClassDesc)(implicit mv: MethodVisitor): Unit = {
+    import java.lang.constant.ConstantDescs.*
+    (from, to) match {
+      case (f, t) if f == t => ()
+      case (CD_byte, CD_short | CD_int) => ()
+      case (CD_short | CD_char, CD_int) => ()
+      case (CD_byte | CD_short | CD_char | CD_int, CD_long) => mv.visitInsn(Opcodes.I2L)
+      case (CD_byte | CD_short | CD_char | CD_int, CD_float) => mv.visitInsn(Opcodes.I2F)
+      case (CD_byte | CD_short | CD_char | CD_int, CD_double) => mv.visitInsn(Opcodes.I2D)
+      case (CD_long, CD_float) => mv.visitInsn(Opcodes.L2F)
+      case (CD_long, CD_double) => mv.visitInsn(Opcodes.L2D)
+      case (CD_float, CD_double) => mv.visitInsn(Opcodes.F2D)
+      case _ => throw InternalCompilerException(s"Unexpected primitive widening from '${from.displayName()}' to '${to.displayName()}'", SourceLocation.Unknown)
+    }
+  }
+
   /** Emits the array-load instruction appropriate for `elmTpe`. */
   def xArrayLoad(elmTpe: ClassDesc)(implicit mv: MethodVisitor): Unit = {
     import java.lang.constant.ConstantDescs.*

--- a/main/test/flix/Test.Exp.Jvm.PrimitiveWidening.flix
+++ b/main/test/flix/Test.Exp.Jvm.PrimitiveWidening.flix
@@ -1,0 +1,101 @@
+mod Test.Exp.Jvm.PrimitiveWidening {
+
+    use Assert.assertEq
+
+    import java.lang.{Double => JDouble}
+    import java.lang.{Float => JFloat}
+    import java.lang.{Integer => JInteger}
+    import java.lang.{Long => JLong}
+    import java.lang.Math
+    import java.lang.StringBuilder
+    import java.util.concurrent.atomic.AtomicLong
+
+    //
+    // Static methods
+    //
+
+    @Test
+    def testStaticInt32ToInt64(): Unit \ Assert =
+        // Long.valueOf(long)
+        assertEq(expected = 42i64, JLong.valueOf(42).longValue())
+
+    @Test
+    def testStaticInt8ToInt64(): Unit \ Assert + IO =
+        // Math.max(long, long)
+        assertEq(expected = 2i64, Math.max(1i8, 2i64))
+
+    @Test
+    def testStaticInt16ToInt64(): Unit \ Assert + IO =
+        assertEq(expected = 300i64, Math.max(300i16, 2i64))
+
+    @Test
+    def testStaticCharToInt32(): Unit \ Assert =
+        // Integer.valueOf(int)
+        assertEq(expected = 65, JInteger.valueOf('A').intValue())
+
+    @Test
+    def testStaticInt32ToFloat32(): Unit \ Assert =
+        // Float.valueOf(float)
+        assertEq(expected = 42.0f32, JFloat.valueOf(42).floatValue())
+
+    @Test
+    def testStaticInt32ToFloat64(): Unit \ Assert + IO =
+        // Math.sqrt(double)
+        assertEq(expected = 4.0f64, Math.sqrt(16))
+
+    @Test
+    def testStaticInt64ToFloat32(): Unit \ Assert =
+        assertEq(expected = 42.0f32, JFloat.valueOf(42i64).floatValue())
+
+    @Test
+    def testStaticInt64ToFloat64(): Unit \ Assert + IO =
+        assertEq(expected = 4.0f64, Math.sqrt(16i64))
+
+    @Test
+    def testStaticFloat32ToFloat64(): Unit \ Assert + IO =
+        assertEq(expected = 4.0f64, Math.sqrt(16.0f32))
+
+    //
+    // Instance methods
+    //
+
+    @Test
+    def testInstanceInt32ToInt64(): Unit \ Assert + IO =
+        // AtomicLong.set(long)
+        let a = new AtomicLong(0i64);
+        a.set(42);
+        assertEq(expected = 42i64, a.get())
+
+    @Test
+    def testInstanceInt8ToInt64(): Unit \ Assert + IO =
+        // AtomicLong.addAndGet(long)
+        let a = new AtomicLong(40i64);
+        assertEq(expected = 42i64, a.addAndGet(2i8))
+
+    @Test
+    def testInstanceInt8ToInt32(): Unit \ Assert + IO =
+        // StringBuilder.append(int) needs no instruction since a byte is an int on the stack
+        let sb = new StringBuilder();
+        assertEq(expected = "1", sb.append(1i8).toString())
+
+    //
+    // Constructors
+    //
+
+    @Test
+    def testConstructorInt32ToInt64(): Unit \ Assert + IO =
+        // AtomicLong(long)
+        let a = new AtomicLong(42);
+        assertEq(expected = 42i64, a.get())
+
+    @Test
+    def testConstructorInt16ToInt64(): Unit \ Assert =
+        // Long(long)
+        assertEq(expected = 42i64, (new JLong(42i16)).longValue())
+
+    @Test
+    def testConstructorInt32ToFloat64(): Unit \ Assert =
+        // Double(double)
+        assertEq(expected = 42.0f64, (new JDouble(42)).doubleValue())
+
+}


### PR DESCRIPTION
## Summary

Overload resolution admits widening primitive conversions (JLS §5.1.2) when matching a Flix argument to a Java parameter, but the backend never emitted them. `byte`, `short` and `char` to `int` happened to work because all four are `int` on the operand stack. Widening to `long`, `float` or `double` reached the JVM unconverted:

```flix
JLong.valueOf(42)      // resolves to valueOf(long)
Math.max(1i8, 2i64)    // resolves to max(long, long)
```

The first failed at class load with

```
VerifyError: Bad type on operand stack
  Reason: Type integer (current frame, stack[3]) is not assignable to long_2nd
```

and the second crashed the compiler with an `ArrayIndexOutOfBoundsException` inside ASM's frame computation, since an `int` was pushed where a two-slot `long` was expected.

## Changes

- `Instructions.xWidenPrimitive(from, to)` emits the conversion for each pair in the JLS widening table: nothing among `byte`, `short`, `char` and `int`, and one of `I2L`, `I2F`, `I2D`, `L2F`, `L2D`, `F2D` otherwise. Any other pair is a compiler bug and throws.
- `GenExpression.compileJavaArgs` compiles the arguments of a Java call and converts each to its parameter type: a `CHECKCAST` for a reference parameter, the widening conversion for a primitive one. It replaces the five identical compile-and-checkcast loops at `InvokeConstructor`, `InvokeMethod`, `InvokeSuperMethod`, `InvokeStaticMethod` and the super-constructor call in `NewObject`.
- `Test.Exp.Jvm.PrimitiveWidening` covers static methods, instance methods and constructors for every widening that emits an instruction, plus the `byte` to `int` no-op.

Part of the overload-resolution redesign discussed separately; this fix stands on its own and does not change which overload is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013R3jvCiqAtLvLCcntyBhfy
