### PR TITLE
feat: parse polymorphic effect declarations

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -277,20 +277,20 @@ object WeederError {
   }
 
   /**
-    * An error raised to indicate that type parameters are present on an effect or operation.
+    * An error raised to indicate that type parameters are present on an effect operation.
     *
     * @param loc the location where the error occurred.
     */
-  case class IllegalEffectTypeParams(loc: SourceLocation) extends WeederError {
+  case class IllegalOperationTypeParams(loc: SourceLocation) extends WeederError {
     def code: ErrorCode = ErrorCode.E9245
 
-    def summary: String = "Unexpected effect type parameters."
+    def summary: String = "Unexpected effect operation type parameters."
 
     def message(formatter: Formatter)(implicit root: Option[TypedAst.Root]): String = {
       import formatter.*
-      s""">> Unexpected effect type parameters.
+      s""">> Unexpected effect operation type parameters.
          |
-         |${src(loc, "type parameters on effects are not yet supported")}
+         |${src(loc, "effect operations cannot declare type parameters")}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1303,12 +1303,8 @@ object Parser2 {
       expect(TokenKind.KeywordEff)
       nameUnqualified(NAME_EFFECT)
 
-      // Check for illegal type parameters.
       if (at(TokenKind.BracketL)) {
-        val mark = open()
-        val loc = currentSourceLocation()
         Type.parameters()
-        closeWithError(mark, WeederError.IllegalEffectTypeParams(loc))
       }
 
       if (eat(TokenKind.CurlyL)) {
@@ -1346,7 +1342,7 @@ object Parser2 {
         val mark = open()
         val loc = currentSourceLocation()
         Type.parameters()
-        closeWithError(mark, WeederError.IllegalEffectTypeParams(loc))
+        closeWithError(mark, WeederError.IllegalOperationTypeParams(loc))
       }
 
       if (at(TokenKind.ParenL)) {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParserSad.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParserSad.scala
@@ -55,16 +55,7 @@ class TestParserSad extends AnyFunSuite with TestUtils {
     expectError[ParseError](result)
   }
 
-  test("IllegalEffectTypeParams.01") {
-    val input =
-      """
-        |eff MyEffect[a]
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEffectTypeParams](result)
-  }
-
-  test("IllegalEffectTypeParams.02") {
+  test("IllegalOperationTypeParams.01") {
     val input =
       """
         |eff MyEffect {
@@ -72,10 +63,10 @@ class TestParserSad extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEffectTypeParams](result)
+    expectError[WeederError.IllegalOperationTypeParams](result)
   }
 
-  test("IllegalEffectTypeParams.03") {
+  test("IllegalOperationTypeParams.02") {
     val input =
       """
         |eff MyEffect[a] {
@@ -83,7 +74,7 @@ class TestParserSad extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEffectTypeParams](result)
+    expectError[WeederError.IllegalOperationTypeParams](result)
   }
 
   test("IllegalExtMatchRule.01") {

--- a/main/test/flix/Test.Dec.Effect.flix
+++ b/main/test/flix/Test.Dec.Effect.flix
@@ -21,4 +21,10 @@ mod Test.Dec.Effect {
     pub eff EmptyWithParens {
 
     }
+
+    pub eff Polymorphic[a]
+
+    pub eff PolymorphicWithKinds[a: Type, b: Type] {
+        def op(x: a): b
+    }
 }


### PR DESCRIPTION
Part of #13229.

## Summary

- accept type parameters on effect declarations
- continue rejecting type parameters declared on individual effect operations
- rename the operation-level diagnostic to reflect its narrower scope
- add compiler-level coverage for unkinded and explicitly kinded effect parameters

## Tests

- `./mill --no-server flix.test`
- `./mill --no-server flix.test.testOnly flix.CompilerSuite -- -z Test.Dec.Effect`