### PR TITLE
test: cover enums named after generated classes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Mangle.scala
@@ -25,6 +25,55 @@ import java.lang.constant.ConstantDescs.{CD_boolean, CD_byte, CD_char, CD_double
 
 /**
   * Name mangling and construction of class names for generated classes.
+  *
+  * == The Name Space ==
+  *
+  * A generated class is named in one of three ways.
+  *
+  * Structural classes are named after the erased types they hold, so that every value of
+  * the same shape shares one class. They live in the root package:
+  *
+  * {{{
+  * Tuple$Obj$Int32     every pair whose second component is an Int32
+  * Tag$Obj             every tag with a single reference-typed term
+  * Struct$Obj          every struct with a single reference-typed field
+  * Lazy$Int32          every lazy Int32
+  * Fn2$Obj$Obj$Obj     every binary function on reference types
+  * }}}
+  *
+  * Runtime classes have fixed names in the `dev.flix.runtime` package, e.g. `Thunk` and
+  * `Resumption`.
+  *
+  * The rest are named after a declaration the programmer wrote, and live in the package of
+  * its namespace:
+  *
+  * {{{
+  * Def$map             the function class of the def `map`
+  * Clo$map             the closure class of the def `map`
+  * Eff$Console         the effect class of the effect `Console`
+  * Case$Color$Red      the class of the nullary case `Red` of `enum Color`
+  * }}}
+  *
+  * == The Prefix Invariant ==
+  *
+  * A class named after a programmer-chosen identifier must carry a reserved prefix, as
+  * `Def`, `Clo`, `Eff`, and `Case` do above.
+  *
+  * The reason is that the segments of a structural name -- `Bool`, `Int32`, `Obj`, and the
+  * rest of [[erasedName]] -- are legal Flix identifiers, and so are the family names that
+  * precede them. Without a prefix, a program could name a class after a generated one:
+  *
+  * {{{
+  * enum Tag { case Obj }       // would be Tag$Obj, as above
+  * enum Struct { case Obj }    // would be Struct$Obj, as above
+  * }}}
+  *
+  * A clash is caught in [[CodeGen]], but only as an internal error, and only once both
+  * classes happen to be generated -- a case that the optimizer folds away emits none. The
+  * prefix is what keeps the two apart to begin with.
+  *
+  * The same holds for the packages: a namespace supplies the package of the classes above,
+  * so `dev.flix.runtime` is out of reach only because module names must be capitalized.
   */
 object Mangle {
 

--- a/main/test/flix/Test.Dec.Enum.ClassName.flix
+++ b/main/test/flix/Test.Dec.Enum.ClassName.flix
@@ -1,0 +1,153 @@
+// The compiler generates classes whose names are built from a fixed vocabulary of
+// erased type names -- Bool, Char, Int8, Int16, Int32, Int64, Float32, Float64, and
+// Obj -- e.g. `Tag$Obj`, `Struct$Obj`, and `RecordExtend$Obj`. Each of those is also a
+// legal enum case name, and each family prefix is a legal enum name, so an enum in the
+// root namespace can name its class after one of them.
+//
+// The enums below are declared in the root namespace on purpose: that is the namespace
+// whose classes share a package with the generated ones.
+//
+// Each case is reached through a recursive function so that the enum survives to code
+// generation. A tag folded away by the optimizer generates no class, and would make
+// these tests pass without testing anything.
+
+pub enum Tag {
+    case Obj
+    case Int64
+    case Other
+}
+
+pub enum Tuple {
+    case Obj
+    case Other
+}
+
+pub enum Struct {
+    case Obj
+    case Other
+}
+
+pub enum ExtTag {
+    case Obj
+    case Other
+}
+
+pub enum RecordExtend {
+    case Obj
+    case Other
+}
+
+pub enum Main {
+    case Obj
+    case Other
+}
+
+pub enum Eff {
+    case Beep
+    case Other
+}
+
+pub eff Beep {
+    def beep(): Unit
+}
+
+mod Test.Dec.Enum.ClassName {
+
+    use Assert.assertEq;
+
+    /// Returns `x` after `n` recursive steps. Opaque to the optimizer, so the tag
+    /// it is applied to is not folded into a constant.
+    def opaque(n: Int32, x: a): a = if (n <= 0) x else opaque(n - 1, x)
+
+    @Test
+    def testTagObj(): Unit \ Assert =
+        match opaque(3, Tag.Obj) {
+            case Tag.Obj   => assertEq(expected = 1, 1)
+            case Tag.Int64 => assertEq(expected = 1, 2)
+            case Tag.Other => assertEq(expected = 1, 3)
+        }
+
+    @Test
+    def testTagInt64(): Unit \ Assert =
+        match opaque(3, Tag.Int64) {
+            case Tag.Obj   => assertEq(expected = 2, 1)
+            case Tag.Int64 => assertEq(expected = 2, 2)
+            case Tag.Other => assertEq(expected = 2, 3)
+        }
+
+    @Test
+    def testTupleObj(): Unit \ Assert =
+        match opaque(3, Tuple.Obj) {
+            case Tuple.Obj   => assertEq(expected = 1, 1)
+            case Tuple.Other => assertEq(expected = 1, 2)
+        }
+
+    @Test
+    def testStructObj(): Unit \ Assert =
+        match opaque(3, Struct.Obj) {
+            case Struct.Obj   => assertEq(expected = 1, 1)
+            case Struct.Other => assertEq(expected = 1, 2)
+        }
+
+    @Test
+    def testExtTagObj(): Unit \ Assert =
+        match opaque(3, ExtTag.Obj) {
+            case ExtTag.Obj   => assertEq(expected = 1, 1)
+            case ExtTag.Other => assertEq(expected = 1, 2)
+        }
+
+    @Test
+    def testRecordExtendObj(): Unit \ Assert =
+        match opaque(3, RecordExtend.Obj) {
+            case RecordExtend.Obj   => assertEq(expected = 1, 1)
+            case RecordExtend.Other => assertEq(expected = 1, 2)
+        }
+
+    /// A struct with a single reference-typed field generates `Struct$Obj`, which is
+    /// what the case class of `Struct.Obj` would be named without the prefix.
+    struct Boxed[r] {
+        boxedValue: String
+    }
+
+    mod Boxed {
+        use Assert.assertEq;
+
+        @Test
+        def testStructClassIsGenerated(): Unit \ Assert = region rc {
+            let b = new Boxed @ rc { boxedValue = "v" };
+            assertEq(expected = "v", b->boxedValue)
+        }
+    }
+
+    /// An extensible variant with a single reference-typed term generates `ExtTag$Obj`,
+    /// which is what the case class of `ExtTag.Obj` would be named without the prefix.
+    @Test
+    def testExtTagClassIsGenerated(): Unit \ Assert =
+        ematch (xvar A("x")) {
+            case A(s) => assertEq(expected = "x", s)
+        }
+
+    /// `Main` is reserved for modules only, so an enum may still use it.
+    @Test
+    def testMainObj(): Unit \ Assert =
+        match opaque(3, Main.Obj) {
+            case Main.Obj   => assertEq(expected = 1, 1)
+            case Main.Other => assertEq(expected = 1, 2)
+        }
+
+    /// The case `Eff.Beep` and the effect `Beep` would generate the same class if the
+    /// case classes were not prefixed, since the effect class is named `Eff$Beep`.
+    @Test
+    def testEffBeep(): Unit \ Assert =
+        let result = run {
+            Beep.beep();
+            opaque(3, Eff.Beep)
+        } with handler Beep {
+            def beep(k) = k(())
+        };
+        match result {
+            case Eff.Beep  => assertEq(expected = 1, 1)
+            case Eff.Other => assertEq(expected = 1, 2)
+        }
+
+}


### PR DESCRIPTION
#13230 gave the class of a nullary case a `Case` prefix so that an enum cannot take the name of a generated class, but it landed without tests. This adds them, and writes down the invariant it restored.

### Tests

`main/test/flix/Test.Dec.Enum.ClassName.flix` declares an enum for each family whose class an enum could otherwise have named — `Tag`, `Tuple`, `Struct`, `ExtTag`, `RecordExtend` — plus an `enum Eff` whose case names an effect, and an `enum Main`, which is allowed since only modules are reserved.

Two details make the tests real rather than decorative:

- **The enums are in the root namespace.** That is the namespace whose classes share a package with the generated ones; an enum inside `mod Test.…` is mangled to `Case$Test$dotDec$dot…` and could never have clashed, so it would test nothing.
- **Every case is reached through a recursive function.** A case that the optimizer folds away generates no class at all, which is exactly how the clash escaped notice: my first attempt at a repro for the `Eff` case compiled clean until the value was made runtime-dependent.

The file also declares a struct and an extensible variant, so that `Struct$Obj` and `ExtTag$Obj` are actually generated and those two tests exercise a live clash rather than only pinning a name. I checked the built jar to confirm each pair now coexists:

```
Case$Tag$Obj           Tag$Obj
Case$Tag$Int64         Tag$Int64
Case$Struct$Obj        Struct$Obj
Case$ExtTag$Obj        ExtTag$Obj
Case$RecordExtend$Obj  RecordExtend$Obj
Case$Eff$Beep          Eff$Beep
```

### Documentation

`Mangle` now describes the three ways a generated class is named and states the invariant that `GenNullaryTag` broke: a class named after a programmer-chosen identifier must carry a reserved prefix, because the segments of a structural name — `Bool`, `Int32`, `Obj` — and the family names that precede them are all legal Flix identifiers. That rule was written down nowhere, which is why it drifted.

Full suite: 16696 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CvfCqYQcj11bN4f1QCNy5