### PR TITLE
fix: cast erased Java method results to the Flix type

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -873,6 +873,7 @@ object GenExpression {
         } else {
           mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, declaration, method.name, method.descriptor.descriptorString(), false)
         }
+        castJavaResult(method.descriptor.returnType(), tpe)
 
         // If the method is void, put a unit on top of the stack
         if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
@@ -896,6 +897,7 @@ object GenExpression {
 
         // Call the bridge method super$methodName on the anonymous class.
         mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, anonClassInternalName, GenAnonymousClasses.bridgeName(method), method.descriptor.descriptorString(), false)
+        castJavaResult(method.descriptor.returnType(), tpe)
 
         // If the method is void, put a unit on top of the stack
         if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
@@ -908,6 +910,7 @@ object GenExpression {
         compileJavaArgs(exps, method.descriptor)
         val declaration = internalNameOf(method.owner)
         mv.visitMethodInsn(Opcodes.INVOKESTATIC, declaration, method.name, method.descriptor.descriptorString(), method.isInterface)
+        castJavaResult(method.descriptor.returnType(), tpe)
         if (method.descriptor.returnType() == java.lang.constant.ConstantDescs.CD_void) {
           mv.visitFieldInsn(Opcodes.GETSTATIC, internalNameOf(GenUnit.Desc), GenUnit.SingletonField.name, GenUnit.Desc.descriptorString())
         }
@@ -1591,6 +1594,22 @@ object GenExpression {
       compileExpr(arg)
       if (paramType.isPrimitive) xWidenPrimitive(TypeDescs.toClassDesc(arg.tpe), paramType)
       else CHECKCAST(paramType)
+    }
+  }
+
+  /**
+    * Casts the value returned by a Java method with return type `returnType` to the erased Flix type `tpe` of
+    * the call.
+    *
+    * A method whose declared return type is a type variable returns its erasure, usually `Object`, while the
+    * Flix type of the call is the instantiation, e.g. `Vector[Int32]` for `ArrayList[Vector[Int32]].get(0)`.
+    * The cast recovers the JVM type the rest of the code expects, as javac does after an erased generic call.
+    * Nothing is emitted for `void` and primitive return types, or when the erasure already is the Flix type.
+    */
+  private def castJavaResult(returnType: ClassDesc, tpe: SimpleType)(implicit mv: MethodVisitor, root: Root): Unit = {
+    if (returnType != CD_void && !returnType.isPrimitive) {
+      val resultType = TypeDescs.toClassDesc(tpe)
+      if (resultType != returnType) castIfNotPrim(resultType)
     }
   }
 

--- a/main/test/flix/Test.Exp.Jvm.Generic.ErasedReturn.flix
+++ b/main/test/flix/Test.Exp.Jvm.Generic.ErasedReturn.flix
@@ -1,0 +1,92 @@
+mod Test.Exp.Jvm.Generic.ErasedReturn {
+
+    use Assert.{assertEq, assertTrue}
+
+    import java.util.ArrayList
+    import java.util.HashMap
+    import java.util.Objects
+    import java.util.Optional
+
+    //
+    // A generic Java method returns its erasure, so the value must be cast to the Flix type of the call
+    // before it is used as a vector, tuple, enum, record, or function.
+    //
+
+    @Test
+    def testVectorOfInt32(): Unit \ {Assert, IO} =
+        let l: ArrayList[Vector[Int32]] = new ArrayList();
+        discard l.add(Vector#{1, 2});
+        let v = l.get(0);
+        assertEq(expected = 2, Vector.length(v))
+
+    @Test
+    def testVectorOfString(): Unit \ {Assert, IO} =
+        let l: ArrayList[Vector[String]] = new ArrayList();
+        discard l.add(Vector#{"a", "b", "c"});
+        let v = l.get(0);
+        assertEq(expected = 3, Vector.length(v))
+
+    @Test
+    def testTuple(): Unit \ {Assert, IO} =
+        let l: ArrayList[(Int32, Int32)] = new ArrayList();
+        discard l.add((1, 2));
+        let (a, b) = l.get(0);
+        assertEq(expected = 3, a + b)
+
+    @Test
+    def testEnum(): Unit \ {Assert, IO} =
+        let l: ArrayList[Option[Int32]] = new ArrayList();
+        discard l.add(Some(42));
+        let r = match l.get(0) {
+            case Some(x) => x
+            case None    => 0
+        };
+        assertEq(expected = 42, r)
+
+    @Test
+    def testRecord(): Unit \ {Assert, IO} =
+        let l: ArrayList[{x = Int32, y = Int32}] = new ArrayList();
+        discard l.add({x = 1, y = 2});
+        let r = l.get(0);
+        assertEq(expected = 3, r#x + r#y)
+
+    @Test
+    def testFunction(): Unit \ {Assert, IO} =
+        let l: ArrayList[Int32 -> Int32] = new ArrayList();
+        discard l.add(x -> x + 1);
+        let f = l.get(0);
+        assertEq(expected = 42, f(41))
+
+    @Test
+    def testHashMapValue(): Unit \ {Assert, IO} =
+        let m: HashMap[String, (Int32, Int32)] = new HashMap();
+        discard m.put("k", (1, 2));
+        let (a, b) = m.get("k");
+        assertEq(expected = 3, a + b)
+
+    @Test
+    def testIterator(): Unit \ {Assert, IO} =
+        let l: ArrayList[Vector[Int32]] = new ArrayList();
+        discard l.add(Vector#{1, 2, 3});
+        let v = l.iterator().next();
+        assertEq(expected = 3, Vector.length(v))
+
+    @Test
+    def testOptionalGet(): Unit \ {Assert, IO} =
+        let o = Optional.of((1, 2));
+        let (a, b) = o.get();
+        assertEq(expected = 3, a + b)
+
+    @Test
+    def testStaticGenericMethod(): Unit \ {Assert, IO} =
+        // Objects.requireNonNull(T) returns T
+        let v = Objects.requireNonNull(Vector#{1, 2});
+        assertEq(expected = 2, Vector.length(v))
+
+    @Test
+    def testNativeUnaffected(): Unit \ {Assert, IO} =
+        let l: ArrayList[String] = new ArrayList();
+        discard l.add("hello");
+        assertTrue(l.get(0).startsWith("he"))
+
+}


### PR DESCRIPTION
## Summary

A Java method whose declared return type is a type variable returns its erasure, usually `Object`, while the Flix type of the call is the instantiation. The backend pushed the erased value and never cast it. A native type or a string survived this because the receiver of the next Java call is cast anyway, but every Flix value with its own JVM class failed verification as soon as it was used directly:

```flix
let l: ArrayList[Vector[Int32]] = new ArrayList();
discard l.add(Vector#{1, 2});
Vector.length(l.get(0))          // VerifyError: Bad type on operand stack in arraylength
```

The same happened for a `Vector[String]`, a tuple (`GETFIELD` on an `Object`), and by the same mechanism for enums, records and closures.

## Changes

- `GenExpression.castJavaResult` emits a `CHECKCAST` to the erased Flix type of the call after `InvokeMethod`, `InvokeSuperMethod` and `InvokeStaticMethod`, when the declared return type is a non-void reference that differs from it. This is the cast javac inserts after every erased generic call. Constructors return their exact class and need nothing.
- `Test.Exp.Jvm.Generic.ErasedReturn` covers vectors, a tuple, an enum, a record and a function coming back through `ArrayList.get`, `HashMap.get`, `Iterator.next`, `Optional.get` and the static `Objects.requireNonNull`, plus a native-type call that was already fine.

The cast fires only where the erasure and the Flix type differ, so a call with a non-generic return type is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013R3jvCiqAtLvLCcntyBhfy
