### PR TITLE
feat: apply effect parameters to operation schemes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -274,7 +274,9 @@ object Kinder {
     case ResolvedAst.Declaration.Effect(doc, ann, mod, sym, tparams0, ops0, loc) =>
       val kenv = getKindEnvFromTypeParams(tparams0)
       val tparams = tparams0.map(visitTypeParam(_, kenv))
-      val ops = ops0.map(visitOp(_, tparams, kenv, root))
+      val targs = tparams.map(tparam => Type.Var(tparam.sym, tparam.loc.asSynthetic))
+      val tpe = Type.mkApply(Type.Cst(TypeConstructor.Effect(sym, declKinds.effectKinds(sym)), sym.loc.asSynthetic), targs, sym.loc.asSynthetic)
+      val ops = ops0.map(visitOp(_, tparams, tpe, kenv, root))
       KindedAst.Effect(doc, ann, mod, sym, tparams, ops, loc)
   }
 
@@ -345,10 +347,10 @@ object Kinder {
   /**
     * Performs kinding on the given effect operation under the given kind environment.
     */
-  private def visitOp(op: ResolvedAst.Declaration.Op, tparams: List[KindedAst.TypeParam], kenv0: KindEnv, root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): KindedAst.Op = op match {
+  private def visitOp(op: ResolvedAst.Declaration.Op, tparams: List[KindedAst.TypeParam], eff: Type, kenv0: KindEnv, root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): KindedAst.Op = op match {
     case ResolvedAst.Declaration.Op(sym, spec0, loc) =>
       val kenv = inferSpec(spec0, kenv0, root)
-      val spec = visitSpec(spec0, tparams.map(_.sym), Some(sym.eff), kenv, root)
+      val spec = visitSpec(spec0, tparams.map(_.sym), Some(eff), kenv, root)
       KindedAst.Op(sym, spec, loc)
   }
 
@@ -358,7 +360,7 @@ object Kinder {
     * Adds `quantifiers` to the generated scheme's quantifier list.
     * Adds `effect` to the generated scheme's effect set
     */
-  private def visitSpec(spec0: ResolvedAst.Spec, quantifiers: List[Symbol.KindedTypeVarSym], effect: Option[Symbol.EffSym], kenv: KindEnv, root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): KindedAst.Spec = spec0 match {
+  private def visitSpec(spec0: ResolvedAst.Spec, quantifiers: List[Symbol.KindedTypeVarSym], effect: Option[Type], kenv: KindEnv, root: ResolvedAst.Root)(implicit taenv: TypeAliasEnv, declKinds: DeclKinds, sctx: SharedContext, flix: Flix): KindedAst.Spec = spec0 match {
     case ResolvedAst.Spec(doc, ann, mod, tparams0, fparams0, tpe0, eff0, tconstrs0, econstrs0) =>
       val tparams = tparams0.map(visitTypeParam(_, kenv))
       val fparams = fparams0.map(visitFormalParam(_, kenv, root))
@@ -367,10 +369,10 @@ object Kinder {
       // If we're inside an effect, add that effect to the scheme.
       val eff = effect match {
         case None => declaredEff
-        case Some(sym) =>
+        case Some(tpe) =>
           Some(
             Type.mkUnion(
-              Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), SourceLocation.Unknown), // TODO EFFECT-TPARAMS need kind
+              tpe,
               declaredEff.getOrElse(Type.Pure),
               SourceLocation.Unknown
             )

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -441,8 +441,8 @@ object Specialization {
   private def visitEffectOp(op: TypedAst.Op)(implicit root: TypedAst.Root, flix: Flix): TypedAst.Op =
     op match {
       case TypedAst.Op(sym, TypedAst.Spec(doc, ann, mod, tparams, fparams0, declaredScheme, retTpe, eff, tconstrs, econstrs), loc) =>
-        // Effect operations are monomorphic - they have no variables.
-        // The substitution can be left empty.
+        // Effect declaration parameters are erased at this boundary.
+        // The empty strict substitution grounds them to their default types.
         val fparams = fparams0.map {
           case TypedAst.FormalParam(varSym, tpe, src, decreasing, fpLoc) =>
             TypedAst.FormalParam(varSym, StrictSubstitution.empty(tpe), src, decreasing, fpLoc)
@@ -1414,7 +1414,7 @@ object Specialization {
   private def eval(eff: Type): CofiniteSet[Symbol.EffSym] = eff match {
     case Type.Univ => CofiniteSet.universe
     case Type.Pure => CofiniteSet.empty
-    case Type.Cst(TypeConstructor.Effect(sym, _), _) =>
+    case EffectType(sym) =>
       CofiniteSet.mkSet(sym)
     case Type.Cst(TypeConstructor.Region(_), _) =>
       CofiniteSet.mkSet(RegionInstantiation.sym)
@@ -1429,6 +1429,13 @@ object Specialization {
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y, _) =>
       CofiniteSet.xor(eval(x), eval(y))
     case other => throw InternalCompilerException(s"Unexpected effect $other", other.loc)
+  }
+
+  /** Extracts the symbol from a fully applied or nullary effect type. */
+  private object EffectType {
+    def unapply(tpe: Type): Option[Symbol.EffSym] = tpe.typeConstructor.collect {
+      case TypeConstructor.Effect(sym, _) => sym
+    }
   }
 
   /** Returns the [[Type]] representation of `set` with `loc`. */

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Specialization.scala
@@ -1414,7 +1414,7 @@ object Specialization {
   private def eval(eff: Type): CofiniteSet[Symbol.EffSym] = eff match {
     case Type.Univ => CofiniteSet.universe
     case Type.Pure => CofiniteSet.empty
-    case EffectType(sym) =>
+    case Type.Cst(TypeConstructor.Effect(sym, _), _) =>
       CofiniteSet.mkSet(sym)
     case Type.Cst(TypeConstructor.Region(_), _) =>
       CofiniteSet.mkSet(RegionInstantiation.sym)
@@ -1428,14 +1428,9 @@ object Specialization {
       CofiniteSet.difference(eval(x), eval(y))
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y, _) =>
       CofiniteSet.xor(eval(x), eval(y))
+    // Effect arguments are erased at the monomorphic boundary.
+    case Type.Apply(tpe, _, _) => eval(tpe)
     case other => throw InternalCompilerException(s"Unexpected effect $other", other.loc)
-  }
-
-  /** Extracts the symbol from a fully applied or nullary effect type. */
-  private object EffectType {
-    def unapply(tpe: Type): Option[Symbol.EffSym] = tpe.typeConstructor.collect {
-      case TypeConstructor.Effect(sym, _) => sym
-    }
   }
 
   /** Returns the [[Type]] representation of `set` with `loc`. */

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
@@ -45,7 +45,7 @@ private[monomorph2] object Canonicalization {
   private[monomorph2] def evalEff(eff: Type): CofiniteSet[Symbol.EffSym] = eff match {
     case Type.Univ                                                                      => CofiniteSet.universe
     case Type.Pure                                                                      => CofiniteSet.empty
-    case EffectType(sym)                                                                => CofiniteSet.mkSet(sym)
+    case Type.Cst(TypeConstructor.Effect(sym, _), _)                                    => CofiniteSet.mkSet(sym)
     case Type.Cst(TypeConstructor.Region(_), _)                                         => CofiniteSet.mkSet(Symbol.IO)
     case Type.Alias(_, _, inner, _)                                                     => evalEff(inner)
     case Type.Apply(Type.Cst(TypeConstructor.Complement, _), y, _)                      => CofiniteSet.complement(evalEff(y))
@@ -53,14 +53,9 @@ private[monomorph2] object Canonicalization {
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Intersection, _), x, _), y, _)  => CofiniteSet.intersection(evalEff(x), evalEff(y))
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Difference, _), x, _), y, _)    => CofiniteSet.difference(evalEff(x), evalEff(y))
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y, _) => CofiniteSet.xor(evalEff(x), evalEff(y))
+    // Effect arguments are erased at the monomorphic boundary.
+    case Type.Apply(tpe, _, _)                                                          => evalEff(tpe)
     case other => throw InternalCompilerException(s"Unexpected effect $other", other.loc)
-  }
-
-  /** Extracts the symbol from a fully applied or nullary effect type. */
-  private object EffectType {
-    def unapply(tpe: Type): Option[Symbol.EffSym] = tpe.typeConstructor.collect {
-      case TypeConstructor.Effect(sym, _) => sym
-    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Canonicalization.scala
@@ -45,7 +45,7 @@ private[monomorph2] object Canonicalization {
   private[monomorph2] def evalEff(eff: Type): CofiniteSet[Symbol.EffSym] = eff match {
     case Type.Univ                                                                      => CofiniteSet.universe
     case Type.Pure                                                                      => CofiniteSet.empty
-    case Type.Cst(TypeConstructor.Effect(sym, _), _)                                    => CofiniteSet.mkSet(sym)
+    case EffectType(sym)                                                                => CofiniteSet.mkSet(sym)
     case Type.Cst(TypeConstructor.Region(_), _)                                         => CofiniteSet.mkSet(Symbol.IO)
     case Type.Alias(_, _, inner, _)                                                     => evalEff(inner)
     case Type.Apply(Type.Cst(TypeConstructor.Complement, _), y, _)                      => CofiniteSet.complement(evalEff(y))
@@ -54,6 +54,13 @@ private[monomorph2] object Canonicalization {
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Difference, _), x, _), y, _)    => CofiniteSet.difference(evalEff(x), evalEff(y))
     case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y, _) => CofiniteSet.xor(evalEff(x), evalEff(y))
     case other => throw InternalCompilerException(s"Unexpected effect $other", other.loc)
+  }
+
+  /** Extracts the symbol from a fully applied or nullary effect type. */
+  private object EffectType {
+    def unapply(tpe: Type): Option[Symbol.EffSym] = tpe.typeConstructor.collect {
+      case TypeConstructor.Effect(sym, _) => sym
+    }
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -16,7 +16,6 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor}
 import ca.uwaterloo.flix.language.errors.KindError
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
@@ -24,30 +23,6 @@ import org.scalatest.funsuite.AnyFunSuite
 class TestKinder extends AnyFunSuite with TestUtils {
 
   private val DefaultOptions = Options.TestWithLibNix
-
-  test("PolymorphicEffect.OperationScheme.01") {
-    val input =
-      """
-        |eff F[a, b] {
-        |    def op(x: a): b
-        |}
-        |""".stripMargin
-    val result = check(input, DefaultOptions)
-    expectSuccess(result)
-
-    val root = result._1.get
-    val eff = root.effects.values.find(_.sym.name == "F").get
-    val op = eff.ops.head
-    val opEff = op.spec.declaredScheme.base.arrowEffectType
-    val expectedTargs = eff.tparams.map(tparam => Type.Var(tparam.sym, tparam.loc))
-
-    assert(op.spec.declaredScheme.quantifiers == eff.tparams.map(_.sym))
-    assert(opEff.typeArguments == expectedTargs)
-    opEff.typeConstructor match {
-      case Some(TypeConstructor.Effect(sym, _)) => assert(sym == eff.sym)
-      case other => fail(s"Expected an applied effect type, got: $other")
-    }
-  }
 
   // ---------------------------------------------------------------------------
   // --- KindError (base trait, no specific subtype) ---

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -16,6 +16,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
+import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor}
 import ca.uwaterloo.flix.language.errors.KindError
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
@@ -23,6 +24,30 @@ import org.scalatest.funsuite.AnyFunSuite
 class TestKinder extends AnyFunSuite with TestUtils {
 
   private val DefaultOptions = Options.TestWithLibNix
+
+  test("PolymorphicEffect.OperationScheme.01") {
+    val input =
+      """
+        |eff F[a, b] {
+        |    def op(x: a): b
+        |}
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectSuccess(result)
+
+    val root = result._1.get
+    val eff = root.effects.values.find(_.sym.name == "F").get
+    val op = eff.ops.head
+    val opEff = op.spec.declaredScheme.base.arrowEffectType
+    val expectedTargs = eff.tparams.map(tparam => Type.Var(tparam.sym, tparam.loc))
+
+    assert(op.spec.declaredScheme.quantifiers == eff.tparams.map(_.sym))
+    assert(opEff.typeArguments == expectedTargs)
+    opEff.typeConstructor match {
+      case Some(TypeConstructor.Effect(sym, _)) => assert(sym == eff.sym)
+      case other => fail(s"Expected an applied effect type, got: $other")
+    }
+  }
 
   // ---------------------------------------------------------------------------
   // --- KindError (base trait, no specific subtype) ---


### PR DESCRIPTION
Part of #13229.

## Summary

- construct each operation latent effect as the fully applied declaration effect, e.g. `F[t]`
- retain the declaration parameters as operation-scheme quantifiers
- erase effect arguments at the monomorphic boundary in both monomorphization pipelines, where runtime effect identity remains the effect symbol

This PR does not yet add shared handler instantiation or applied-effect constraint solving.

## Tests

- `./mill --no-server flix.test` (16,696 succeeded, 0 failed, 8 ignored)
- `./mill --no-server flix.test.testOnly flix.CompilerSuite -- -z Test.Dec.Effect`
- `XNEWMONO=1 ./mill --no-server flix.test.testOnly flix.CompilerSuite -- -z Test.Dec.Effect`