### PR TITLE
feat: support polymorphic effects in the typer

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -139,9 +139,14 @@ object Kind {
   /**
     * Returns the kind: k1 -> (k2 ... -> (kn -> *)) for the given list of kinds `ks`.
     */
-  def mkArrow(ks: List[Kind]): Kind = ks match {
-    case Nil => Star
-    case x :: xs => mkArrow(x, mkArrow(xs))
+  def mkArrow(ks: List[Kind]): Kind = mkArrowTo(ks, Star)
+
+  /**
+    * Returns the kind: k1 -> (k2 ... -> (kn -> ret)) for the given list of kinds `ks`.
+    */
+  def mkArrowTo(ks: List[Kind], ret: Kind): Kind = ks match {
+    case Nil => ret
+    case x :: xs => mkArrow(x, mkArrowTo(xs, ret))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1898,9 +1898,7 @@ object Kinder {
     private def getEffectKind(eff0: ResolvedAst.Declaration.Effect): Kind = eff0 match {
       case ResolvedAst.Declaration.Effect(_, _, _, _, tparams, _, _) =>
         val kenv = getKindEnvFromTypeParams(tparams)
-        tparams.foldRight(Kind.Eff: Kind) {
-          case (tparam, acc) => kenv.map(tparam.sym) ->: acc
-        }
+        Kind.mkArrowTo(tparams.map(tparam => kenv.map(tparam.sym)), Kind.Eff)
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -884,8 +884,9 @@ object ConstraintGen {
 
       case Expr.Handler(symUse, rules, tvar, evar1, evar2, loc) =>
         //
-        // ∀i. Γ, opix1: opit1, .., ki: opit -> t \ k_ef ⊢ ei: t \ ei_ef
-        //     k_ef = (ef - Eff) ∪ (∪_i ei_ef)
+        // β̄ fresh
+        // ∀i. Γ, opix1: opit1[ᾱ ↦ β̄], .., ki: opit[ᾱ ↦ β̄] -> t \ k_ef ⊢ ei: t \ ei_ef
+        //     k_ef = (ef - Eff[β̄]) ∪ (∪_i ei_ef)
         // ---------------------------------------------------------------------
         // Γ ⊢ handler Eff {
         //   def op1(op1x1, .., k1) = e1
@@ -894,24 +895,24 @@ object ConstraintGen {
         // }: (Unit -> t \ ef) -> t \ k_ef
         //
         // where:
-        // eff Eff {
+        // eff Eff[ᾱ] {
         //  def op1(op1x1: op1t1, ..): op1t
         //  def op2(op2x1: op2t2, ..): op2t
         //  ..
         // }
         //
         val effect = root.effects(symUse.sym)
-        val targs = effect.tparams.map(tparam => freshVar(tparam.sym.kind, loc))
-        val effectSubst = Substitution(effect.tparams.map(_.sym).zip(targs).toMap)
+        val effectParams: List[(Symbol.KindedTypeVarSym, Type)] = effect.tparams.map(tparam => tparam.sym -> freshVar(tparam.sym.kind, loc))
+        val effectParamMap = effectParams.toMap
         val effectKind = effect.tparams.foldRight(Kind.Eff: Kind) {
           case (tparam, acc) => tparam.sym.kind ->: acc
         }
 
-        val (tpes, effs) = rules.map(visitHandlerRule(_, tvar, evar2, effectSubst)).unzip
+        val (tpes, effs) = rules.map(visitHandlerRule(_, tvar, evar2, effectParamMap)).unzip
         c.unifyAllTypes(tvar :: tpes, loc)
 
         val handledEffectConstructor = Type.Cst(TypeConstructor.Effect(symUse.sym, effectKind), symUse.qname.loc)
-        val handledEffect = Type.mkApply(handledEffectConstructor, targs, symUse.qname.loc)
+        val handledEffect = Type.mkApply(handledEffectConstructor, effectParams.map(_._2), symUse.qname.loc)
         // Subtract the effect from the body effect and add the handler effects.
         val continuationEffect = Type.mkUnion(Type.mkDifference(evar1, handledEffect, symUse.qname.loc), Type.mkUnion(effs, loc), loc)
         c.unifyType(evar2, continuationEffect, loc)
@@ -1306,12 +1307,13 @@ object ConstraintGen {
     *
     * @param tryBlockTpe        the type of the try-block associated with the handler
     * @param continuationEffect the effect of the continuation
-    * @param effectSubst        the shared instantiation of the effect's type parameters
+    * @param effectParams       the shared instantiation of the effect's type parameters
     */
-  private def visitHandlerRule(rule: KindedAst.HandlerRule, tryBlockTpe: Type, continuationEffect: Type, effectSubst: Substitution)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = rule match {
+  private def visitHandlerRule(rule: KindedAst.HandlerRule, tryBlockTpe: Type, continuationEffect: Type, effectParams: Map[Symbol.KindedTypeVarSym, Type])(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = rule match {
     case KindedAst.HandlerRule(symUse, actualFparams0, body, opTvar, loc) =>
       val effect = root.effects(symUse.sym.eff)
       val ops = effect.ops.map(op => op.sym -> op).toMap
+      def instantiate(tpe: Type): Type = tpe.map(tvar => effectParams.getOrElse(tvar.sym, tvar))
       // The effect parameters have already been instantiated once for the enclosing handler.
       // Don't need to handle unknown op because resolver would have caught this
       // The last formal parameter is the resumption, the rest correspond to the operation's parameters.
@@ -1319,8 +1321,8 @@ object ConstraintGen {
       val resumptionFparam = actualFparams0.last
       ops(symUse.sym) match {
         case KindedAst.Op(_, KindedAst.Spec(_, _, _, _, expectedFparams, _, opTpe, _, _, _), _) =>
-          val expectedParamTypes = expectedFparams.toList.map(fparam => effectSubst(fparam.tpe))
-          val resumptionArgType = effectSubst(opTpe)
+          val expectedParamTypes = expectedFparams.toList.map(fparam => instantiate(fparam.tpe))
+          val resumptionArgType = instantiate(opTpe)
           val resumptionResType = tryBlockTpe
           val resumptionEff = continuationEffect
           val expectedResumptionType = Type.mkArrowWithEffect(resumptionArgType, resumptionEff, resumptionResType, loc.asSynthetic)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -902,17 +902,16 @@ object ConstraintGen {
         // }
         //
         val effect = root.effects(symUse.sym)
-        val effectParams: List[(Symbol.KindedTypeVarSym, Type)] = effect.tparams.map(tparam => tparam.sym -> freshVar(tparam.sym.kind, loc))
-        val effectParamMap = effectParams.toMap
+        val effectParams = effect.tparams.map(tparam => tparam.sym -> freshVar(tparam.sym.kind, loc)).toMap
         val effectKind = effect.tparams.foldRight(Kind.Eff: Kind) {
           case (tparam, acc) => tparam.sym.kind ->: acc
         }
 
-        val (tpes, effs) = rules.map(visitHandlerRule(_, tvar, evar2, effectParamMap)).unzip
+        val (tpes, effs) = rules.map(visitHandlerRule(_, tvar, evar2, effectParams)).unzip
         c.unifyAllTypes(tvar :: tpes, loc)
 
         val handledEffectConstructor = Type.Cst(TypeConstructor.Effect(symUse.sym, effectKind), symUse.qname.loc)
-        val handledEffect = Type.mkApply(handledEffectConstructor, effectParams.map(_._2), symUse.qname.loc)
+        val handledEffect = Type.mkApply(handledEffectConstructor, effect.tparams.map(tparam => effectParams(tparam.sym)), symUse.qname.loc)
         // Subtract the effect from the body effect and add the handler effects.
         val continuationEffect = Type.mkUnion(Type.mkDifference(evar1, handledEffect, symUse.qname.loc), Type.mkUnion(effs, loc), loc)
         c.unifyType(evar2, continuationEffect, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -902,16 +902,15 @@ object ConstraintGen {
         // }
         //
         val effect = root.effects(symUse.sym)
-        val effectParams = effect.tparams.map(tparam => tparam.sym -> freshVar(tparam.sym.kind, loc)).toMap
-        val effectKind = effect.tparams.foldRight(Kind.Eff: Kind) {
-          case (tparam, acc) => tparam.sym.kind ->: acc
-        }
+        val effectArgs = effect.tparams.map(tparam => freshVar(tparam.sym.kind, loc))
+        val effectSubst = Substitution(ListOps.zip(effect.tparams.map(_.sym), effectArgs).toMap)
+        val effectKind = Kind.mkArrowTo(effect.tparams.map(_.sym.kind), Kind.Eff)
 
-        val (tpes, effs) = rules.map(visitHandlerRule(_, tvar, evar2, effectParams)).unzip
+        val (tpes, effs) = rules.map(visitHandlerRule(_, tvar, evar2, effectSubst)).unzip
         c.unifyAllTypes(tvar :: tpes, loc)
 
         val handledEffectConstructor = Type.Cst(TypeConstructor.Effect(symUse.sym, effectKind), symUse.qname.loc)
-        val handledEffect = Type.mkApply(handledEffectConstructor, effect.tparams.map(tparam => effectParams(tparam.sym)), symUse.qname.loc)
+        val handledEffect = Type.mkApply(handledEffectConstructor, effectArgs, symUse.qname.loc)
         // Subtract the effect from the body effect and add the handler effects.
         val continuationEffect = Type.mkUnion(Type.mkDifference(evar1, handledEffect, symUse.qname.loc), Type.mkUnion(effs, loc), loc)
         c.unifyType(evar2, continuationEffect, loc)
@@ -1306,13 +1305,12 @@ object ConstraintGen {
     *
     * @param tryBlockTpe        the type of the try-block associated with the handler
     * @param continuationEffect the effect of the continuation
-    * @param effectParams       the shared instantiation of the effect's type parameters
+    * @param effectSubst        the shared instantiation of the effect's type parameters
     */
-  private def visitHandlerRule(rule: KindedAst.HandlerRule, tryBlockTpe: Type, continuationEffect: Type, effectParams: Map[Symbol.KindedTypeVarSym, Type])(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = rule match {
+  private def visitHandlerRule(rule: KindedAst.HandlerRule, tryBlockTpe: Type, continuationEffect: Type, effectSubst: Substitution)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = rule match {
     case KindedAst.HandlerRule(symUse, actualFparams0, body, opTvar, loc) =>
       val effect = root.effects(symUse.sym.eff)
       val ops = effect.ops.map(op => op.sym -> op).toMap
-      def instantiate(tpe: Type): Type = tpe.map(tvar => effectParams.getOrElse(tvar.sym, tvar))
       // The effect parameters have already been instantiated once for the enclosing handler.
       // Don't need to handle unknown op because resolver would have caught this
       // The last formal parameter is the resumption, the rest correspond to the operation's parameters.
@@ -1320,8 +1318,8 @@ object ConstraintGen {
       val resumptionFparam = actualFparams0.last
       ops(symUse.sym) match {
         case KindedAst.Op(_, KindedAst.Spec(_, _, _, _, expectedFparams, _, opTpe, _, _, _), _) =>
-          val expectedParamTypes = expectedFparams.toList.map(fparam => instantiate(fparam.tpe))
-          val resumptionArgType = instantiate(opTpe)
+          val expectedParamTypes = expectedFparams.toList.map(fparam => effectSubst(fparam.tpe))
+          val resumptionArgType = effectSubst(opTpe)
           val resumptionResType = tryBlockTpe
           val resumptionEff = continuationEffect
           val expectedResumptionType = Type.mkArrowWithEffect(resumptionArgType, resumptionEff, resumptionResType, loc.asSynthetic)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -900,10 +900,18 @@ object ConstraintGen {
         //  ..
         // }
         //
-        val (tpes, effs) = rules.map(visitHandlerRule(_, tvar, evar2)).unzip
+        val effect = root.effects(symUse.sym)
+        val targs = effect.tparams.map(tparam => freshVar(tparam.sym.kind, loc))
+        val effectSubst = Substitution(effect.tparams.map(_.sym).zip(targs).toMap)
+        val effectKind = effect.tparams.foldRight(Kind.Eff: Kind) {
+          case (tparam, acc) => tparam.sym.kind ->: acc
+        }
+
+        val (tpes, effs) = rules.map(visitHandlerRule(_, tvar, evar2, effectSubst)).unzip
         c.unifyAllTypes(tvar :: tpes, loc)
 
-        val handledEffect = Type.Cst(TypeConstructor.Effect(symUse.sym, Kind.Eff), symUse.qname.loc) // TODO EFF-TPARAMS need kind
+        val handledEffectConstructor = Type.Cst(TypeConstructor.Effect(symUse.sym, effectKind), symUse.qname.loc)
+        val handledEffect = Type.mkApply(handledEffectConstructor, targs, symUse.qname.loc)
         // Subtract the effect from the body effect and add the handler effects.
         val continuationEffect = Type.mkUnion(Type.mkDifference(evar1, handledEffect, symUse.qname.loc), Type.mkUnion(effs, loc), loc)
         c.unifyType(evar2, continuationEffect, loc)
@@ -1286,9 +1294,9 @@ object ConstraintGen {
   /**
     * Generates constraints unifying the given expected and actual formal parameters.
     */
-  private def unifyFormalParams(op: Symbol.OpSym, expected: List[KindedAst.FormalParam], actual: List[KindedAst.FormalParam])(implicit c: TypeContext): Unit = {
+  private def unifyFormalParams(op: Symbol.OpSym, expected: List[Type], actual: List[KindedAst.FormalParam])(implicit c: TypeContext): Unit = {
     // length check done in Resolver
-    c.expectTypeArguments(op, expectedTypes = expected.map(_.tpe), actualTypes = actual.map(_.tpe), actual.map(_.loc))
+    c.expectTypeArguments(op, expectedTypes = expected, actualTypes = actual.map(_.tpe), actual.map(_.loc))
   }
 
   /**
@@ -1298,23 +1306,25 @@ object ConstraintGen {
     *
     * @param tryBlockTpe        the type of the try-block associated with the handler
     * @param continuationEffect the effect of the continuation
+    * @param effectSubst        the shared instantiation of the effect's type parameters
     */
-  private def visitHandlerRule(rule: KindedAst.HandlerRule, tryBlockTpe: Type, continuationEffect: Type)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = rule match {
+  private def visitHandlerRule(rule: KindedAst.HandlerRule, tryBlockTpe: Type, continuationEffect: Type, effectSubst: Substitution)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = rule match {
     case KindedAst.HandlerRule(symUse, actualFparams0, body, opTvar, loc) =>
       val effect = root.effects(symUse.sym.eff)
       val ops = effect.ops.map(op => op.sym -> op).toMap
-      // Don't need to generalize since ops are monomorphic
+      // The effect parameters have already been instantiated once for the enclosing handler.
       // Don't need to handle unknown op because resolver would have caught this
       // The last formal parameter is the resumption, the rest correspond to the operation's parameters.
       val actualFparams = actualFparams0.init
       val resumptionFparam = actualFparams0.last
       ops(symUse.sym) match {
         case KindedAst.Op(_, KindedAst.Spec(_, _, _, _, expectedFparams, _, opTpe, _, _, _), _) =>
-          val resumptionArgType = opTpe
+          val expectedParamTypes = expectedFparams.toList.map(fparam => effectSubst(fparam.tpe))
+          val resumptionArgType = effectSubst(opTpe)
           val resumptionResType = tryBlockTpe
           val resumptionEff = continuationEffect
           val expectedResumptionType = Type.mkArrowWithEffect(resumptionArgType, resumptionEff, resumptionResType, loc.asSynthetic)
-          unifyFormalParams(symUse.sym, expected = expectedFparams.toList, actual = actualFparams)
+          unifyFormalParams(symUse.sym, expected = expectedParamTypes, actual = actualFparams)
           c.expectType(expected = expectedResumptionType, actual = resumptionFparam.tpe, resumptionFparam.loc)
           val (actualTpe, actualEff) = visitExp(body)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -141,8 +141,8 @@ object ConstraintSolver2 {
     */
   def solveAll(constrs0: List[TypeConstraint], initialSubst: SubstitutionTree)(implicit scope: RegionScope, renv: RigidityEnv, trenv: TraitEnv, eqenv: EqualityEnv, flix: Flix): (List[TypeConstraint], SubstitutionTree) = {
     val initialConstrs = constrs0.map(initialSubst.apply)
-    val effectArgConstrs = mkEffectArgConstraints(initialConstrs, initialSubst)
-    val constrs = effectArgConstrs ::: initialConstrs
+    val effectArgEqualities = collectEffectArgumentEqualities(initialConstrs, initialSubst)
+    val constrs = effectArgEqualities ::: initialConstrs
     val soup = new Soup(constrs, initialSubst)
     val progress = Progress()
     val res = soup.exhaustively(progress)(solveOne)
@@ -150,10 +150,20 @@ object ConstraintSolver2 {
   }
 
   /**
-    * Returns pointwise equality constraints between the arguments of every saturated application
-    * of the same effect constructor in the constraint system.
+    * Collects pointwise equalities between saturated applications of the same effect constructor.
+    * Every occurrence in one constraint system must agree on the constructor's type arguments.
+    *
+    * For example, given the declarations:
+    * {{{
+    * eff F[t] {
+    *     def op(x: t): Unit
+    * }
+    * def f(): Unit \ F[Int32] + F[String] = ()
+    * }}}
+    * the two applications of `F` produce the additional equality `Int32 ~ String`, making `f`
+    * ill-typed before its effect equations are solved.
     */
-  private def mkEffectArgConstraints(constrs: List[TypeConstraint], initialSubst: SubstitutionTree): List[TypeConstraint] = {
+  private def collectEffectArgumentEqualities(constrs: List[TypeConstraint], initialSubst: SubstitutionTree): List[TypeConstraint] = {
     val applications = mutable.Map.empty[Symbol.EffSym, mutable.ListBuffer[Type]]
 
     def visitType(tpe: Type): Unit = tpe match {
@@ -182,7 +192,9 @@ object ConstraintSolver2 {
       case Type.UnresolvedJvmType(member, _) =>
         member.getTypeArguments.foreach(visitType)
 
-      case Type.Var(_, _) | Type.Cst(_, _) => ()
+      case Type.Var(_, _) => ()
+
+      case Type.Cst(_, _) => ()
     }
 
     def visitConstraint(constr: TypeConstraint): Unit = constr match {
@@ -209,19 +221,19 @@ object ConstraintSolver2 {
     constrs.foreach(visitConstraint)
     visitSubstitutionTree(initialSubst)
 
-    applications.keys.toList.sorted.flatMap { sym =>
-      val occurrences = applications(sym).toList.sortBy(tpe => (tpe.loc, tpe.toString)).distinct
-      occurrences match {
-        case representative :: rest =>
-          rest.flatMap { occurrence =>
-            representative.typeArguments.zip(occurrence.typeArguments).collect {
-              case (tpe1, tpe2) if tpe1 != tpe2 =>
-                TypeConstraint.Equality(tpe1, tpe2, Provenance.Match(representative, occurrence, occurrence.loc))
-            }
+    val equalities = mutable.ListBuffer.empty[TypeConstraint]
+    applications.toList.sortBy(_._1).foreach {
+      case (_, effectApplications) =>
+        val occurrences = effectApplications.toList.sortBy(_.loc).distinct
+        val representative = occurrences.head
+        occurrences.tail.foreach { occurrence =>
+          representative.typeArguments.zip(occurrence.typeArguments).foreach {
+            case (tpe1, tpe2) =>
+              equalities += TypeConstraint.Equality(tpe1, tpe2, Provenance.Match(representative, occurrence, occurrence.loc))
           }
-        case Nil => Nil
+        }
       }
-    }
+    equalities.toList
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -140,8 +140,9 @@ object ConstraintSolver2 {
     * Solves the given constraint set as far as possible.
     */
   def solveAll(constrs0: List[TypeConstraint], initialSubst: SubstitutionTree)(implicit scope: RegionScope, renv: RigidityEnv, trenv: TraitEnv, eqenv: EqualityEnv, flix: Flix): (List[TypeConstraint], SubstitutionTree) = {
+    // Apply the initial substitution to the constraints.
     val initialConstrs = constrs0.map(initialSubst.apply)
-    val effectArgEqualities = deriveEffectArgumentEqualities(initialConstrs, initialSubst)
+    val effectArgEqualities = breakdownPolyEffConstraints(initialConstrs, initialSubst)
     val constrs = effectArgEqualities ::: initialConstrs
     val soup = new Soup(constrs, initialSubst)
     val progress = Progress()
@@ -152,6 +153,8 @@ object ConstraintSolver2 {
   /**
     * Collects pointwise equalities between saturated applications of the same effect constructor.
     * Every occurrence in one constraint system must agree on the constructor's type arguments.
+    * An application is saturated when all the constructor's type parameters are supplied and the
+    * result has kind `Eff`; for `F: Type -> Eff`, `F[Int32]` is saturated while `F` is not.
     *
     * For example, given the declarations:
     * {{{
@@ -163,37 +166,32 @@ object ConstraintSolver2 {
     * the two applications of `F` produce the additional equality `Int32 ~ String`, making `f`
     * ill-typed before its effect equations are solved.
     */
-  private def deriveEffectArgumentEqualities(constrs: List[TypeConstraint], initialSubst: SubstitutionTree): List[TypeConstraint] = {
-    val applications = mutable.Map.empty[Symbol.EffSym, mutable.ListBuffer[Type]]
+  private def breakdownPolyEffConstraints(constrs: List[TypeConstraint], initialSubst: SubstitutionTree): List[TypeConstraint] = {
+    // Maps each effect symbol to the saturated effect types whose arguments must agree.
+    // For example, `F[Int32] + F[String]` maps `F` to `F[Int32]` and `F[String]`.
+    val effectTypes = mutable.Map.empty[Symbol.EffSym, List[Type]]
 
     def visitType(tpe: Type): Unit = tpe match {
       case app@Type.Apply(tpe1, tpe2, _) =>
         app.baseType match {
           case Type.Cst(TypeConstructor.Effect(sym, _), _) if app.kind == Kind.Eff =>
-            applications.getOrElseUpdate(sym, mutable.ListBuffer.empty) += app
+            effectTypes(sym) = app :: effectTypes.getOrElse(sym, Nil)
           case _ => ()
         }
         visitType(tpe1)
         visitType(tpe2)
-
       case Type.Alias(_, args, inner, _) =>
         args.foreach(visitType)
         visitType(inner)
-
       case Type.AssocType(_, arg, _, _) =>
         visitType(arg)
-
       case Type.JvmToType(inner, _) =>
         visitType(inner)
-
       case Type.JvmToEff(inner, _) =>
         visitType(inner)
-
       case Type.UnresolvedJvmType(member, _) =>
         member.getTypeArguments.foreach(visitType)
-
       case Type.Var(_, _) => ()
-
       case Type.Cst(_, _) => ()
     }
 
@@ -218,21 +216,19 @@ object ConstraintSolver2 {
       tree.branches.values.foreach(visitSubstitutionTree)
     }
 
+    // Collect all saturated effect applications in the constraint system.
     constrs.foreach(visitConstraint)
     visitSubstitutionTree(initialSubst)
 
     val equalities = mutable.ListBuffer.empty[TypeConstraint]
-    applications.toList.sortBy(_._1).foreach {
-      case (_, effectApplications) =>
-        val occurrences = effectApplications.toList.sortBy(_.loc).distinct
-        val representative = occurrences.head
-        occurrences.tail.foreach { occurrence =>
-          representative.typeArguments.zip(occurrence.typeArguments).foreach {
-            case (tpe1, tpe2) =>
-              equalities += TypeConstraint.Equality(tpe1, tpe2, Provenance.Match(representative, occurrence, occurrence.loc))
-          }
+    for ((_, occurrences) <- effectTypes) {
+      val representative = occurrences.head
+      for (occurrence <- occurrences.tail) {
+        for ((tpe1, tpe2) <- representative.typeArguments.zip(occurrence.typeArguments)) {
+          equalities += TypeConstraint.Equality(tpe1, tpe2, Provenance.PolyEffEq(representative, occurrence, occurrence.loc))
         }
       }
+    }
     equalities.toList
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -25,6 +25,7 @@ import ca.uwaterloo.flix.util.collection.ListOps
 import ca.uwaterloo.flix.util.{ChaosMonkey, Result}
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 
 /**
   * The constraint solver reduces a collection of constraints by iteratively applying reduction rules.
@@ -139,11 +140,88 @@ object ConstraintSolver2 {
     * Solves the given constraint set as far as possible.
     */
   def solveAll(constrs0: List[TypeConstraint], initialSubst: SubstitutionTree)(implicit scope: RegionScope, renv: RigidityEnv, trenv: TraitEnv, eqenv: EqualityEnv, flix: Flix): (List[TypeConstraint], SubstitutionTree) = {
-    val constrs = constrs0.map(initialSubst.apply)
+    val initialConstrs = constrs0.map(initialSubst.apply)
+    val effectArgConstrs = mkEffectArgConstraints(initialConstrs, initialSubst)
+    val constrs = effectArgConstrs ::: initialConstrs
     val soup = new Soup(constrs, initialSubst)
     val progress = Progress()
     val res = soup.exhaustively(progress)(solveOne)
     res.get
+  }
+
+  /**
+    * Returns pointwise equality constraints between the arguments of every saturated application
+    * of the same effect constructor in the constraint system.
+    */
+  private def mkEffectArgConstraints(constrs: List[TypeConstraint], initialSubst: SubstitutionTree): List[TypeConstraint] = {
+    val applications = mutable.Map.empty[Symbol.EffSym, mutable.ListBuffer[Type]]
+
+    def visitType(tpe: Type): Unit = tpe match {
+      case app@Type.Apply(tpe1, tpe2, _) =>
+        app.baseType match {
+          case Type.Cst(TypeConstructor.Effect(sym, _), _) if app.kind == Kind.Eff =>
+            applications.getOrElseUpdate(sym, mutable.ListBuffer.empty) += app
+          case _ => ()
+        }
+        visitType(tpe1)
+        visitType(tpe2)
+
+      case Type.Alias(_, args, inner, _) =>
+        args.foreach(visitType)
+        visitType(inner)
+
+      case Type.AssocType(_, arg, _, _) =>
+        visitType(arg)
+
+      case Type.JvmToType(inner, _) =>
+        visitType(inner)
+
+      case Type.JvmToEff(inner, _) =>
+        visitType(inner)
+
+      case Type.UnresolvedJvmType(member, _) =>
+        member.getTypeArguments.foreach(visitType)
+
+      case Type.Var(_, _) | Type.Cst(_, _) => ()
+    }
+
+    def visitConstraint(constr: TypeConstraint): Unit = constr match {
+      case TypeConstraint.Equality(tpe1, tpe2, _) =>
+        visitType(tpe1)
+        visitType(tpe2)
+      case TypeConstraint.Trait(_, tpe, _) =>
+        visitType(tpe)
+      case TypeConstraint.Purification(_, eff1, eff2, _, nested) =>
+        visitType(eff1)
+        visitType(eff2)
+        nested.foreach(visitConstraint)
+      case TypeConstraint.Conflicted(tpe1, tpe2, _) =>
+        visitType(tpe1)
+        visitType(tpe2)
+      case TypeConstraint.EffConflicted(_) => ()
+    }
+
+    def visitSubstitutionTree(tree: SubstitutionTree): Unit = {
+      tree.root.m.values.foreach(visitType)
+      tree.branches.values.foreach(visitSubstitutionTree)
+    }
+
+    constrs.foreach(visitConstraint)
+    visitSubstitutionTree(initialSubst)
+
+    applications.keys.toList.sorted.flatMap { sym =>
+      val occurrences = applications(sym).toList.sortBy(tpe => (tpe.loc, tpe.toString)).distinct
+      occurrences match {
+        case representative :: rest =>
+          rest.flatMap { occurrence =>
+            representative.typeArguments.zip(occurrence.typeArguments).collect {
+              case (tpe1, tpe2) if tpe1 != tpe2 =>
+                TypeConstraint.Equality(tpe1, tpe2, Provenance.Match(representative, occurrence, occurrence.loc))
+            }
+          }
+        case Nil => Nil
+      }
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint.Provenance
 import ca.uwaterloo.flix.language.phase.typer.TypeReduction2.reduce
 import ca.uwaterloo.flix.language.phase.unification.*
-import ca.uwaterloo.flix.util.collection.ListOps
+import ca.uwaterloo.flix.util.collection.{ListMap, ListOps}
 import ca.uwaterloo.flix.util.{ChaosMonkey, Result}
 
 import scala.annotation.tailrec
@@ -169,13 +169,13 @@ object ConstraintSolver2 {
   private def breakdownPolyEffConstraints(constrs: List[TypeConstraint], initialSubst: SubstitutionTree): List[TypeConstraint] = {
     // Maps each effect symbol to the saturated effect types whose arguments must agree.
     // For example, `F[Int32] + F[String]` maps `F` to `F[Int32]` and `F[String]`.
-    val effectTypes = mutable.Map.empty[Symbol.EffSym, List[Type]]
+    var effectTypes = ListMap.empty[Symbol.EffSym, Type]
 
     def visitType(tpe: Type): Unit = tpe match {
       case app@Type.Apply(tpe1, tpe2, _) =>
         app.baseType match {
           case Type.Cst(TypeConstructor.Effect(sym, _), _) if app.kind == Kind.Eff =>
-            effectTypes(sym) = app :: effectTypes.getOrElse(sym, Nil)
+            effectTypes = effectTypes + (sym -> app)
           case _ => ()
         }
         visitType(tpe1)
@@ -221,10 +221,10 @@ object ConstraintSolver2 {
     visitSubstitutionTree(initialSubst)
 
     val equalities = mutable.ListBuffer.empty[TypeConstraint]
-    for ((_, occurrences) <- effectTypes) {
+    for (occurrences <- effectTypes.valueLists) {
       val representative = occurrences.head
       for (occurrence <- occurrences.tail) {
-        for ((tpe1, tpe2) <- representative.typeArguments.zip(occurrence.typeArguments)) {
+        for ((tpe1, tpe2) <- ListOps.zip(representative.typeArguments, occurrence.typeArguments)) {
           equalities += TypeConstraint.Equality(tpe1, tpe2, Provenance.PolyEffEq(representative, occurrence, occurrence.loc))
         }
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -141,7 +141,7 @@ object ConstraintSolver2 {
     */
   def solveAll(constrs0: List[TypeConstraint], initialSubst: SubstitutionTree)(implicit scope: RegionScope, renv: RigidityEnv, trenv: TraitEnv, eqenv: EqualityEnv, flix: Flix): (List[TypeConstraint], SubstitutionTree) = {
     val initialConstrs = constrs0.map(initialSubst.apply)
-    val effectArgEqualities = collectEffectArgumentEqualities(initialConstrs, initialSubst)
+    val effectArgEqualities = deriveEffectArgumentEqualities(initialConstrs, initialSubst)
     val constrs = effectArgEqualities ::: initialConstrs
     val soup = new Soup(constrs, initialSubst)
     val progress = Progress()
@@ -163,7 +163,7 @@ object ConstraintSolver2 {
     * the two applications of `F` produce the additional equality `Int32 ~ String`, making `f`
     * ill-typed before its effect equations are solved.
     */
-  private def collectEffectArgumentEqualities(constrs: List[TypeConstraint], initialSubst: SubstitutionTree): List[TypeConstraint] = {
+  private def deriveEffectArgumentEqualities(constrs: List[TypeConstraint], initialSubst: SubstitutionTree): List[TypeConstraint] = {
     val applications = mutable.Map.empty[Symbol.EffSym, mutable.ListBuffer[Type]]
 
     def visitType(tpe: Type): Unit = tpe match {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -205,6 +205,9 @@ object ConstraintSolverInterface {
       mkArrowAndNonArrowError(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc)
         .getOrElse(List(mkMismatchedTypesOrEffects(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc)))
 
+    case TypeConstraint.Equality(baseType1, baseType2, Provenance.PolyEffEq(eff1, eff2, loc)) =>
+      List(TypeError.MismatchedTypes(subst(baseType1), subst(baseType2), subst(eff1), subst(eff2), renv, loc))
+
     case TypeConstraint.Equality(tpe1, tpe2, Provenance.Label(label, loc1, loc2, inner)) =>
       if (ConstraintSolver2.isSyntactic(tpe1.kind)) {
         // The leftover is (a part of) the type of the label.
@@ -261,6 +264,9 @@ object ConstraintSolverInterface {
 
     case TypeConstraint.Conflicted(tpe1, tpe2, Provenance.Match(baseTpe1, baseTpe2, loc)) =>
       List(mkMismatchedTypesOrEffects(subst(baseTpe1), subst(baseTpe2), subst(tpe1), subst(tpe2), renv, loc))
+
+    case TypeConstraint.Conflicted(tpe1, tpe2, Provenance.PolyEffEq(eff1, eff2, loc)) =>
+      List(TypeError.MismatchedTypes(subst(tpe1), subst(tpe2), subst(eff1), subst(eff2), renv, loc))
 
     case TypeConstraint.Conflicted(_, _, Provenance.Timeout(msg, loc)) =>
       List(TypeError.TooComplex(msg, loc))
@@ -319,6 +325,7 @@ object ConstraintSolverInterface {
     case Provenance.ExpectEffect(expected, actual, _) => Some((expected, actual))
     case Provenance.ExpectArgument(expected, actual, _, _, _) => Some((expected, actual))
     case Provenance.Match(tpe1, tpe2, _) => Some((tpe1, tpe2))
+    case Provenance.PolyEffEq(eff1, eff2, _) => Some((eff1, eff2))
     case Provenance.Source(eff1, eff2, _) => Some((eff1, eff2))
     case Provenance.Label(_, _, _, inner) => enclosingTypes(inner)
     case Provenance.Predicate(_, _, _, inner) => enclosingTypes(inner)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/EffectProvenance.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/EffectProvenance.scala
@@ -303,6 +303,7 @@ object EffectProvenance {
             Some((SinkNode, IntermediateNode, l))
           case TypeConstraint.Provenance.Source(_, _, _) => Some((IntermediateNode, SourceNode, prov.loc))
           case TypeConstraint.Provenance.Match(_, _, _) => Some((IntermediateNode, IntermediateNode, prov.loc))
+          case TypeConstraint.Provenance.PolyEffEq(_, _, _) => Some((IntermediateNode, IntermediateNode, prov.loc))
           case TypeConstraint.Provenance.ExpectType(_, _, _) => Some((IntermediateNode, SourceNode, prov.loc))
           case TypeConstraint.Provenance.ExpectArgument(arg, _, _, _, _) => Some((ArgNode, IntermediateNode, arg.loc))
           case _ => None

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
@@ -134,6 +134,11 @@ object TypeConstraint {
     case class Match(tpe1: Type, tpe2: Type, loc: SourceLocation) extends Provenance
 
     /**
+      * The constraint equates type arguments from two applications of the same polymorphic effect.
+      */
+    case class PolyEffEq(eff1: Type, eff2: Type, loc: SourceLocation) extends Provenance
+
+    /**
       * The constraint relates the types of the record label `label` in two record rows.
       *
       * `loc1` and `loc2` are the locations of the two occurrences of the label, and `inner` is the

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
@@ -26,6 +26,8 @@ private object AtomBimap {
 
   /**
     * Returns an [[AtomBimap]] numbering the [[EffAtom]]s of `eqs` using [[EffAtom.collectAtoms]].
+    * The map also records the type arguments of each polymorphic effect constructor so that the
+    * effect applications can be reconstructed after set unification.
     *
     * The atoms are sorted before numbering: the assignment must be deterministic across
     * runs since it determines the solving order in
@@ -44,7 +46,11 @@ private object AtomBimap {
     fromAtoms(buf, effectArgs.toMap)
   }
 
-  /** Returns an [[AtomBimap]] numbering the [[EffAtom]]s of `tpe` using [[EffAtom.collectAtoms]]. */
+  /**
+    * Returns an [[AtomBimap]] numbering the [[EffAtom]]s of `tpe` using [[EffAtom.collectAtoms]].
+    * The map also records the type arguments of each polymorphic effect constructor so that the
+    * effect applications can be reconstructed after simplification.
+    */
   def fromType(tpe: Type)(implicit scope: RegionScope, renv: RigidityEnv): AtomBimap = {
     val buf = mutable.HashSet.empty[EffAtom]
     val effectArgs = mutable.Map.empty[Symbol.EffSym, List[Type]]
@@ -52,7 +58,10 @@ private object AtomBimap {
     fromAtoms(buf, effectArgs.toMap)
   }
 
-  /** Returns an [[AtomBimap]] numbering the given atoms `0..n-1` in sorted order. */
+  /**
+    * Returns an [[AtomBimap]] numbering `atoms` from `0` to `n - 1` in sorted order.
+    * `effectArgs` maps each effect constructor to the type arguments used to reconstruct it.
+    */
   private def fromAtoms(atoms: mutable.HashSet[EffAtom], effectArgs: Map[Symbol.EffSym, List[Type]]): AtomBimap = {
     val arr = atoms.toArray
     java.util.Arrays.sort(arr, implicitly[Ordering[EffAtom]])

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
@@ -101,9 +101,7 @@ private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAto
   def toType(atom: EffAtom, loc: SourceLocation): Type = atom match {
     case EffAtom.Eff(sym) =>
       val args = effectArgs.getOrElse(sym, Nil)
-      val kind = args.foldRight(Kind.Eff: Kind) {
-        case (arg, acc) => arg.kind ->: acc
-      }
+      val kind = Kind.mkArrowTo(args.map(_.kind), Kind.Eff)
       Type.mkApply(Type.Cst(TypeConstructor.Effect(sym, kind), loc), args, loc)
     case EffAtom.Region(sym) => Type.Cst(TypeConstructor.Region(sym), loc)
     case EffAtom.VarRigid(sym) => Type.Var(sym, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
@@ -37,27 +37,23 @@ private object AtomBimap {
 
     // The arguments used to reconstruct each effect constructor after set unification.
     val effectArgs = mutable.Map.empty[Symbol.EffSym, List[Type]]
-
-    // The effect constructors that occur with more than one argument list.
-    val conflictedEffects = mutable.Set.empty[Symbol.EffSym]
     for (eq <- eqs) {
-      EffAtom.collectAtoms(eq.tpe1, buf, effectArgs, conflictedEffects)
-      EffAtom.collectAtoms(eq.tpe2, buf, effectArgs, conflictedEffects)
+      EffAtom.collectAtoms(eq.tpe1, buf, effectArgs)
+      EffAtom.collectAtoms(eq.tpe2, buf, effectArgs)
     }
-    fromAtoms(buf, effectArgs.toMap, conflictedEffects.toSet)
+    fromAtoms(buf, effectArgs.toMap)
   }
 
   /** Returns an [[AtomBimap]] numbering the [[EffAtom]]s of `tpe` using [[EffAtom.collectAtoms]]. */
   def fromType(tpe: Type)(implicit scope: RegionScope, renv: RigidityEnv): AtomBimap = {
     val buf = mutable.HashSet.empty[EffAtom]
     val effectArgs = mutable.Map.empty[Symbol.EffSym, List[Type]]
-    val conflictedEffects = mutable.Set.empty[Symbol.EffSym]
-    EffAtom.collectAtoms(tpe, buf, effectArgs, conflictedEffects)
-    fromAtoms(buf, effectArgs.toMap, conflictedEffects.toSet)
+    EffAtom.collectAtoms(tpe, buf, effectArgs)
+    fromAtoms(buf, effectArgs.toMap)
   }
 
   /** Returns an [[AtomBimap]] numbering the given atoms `0..n-1` in sorted order. */
-  private def fromAtoms(atoms: mutable.HashSet[EffAtom], effectArgs: Map[Symbol.EffSym, List[Type]], conflictedEffects: Set[Symbol.EffSym]): AtomBimap = {
+  private def fromAtoms(atoms: mutable.HashSet[EffAtom], effectArgs: Map[Symbol.EffSym, List[Type]]): AtomBimap = {
     val arr = atoms.toArray
     java.util.Arrays.sort(arr, implicitly[Ordering[EffAtom]])
     var forward = Map.empty[EffAtom, Int]
@@ -66,7 +62,7 @@ private object AtomBimap {
       forward = forward.updated(arr(i), i)
       i += 1
     }
-    new AtomBimap(forward, arr, effectArgs, conflictedEffects)
+    new AtomBimap(forward, arr, effectArgs)
   }
 }
 
@@ -78,10 +74,7 @@ private object AtomBimap {
   * index assignment itself must be deterministic; it is always derived from atoms in
   * sorted order.
   */
-private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAtom], effectArgs: Map[Symbol.EffSym, List[Type]], conflictedEffects: Set[Symbol.EffSym]) {
-
-  /** Returns whether the same effect constructor was observed with different arguments. */
-  def hasConflictedEffectArgs: Boolean = conflictedEffects.nonEmpty
+private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAtom], effectArgs: Map[Symbol.EffSym, List[Type]]) {
 
   /** Returns the index of `a`, or -1 if absent (allocation-free). */
   def getForwardIndex(a: EffAtom): Int = forward.getOrElse(a, -1)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
@@ -32,8 +32,13 @@ private object AtomBimap {
     * [[ca.uwaterloo.flix.language.phase.unification.set.SetUnification]].
     */
   def fromConstraints(eqs: List[TypeConstraint.Equality])(implicit scope: RegionScope, renv: RigidityEnv): AtomBimap = {
+    // The distinct effect atoms that occur in the equations.
     val buf = mutable.HashSet.empty[EffAtom]
+
+    // The arguments used to reconstruct each effect constructor after set unification.
     val effectArgs = mutable.Map.empty[Symbol.EffSym, List[Type]]
+
+    // The effect constructors that occur with more than one argument list.
     val conflictedEffects = mutable.Set.empty[Symbol.EffSym]
     for (eq <- eqs) {
       EffAtom.collectAtoms(eq.tpe1, buf, effectArgs, conflictedEffects)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
@@ -19,6 +19,7 @@ import ca.uwaterloo.flix.language.ast.shared.RegionScope
 import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
 import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
+import ca.uwaterloo.flix.util.collection.Nel
 
 import scala.collection.mutable
 
@@ -37,8 +38,8 @@ private object AtomBimap {
     // The distinct effect atoms that occur in the equations.
     val buf = mutable.HashSet.empty[EffAtom]
 
-    // The arguments used to reconstruct each effect constructor after set unification.
-    val effectArgs = mutable.Map.empty[Symbol.EffSym, List[Type]]
+    // The arguments used to reconstruct each polymorphic effect after set unification.
+    val effectArgs = mutable.Map.empty[Symbol.EffSym, Nel[Type]]
     for (eq <- eqs) {
       EffAtom.collectAtoms(eq.tpe1, buf, effectArgs)
       EffAtom.collectAtoms(eq.tpe2, buf, effectArgs)
@@ -53,16 +54,16 @@ private object AtomBimap {
     */
   def fromType(tpe: Type)(implicit scope: RegionScope, renv: RigidityEnv): AtomBimap = {
     val buf = mutable.HashSet.empty[EffAtom]
-    val effectArgs = mutable.Map.empty[Symbol.EffSym, List[Type]]
+    val effectArgs = mutable.Map.empty[Symbol.EffSym, Nel[Type]]
     EffAtom.collectAtoms(tpe, buf, effectArgs)
     fromAtoms(buf, effectArgs.toMap)
   }
 
   /**
     * Returns an [[AtomBimap]] numbering `atoms` from `0` to `n - 1` in sorted order.
-    * `effectArgs` maps each effect constructor to the type arguments used to reconstruct it.
+    * `effectArgs` maps each polymorphic effect constructor to its non-empty type argument list.
     */
-  private def fromAtoms(atoms: mutable.HashSet[EffAtom], effectArgs: Map[Symbol.EffSym, List[Type]]): AtomBimap = {
+  private def fromAtoms(atoms: mutable.HashSet[EffAtom], effectArgs: Map[Symbol.EffSym, Nel[Type]]): AtomBimap = {
     val arr = atoms.toArray
     java.util.Arrays.sort(arr, implicitly[Ordering[EffAtom]])
     var forward = Map.empty[EffAtom, Int]
@@ -83,7 +84,7 @@ private object AtomBimap {
   * index assignment itself must be deterministic; it is always derived from atoms in
   * sorted order.
   */
-private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAtom], effectArgs: Map[Symbol.EffSym, List[Type]]) {
+private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAtom], effectArgs: Map[Symbol.EffSym, Nel[Type]]) {
 
   /** Returns the index of `a`, or -1 if absent (allocation-free). */
   def getForwardIndex(a: EffAtom): Int = forward.getOrElse(a, -1)
@@ -100,9 +101,13 @@ private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAto
   /** Returns the [[Type]] represented by `atom` with location `loc`. */
   def toType(atom: EffAtom, loc: SourceLocation): Type = atom match {
     case EffAtom.Eff(sym) =>
-      val args = effectArgs.getOrElse(sym, Nil)
-      val kind = Kind.mkArrowTo(args.map(_.kind), Kind.Eff)
-      Type.mkApply(Type.Cst(TypeConstructor.Effect(sym, kind), loc), args, loc)
+      effectArgs.get(sym) match {
+        case None => Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc)
+        case Some(args) =>
+          val ts = args.toList
+          val kind = Kind.mkArrowTo(ts.map(_.kind), Kind.Eff)
+          Type.mkApply(Type.Cst(TypeConstructor.Effect(sym, kind), loc), ts, loc)
+      }
     case EffAtom.Region(sym) => Type.Cst(TypeConstructor.Region(sym), loc)
     case EffAtom.VarRigid(sym) => Type.Var(sym, loc)
     case EffAtom.VarFlex(sym) => Type.Var(sym, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/AtomBimap.scala
@@ -16,7 +16,8 @@
 package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
-import ca.uwaterloo.flix.language.ast.{RigidityEnv, Type}
+import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
+import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
 
 import scala.collection.mutable
@@ -32,22 +33,26 @@ private object AtomBimap {
     */
   def fromConstraints(eqs: List[TypeConstraint.Equality])(implicit scope: RegionScope, renv: RigidityEnv): AtomBimap = {
     val buf = mutable.HashSet.empty[EffAtom]
+    val effectArgs = mutable.Map.empty[Symbol.EffSym, List[Type]]
+    val conflictedEffects = mutable.Set.empty[Symbol.EffSym]
     for (eq <- eqs) {
-      EffAtom.collectAtoms(eq.tpe1, buf)
-      EffAtom.collectAtoms(eq.tpe2, buf)
+      EffAtom.collectAtoms(eq.tpe1, buf, effectArgs, conflictedEffects)
+      EffAtom.collectAtoms(eq.tpe2, buf, effectArgs, conflictedEffects)
     }
-    fromAtoms(buf)
+    fromAtoms(buf, effectArgs.toMap, conflictedEffects.toSet)
   }
 
   /** Returns an [[AtomBimap]] numbering the [[EffAtom]]s of `tpe` using [[EffAtom.collectAtoms]]. */
   def fromType(tpe: Type)(implicit scope: RegionScope, renv: RigidityEnv): AtomBimap = {
     val buf = mutable.HashSet.empty[EffAtom]
-    EffAtom.collectAtoms(tpe, buf)
-    fromAtoms(buf)
+    val effectArgs = mutable.Map.empty[Symbol.EffSym, List[Type]]
+    val conflictedEffects = mutable.Set.empty[Symbol.EffSym]
+    EffAtom.collectAtoms(tpe, buf, effectArgs, conflictedEffects)
+    fromAtoms(buf, effectArgs.toMap, conflictedEffects.toSet)
   }
 
   /** Returns an [[AtomBimap]] numbering the given atoms `0..n-1` in sorted order. */
-  private def fromAtoms(atoms: mutable.HashSet[EffAtom]): AtomBimap = {
+  private def fromAtoms(atoms: mutable.HashSet[EffAtom], effectArgs: Map[Symbol.EffSym, List[Type]], conflictedEffects: Set[Symbol.EffSym]): AtomBimap = {
     val arr = atoms.toArray
     java.util.Arrays.sort(arr, implicitly[Ordering[EffAtom]])
     var forward = Map.empty[EffAtom, Int]
@@ -56,7 +61,7 @@ private object AtomBimap {
       forward = forward.updated(arr(i), i)
       i += 1
     }
-    new AtomBimap(forward, arr)
+    new AtomBimap(forward, arr, effectArgs, conflictedEffects)
   }
 }
 
@@ -68,7 +73,10 @@ private object AtomBimap {
   * index assignment itself must be deterministic; it is always derived from atoms in
   * sorted order.
   */
-private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAtom]) {
+private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAtom], effectArgs: Map[Symbol.EffSym, List[Type]], conflictedEffects: Set[Symbol.EffSym]) {
+
+  /** Returns whether the same effect constructor was observed with different arguments. */
+  def hasConflictedEffectArgs: Boolean = conflictedEffects.nonEmpty
 
   /** Returns the index of `a`, or -1 if absent (allocation-free). */
   def getForwardIndex(a: EffAtom): Int = forward.getOrElse(a, -1)
@@ -81,4 +89,20 @@ private final class AtomBimap(forward: Map[EffAtom, Int], backward: Array[EffAto
     */
   def getBackward(i: Int): Option[EffAtom] =
     if (i >= 0 && i < backward.length) Some(backward(i)) else None
+
+  /** Returns the [[Type]] represented by `atom` with location `loc`. */
+  def toType(atom: EffAtom, loc: SourceLocation): Type = atom match {
+    case EffAtom.Eff(sym) =>
+      val args = effectArgs.getOrElse(sym, Nil)
+      val kind = args.foldRight(Kind.Eff: Kind) {
+        case (arg, acc) => arg.kind ->: acc
+      }
+      Type.mkApply(Type.Cst(TypeConstructor.Effect(sym, kind), loc), args, loc)
+    case EffAtom.Region(sym) => Type.Cst(TypeConstructor.Region(sym), loc)
+    case EffAtom.VarRigid(sym) => Type.Var(sym, loc)
+    case EffAtom.VarFlex(sym) => Type.Var(sym, loc)
+    case EffAtom.Assoc(sym, arg0) =>
+      Type.AssocType(AssocTypeSymUse(sym, loc), toType(arg0, loc), Kind.Eff, loc)
+    case EffAtom.Error(id) => Type.Cst(TypeConstructor.Error(id, Kind.Eff), loc)
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
 import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
-import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, Symbol, Type, TypeConstructor}
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -34,9 +34,7 @@ private sealed trait EffAtom extends Ordered[EffAtom] {
   override def compare(that: EffAtom): Int = (this, that) match {
     case (EffAtom.VarFlex(sym1), EffAtom.VarFlex(sym2)) => sym1.id - sym2.id
     case (EffAtom.VarRigid(sym1), EffAtom.VarRigid(sym2)) => sym1.id - sym2.id
-    case (EffAtom.Eff(sym1, args1), EffAtom.Eff(sym2, args2)) =>
-      val symCmp = sym1.compare(sym2)
-      if (symCmp != 0) symCmp else compareTypeLists(args1, args2)
+    case (EffAtom.Eff(sym1), EffAtom.Eff(sym2)) => sym1.compare(sym2)
     case (EffAtom.Region(sym1), EffAtom.Region(sym2)) => sym1.compare(sym2)
     case (EffAtom.Assoc(sym1, arg1), EffAtom.Assoc(sym2, arg2)) =>
       val symCmp = sym1.compare(sym2)
@@ -47,37 +45,12 @@ private sealed trait EffAtom extends Ordered[EffAtom] {
         case EffAtom.VarFlex(_) => 0
         case EffAtom.VarRigid(_) => 1
         case EffAtom.Region(_) => 2
-        case EffAtom.Eff(_, _) => 3
+        case EffAtom.Eff(_) => 3
         case EffAtom.Assoc(_, _) => 4
         case EffAtom.Error(_) => 5
       }
 
       ordinal(this) - ordinal(that)
-  }
-
-  /** Compares type lists deterministically using their internal representation. */
-  private def compareTypeLists(ts1: List[Type], ts2: List[Type]): Int = (ts1, ts2) match {
-    case (Nil, Nil) => 0
-    case (Nil, _ :: _) => -1
-    case (_ :: _, Nil) => 1
-    case (t1 :: rest1, t2 :: rest2) =>
-      val cmp = compareTypes(t1, t2)
-      if (cmp != 0) cmp else compareTypeLists(rest1, rest2)
-  }
-
-  /** Compares types deterministically, ignoring source locations when the types are equal. */
-  private def compareTypes(t1: Type, t2: Type): Int = {
-    if (t1 == t2) {
-      0
-    } else {
-      val textCmp = t1.toString.compareTo(t2.toString)
-      if (textCmp != 0) {
-        textCmp
-      } else {
-        val hashCmp = Integer.compare(t1.hashCode(), t2.hashCode())
-        if (hashCmp != 0) hashCmp else SourceLocation.Order.compare(t1.loc, t2.loc)
-      }
-    }
   }
 }
 
@@ -88,8 +61,8 @@ private object EffAtom {
   /** Representing a rigid variable. */
   case class VarRigid(sym: Symbol.KindedTypeVarSym) extends EffAtom
 
-  /** Representing an effect constant. */
-  case class Eff(sym: Symbol.EffSym, args: List[Type]) extends EffAtom
+  /** Represents an effect constructor. */
+  case class Eff(sym: Symbol.EffSym) extends EffAtom
 
   /** Represents an associated effect. */
   case class Assoc(sym: Symbol.AssocTypeSym, arg: EffAtom) extends EffAtom
@@ -105,9 +78,9 @@ private object EffAtom {
   def fromType(t: Type)(implicit scope: RegionScope, renv: RigidityEnv): EffAtom = t match {
     case Type.Var(sym, _) if renv.isRigid(sym) => EffAtom.VarRigid(sym)
     case Type.Var(sym, _) => EffAtom.VarFlex(sym)
-    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => EffAtom.Eff(sym, Nil)
+    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => EffAtom.Eff(sym)
     case app@Type.Apply(_, _, _) if app.kind == Kind.Eff => app.baseType match {
-      case Type.Cst(TypeConstructor.Effect(sym, _), _) => EffAtom.Eff(sym, app.typeArguments)
+      case Type.Cst(TypeConstructor.Effect(sym, _), _) => EffAtom.Eff(sym)
       case _ => throw InvalidType(t)
     }
     case Type.Cst(TypeConstructor.Region(sym), _) => EffAtom.Region(sym)
@@ -139,21 +112,32 @@ private object EffAtom {
     *     [[RigidityEnv.isRigid]] is false for `ef`)
     *   - `collectAtoms(Indexable.Aef[Error], acc)` adds nothing
     */
-  def collectAtoms(t: Type, acc: mutable.HashSet[EffAtom])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
+  def collectAtoms(t: Type, acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, List[Type]], conflictedEffects: mutable.Set[Symbol.EffSym])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
     case Type.Var(sym, _) if renv.isRigid(sym) => acc += EffAtom.VarRigid(sym)
     case Type.Var(sym, _) => acc += EffAtom.VarFlex(sym)
-    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => acc += EffAtom.Eff(sym, Nil)
+    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => addEffect(sym, Nil, acc, effectArgs, conflictedEffects)
     case app@Type.Apply(tpe1, tpe2, _) => app.baseType match {
-      case Type.Cst(TypeConstructor.Effect(_, _), _) if app.kind == Kind.Eff => acc += fromType(app)
+      case Type.Cst(TypeConstructor.Effect(sym, _), _) if app.kind == Kind.Eff =>
+        addEffect(sym, app.typeArguments, acc, effectArgs, conflictedEffects)
       case _ =>
-        collectAtoms(tpe1, acc)
-        collectAtoms(tpe2, acc)
+        collectAtoms(tpe1, acc, effectArgs, conflictedEffects)
+        collectAtoms(tpe2, acc, effectArgs, conflictedEffects)
     }
     case Type.Cst(TypeConstructor.Region(sym), _) => acc += EffAtom.Region(sym)
     case Type.Cst(TypeConstructor.Error(id, _), _) => acc += EffAtom.Error(id)
-    case Type.Alias(_, _, tpe, _) => collectAtoms(tpe, acc)
+    case Type.Alias(_, _, tpe, _) => collectAtoms(tpe, acc, effectArgs, conflictedEffects)
     case assoc@Type.AssocType(_, _, _, _) => getAssocAtoms(assoc).foreach(acc += _)
     case _ => ()
+  }
+
+  /** Adds an effect atom and records the arguments used to reconstruct it. */
+  private def addEffect(sym: Symbol.EffSym, args: List[Type], acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, List[Type]], conflictedEffects: mutable.Set[Symbol.EffSym]): Unit = {
+    acc += EffAtom.Eff(sym)
+    effectArgs.get(sym) match {
+      case None => effectArgs(sym) = args
+      case Some(previousArgs) if previousArgs != args => conflictedEffects += sym
+      case Some(_) => ()
+    }
   }
 
   /**
@@ -168,23 +152,6 @@ private object EffAtom {
     case _ => None
   }
 
-  /**
-    * Returns the [[Type]] represented by `atom` with location `loc`. The kind of errors and
-    * associated types are set to be [[Kind.Eff]].
-    */
-  def toType(atom: EffAtom, loc: SourceLocation): Type = atom match {
-    case EffAtom.Eff(sym, args) =>
-      val kind = args.foldRight(Kind.Eff: Kind) {
-        case (arg, acc) => arg.kind ->: acc
-      }
-      Type.mkApply(Type.Cst(TypeConstructor.Effect(sym, kind), loc), args, loc)
-    case EffAtom.Region(sym) => Type.Cst(TypeConstructor.Region(sym), loc)
-    case EffAtom.VarRigid(sym) => Type.Var(sym, loc)
-    case EffAtom.VarFlex(sym) => Type.Var(sym, loc)
-    case EffAtom.Assoc(sym, arg0) =>
-      Type.AssocType(AssocTypeSymUse(sym, loc), toType(arg0, loc), Kind.Eff, loc)
-    case EffAtom.Error(id) => Type.Cst(TypeConstructor.Error(id, Kind.Eff), loc)
-  }
 }
 
 /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
@@ -123,7 +123,8 @@ private object EffAtom {
     case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => acc += EffAtom.Eff(sym)
     case app@Type.Apply(tpe1, tpe2, _) => app.baseType match {
       case Type.Cst(TypeConstructor.Effect(sym, _), _) if app.kind == Kind.Eff =>
-        addEffect(sym, Nel.unsafeFrom(app.typeArguments), acc, effectArgs)
+        acc += EffAtom.Eff(sym)
+        effectArgs.getOrElseUpdate(sym, Nel.unsafeFrom(app.typeArguments))
       case _ =>
         collectAtoms(tpe1, acc, effectArgs)
         collectAtoms(tpe2, acc, effectArgs)
@@ -133,12 +134,6 @@ private object EffAtom {
     case Type.Alias(_, _, tpe, _) => collectAtoms(tpe, acc, effectArgs)
     case assoc@Type.AssocType(_, _, _, _) => getAssocAtoms(assoc).foreach(acc += _)
     case _ => ()
-  }
-
-  /** Adds an effect atom and records the arguments used to reconstruct it. */
-  private def addEffect(sym: Symbol.EffSym, args: Nel[Type], acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, Nel[Type]]): Unit = {
-    acc += EffAtom.Eff(sym)
-    effectArgs.getOrElseUpdate(sym, args)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
@@ -112,32 +112,28 @@ private object EffAtom {
     *     [[RigidityEnv.isRigid]] is false for `ef`)
     *   - `collectAtoms(Indexable.Aef[Error], acc)` adds nothing
     */
-  def collectAtoms(t: Type, acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, List[Type]], conflictedEffects: mutable.Set[Symbol.EffSym])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
+  def collectAtoms(t: Type, acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, List[Type]])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
     case Type.Var(sym, _) if renv.isRigid(sym) => acc += EffAtom.VarRigid(sym)
     case Type.Var(sym, _) => acc += EffAtom.VarFlex(sym)
-    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => addEffect(sym, Nil, acc, effectArgs, conflictedEffects)
+    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => addEffect(sym, Nil, acc, effectArgs)
     case app@Type.Apply(tpe1, tpe2, _) => app.baseType match {
       case Type.Cst(TypeConstructor.Effect(sym, _), _) if app.kind == Kind.Eff =>
-        addEffect(sym, app.typeArguments, acc, effectArgs, conflictedEffects)
+        addEffect(sym, app.typeArguments, acc, effectArgs)
       case _ =>
-        collectAtoms(tpe1, acc, effectArgs, conflictedEffects)
-        collectAtoms(tpe2, acc, effectArgs, conflictedEffects)
+        collectAtoms(tpe1, acc, effectArgs)
+        collectAtoms(tpe2, acc, effectArgs)
     }
     case Type.Cst(TypeConstructor.Region(sym), _) => acc += EffAtom.Region(sym)
     case Type.Cst(TypeConstructor.Error(id, _), _) => acc += EffAtom.Error(id)
-    case Type.Alias(_, _, tpe, _) => collectAtoms(tpe, acc, effectArgs, conflictedEffects)
+    case Type.Alias(_, _, tpe, _) => collectAtoms(tpe, acc, effectArgs)
     case assoc@Type.AssocType(_, _, _, _) => getAssocAtoms(assoc).foreach(acc += _)
     case _ => ()
   }
 
   /** Adds an effect atom and records the arguments used to reconstruct it. */
-  private def addEffect(sym: Symbol.EffSym, args: List[Type], acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, List[Type]], conflictedEffects: mutable.Set[Symbol.EffSym]): Unit = {
+  private def addEffect(sym: Symbol.EffSym, args: List[Type], acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, List[Type]]): Unit = {
     acc += EffAtom.Eff(sym)
-    effectArgs.get(sym) match {
-      case None => effectArgs(sym) = args
-      case Some(previousArgs) if previousArgs != args => conflictedEffects += sym
-      case Some(_) => ()
-    }
+    effectArgs.getOrElseUpdate(sym, args)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
@@ -108,9 +108,13 @@ private object EffAtom {
     * the needs of [[EffUnification3.toSetFormula]].
     *
     * Examples:
-    *   - `collectAtoms(Crash ∪ ef, acc)` adds `Eff(Crash)` and `VarFlex(ef)` (if
-    *     [[RigidityEnv.isRigid]] is false for `ef`)
-    *   - `collectAtoms(Indexable.Aef[Error], acc)` adds nothing
+    *   - `collectAtoms(F[Int32] ∪ ef, acc, effectArgs)` adds `Eff(F)` and `VarFlex(ef)`
+    *     to `acc`, and records `F -> List(Int32)` in `effectArgs`
+    *   - `collectAtoms(Indexable.Aef[Error], acc, effectArgs)` adds nothing
+    *
+    * @param t the type whose effect atoms are collected.
+    * @param acc the set to which the collected atoms are added.
+    * @param effectArgs the map from effect constructors to the arguments used to reconstruct them.
     */
   def collectAtoms(t: Type, acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, List[Type]])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
     case Type.Var(sym, _) if renv.isRigid(sym) => acc += EffAtom.VarRigid(sym)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
@@ -34,7 +34,9 @@ private sealed trait EffAtom extends Ordered[EffAtom] {
   override def compare(that: EffAtom): Int = (this, that) match {
     case (EffAtom.VarFlex(sym1), EffAtom.VarFlex(sym2)) => sym1.id - sym2.id
     case (EffAtom.VarRigid(sym1), EffAtom.VarRigid(sym2)) => sym1.id - sym2.id
-    case (EffAtom.Eff(sym1), EffAtom.Eff(sym2)) => sym1.compare(sym2)
+    case (EffAtom.Eff(sym1, args1), EffAtom.Eff(sym2, args2)) =>
+      val symCmp = sym1.compare(sym2)
+      if (symCmp != 0) symCmp else compareTypeLists(args1, args2)
     case (EffAtom.Region(sym1), EffAtom.Region(sym2)) => sym1.compare(sym2)
     case (EffAtom.Assoc(sym1, arg1), EffAtom.Assoc(sym2, arg2)) =>
       val symCmp = sym1.compare(sym2)
@@ -45,12 +47,37 @@ private sealed trait EffAtom extends Ordered[EffAtom] {
         case EffAtom.VarFlex(_) => 0
         case EffAtom.VarRigid(_) => 1
         case EffAtom.Region(_) => 2
-        case EffAtom.Eff(_) => 3
+        case EffAtom.Eff(_, _) => 3
         case EffAtom.Assoc(_, _) => 4
         case EffAtom.Error(_) => 5
       }
 
       ordinal(this) - ordinal(that)
+  }
+
+  /** Compares type lists deterministically using their internal representation. */
+  private def compareTypeLists(ts1: List[Type], ts2: List[Type]): Int = (ts1, ts2) match {
+    case (Nil, Nil) => 0
+    case (Nil, _ :: _) => -1
+    case (_ :: _, Nil) => 1
+    case (t1 :: rest1, t2 :: rest2) =>
+      val cmp = compareTypes(t1, t2)
+      if (cmp != 0) cmp else compareTypeLists(rest1, rest2)
+  }
+
+  /** Compares types deterministically, ignoring source locations when the types are equal. */
+  private def compareTypes(t1: Type, t2: Type): Int = {
+    if (t1 == t2) {
+      0
+    } else {
+      val textCmp = t1.toString.compareTo(t2.toString)
+      if (textCmp != 0) {
+        textCmp
+      } else {
+        val hashCmp = Integer.compare(t1.hashCode(), t2.hashCode())
+        if (hashCmp != 0) hashCmp else SourceLocation.Order.compare(t1.loc, t2.loc)
+      }
+    }
   }
 }
 
@@ -62,7 +89,7 @@ private object EffAtom {
   case class VarRigid(sym: Symbol.KindedTypeVarSym) extends EffAtom
 
   /** Representing an effect constant. */
-  case class Eff(sym: Symbol.EffSym) extends EffAtom
+  case class Eff(sym: Symbol.EffSym, args: List[Type]) extends EffAtom
 
   /** Represents an associated effect. */
   case class Assoc(sym: Symbol.AssocTypeSym, arg: EffAtom) extends EffAtom
@@ -78,7 +105,11 @@ private object EffAtom {
   def fromType(t: Type)(implicit scope: RegionScope, renv: RigidityEnv): EffAtom = t match {
     case Type.Var(sym, _) if renv.isRigid(sym) => EffAtom.VarRigid(sym)
     case Type.Var(sym, _) => EffAtom.VarFlex(sym)
-    case Type.Cst(TypeConstructor.Effect(sym, _), _) => EffAtom.Eff(sym)
+    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => EffAtom.Eff(sym, Nil)
+    case app@Type.Apply(_, _, _) if app.kind == Kind.Eff => app.baseType match {
+      case Type.Cst(TypeConstructor.Effect(sym, _), _) => EffAtom.Eff(sym, app.typeArguments)
+      case _ => throw InvalidType(t)
+    }
     case Type.Cst(TypeConstructor.Region(sym), _) => EffAtom.Region(sym)
     case assoc@Type.AssocType(_, _, _, _) => assocFromType(assoc)
     case Type.Cst(TypeConstructor.Error(id, _), _) => EffAtom.Error(id)
@@ -111,12 +142,15 @@ private object EffAtom {
   def collectAtoms(t: Type, acc: mutable.HashSet[EffAtom])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
     case Type.Var(sym, _) if renv.isRigid(sym) => acc += EffAtom.VarRigid(sym)
     case Type.Var(sym, _) => acc += EffAtom.VarFlex(sym)
-    case Type.Cst(TypeConstructor.Effect(sym, _), _) => acc += EffAtom.Eff(sym)
+    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => acc += EffAtom.Eff(sym, Nil)
+    case app@Type.Apply(tpe1, tpe2, _) => app.baseType match {
+      case Type.Cst(TypeConstructor.Effect(_, _), _) if app.kind == Kind.Eff => acc += fromType(app)
+      case _ =>
+        collectAtoms(tpe1, acc)
+        collectAtoms(tpe2, acc)
+    }
     case Type.Cst(TypeConstructor.Region(sym), _) => acc += EffAtom.Region(sym)
     case Type.Cst(TypeConstructor.Error(id, _), _) => acc += EffAtom.Error(id)
-    case Type.Apply(tpe1, tpe2, _) =>
-      collectAtoms(tpe1, acc)
-      collectAtoms(tpe2, acc)
     case Type.Alias(_, _, tpe, _) => collectAtoms(tpe, acc)
     case assoc@Type.AssocType(_, _, _, _) => getAssocAtoms(assoc).foreach(acc += _)
     case _ => ()
@@ -139,7 +173,11 @@ private object EffAtom {
     * associated types are set to be [[Kind.Eff]].
     */
   def toType(atom: EffAtom, loc: SourceLocation): Type = atom match {
-    case EffAtom.Eff(sym) => Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc)
+    case EffAtom.Eff(sym, args) =>
+      val kind = args.foldRight(Kind.Eff: Kind) {
+        case (arg, acc) => arg.kind ->: acc
+      }
+      Type.mkApply(Type.Cst(TypeConstructor.Effect(sym, kind), loc), args, loc)
     case EffAtom.Region(sym) => Type.Cst(TypeConstructor.Region(sym), loc)
     case EffAtom.VarRigid(sym) => Type.Var(sym, loc)
     case EffAtom.VarFlex(sym) => Type.Var(sym, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffAtom.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase.unification
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
 import ca.uwaterloo.flix.language.ast.shared.SymUse.AssocTypeSymUse
 import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.util.collection.Nel
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -109,20 +110,20 @@ private object EffAtom {
     *
     * Examples:
     *   - `collectAtoms(F[Int32] ∪ ef, acc, effectArgs)` adds `Eff(F)` and `VarFlex(ef)`
-    *     to `acc`, and records `F -> List(Int32)` in `effectArgs`
+    *     to `acc`, and records `F -> Nel(Int32)` in `effectArgs`
     *   - `collectAtoms(Indexable.Aef[Error], acc, effectArgs)` adds nothing
     *
     * @param t the type whose effect atoms are collected.
     * @param acc the set to which the collected atoms are added.
-    * @param effectArgs the map from effect constructors to the arguments used to reconstruct them.
+    * @param effectArgs the map from polymorphic effect constructors to their non-empty argument lists.
     */
-  def collectAtoms(t: Type, acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, List[Type]])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
+  def collectAtoms(t: Type, acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, Nel[Type]])(implicit scope: RegionScope, renv: RigidityEnv): Unit = t match {
     case Type.Var(sym, _) if renv.isRigid(sym) => acc += EffAtom.VarRigid(sym)
     case Type.Var(sym, _) => acc += EffAtom.VarFlex(sym)
-    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => addEffect(sym, Nil, acc, effectArgs)
+    case Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), _) => acc += EffAtom.Eff(sym)
     case app@Type.Apply(tpe1, tpe2, _) => app.baseType match {
       case Type.Cst(TypeConstructor.Effect(sym, _), _) if app.kind == Kind.Eff =>
-        addEffect(sym, app.typeArguments, acc, effectArgs)
+        addEffect(sym, Nel.unsafeFrom(app.typeArguments), acc, effectArgs)
       case _ =>
         collectAtoms(tpe1, acc, effectArgs)
         collectAtoms(tpe2, acc, effectArgs)
@@ -135,7 +136,7 @@ private object EffAtom {
   }
 
   /** Adds an effect atom and records the arguments used to reconstruct it. */
-  private def addEffect(sym: Symbol.EffSym, args: List[Type], acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, List[Type]]): Unit = {
+  private def addEffect(sym: Symbol.EffSym, args: Nel[Type], acc: mutable.HashSet[EffAtom], effectArgs: mutable.Map[Symbol.EffSym, Nel[Type]]): Unit = {
     acc += EffAtom.Eff(sym)
     effectArgs.getOrElseUpdate(sym, args)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.api.{Flix, FlixEvent}
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
-import ca.uwaterloo.flix.language.ast.{RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint.Provenance
 import ca.uwaterloo.flix.language.phase.unification.PreEffUnification.PreSolveResult
@@ -166,6 +166,11 @@ object EffUnification3 {
       if (x < 0) throw InternalCompilerException(s"Unexpected unbound effect: '$tpe'.", tpe.loc)
       SetFormula.mkElemSet(x)
 
+    case tpe@Type.Apply(_, _, _) if isSaturatedEffect(tpe) =>
+      val x = m.getForwardIndex(EffAtom.fromType(tpe))
+      if (x < 0) throw InternalCompilerException(s"Unexpected unbound effect: '$tpe'.", tpe.loc)
+      SetFormula.mkElemSet(x)
+
     case tpe@Type.Cst(TypeConstructor.Region(_), _) =>
       val x = m.getForwardIndex(EffAtom.fromType(tpe))
       if (x < 0) throw InternalCompilerException(s"Unexpected unbound effect: '$tpe'.", tpe.loc)
@@ -201,6 +206,18 @@ object EffUnification3 {
     case Type.Alias(_, _, tpe, _) => toSetFormula(tpe)
 
     case _ => throw InvalidType(t)
+  }
+
+  /** Returns whether `tpe` is a saturated application of an effect constructor. */
+  private def isSaturatedEffect(tpe: Type): Boolean = {
+    if (tpe.kind != Kind.Eff) {
+      false
+    } else {
+      tpe.baseType match {
+        case Type.Cst(TypeConstructor.Effect(_, _), _) => true
+        case _ => false
+      }
+    }
   }
 
   /** Returns [[Substitution]] where each mapping in `s` is converted to [[Type]]. */

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
@@ -79,8 +79,16 @@ object EffUnification3 {
       }
     }
 
-    // Choose a unique number for each atom.
-    implicit val bimap: AtomBimap = AtomBimap.fromConstraints(eqs)
+    // Choose a unique number for each atom. Use the original constraint order so the effect
+    // argument representative stored in the bimap is independent of the chaos monkey.
+    implicit val bimap: AtomBimap = AtomBimap.fromConstraints(eqs0)
+
+    // Effect arguments are unified before effect equations reach this solver. If different
+    // arguments remain, leave the equations unsolved until the ordinary type constraints make
+    // progress or report the conflict.
+    if (bimap.hasConflictedEffectArgs) {
+      return Result.Err(eqs)
+    }
 
     //
     // Phase 1: Try to solve without subeffecting.
@@ -277,16 +285,16 @@ object EffUnification3 {
     case SetFormula.Univ => Type.Univ
     case SetFormula.Empty => Type.Pure
     case SetFormula.Cst(c) => m.getBackward(c) match {
-      case Some(atom) => EffAtom.toType(atom, loc)
+      case Some(atom) => m.toType(atom, loc)
       case None => throw InternalCompilerException(s"Unexpected unbound constant identifier '$c'", loc)
     }
     case SetFormula.Var(x) => m.getBackward(x) match {
-      case Some(atom) => EffAtom.toType(atom, loc)
+      case Some(atom) => m.toType(atom, loc)
       case None => throw InternalCompilerException(s"Unexpected unbound variable identifier '$x'", loc)
     }
     case SetFormula.ElemSet(s) =>
       val elementTypes = s.toList.map(e => m.getBackward(e) match {
-        case Some(atom) => EffAtom.toType(atom, loc)
+        case Some(atom) => m.toType(atom, loc)
         case None => throw InternalCompilerException(s"Unexpected unbound element identifier '$e'", loc)
       })
       Type.mkUnion(elementTypes, loc)
@@ -322,6 +330,10 @@ object EffUnification3 {
     implicit val scope: RegionScope = RegionScope.Top
     implicit val renv: RigidityEnv = RigidityEnv.empty
     implicit val bimap: AtomBimap = AtomBimap.fromType(tpe)
+
+    if (bimap.hasConflictedEffectArgs) {
+      return tpe
+    }
 
     val f0 = toSetFormula(tpe)(withSlack = true, scope, renv, bimap)
     val z = Zhegalkin.toZhegalkin(f0)(Algebra, CofiniteIntSet.LatticeOps)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
@@ -216,7 +216,11 @@ object EffUnification3 {
     case _ => throw InvalidType(t)
   }
 
-  /** Returns whether `tpe` is a saturated application of an effect constructor. */
+  /**
+    * Returns whether `tpe` is a saturated application of an effect constructor.
+    *
+    * For example, if `F` has kind `Type -> Eff`, then `F[Int32]` is saturated while `F` is not.
+    */
   private def isSaturatedEffect(tpe: Type): Boolean = {
     if (tpe.kind != Kind.Eff) {
       false

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
@@ -53,6 +53,12 @@ object EffUnification3 {
     * Returns `Result.Err(eqns0)` if `eqns0` contains an equation that is ill-kinded. Hence, it is better to handle ill-kinded equations elsewhere.
     *
     * Note: Treats `Type.Error` as a constant, i.e. only equal to itself. Hence, it is better to drop equations that contain `Type.Error`.
+    *
+    * Invariant: For every polymorphic effect constructor in `eqns0`, all saturated
+    * occurrences must have identical type arguments. The caller must first equate and
+    * solve these arguments, and apply the resulting substitution to `eqns0`. For example,
+    * `F[a]` and `F[b]` may reach this function only after `a` and `b` have become equal;
+    * `F[Int32]` and `F[String]` must be rejected by ordinary type unification beforehand.
     */
   def unifyAll(eqs0: List[TypeConstraint.Equality], scope: RegionScope, renv: RigidityEnv)(implicit flix: Flix): Result[Substitution, List[TypeConstraint]] = {
     // Performance: Nothing to do if the equation list is empty
@@ -82,13 +88,6 @@ object EffUnification3 {
     // Choose a unique number for each atom. Use the original constraint order so the effect
     // argument representative stored in the bimap is independent of the chaos monkey.
     implicit val bimap: AtomBimap = AtomBimap.fromConstraints(eqs0)
-
-    // Effect arguments are unified before effect equations reach this solver. If different
-    // arguments remain, leave the equations unsolved until the ordinary type constraints make
-    // progress or report the conflict.
-    if (bimap.hasConflictedEffectArgs) {
-      return Result.Err(eqs)
-    }
 
     //
     // Phase 1: Try to solve without subeffecting.
@@ -320,6 +319,9 @@ object EffUnification3 {
     * WARNING:
     * - The type `tpe` *MUST* have kind `Eff`.
     * - The type `tpe` *MUST* be well-kinded. Do not use this function for ill-kinded effects!
+    * - Every saturated occurrence of the same polymorphic effect constructor *MUST* have
+    *   identical type arguments. For example, `F[a] + F[a]` is permitted, whereas
+    *   `F[Int32] + F[String]` must have been rejected before calling this function.
     *
     * The type `tpe` may contain `Type.Error`.
     */
@@ -334,10 +336,6 @@ object EffUnification3 {
     implicit val scope: RegionScope = RegionScope.Top
     implicit val renv: RigidityEnv = RigidityEnv.empty
     implicit val bimap: AtomBimap = AtomBimap.fromType(tpe)
-
-    if (bimap.hasConflictedEffectArgs) {
-      return tpe
-    }
 
     val f0 = toSetFormula(tpe)(withSlack = true, scope, renv, bimap)
     val z = Zhegalkin.toZhegalkin(f0)(Algebra, CofiniteIntSet.LatticeOps)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/PreEffUnification.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.language.ast.shared.RegionScope
-import ca.uwaterloo.flix.language.ast.{RigidityEnv, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.typer.TypeConstraint
 
 import scala.annotation.tailrec
@@ -55,7 +55,7 @@ object PreEffUnification {
     * Eliminates the atomic equations of the given system syntactically, without the set
     * algebra machinery.
     *
-    * An equation is atomic if it relates two atoms (variables, `Pure`, effect constants, or
+    * An equation is atomic if it relates two atoms (variables, `Pure`, effect applications, or
     * regions) where at least one side is a flexible variable (or the sides are identical).
     * Such equations are solvable by pure variable elimination: atoms need no normalization,
     * and the variable orientation mirrors `Equation.mk` (a variable on the right-hand side
@@ -116,13 +116,17 @@ object PreEffUnification {
   }
 
   /**
-    * Returns `true` if `t` is an atom: a variable, `Pure`, an effect constant, or a region.
+    * Returns `true` if `t` is an atom: a variable, `Pure`, an effect application, or a region.
     */
   private def isAtom(t: Type): Boolean = t match {
     case Type.Var(_, _) => true
     case Type.Cst(TypeConstructor.Pure, _) => true
     case Type.Cst(TypeConstructor.Effect(_, _), _) => true
     case Type.Cst(TypeConstructor.Region(_), _) => true
+    case app@Type.Apply(_, _, _) if app.kind == Kind.Eff => app.baseType match {
+      case Type.Cst(TypeConstructor.Effect(_, _), _) => true
+      case _ => false
+    }
     case _ => false
   }
 
@@ -131,13 +135,7 @@ object PreEffUnification {
     *
     * Assumes that `t1` and `t2` satisfy [[isAtom]].
     */
-  private def sameAtom(t1: Type, t2: Type): Boolean = (t1, t2) match {
-    case (Type.Var(s1, _), Type.Var(s2, _)) => s1 == s2
-    case (Type.Cst(TypeConstructor.Pure, _), Type.Cst(TypeConstructor.Pure, _)) => true
-    case (Type.Cst(TypeConstructor.Effect(s1, _), _), Type.Cst(TypeConstructor.Effect(s2, _), _)) => s1 == s2
-    case (Type.Cst(TypeConstructor.Region(s1), _), Type.Cst(TypeConstructor.Region(s2), _)) => s1 == s2
-    case _ => false
-  }
+  private def sameAtom(t1: Type, t2: Type): Boolean = t1 == t2
 
   /**
     * Follows variable bindings in `m` to the representative of `t`.

--- a/main/test/ca/uwaterloo/flix/language/TestTypeSimplifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestTypeSimplifier.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.{Consumer, Visitor}
-import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Type, TypedAst}
 import ca.uwaterloo.flix.language.phase.TypeSimplifier
 import ca.uwaterloo.flix.language.phase.typer.ConstraintSolver2
 import ca.uwaterloo.flix.language.phase.unification.EqualityEnv
@@ -42,16 +42,6 @@ class TestTypeSimplifier extends AnyFunSuite with TestUtils {
       val simplifiedType = TypeSimplifier.simplify(tpe)
       assert(ConstraintSolver2.isEquivalent(tpe, simplifiedType)(eqEnv, flix), s"\n$tpe\ndoes not unify with\n$simplifiedType")
     }
-  }
-
-  test("PolymorphicEffectArguments") {
-    val loc = SourceLocation.Unknown
-    val sym = new Symbol.EffSym(Nil, "F", loc)
-    val constructor = Type.Cst(TypeConstructor.Effect(sym, Kind.Star ->: Kind.Eff), loc)
-    val effect = Type.mkApply(constructor, Type.Int32 :: Nil, loc)
-    val union = Type.mkUnion(effect, effect, loc)
-
-    assert(TypeSimplifier.simplify(union) == effect)
   }
 
   /** Returns a list of types to use for testing. */

--- a/main/test/ca/uwaterloo/flix/language/TestTypeSimplifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestTypeSimplifier.scala
@@ -54,17 +54,6 @@ class TestTypeSimplifier extends AnyFunSuite with TestUtils {
     assert(TypeSimplifier.simplify(union) == effect)
   }
 
-  test("ConflictingPolymorphicEffectArguments") {
-    val loc = SourceLocation.Unknown
-    val sym = new Symbol.EffSym(Nil, "F", loc)
-    val constructor = Type.Cst(TypeConstructor.Effect(sym, Kind.Star ->: Kind.Eff), loc)
-    val intEffect = Type.mkApply(constructor, Type.Int32 :: Nil, loc)
-    val stringEffect = Type.mkApply(constructor, Type.Str :: Nil, loc)
-    val union = Type.mkUnion(intEffect, stringEffect, loc)
-
-    assert(TypeSimplifier.simplify(union) == union)
-  }
-
   /** Returns a list of types to use for testing. */
   private def getSampleTypes: List[Type] = {
     // Find sample types in the standard library.

--- a/main/test/ca/uwaterloo/flix/language/TestTypeSimplifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestTypeSimplifier.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.{Consumer, Visitor}
-import ca.uwaterloo.flix.language.ast.{SourceLocation, Type, TypedAst}
+import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.phase.TypeSimplifier
 import ca.uwaterloo.flix.language.phase.typer.ConstraintSolver2
 import ca.uwaterloo.flix.language.phase.unification.EqualityEnv
@@ -42,6 +42,27 @@ class TestTypeSimplifier extends AnyFunSuite with TestUtils {
       val simplifiedType = TypeSimplifier.simplify(tpe)
       assert(ConstraintSolver2.isEquivalent(tpe, simplifiedType)(eqEnv, flix), s"\n$tpe\ndoes not unify with\n$simplifiedType")
     }
+  }
+
+  test("PolymorphicEffectArguments") {
+    val loc = SourceLocation.Unknown
+    val sym = new Symbol.EffSym(Nil, "F", loc)
+    val constructor = Type.Cst(TypeConstructor.Effect(sym, Kind.Star ->: Kind.Eff), loc)
+    val effect = Type.mkApply(constructor, Type.Int32 :: Nil, loc)
+    val union = Type.mkUnion(effect, effect, loc)
+
+    assert(TypeSimplifier.simplify(union) == effect)
+  }
+
+  test("ConflictingPolymorphicEffectArguments") {
+    val loc = SourceLocation.Unknown
+    val sym = new Symbol.EffSym(Nil, "F", loc)
+    val constructor = Type.Cst(TypeConstructor.Effect(sym, Kind.Star ->: Kind.Eff), loc)
+    val intEffect = Type.mkApply(constructor, Type.Int32 :: Nil, loc)
+    val stringEffect = Type.mkApply(constructor, Type.Str :: Nil, loc)
+    val union = Type.mkUnion(intEffect, stringEffect, loc)
+
+    assert(TypeSimplifier.simplify(union) == union)
   }
 
   /** Returns a list of types to use for testing. */

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1618,6 +1618,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
+  // TODO: Move this positive test to main/test/flix when polymorphic effects are fully implemented.
   test("TestPolymorphicEffectHandler.Pos.01") {
     val input =
       """
@@ -1639,6 +1640,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectSuccess(result)
   }
 
+  // TODO: Move this positive test to main/test/flix when polymorphic effects are fully implemented.
   test("TestPolymorphicEffect.Pos.01") {
     val input =
       """
@@ -1654,6 +1656,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectSuccess(result)
   }
 
+  // TODO: Move this positive test to main/test/flix when polymorphic effects are fully implemented.
   test("TestPolymorphicEffect.Pos.02") {
     val input =
       """
@@ -1674,6 +1677,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectSuccess(result)
   }
 
+  // TODO: Move this positive test to main/test/flix when polymorphic effects are fully implemented.
   test("TestPolymorphicEffect.Pos.03") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1618,6 +1618,144 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
+  test("TestPolymorphicEffectHandler.Pos.01") {
+    val input =
+      """
+        |eff State[s] {
+        |    def get(): s
+        |    def put(x: s): Unit
+        |}
+        |
+        |def f(): Int32 =
+        |    run {
+        |        State.put(42);
+        |        State.get()
+        |    } with handler State {
+        |        def get(k) = k(0)
+        |        def put(_x, k) = k(())
+        |    }
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectSuccess(result)
+  }
+
+  test("TestPolymorphicEffect.Pos.01") {
+    val input =
+      """
+        |eff Emit[t] {
+        |    def emit(x: t): Unit
+        |}
+        |
+        |def emitInt(): Unit \ Emit[Int32] = Emit.emit(42)
+        |
+        |def emitString(): Unit \ Emit[String] = Emit.emit("hello")
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectSuccess(result)
+  }
+
+  test("TestPolymorphicEffect.Pos.02") {
+    val input =
+      """
+        |eff F[t] {
+        |    def f(x: t): Unit
+        |}
+        |
+        |eff G[t] {
+        |    def g(x: t): Unit
+        |}
+        |
+        |def useBoth(): Unit \ F[Int32] + G[String] = {
+        |    F.f(42);
+        |    G.g("hello")
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectSuccess(result)
+  }
+
+  test("TestPolymorphicEffect.Pos.03") {
+    val input =
+      """
+        |eff Pair[a, b] {
+        |    def put(x: a, y: b): Unit
+        |}
+        |
+        |def f(): Unit \ Pair[Int32, String] = Pair.put(42, "hello")
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectSuccess(result)
+  }
+
+  test("TestPolymorphicEffectHandler.Neg.01") {
+    val input =
+      """
+        |eff State[s] {
+        |    def get(): s
+        |    def put(x: s): Unit
+        |}
+        |
+        |def f(): Unit =
+        |    run {
+        |        ()
+        |    } with handler State {
+        |        def get(k) = k("hello")
+        |        def put(x, k) = {
+        |            let _y: Int32 = x;
+        |            k(())
+        |        }
+        |    }
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.UnexpectedType](result)
+  }
+
+  test("TestPolymorphicEffect.Neg.01") {
+    val input =
+      """
+        |eff Emit[t] {
+        |    def emit(x: t): Unit
+        |}
+        |
+        |def f(): Unit \ Emit[Int32] + Emit[String] = {
+        |    Emit.emit(42);
+        |    Emit.emit("hello")
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[MismatchedTypes](result)
+  }
+
+  test("TestPolymorphicEffect.Neg.02") {
+    val input =
+      """
+        |eff Emit[t] {
+        |    def emit(x: t): Unit
+        |}
+        |
+        |def f(g: Unit -> Unit \ Emit[Int32], h: Unit -> Unit \ Emit[String]): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[MismatchedTypes](result)
+  }
+
+  test("TestPolymorphicEffect.Neg.03") {
+    val input =
+      """
+        |eff Pair[a, b] {
+        |    def put(x: a, y: b): Unit
+        |}
+        |
+        |def f(): Unit =
+        |    region _rc {
+        |        Pair.put(42, "hello");
+        |        Pair.put(42, true)
+        |    }
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.UnexpectedArg](result)
+  }
+
   test("TestTryCatch.01") {
     val input =
       """


### PR DESCRIPTION
## Summary

- instantiate effect declaration parameters once per handler and share them across every handler rule
- collect saturated applications of each effect constructor across the complete constraint system and unify their arguments before effect solving
- preserve applied effect arguments through effect-set unification
- add positive and negative check-only typer tests, including handlers, nested regions, separate functions, different constructors, and multiple parameters

## Testing

- ./mill --no-server flix.compile
- complete TestTyper suite: 250 passed
- ./mill --no-server flix.test: 16,705 passed, 0 failed, 8 ignored

Part of #13229.