### PR TITLE
feat: add wolf, goat, and cabbage Datalog example

### DIFF
--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -22,8 +22,12 @@ type alias Cargo = String
 /// Solves the wolf, goat, and cabbage problem.
 ///
 /// We model a configuration as the four banks that the farmer, wolf, goat, and
-/// cabbage are currently on. `Reachable` is the set of configurations reachable
-/// from the starting configuration without anything being eaten.
+/// cabbage are currently on. A single crossing is a `Step`: the fact
+/// `Step(f, w, g, c, cargo, f2, w2, g2, c2)` says that from the configuration
+/// `(f, w, g, c)` the farmer can cross with `cargo` to the configuration
+/// `(f2, w2, g2, c2)`. A `Step` may be unsafe; `Safe` holds for the
+/// configurations where nothing gets eaten. `Reachable` is the set of
+/// configurations reachable from the starting configuration by safe steps.
 ///
 /// Datalog can tell us *whether* the puzzle is solvable, because that is a
 /// membership question about the minimal model. It cannot return the sequence of

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -1,15 +1,11 @@
-//
-// The wolf, goat, and cabbage problem is a river crossing puzzle that dates
-// back to at least the 9th century:
-//
-//     A farmer with a wolf, a goat, and a cabbage must cross a river by boat.
-//     The boat can carry only the farmer and a single item. If left unattended
-//     together, the wolf would eat the goat, or the goat would eat the cabbage.
-//     How can they cross the river without anything being eaten?
-//
-
 ///
-/// Solves the wolf, goat, and cabbage problem.
+/// Solves the wolf, goat, and cabbage problem, a river crossing puzzle that
+/// dates back to at least the 9th century:
+///
+///     A farmer with a wolf, a goat, and a cabbage must cross a river by boat.
+///     The boat can carry only the farmer and a single item. If left unattended
+///     together, the wolf would eat the goat, or the goat would eat the cabbage.
+///     How can they cross the river without anything being eaten?
 ///
 /// We model a configuration as the four banks that the farmer, wolf, goat, and
 /// cabbage are currently on. A single crossing is a `Step`: the fact

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -66,10 +66,18 @@ def main(): Unit \ IO =
         // goat is then either with everyone else or alone on the other bank.
         Safe(f, f, g, f) :- Bank(f), Bank(g).
 
+        // `Reachable` is the set of configurations the farmer can bring about
+        // without anything being eaten: the starting configuration, and every
+        // configuration one safe crossing away from a reachable one.
+
         // Everyone starts on the west bank.
         Reachable("west", "west", "west", "west").
 
-        // We may cross into any configuration that is safe.
+        // From a reachable configuration, one `Step` leads to a new
+        // configuration, which must be `Safe`.
+        //
+        // Every application of this rule is one crossing, so the derivation of
+        // a `Reachable` fact is the sequence of crossings that leads to it.
         //
         // Note that `Reachable` occurs *before* `Step` in the body. A provenance
         // query lists the facts of a proof in pre-order, so the sub-proof of the

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -94,7 +94,7 @@ def main(): Unit \ IO =
     // 2^4 = 16 configurations in total: each of the four participants is on one
     // of two banks.
     let reachable = query pr select (f, w, g, c) from Reachable(f, w, g, c);
-    println("Reachable configurations: ${Vector.length(reachable)} (of 16).");
+    println("Reachable configurations: ${Vector.length(reachable)}.");
 
     // The puzzle is solvable if everyone can end up on the east bank.
     if (not Vector.memberOf(("east", "east", "east", "east"), reachable)) {

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -9,16 +9,6 @@
 //
 
 ///
-/// A type alias for a bank of the river: "west" or "east".
-///
-type alias Bank = String
-
-///
-/// A type alias for what the farmer brings along: "wolf", "goat", "cabbage", or "nothing".
-///
-type alias Cargo = String
-
-///
 /// Solves the wolf, goat, and cabbage problem.
 ///
 /// We model a configuration as the four banks that the farmer, wolf, goat, and
@@ -119,7 +109,7 @@ def main(): Unit \ IO =
 ///
 /// For example, `describe("east", "goat")` is "The farmer crosses to the east bank with the goat.".
 ///
-def describe(dst: Bank, cargo: Cargo): String =
+def describe(dst: String, cargo: String): String =
     if (cargo == "nothing")
         "The farmer crosses to the ${dst} bank alone."
     else

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -113,3 +113,18 @@ def describe(dst: String, cargo: String): String =
 /// Returns the bank opposite to `b`.
 ///
 def opposite(b: String): String = if (b == "west") "east" else "west"
+
+//
+// Compared to a Prolog solution, this program shows a few strengths of Flix:
+//
+// - Every Datalog program terminates and has a unique minimal model. The
+//   left-recursive `Reachable` rule is therefore fine as written: it needs no
+//   tabling, no visited list, and does not depend on the order of the clauses.
+// - The sequence of crossings is recovered by a provenance query instead of
+//   being threaded through the recursion as a list.
+// - The recovered sequence is a shortest one, since the proof tree has minimal
+//   height. A depth-first search returns whichever solution it finds first.
+// - Reachable configurations are found bottom-up, so they can be discovered in
+//   parallel when the problem admits it. A Prolog search explores one path at
+//   a time.
+//

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -58,10 +58,13 @@ def main(): Unit \ IO =
         // The farmer crosses with the cabbage: both go from `f` to `f2`; `w` and `g` stay put.
         Step(f, w, g, f, "cabbage", f2, w,  g,  f2) :- Travel(f, f2), Bank(w), Bank(g).
 
-        // Nothing is eaten if the goat is with the farmer, or if the wolf and
-        // the cabbage are with the farmer (and hence the goat is left alone).
-        Safe(x, y, x, z) :- Bank(x), Bank(y), Bank(z).
-        Safe(x, x, y, x) :- Bank(x), Bank(y).
+        // Nothing is eaten if the goat is with the farmer: the wolf and the
+        // cabbage may then be on either bank.
+        Safe(f, w, f, c) :- Bank(f), Bank(w), Bank(c).
+
+        // Nothing is eaten if the wolf and the cabbage are with the farmer: the
+        // goat is then either with everyone else or alone on the other bank.
+        Safe(f, f, g, f) :- Bank(f), Bank(g).
 
         // Everyone starts on the west bank.
         Reachable("west", "west", "west", "west").

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -11,9 +11,9 @@
 /// cabbage are currently on. A single crossing is a `Step`: the fact
 /// `Step(f, w, g, c, cargo, f2, w2, g2, c2)` says that from the configuration
 /// `(f, w, g, c)` the farmer can cross with `cargo` to the configuration
-/// `(f2, w2, g2, c2)`. A `Step` may be unsafe; `Safe` holds for the
-/// configurations where nothing gets eaten. `Reachable` is the set of
-/// configurations reachable from the starting configuration by safe steps.
+/// `(f2, w2, g2, c2)`. `Unsafe` holds for the configurations where something
+/// gets eaten. `Reachable` is the set of configurations reachable from the
+/// starting configuration without ever passing through an unsafe one.
 ///
 /// Datalog can tell us *whether* the puzzle is solvable, because that is a
 /// membership question about the minimal model. It cannot return the sequence of
@@ -44,13 +44,13 @@ def main(): Unit \ IO =
         // The farmer crosses with the cabbage: both go from `f` to `f2`; `w` and `g` stay put.
         Step(f, w, g, f, "cabbage", f2, w,  g,  f2) :- Travel(f, f2), Bank(w), Bank(g).
 
-        // Nothing is eaten if the goat is with the farmer: the wolf and the
-        // cabbage may then be on either bank.
-        Safe(f, w, f, c) :- Bank(f), Bank(w), Bank(c).
+        // The goat is eaten if it is left with the wolf: both are on bank `x`
+        // and the farmer is on the opposite bank.
+        Unsafe(opposite(x), x, x, c) :- Bank(x), Bank(c).
 
-        // Nothing is eaten if the wolf and the cabbage are with the farmer: the
-        // goat is then either with everyone else or alone on the other bank.
-        Safe(f, f, g, f) :- Bank(f), Bank(g).
+        // The cabbage is eaten if it is left with the goat: both are on bank `x`
+        // and the farmer is on the opposite bank.
+        Unsafe(opposite(x), w, x, x) :- Bank(x), Bank(w).
 
         // `Reachable` is the set of configurations the farmer can bring about
         // without anything being eaten: the starting configuration, and every
@@ -60,7 +60,7 @@ def main(): Unit \ IO =
         Reachable("west", "west", "west", "west").
 
         // From a reachable configuration, one `Step` leads to a new
-        // configuration, which must be `Safe`.
+        // configuration, which must not be `Unsafe`.
         //
         // Every application of this rule is one crossing, so the derivation of
         // a `Reachable` fact is the sequence of crossings that leads to it.
@@ -73,7 +73,7 @@ def main(): Unit \ IO =
         Reachable(f2, w2, g2, c2) :-
             Reachable(f, w, g, c),
             Step(f, w, g, c, _, f2, w2, g2, c2),
-            Safe(f2, w2, g2, c2).
+            not Unsafe(f2, w2, g2, c2).
     };
 
     // The configurations reachable without anything being eaten.
@@ -108,3 +108,8 @@ def describe(dst: String, cargo: String): String =
         "The farmer crosses to the ${dst} bank alone."
     else
         "The farmer crosses to the ${dst} bank with the ${cargo}."
+
+///
+/// Returns the bank opposite to `b`.
+///
+def opposite(b: String): String = if (b == "west") "east" else "west"

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -79,10 +79,11 @@ def main(): Unit \ IO =
         // Every application of this rule is one crossing, so the derivation of
         // a `Reachable` fact is the sequence of crossings that leads to it.
         //
-        // Note that `Reachable` occurs *before* `Step` in the body. A provenance
-        // query lists the facts of a proof in pre-order, so the sub-proof of the
-        // earlier crossings comes before the `Step` of the latest one. That is
-        // what puts the crossings in chronological order.
+        // Note that the rule is left-recursive: `Reachable` comes first in the
+        // body. A provenance query lists the facts of a proof in pre-order, so
+        // the recursive sub-proof, which holds all the earlier crossings, is
+        // listed before the `Step` of the latest one. That puts the crossings
+        // in chronological order.
         Reachable(f2, w2, g2, c2) :-
             Reachable(f, w, g, c),
             Step(f, w, g, c, _, f2, w2, g2, c2),

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -73,7 +73,9 @@ def main(): Unit \ IO =
             Safe(f2, w2, g2, c2).
     };
 
-    // The configurations reachable without anything being eaten.
+    // The configurations reachable without anything being eaten. There are
+    // 2^4 = 16 configurations in total: each of the four participants is on one
+    // of two banks.
     let reachable = query pr select (f, w, g, c) from Reachable(f, w, g, c);
     println("Reachable configurations: ${Vector.length(reachable)} (of 16).");
 

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -1,0 +1,103 @@
+//
+// The wolf, goat, and cabbage problem is a river crossing puzzle that dates
+// back to at least the 9th century:
+//
+//     A farmer with a wolf, a goat, and a cabbage must cross a river by boat.
+//     The boat can carry only the farmer and a single item. If left unattended
+//     together, the wolf would eat the goat, or the goat would eat the cabbage.
+//     How can they cross the river without anything being eaten?
+//
+
+///
+/// A type alias for a bank of the river: "west" or "east".
+///
+type alias Bank = String
+
+///
+/// A type alias for what the farmer brings along: "wolf", "goat", "cabbage", or "nothing".
+///
+type alias Cargo = String
+
+///
+/// Solves the wolf, goat, and cabbage problem.
+///
+/// We model a configuration as the four banks that the farmer, wolf, goat, and
+/// cabbage are currently on. `Reachable` is the set of configurations reachable
+/// from the starting configuration without anything being eaten.
+///
+/// Datalog can tell us *whether* the puzzle is solvable, because that is a
+/// membership question about the minimal model. It cannot return the sequence of
+/// crossings, because a sequence is a term and Datalog has no function symbols.
+///
+/// But the sequence of crossings *is* the derivation of the goal configuration,
+/// so `pquery` recovers it: the `Step` facts along the provenance path are the
+/// crossings, in order.
+///
+def main(): Unit \ IO =
+    let pr = #{
+        // The two banks of the river and the crossings between them.
+        IsBank("west").
+        IsBank("east").
+
+        Travel("west", "east").
+        Travel("east", "west").
+
+        // The farmer crosses alone, or with the wolf, the goat, or the cabbage.
+        // The `IsBank` atoms bind the variables that do not occur in `Travel`.
+        Step(f, w, g, c, "nothing", f2, w,  g,  c ) :- Travel(f, f2), IsBank(w), IsBank(g), IsBank(c).
+        Step(f, f, g, c, "wolf",    f2, f2, g,  c ) :- Travel(f, f2), IsBank(g), IsBank(c).
+        Step(f, w, f, c, "goat",    f2, w,  f2, c ) :- Travel(f, f2), IsBank(w), IsBank(c).
+        Step(f, w, g, f, "cabbage", f2, w,  g,  f2) :- Travel(f, f2), IsBank(w), IsBank(g).
+
+        // Nothing is eaten if the goat is with the farmer, or if the wolf and
+        // the cabbage are with the farmer (and hence the goat is left alone).
+        Safe(x, y, x, z) :- IsBank(x), IsBank(y), IsBank(z).
+        Safe(x, x, y, x) :- IsBank(x), IsBank(y).
+
+        // Everyone starts on the west bank.
+        Reachable("west", "west", "west", "west").
+
+        // We may cross into any configuration that is safe.
+        //
+        // Note that `Reachable` occurs *before* `Step` in the body. A provenance
+        // query lists the facts of a proof in pre-order, so the sub-proof of the
+        // earlier crossings comes before the `Step` of the latest one. That is
+        // what puts the crossings in chronological order.
+        Reachable(f2, w2, g2, c2) :-
+            Reachable(f, w, g, c),
+            Step(f, w, g, c, _, f2, w2, g2, c2),
+            Safe(f2, w2, g2, c2).
+    };
+
+    // The configurations reachable without anything being eaten.
+    let reachable = query pr select (f, w, g, c) from Reachable(f, w, g, c);
+    println("Reachable configurations: ${Vector.length(reachable)} (of 16).");
+
+    // The puzzle is solvable if everyone can end up on the east bank.
+    if (not Vector.memberOf(("east", "east", "east", "east"), reachable)) {
+        println("The puzzle has no solution.")
+    } else {
+        // It is solvable, so we ask *how*. A provenance query returns the `Step`
+        // facts used to derive the goal configuration -- i.e. the crossings.
+        //
+        // Flix computes a proof tree of minimal height. Every crossing adds one
+        // level to the tree, so we get a shortest solution for free.
+        let plan = pquery pr select Reachable("east", "east", "east", "east") with {Step};
+        println("A shortest solution takes ${Vector.length(plan)} crossings:");
+        foreach (crossing <- plan) {
+            ematch crossing {
+                case Step(_, _, _, _, cargo, dst, _, _, _) => println("  ${describe(dst, cargo)}")
+            }
+        }
+    }
+
+///
+/// Returns a human-readable description of the farmer crossing to `dst` with `cargo`.
+///
+/// For example, `describe("east", "goat")` is "The farmer crosses to the east bank with the goat.".
+///
+def describe(dst: Bank, cargo: Cargo): String =
+    if (cargo == "nothing")
+        "The farmer crosses to the ${dst} bank alone."
+    else
+        "The farmer crosses to the ${dst} bank with the ${cargo}."

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -76,9 +76,7 @@ def main(): Unit \ IO =
             Safe(f2, w2, g2, c2).
     };
 
-    // The configurations reachable without anything being eaten. There are
-    // 2^4 = 16 configurations in total: each of the four participants is on one
-    // of two banks.
+    // The configurations reachable without anything being eaten.
     let reachable = query pr select (f, w, g, c) from Reachable(f, w, g, c);
     println("Reachable configurations: ${Vector.length(reachable)}.");
 

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -46,11 +46,16 @@ def main(): Unit \ IO =
         Travel("west", "east").
         Travel("east", "west").
 
-        // The farmer crosses alone, or with the wolf, the goat, or the cabbage.
-        // The `Bank` atoms bind the variables that do not occur in `Travel`.
+        // The farmer crosses alone: from `f` to `f2`; `w`, `g`, and `c` stay put.
         Step(f, w, g, c, "nothing", f2, w,  g,  c ) :- Travel(f, f2), Bank(w), Bank(g), Bank(c).
+
+        // The farmer crosses with the wolf: both go from `f` to `f2`; `g` and `c` stay put.
         Step(f, f, g, c, "wolf",    f2, f2, g,  c ) :- Travel(f, f2), Bank(g), Bank(c).
+
+        // The farmer crosses with the goat: both go from `f` to `f2`; `w` and `c` stay put.
         Step(f, w, f, c, "goat",    f2, w,  f2, c ) :- Travel(f, f2), Bank(w), Bank(c).
+
+        // The farmer crosses with the cabbage: both go from `f` to `f2`; `w` and `g` stay put.
         Step(f, w, g, f, "cabbage", f2, w,  g,  f2) :- Travel(f, f2), Bank(w), Bank(g).
 
         // Nothing is eaten if the goat is with the farmer, or if the wolf and

--- a/examples/datalog/wolf-goat-cabbage.flix
+++ b/examples/datalog/wolf-goat-cabbage.flix
@@ -36,23 +36,23 @@ type alias Cargo = String
 def main(): Unit \ IO =
     let pr = #{
         // The two banks of the river and the crossings between them.
-        IsBank("west").
-        IsBank("east").
+        Bank("west").
+        Bank("east").
 
         Travel("west", "east").
         Travel("east", "west").
 
         // The farmer crosses alone, or with the wolf, the goat, or the cabbage.
-        // The `IsBank` atoms bind the variables that do not occur in `Travel`.
-        Step(f, w, g, c, "nothing", f2, w,  g,  c ) :- Travel(f, f2), IsBank(w), IsBank(g), IsBank(c).
-        Step(f, f, g, c, "wolf",    f2, f2, g,  c ) :- Travel(f, f2), IsBank(g), IsBank(c).
-        Step(f, w, f, c, "goat",    f2, w,  f2, c ) :- Travel(f, f2), IsBank(w), IsBank(c).
-        Step(f, w, g, f, "cabbage", f2, w,  g,  f2) :- Travel(f, f2), IsBank(w), IsBank(g).
+        // The `Bank` atoms bind the variables that do not occur in `Travel`.
+        Step(f, w, g, c, "nothing", f2, w,  g,  c ) :- Travel(f, f2), Bank(w), Bank(g), Bank(c).
+        Step(f, f, g, c, "wolf",    f2, f2, g,  c ) :- Travel(f, f2), Bank(g), Bank(c).
+        Step(f, w, f, c, "goat",    f2, w,  f2, c ) :- Travel(f, f2), Bank(w), Bank(c).
+        Step(f, w, g, f, "cabbage", f2, w,  g,  f2) :- Travel(f, f2), Bank(w), Bank(g).
 
         // Nothing is eaten if the goat is with the farmer, or if the wolf and
         // the cabbage are with the farmer (and hence the goat is left alone).
-        Safe(x, y, x, z) :- IsBank(x), IsBank(y), IsBank(z).
-        Safe(x, x, y, x) :- IsBank(x), IsBank(y).
+        Safe(x, y, x, z) :- Bank(x), Bank(y), Bank(z).
+        Safe(x, x, y, x) :- Bank(x), Bank(y).
 
         // Everyone starts on the west bank.
         Reachable("west", "west", "west", "west").


### PR DESCRIPTION
Adds `examples/datalog/wolf-goat-cabbage.flix`, a river crossing puzzle in the style of the existing Datalog examples:

> A farmer with a wolf, a goat, and a cabbage must cross a river by boat. The boat can carry only the farmer and a single item. If left unattended together, the wolf would eat the goat, or the goat would eat the cabbage. How can they cross the river without anything being eaten?

A configuration is the four banks that the farmer, wolf, goat, and cabbage are on. `Reachable` is computed with an ordinary query, which answers *whether* the puzzle is solvable — but not *how*, since a sequence of crossings is a term and Datalog has no function symbols.

The sequence is instead the derivation of the goal configuration, so `pquery` recovers it: the `Step` facts along the provenance path are the crossings. Two details of the encoding are what make that work:

- `Step` is derived from the `Bank`/`Travel` facts rather than from `Reachable`. Deriving it from `Reachable` would read more naturally, but it makes each `Step`'s sub-proof re-expand the whole chain, so the crossings come out duplicated.
- The recursive rule is left-recursive: `Reachable` comes first in its body. Proof facts are listed in pre-order, so this is what puts the crossings in chronological order.

Since `ProvenanceAugment` tracks minimal derivation depth, the recovered plan is a shortest one — 7 crossings.

Output:

```
Reachable configurations: 10.
A shortest solution takes 7 crossings:
  The farmer crosses to the east bank with the goat.
  The farmer crosses to the west bank alone.
  The farmer crosses to the east bank with the cabbage.
  The farmer crosses to the west bank with the goat.
  The farmer crosses to the east bank with the wolf.
  The farmer crosses to the west bank alone.
  The farmer crosses to the east bank with the goat.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dd2RGNoPiR6LQHnJdxLzj
https://claude.ai/code/session_01SpP5f322NFs6n6XioCySo5
