### PR TITLE
feat: report mismatched effect type arguments with a dedicated error

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -223,6 +223,7 @@ object ErrorCode {
   case object E6710 extends ErrorCode
   case object E6736 extends ErrorCode
   case object E6794 extends ErrorCode
+  case object E6795 extends ErrorCode
   case object E6805 extends ErrorCode
   case object E6843 extends ErrorCode
   case object E6916 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -671,6 +671,42 @@ object TypeError {
   }
 
   /**
+    * Mismatched Effect Argument.
+    *
+    * Two applications of the same polymorphic effect disagree on one of their type arguments.
+    *
+    * @param sym    the symbol of the effect.
+    * @param ith    the position of the type argument (1-based).
+    * @param tparam the name of the type parameter at that position.
+    * @param tpe1   the first mismatched (base) type.
+    * @param tpe2   the second mismatched (base) type.
+    * @param eff1   the first effect application.
+    * @param eff2   the second effect application.
+    * @param renv   the rigidity environment.
+    * @param loc    the location where the error occurred.
+    */
+  case class MismatchedEffectArgument(sym: Symbol.EffSym, ith: Int, tparam: Name.Ident, tpe1: Type, tpe2: Type, eff1: Type, eff2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+    def code: ErrorCode = ErrorCode.E6795
+
+    def amb: SymbolSet = SymbolSet.ambiguous(SymbolSet.symbolsOf(eff1), SymbolSet.symbolsOf(eff2))
+
+    def summary: String = s"Mismatched type arguments for effect '$sym': '${formatType(tpe1, Some(renv), amb = amb)}' and '${formatType(tpe2, Some(renv), amb = amb)}'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Mismatched type arguments for effect '${magenta(sym.toString)}': '${red(formatType(tpe1, Some(renv), amb = amb))}' and '${red(formatType(tpe2, Some(renv), amb = amb))}'.
+         |
+         |${highlight(loc, "mismatched effect type argument.", fmt)}
+         |
+         |The effect '${magenta(sym.toString)}' is used with different types for its ${Grammar.ordinal(ith)} type parameter '${cyan(tparam.name)}'.
+         |
+         |Effect One: ${cyan(formatType(eff1, Some(renv), amb = amb))}
+         |Effect Two: ${magenta(formatType(eff2, Some(renv), amb = amb))}
+         |""".stripMargin
+    }
+  }
+
+  /**
     * A mismatch between a function (arrow) type and a non-function type.
     *
     * This is a special case of [[MismatchedTypes]]: a function and a non-function can never be

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -221,11 +221,13 @@ object ConstraintSolver2 {
     visitSubstitutionTree(initialSubst)
 
     val equalities = mutable.ListBuffer.empty[TypeConstraint]
-    for (occurrences <- effectTypes.valueLists) {
+    for ((sym, occurrences) <- effectTypes.m) {
       val representative = occurrences.head
       for (occurrence <- occurrences.tail) {
+        var ith = 1
         for ((tpe1, tpe2) <- ListOps.zip(representative.typeArguments, occurrence.typeArguments)) {
-          equalities += TypeConstraint.Equality(tpe1, tpe2, Provenance.PolyEffEq(representative, occurrence, occurrence.loc))
+          equalities += TypeConstraint.Equality(tpe1, tpe2, Provenance.PolyEffEq(sym, ith, representative, occurrence, occurrence.loc))
+          ith += 1
         }
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolverInterface.scala
@@ -205,8 +205,8 @@ object ConstraintSolverInterface {
       mkArrowAndNonArrowError(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc)
         .getOrElse(List(mkMismatchedTypesOrEffects(baseTpe1, baseTpe2, fullTpe1, fullTpe2, renv, loc)))
 
-    case TypeConstraint.Equality(baseType1, baseType2, Provenance.PolyEffEq(eff1, eff2, loc)) =>
-      List(TypeError.MismatchedTypes(subst(baseType1), subst(baseType2), subst(eff1), subst(eff2), renv, loc))
+    case TypeConstraint.Equality(baseType1, baseType2, Provenance.PolyEffEq(sym, ith, eff1, eff2, loc)) =>
+      List(mkMismatchedEffectArgument(sym, ith, subst(baseType1), subst(baseType2), subst(eff1), subst(eff2), renv, root, loc))
 
     case TypeConstraint.Equality(tpe1, tpe2, Provenance.Label(label, loc1, loc2, inner)) =>
       if (ConstraintSolver2.isSyntactic(tpe1.kind)) {
@@ -265,8 +265,8 @@ object ConstraintSolverInterface {
     case TypeConstraint.Conflicted(tpe1, tpe2, Provenance.Match(baseTpe1, baseTpe2, loc)) =>
       List(mkMismatchedTypesOrEffects(subst(baseTpe1), subst(baseTpe2), subst(tpe1), subst(tpe2), renv, loc))
 
-    case TypeConstraint.Conflicted(tpe1, tpe2, Provenance.PolyEffEq(eff1, eff2, loc)) =>
-      List(TypeError.MismatchedTypes(subst(tpe1), subst(tpe2), subst(eff1), subst(eff2), renv, loc))
+    case TypeConstraint.Conflicted(tpe1, tpe2, Provenance.PolyEffEq(sym, ith, eff1, eff2, loc)) =>
+      List(mkMismatchedEffectArgument(sym, ith, subst(tpe1), subst(tpe2), subst(eff1), subst(eff2), renv, root, loc))
 
     case TypeConstraint.Conflicted(_, _, Provenance.Timeout(msg, loc)) =>
       List(TypeError.TooComplex(msg, loc))
@@ -302,6 +302,17 @@ object ConstraintSolverInterface {
   }
 
   /**
+    * Returns a [[TypeError.MismatchedEffectArgument]] for the `ith` type argument (1-based) of the effect `sym`,
+    * where `tpe1` and `tpe2` are the mismatched parts of the argument and `eff1` and `eff2` the two effect applications.
+    *
+    * The name of the type parameter is looked up in the declaration of the effect.
+    */
+  private def mkMismatchedEffectArgument(sym: Symbol.EffSym, ith: Int, tpe1: Type, tpe2: Type, eff1: Type, eff2: Type, renv: RigidityEnv, root: KindedAst.Root, loc: SourceLocation)(implicit flix: Flix): TypeError = {
+    val tparam = root.effects(sym).tparams(ith - 1).name
+    TypeError.MismatchedEffectArgument(sym, ith, tparam, tpe1, tpe2, eff1, eff2, renv, loc)
+  }
+
+  /**
     * Create either the MismatchedTypes or MismatchedEffects error based on the kind of the type.
     */
   private def mkMismatchedTypesOrEffects(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix): TypeError = {
@@ -325,7 +336,7 @@ object ConstraintSolverInterface {
     case Provenance.ExpectEffect(expected, actual, _) => Some((expected, actual))
     case Provenance.ExpectArgument(expected, actual, _, _, _) => Some((expected, actual))
     case Provenance.Match(tpe1, tpe2, _) => Some((tpe1, tpe2))
-    case Provenance.PolyEffEq(eff1, eff2, _) => Some((eff1, eff2))
+    case Provenance.PolyEffEq(_, _, eff1, eff2, _) => Some((eff1, eff2))
     case Provenance.Source(eff1, eff2, _) => Some((eff1, eff2))
     case Provenance.Label(_, _, _, inner) => enclosingTypes(inner)
     case Provenance.Predicate(_, _, _, inner) => enclosingTypes(inner)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/EffectProvenance.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/EffectProvenance.scala
@@ -303,7 +303,7 @@ object EffectProvenance {
             Some((SinkNode, IntermediateNode, l))
           case TypeConstraint.Provenance.Source(_, _, _) => Some((IntermediateNode, SourceNode, prov.loc))
           case TypeConstraint.Provenance.Match(_, _, _) => Some((IntermediateNode, IntermediateNode, prov.loc))
-          case TypeConstraint.Provenance.PolyEffEq(_, _, _) => Some((IntermediateNode, IntermediateNode, prov.loc))
+          case TypeConstraint.Provenance.PolyEffEq(_, _, _, _, _) => Some((IntermediateNode, IntermediateNode, prov.loc))
           case TypeConstraint.Provenance.ExpectType(_, _, _) => Some((IntermediateNode, SourceNode, prov.loc))
           case TypeConstraint.Provenance.ExpectArgument(arg, _, _, _, _) => Some((ArgNode, IntermediateNode, arg.loc))
           case _ => None

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
@@ -134,9 +134,10 @@ object TypeConstraint {
     case class Match(tpe1: Type, tpe2: Type, loc: SourceLocation) extends Provenance
 
     /**
-      * The constraint equates type arguments from two applications of the same polymorphic effect.
+      * The constraint equates the `ith` type arguments (1-based) of `eff1` and `eff2`,
+      * two applications of the same polymorphic effect `sym`.
       */
-    case class PolyEffEq(eff1: Type, eff2: Type, loc: SourceLocation) extends Provenance
+    case class PolyEffEq(sym: Symbol.EffSym, ith: Int, eff1: Type, eff2: Type, loc: SourceLocation) extends Provenance
 
     /**
       * The constraint relates the types of the record label `label` in two record rows.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1727,7 +1727,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
-    expectError[MismatchedTypes](result)
+    expectError[TypeError.MismatchedEffectArgument](result)
   }
 
   test("TestPolymorphicEffect.Neg.02") {
@@ -1740,7 +1740,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |def f(g: Unit -> Unit \ Emit[Int32], h: Unit -> Unit \ Emit[String]): Unit = ()
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
-    expectError[MismatchedTypes](result)
+    expectError[TypeError.MismatchedEffectArgument](result)
   }
 
   test("TestPolymorphicEffect.Neg.03") {
@@ -1758,6 +1758,52 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[TypeError.UnexpectedArg](result)
+  }
+
+  test("TestPolymorphicEffect.Neg.04") {
+    val input =
+      """
+        |eff Pair[a, b] {
+        |    def put(x: a, y: b): Unit
+        |}
+        |
+        |def f(_g: Unit -> Unit \ Pair[Int32, String], _h: Unit -> Unit \ Pair[Int32, Bool]): Unit = ()
+        |""".stripMargin
+    val (_, errors) = check(input, Options.TestWithLibMin)
+    val mismatches = errors.collect { case e: TypeError.MismatchedEffectArgument => e }
+    assert(mismatches.nonEmpty)
+    assert(mismatches.forall(_.ith == 2))
+  }
+
+  test("TestPolymorphicEffect.Neg.05") {
+    val input =
+      """
+        |eff Emit[t] {
+        |    def emit(x: t): Unit
+        |}
+        |
+        |enum Box[a] {
+        |    case Box(a)
+        |}
+        |
+        |enum Bag[a] {
+        |    case Bag(a)
+        |}
+        |
+        |def emitBox(x: Box[a]): Unit \ Emit[Box[a]] = Emit.emit(x)
+        |
+        |def emitBag(x: Bag[a]): Unit \ Emit[Bag[a]] = Emit.emit(x)
+        |
+        |def f(): Unit =
+        |    run {
+        |        emitBox(Box.Box(1));
+        |        emitBag(Bag.Bag(1))
+        |    } with handler Emit {
+        |        def emit(_x, k) = k(())
+        |    }
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MismatchedEffectArgument](result)
   }
 
   test("TestTryCatch.01") {


### PR DESCRIPTION
## Summary

- add `TypeError.MismatchedEffectArgument` (E6795), reported when two applications of the same polymorphic effect disagree on a type argument
- extend `Provenance.PolyEffEq` with the effect symbol and the 1-based argument position, and look up the type parameter's name from the effect declaration when building the error
- replace the generic `MismatchedTypes` report for this provenance in both the `Equality` and `Conflicted` cases
- add typer tests for a two-parameter effect (checks the reported position) and for structured effect arguments

Example:

```
-- Type Error [E6795] ---------------------------------------- out/example9.flix

>> Mismatched type arguments for effect 'Pair': 'Bool' and 'String'.

5 | def f(_g: Unit -> Unit \ Pair[Int32, String], _h: Unit -> Unit \ Pair[Int32, Bool]): Unit = ()
                             ^^^^^^^^^^^^^^^^^^^
                             mismatched effect type argument.

The effect 'Pair' is used with different types for its 2nd type parameter 'b'.

Effect One: Pair[Int32, Bool]
Effect Two: Pair[Int32, String]
```

Part of #13229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CtTJ9ezmtaGUbEjqjcgSC
