### PR TITLE
feat: support polymorphic effects in entry points and default handlers

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -694,6 +694,36 @@ object Type {
   }
 
   /**
+    * Returns an occurrence of the effect constructor `sym` in the effect formula `eff`.
+    *
+    * A saturated polymorphic effect application is treated as an atomic effect. In particular,
+    * effect types nested in its type arguments are not occurrences in the surrounding formula.
+    */
+  def findEffect(sym: Symbol.EffSym, eff: Type): Option[Type] = eff match {
+    case tpe@Type.Cst(TypeConstructor.Effect(otherSym, Kind.Eff), _) =>
+      Option.when(sym == otherSym)(tpe)
+    case app@Type.Apply(_, _, _) if app.kind == Kind.Eff => app.baseType match {
+      case Type.Cst(TypeConstructor.Effect(otherSym, _), _) =>
+        Option.when(sym == otherSym)(app)
+      case _ => app match {
+        case Type.Apply(Type.Cst(TypeConstructor.Complement, _), x, _) =>
+          findEffect(sym, x)
+        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Union, _), x, _), y, _) =>
+          findEffect(sym, x).orElse(findEffect(sym, y))
+        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Intersection, _), x, _), y, _) =>
+          findEffect(sym, x).orElse(findEffect(sym, y))
+        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Difference, _), x, _), y, _) =>
+          findEffect(sym, x).orElse(findEffect(sym, y))
+        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SymmetricDiff, _), x, _), y, _) =>
+          findEffect(sym, x).orElse(findEffect(sym, y))
+        case _ => None
+      }
+    }
+    case Type.Alias(_, _, tpe, _) => findEffect(sym, tpe)
+    case _ => None
+  }
+
+  /**
     * Returns a fresh type variable of the given kind `k` and rigidity `r`.
     */
   def freshVar(k: Kind, loc: SourceLocation, text: VarText = VarText.Absent)(implicit scope: RegionScope, flix: Flix): Type.Var = {

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -378,7 +378,7 @@ object EntryPoints {
       // previous phase has already reported an error. Either way, report nothing here.
       None
     } else {
-      Some(EntryPointError.IllegalEntryPointEffect(toEffType(residual, eff.loc), eff.loc))
+      Some(EntryPointError.IllegalEntryPointEffect(toEffType(residual, eff), eff.loc))
     }
   }
 
@@ -394,10 +394,12 @@ object EntryPoints {
       case Result.Err(_) => CofiniteSet.empty
     }
 
-  /** Reconstructs an effect [[Type]], located at `loc`, from a set of effect symbols. */
-  private def toEffType(s: CofiniteSet[Symbol.EffSym], loc: SourceLocation): Type = {
+  /** Reconstructs an effect [[Type]] from a set of effect symbols, preserving applied effects from `original`. */
+  private def toEffType(s: CofiniteSet[Symbol.EffSym], original: Type): Type = {
+    val loc = original.loc
+
     def union(syms: SortedSet[Symbol.EffSym]): Type =
-      Type.mkUnion(syms.toList.map(sym => Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc)), loc)
+      Type.mkUnion(syms.toList.map(sym => Type.findEffect(sym, original).getOrElse(Type.Cst(TypeConstructor.Effect(sym, Kind.Eff), loc))), loc)
 
     s match {
       case CofiniteSet.Set(syms) => union(syms)

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph/Lowering.scala
@@ -884,10 +884,18 @@ object Lowering {
       case Result.Err(_) => throw InternalCompilerException("Unexpected illegal effect set on entry point", currentDef.spec.eff.loc)
     }
     // Gather only the default handlers for the effects appearing in the signature of the definition.
-    val requiredHandlers = root.defaultHandlers.filter(h => defEffects.contains(h.handledSym))
+    val requiredHandlers = root.defaultHandlers.collect {
+      case handler if defEffects.contains(handler.handledSym) =>
+        val handledEff = Type.findEffect(handler.handledSym, currentDef.spec.eff).getOrElse {
+          throw InternalCompilerException(s"Missing concrete effect '${handler.handledSym}' in entry point.", currentDef.spec.eff.loc)
+        }
+        (handler, handledEff)
+    }
     // Wrap the expression in each of the required default handlers.
     // Right now, the order depends on the order of defaultHandlers.
-    requiredHandlers.foldLeft(currentDef)((defn, handler) => wrapInHandler(defn, handler))
+    requiredHandlers.foldLeft(currentDef) {
+      case (defn, (handler, handledEff)) => wrapInHandler(defn, handler, handledEff)
+    }
   }
 
   /**
@@ -911,17 +919,18 @@ object Lowering {
     *
     * @param defn           The entry point function definition to wrap
     * @param defaultHandler Information about the default handler to apply
+    * @param handledEff     The concrete application of the handled effect in the entry point
     * @param root           The typed AST root
     * @return The wrapped function definition with updated effect signature
     */
-  private def wrapInHandler(defn: TypedAst.Def, defaultHandler: DefaultHandler)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): TypedAst.Def = {
+  private def wrapInHandler(defn: TypedAst.Def, defaultHandler: DefaultHandler, handledEff: Type)(implicit ctx: Context, lctx: LocalContext, root: TypedAst.Root, flix: Flix): TypedAst.Def = {
     // Create synthetic locations
     val effLoc = defn.spec.eff.loc.asSynthetic
     val baseTypeLoc = defn.spec.declaredScheme.base.loc.asSynthetic
     val expLoc = defn.exp.loc.asSynthetic
     // The new type is the same as the wrapped def with an effect set of
     // `(ef - handledEffect) + IO` where `ef` is the effect set of the previous definition.
-    val effDif = Type.mkDifference(defn.spec.eff, defaultHandler.handledEff, effLoc)
+    val effDif = Type.mkDifference(defn.spec.eff, handledEff, effLoc)
     // Technically we could perform this outside at the wrapInHandlers level
     // by just checking the length of the handlers and if it is greater than 0
     // just adding IO. However, that would only work while default handlers can only generate IO.

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/ConstraintGen.scala
@@ -234,9 +234,15 @@ private[monomorph2] object ConstraintGen {
     if (TypedAstOps.isEntryPoint(defn)(root)) {
       val loc = defn.spec.eff.loc
       val defEffects = Canonicalization.evalEff(defn.spec.eff)
-      val requiredHandlers = root.defaultHandlers.filter(h => defEffects.contains(h.handledSym))
+      val requiredHandlers = root.defaultHandlers.collect {
+        case handler if defEffects.contains(handler.handledSym) =>
+          val handledEff = Type.findEffect(handler.handledSym, defn.spec.eff).getOrElse {
+            throw InternalCompilerException(s"Missing concrete effect '${handler.handledSym}' in entry point.", loc)
+          }
+          (handler, handledEff)
+      }
       requiredHandlers.foldLeft(defn.spec.eff) {
-        case (eff, handler) =>
+        case (eff, (handler, handledEff)) =>
           val handlerDef = root.defs(handler.handlerSym)
           val handlerTparams = handlerDef.spec.tparams
           // E.g. imagine we have this effect declaration:
@@ -262,16 +268,19 @@ private[monomorph2] object ConstraintGen {
           //   [Unit, Ask + IO] ~> Ask.handle
           // }}}
           //
-          // N.B. We use full unification rather than reading `a`/`ef` off fixed positions because
+          // N.B. We use full unification rather than reading type arguments off fixed positions because
           // a default handler's parameter type only has to be *equal* to `Unit -> a \ ef`, not
           // written that way syntactically — e.g. `f: Unit -> a \ (ef + Pure)` is a valid handler
-          // parameter type too.
+          // parameter type too. Unifying the complete handler arrow also recovers type parameters
+          // that occur only in the handled effect.
           val concreteParamTpe = Type.mkArrowWithEffect(Type.Unit, eff, defn.spec.retTpe, loc)
-          val subst = ConstraintSolver2.fullyUnify(handlerDef.spec.fparams.head.tpe, concreteParamTpe, RegionScope.Top, RigidityEnv.empty)(root.eqEnv, flix)
+          val resultEff = Type.mkUnion(Type.mkDifference(eff, handledEff, loc), Type.IO, loc)
+          val concreteHandlerTpe = Type.mkArrowWithEffect(concreteParamTpe, resultEff, defn.spec.retTpe, loc)
+          val subst = ConstraintSolver2.fullyUnify(handlerDef.spec.declaredScheme.base, concreteHandlerTpe, RegionScope.Top, RigidityEnv.empty)(root.eqEnv, flix)
             .getOrElse(throw InternalCompilerException(s"Could not unify default handler '${handler.handlerSym}' against its call site.", loc))
           val args = handlerTparams.map(tp => typeToMonoArg(subst(Type.Var(tp.sym, loc))))
           sctx.addFlowConstraint(FlowConstraint(Instantiation(args), MonoVar.Def(handler.handlerSym)))
-          Canonicalization.canonicalEffect(Type.mkUnion(Type.mkDifference(eff, handler.handledEff, loc), Type.IO, loc))
+          resultEff
       }
       ()
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/Specialize.scala
@@ -41,7 +41,8 @@ private[monomorph2] object Specialize {
     * Lookup tables mapping each parametric def/enum/struct/restrictable-enum's original sym,
     * at a given ground instantiation, to its fresh specialized sym.
     *
-    * @param defTable              Fresh syms for parametric defs.
+    * @param defTable              Fresh syms for parametric defs, keyed by their ground arrow types.
+    * @param defArgTable           Fresh syms for root defs, keyed by their explicit ground type arguments.
     * @param enumTable             Fresh syms for parametric enums only.
     * @param structTable           Fresh syms for parametric structs only.
     * @param restrictableEnumTable Fresh syms for (parametric) restrictable enums. (Restrictable enums always carry the case-set index as an implicit tparam.)
@@ -49,6 +50,7 @@ private[monomorph2] object Specialize {
     */
   private[monomorph2] case class SpecializationTables(
     defTable: Map[(Symbol.DefnSym, Type), Symbol.DefnSym],
+    defArgTable: Map[(Symbol.DefnSym, List[Type]), Symbol.DefnSym],
     enumTable: Map[(Symbol.EnumSym, List[Type]), Symbol.EnumSym],
     structTable: Map[(Symbol.StructSym, List[Type]), Symbol.StructSym],
     restrictableEnumTable: Map[(Symbol.RestrictableEnumSym, List[Type]), Symbol.EnumSym],
@@ -56,11 +58,12 @@ private[monomorph2] object Specialize {
   )
 
   /**
-    * Returns the sym to use for a call to `sym` at ground arrow type `groundArrowTpe`.
+    * Returns the sym to use for a call to `sym` at ground arrow type `groundArrowTpe` and,
+    * when available, explicit ground type arguments `groundTypeArgs`.
     */
-  private[monomorph2] def lookupSym(sym: Symbol.DefnSym, groundArrowTpe: Type)
+  private[monomorph2] def lookupSym(sym: Symbol.DefnSym, groundArrowTpe: Type, groundTypeArgs: List[Type] = Nil)
                        (implicit tables: SpecializationTables, root: TypedAst.Root): Symbol.DefnSym =
-    tables.defTable.get((sym, groundArrowTpe)) match {
+    tables.defArgTable.get((sym, groundTypeArgs)).orElse(tables.defTable.get((sym, groundArrowTpe))) match {
       case Some(specializedSym) => specializedSym
 
       case None =>
@@ -408,6 +411,15 @@ private[monomorph2] object Specialize {
     val defTableMap =
       entries.map { case (freshSym, defn, _, it) => (defn.sym, it) -> freshSym }.toMap
 
+    // Arrow types normally identify a definition specialization. Effect-only type parameters are
+    // erased from those arrows, so retain the explicit arguments as an additional lookup key.
+    val defArgTableMap =
+      entries.collect {
+        case (freshSym, defn, subst, _) if root.defs.contains(defn.sym) =>
+          val args = defn.spec.tparams.map(tparam => subst(Type.Var(tparam.sym, tparam.loc)))
+          (defn.sym, args) -> freshSym
+      }.toMap
+
     val enumEntries = mkEnumEntries(solution)
     val enumTableMap =
       enumEntries.map { case (sym, args, freshSym, _) => (sym, args) -> freshSym }.toMap
@@ -422,7 +434,7 @@ private[monomorph2] object Specialize {
 
     val is: Map[(Symbol.TraitSym, TypeConstructor), Instance] = MonomorphHelpers.mkInstanceMap(root.instances)
 
-    implicit val tables: SpecializationTables = SpecializationTables(defTableMap, enumTableMap, structTableMap, restrictableEnumTableMap, is)
+    implicit val tables: SpecializationTables = SpecializationTables(defTableMap, defArgTableMap, enumTableMap, structTableMap, restrictableEnumTableMap, is)
 
     // Create specialized and lowered versions of the different families of declarations
 

--- a/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/monomorph2/SpecializeAndLower.scala
@@ -26,6 +26,7 @@ import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.jvm.{ClassDescs, JavaMemberResolver}
 import ca.uwaterloo.flix.language.phase.monomorph2.Specialize.*
 import ca.uwaterloo.flix.language.phase.monomorph2.Symbols.{Defs, Enums, Types}
+import ca.uwaterloo.flix.language.phase.typer.ConstraintSolver2
 import ca.uwaterloo.flix.language.phase.typer.jvm.JavaBoxing
 import ca.uwaterloo.flix.util.collection.{CofiniteSet, ListOps, Nel}
 import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
@@ -103,7 +104,7 @@ private[monomorph2] object SpecializeAndLower {
   /** Specializes and lowers `defn0` under `subst` into a `MonoAst.Def` with the specialized symbol `freshSym`. */
   private[monomorph2] def visitDef(freshSym: Symbol.DefnSym, defn0: TypedAst.Def, subst: StrictSubstitution)(implicit tables: SpecializationTables, root: TypedAst.Root, flix: Flix): MonoAst.Def = {
     implicit val lctx: LocalContext = LocalContext.empty
-    val defn = wrapIfEntryPoint(defn0, subst)
+    val defn = wrapIfEntryPoint(defn0)
     defn match {
       case TypedAst.Def(_, spec0, exp, loc) =>
         val (fparams, env0) = specializeFormalParams(spec0.fparams, subst)
@@ -117,30 +118,14 @@ private[monomorph2] object SpecializeAndLower {
     }
   }
 
-  /**
-    * If `defn0` is an entry point, substitutes its spec's types and wraps it with its required
-    * default handlers before the rest of lowering; otherwise returns `defn0` unchanged.
-    */
-  private def wrapIfEntryPoint(defn0: TypedAst.Def, subst: StrictSubstitution)(implicit root: TypedAst.Root, flix: Flix): TypedAst.Def =
+  /** If `defn0` is an entry point, wraps it with its required default handlers. */
+  private def wrapIfEntryPoint(defn0: TypedAst.Def)(implicit root: TypedAst.Root, flix: Flix): TypedAst.Def =
     if (!TypedAstOps.isEntryPoint(defn0)) {
       defn0
     } else {
-      defn0 match {
-        case TypedAst.Def(sym, spec0, exp, loc) =>
-          val spec = spec0 match {
-            case TypedAst.Spec(doc, ann, mod, tparams, fparams0, declaredScheme0, retTpe, eff, tconstrs, econstrs) =>
-              val fparams = fparams0.map {
-                case TypedAst.FormalParam(bnd, tpe, src, decreasing, floc) =>
-                  TypedAst.FormalParam(bnd, subst(tpe), src, decreasing, floc)
-              }
-              val declaredScheme = declaredScheme0 match {
-                case Scheme(quantifiers, tconstrs1, econstrs1, base) =>
-                  Scheme(quantifiers, tconstrs1, econstrs1, subst(base))
-              }
-              TypedAst.Spec(doc, ann, mod, tparams, fparams, declaredScheme, subst(retTpe), subst(eff), tconstrs, econstrs)
-          }
-          wrapDefWithDefaultHandlers(TypedAst.Def(sym, spec, exp, loc))
-      }
+      // Preserve applied effect arguments until the concrete default handlers have been selected.
+      // The regular lowering walk below applies `subst` to every synthesized type afterwards.
+      wrapDefWithDefaultHandlers(defn0)
     }
 
   /**
@@ -187,9 +172,10 @@ private[monomorph2] object SpecializeAndLower {
       val t = visitType(tpe, subst)
       MonoAst.Expr.ApplyClo(e1, e2, t, subst(eff), loc)
 
-    case TypedAst.Expr.ApplyDef(symUse, exps, _, itpe0, tpe, eff, _, loc) =>
+    case TypedAst.Expr.ApplyDef(symUse, exps, targs0, itpe0, tpe, eff, _, loc) =>
       val groundArrowTpe = subst(itpe0)
-      val newSym = lookupSym(symUse.sym, groundArrowTpe)
+      val groundTypeArgs = targs0.map(subst.apply)
+      val newSym = lookupSym(symUse.sym, groundArrowTpe, groundTypeArgs)
       val es = exps.map(visitExp(_, env0, subst))
       MonoAst.Expr.ApplyDef(newSym, es, visitTypeSubstituted(groundArrowTpe), visitType(tpe, subst), subst(eff), loc)
 
@@ -855,22 +841,29 @@ private[monomorph2] object SpecializeAndLower {
       case Result.Err(_) => throw InternalCompilerException("Unexpected illegal effect set on entry point", currentDef.spec.eff.loc)
     }
     // Order of application follows the order of root.defaultHandlers and is otherwise unspecified.
-    val requiredHandlers = root.defaultHandlers.filter(h => defEffects.contains(h.handledSym))
-    requiredHandlers.foldLeft(currentDef)((defn, handler) => wrapInHandler(defn, handler))
+    val requiredHandlers = root.defaultHandlers.collect {
+      case handler if defEffects.contains(handler.handledSym) =>
+        val handledEff = Type.findEffect(handler.handledSym, currentDef.spec.eff).getOrElse {
+          throw InternalCompilerException(s"Missing concrete effect '${handler.handledSym}' in entry point.", currentDef.spec.eff.loc)
+        }
+        (handler, handledEff)
+    }
+    requiredHandlers.foldLeft(currentDef) {
+      case (defn, (handler, handledEff)) => wrapInHandler(defn, handler, handledEff)
+    }
   }
 
   /**
     * Wraps `defn` with `defaultHandler`: `def f(...): tpe \ ef = exp` becomes
     * `def f(...): tpe \ (ef - handledEffect) + IO = handler(_ -> exp)`.
     */
-  private def wrapInHandler(defn: TypedAst.Def, defaultHandler: DefaultHandler)(implicit flix: Flix): TypedAst.Def = defn match {
+  private def wrapInHandler(defn: TypedAst.Def, defaultHandler: DefaultHandler, handledEff: Type)(implicit root: TypedAst.Root, flix: Flix): TypedAst.Def = defn match {
     case TypedAst.Def(sym, spec0, exp, defLoc) =>
       val effLoc = spec0.eff.loc.asSynthetic
       val baseTypeLoc = spec0.declaredScheme.base.loc.asSynthetic
       val expLoc = exp.loc.asSynthetic
-      val effDif = Type.mkDifference(spec0.eff, defaultHandler.handledEff, effLoc)
-      // Canonicalized to match defTable's canonicalized keys.
-      val eff = Canonicalization.canonicalEffect(Type.mkUnion(effDif, Type.IO, effLoc))
+      val effDif = Type.mkDifference(spec0.eff, handledEff, effLoc)
+      val eff = Type.mkUnion(effDif, Type.IO, effLoc)
       val tpe = Type.mkCurriedArrowWithEffect(spec0.fparams.map(_.tpe), eff, spec0.retTpe, baseTypeLoc)
       val spec = spec0 match {
         case TypedAst.Spec(doc, ann, mod, tparams, fparams, declaredScheme0, retTpe, _, tconstrs, econstrs) =>
@@ -893,10 +886,14 @@ private[monomorph2] object SpecializeAndLower {
           expLoc
         )
       val handlerArrowType = Type.mkArrowWithEffect(innerLambda.tpe, eff, spec0.retTpe, expLoc)
+      val handlerDef = root.defs(defaultHandler.handlerSym)
+      val handlerSubst = ConstraintSolver2.fullyUnify(handlerDef.spec.declaredScheme.base, handlerArrowType, RegionScope.Top, RigidityEnv.empty)(root.eqEnv, flix)
+        .getOrElse(throw InternalCompilerException(s"Could not unify default handler '${defaultHandler.handlerSym}' against its call site.", expLoc))
+      val handlerTypeArgs = handlerDef.spec.tparams.map(tparam => handlerSubst(Type.Var(tparam.sym, expLoc)))
       // Left unresolved: visitExp's ApplyDef case resolves it later, like any other call site —
       // pre-resolving here would crash, since root.defs has no entry for a fresh sym.
       val handlerDefSymUse = SymUse.DefSymUse(defaultHandler.handlerSym, expLoc)
-      val handlerCall = TypedAst.Expr.ApplyDef(handlerDefSymUse, List(innerLambda), List(innerLambda.tpe), handlerArrowType, spec0.retTpe, eff, ApplyPosition.NonTail, expLoc)
+      val handlerCall = TypedAst.Expr.ApplyDef(handlerDefSymUse, List(innerLambda), handlerTypeArgs, handlerArrowType, spec0.retTpe, eff, ApplyPosition.NonTail, expLoc)
       TypedAst.Def(sym, spec, handlerCall, defLoc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/DefaultHandlers.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/DefaultHandlers.scala
@@ -86,14 +86,17 @@ object DefaultHandlers {
       case None =>
         sctx.errors.add(TypeError.DefaultHandlerNotInModule(handlerSym, handlerSym.loc))
         None
-      case Some((resolvedEffSym, _)) =>
+      case Some((resolvedEffSym, effect)) =>
         // Synthetic location of our handler
         val loc = handlerSym.loc.asSynthetic
-        // There is a valid effect to wrap
-        val handledEff = Type.Cst(TypeConstructor.Effect(resolvedEffSym, Kind.Eff), loc)
+        // There is a valid effect to wrap. Instantiate its parameters with fresh variables so the
+        // expected handler scheme is polymorphic in the effect arguments as well.
+        val effectArgs = effect.tparams.map(tparam => Type.freshVar(tparam.sym.kind, loc)(RegionScope.Top, flix))
+        val effectKind = Kind.mkArrowTo(effectArgs.map(_.kind), Kind.Eff)
+        val handledEff = Type.mkApply(Type.Cst(TypeConstructor.Effect(resolvedEffSym, effectKind), loc), effectArgs, loc)
         val declaredScheme = handlerDef.spec.sc
         // Generate expected scheme for generating IO
-        val expectedSchemeIO = getDefaultHandlerTypeScheme(handledEff, Type.IO, loc)
+        val expectedSchemeIO = getDefaultHandlerTypeScheme(handledEff, effectArgs.map(_.sym), Type.IO, loc)
         // Check if handler's scheme fits any of the valid handler's schemes and if not generate an error
         if (!Scheme.equal(expectedSchemeIO, declaredScheme, traitEnv, eqEnv, Nil)(RegionScope.Top, flix)) {
           sctx.errors.add(TypeError.IllegalDefaultHandlerSignature(resolvedEffSym, handlerSym, handlerSym.loc))
@@ -114,15 +117,16 @@ object DefaultHandlers {
     * }}}
     *
     * @param handledEff                The type of the effect associated with the default handler
+    * @param effectQuantifiers         The type parameters of the handled effect
     * @param generatedPrimitiveEffects The type of the generated primitive effects by the default handler
     * @param loc                       The source location to be used for members of the scheme
     * @return The expected scheme of the default handler
     */
-  private def getDefaultHandlerTypeScheme(handledEff: Type, generatedPrimitiveEffects: Type, loc: SourceLocation)(implicit flix: Flix): Scheme = {
+  private def getDefaultHandlerTypeScheme(handledEff: Type, effectQuantifiers: List[Symbol.KindedTypeVarSym], generatedPrimitiveEffects: Type, loc: SourceLocation)(implicit flix: Flix): Scheme = {
     val a = Type.freshVar(Kind.Star, loc)(RegionScope.Top, flix)
     val ef = Type.freshVar(Kind.Eff, loc)(RegionScope.Top, flix)
     Scheme(
-      quantifiers = List(a.sym, ef.sym),
+      quantifiers = effectQuantifiers ::: List(a.sym, ef.sym),
       tconstrs = Nil,
       econstrs = Nil,
       base = Type.mkArrowWithEffect(

--- a/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoints.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoints.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.language.ast.Symbol
+import ca.uwaterloo.flix.language.ast.{Symbol, Type}
 import ca.uwaterloo.flix.language.errors.EntryPointError
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
@@ -241,6 +241,10 @@ class TestEntryPoints extends AnyFunSuite with TestUtils {
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectError[EntryPointError.IllegalEntryPointEffect](result)
+    val offendingEffect = result._2.collectFirst {
+      case EntryPointError.IllegalEntryPointEffect(eff, _) => eff
+    }
+    assert(offendingEffect.exists(_.typeArguments == List(Type.Int32)))
   }
 
   test("Test.IllegalEntryPointEffect.Test.01") {
@@ -767,6 +771,27 @@ class TestEntryPoints extends AnyFunSuite with TestUtils {
         |}
         |
         |def main(): Unit \ E1 + E2 + E3 + IO = E1.op1();E2.op2();E3.op3();println("Hello World")
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectSuccess(result)
+  }
+
+  test("Test.ValidEntryPoint.PolymorphicDefaultHandler.01") {
+    val input =
+      """
+        |pub eff Emit[t] {
+        |    def emit(x: t): Unit
+        |}
+        |
+        |mod Emit {
+        |    @DefaultHandler
+        |    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Emit[t]) + IO =
+        |        run f() with handler Emit {
+        |            def emit(_x, k) = k()
+        |        }
+        |}
+        |
+        |def main(): Unit \ Emit[Int32] = Emit.emit(42)
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectSuccess(result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -3687,6 +3687,27 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.IllegalDefaultHandlerSignature](result)
   }
 
+  test("Test.IllegalDefaultHandlerSignature.08") {
+    val input =
+      """
+        |pub eff E[t] {
+        |   def op(x: t): Unit
+        |}
+        |
+        |mod E {
+        |    @DefaultHandler
+        |    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - E[Int32]) + IO =
+        |        run f() with handler E {
+        |            def op(_x, k) = k()
+        |        }
+        |}
+        |
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.IllegalDefaultHandlerSignature](result)
+  }
+
   test("Test.NonPublicDefaultHandler.01") {
     val input =
       """

--- a/main/test/flix/Test.DefaultHandler.Poly.flix
+++ b/main/test/flix/Test.DefaultHandler.Poly.flix
@@ -1,0 +1,65 @@
+mod Test.DefaultHandler.Poly {
+
+    eff Emit[t] {
+        def emit(x: t): Unit
+    }
+
+    mod Emit {
+        @DefaultHandler
+        pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Emit[t]) + IO =
+            run f() with handler Emit {
+                def emit(_x, k) = k()
+            }
+    }
+
+    @Test
+    def testEmitInt32(): Unit \ Emit[Int32] =
+        Emit.emit(42)
+
+    @Test
+    def testEmitString(): Unit \ Emit[String] =
+        Emit.emit("hello")
+
+    eff Echo[t] {
+        def echo(x: t): t
+    }
+
+    mod Echo {
+        @DefaultHandler
+        pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Echo[t]) + IO =
+            run f() with handler Echo {
+                def echo(x, k) = k(x)
+            }
+    }
+
+    @Test
+    def testEchoInt32(): Unit \ Assert + Echo[Int32] =
+        Assert.assertEq(expected = 42, Echo.echo(42))
+
+    @Test
+    def testEchoString(): Unit \ Assert + Echo[String] =
+        Assert.assertEq(expected = "hello", Echo.echo("hello"))
+
+    eff Pair[a, b] {
+        def first(x: a, y: b): a
+    }
+
+    mod Pair {
+        @DefaultHandler
+        pub def runWithIO(f: Unit -> r \ ef): r \ (ef - Pair[a, b]) + IO =
+            run f() with handler Pair {
+                def first(x, _y, k) = k(x)
+            }
+    }
+
+    @Test
+    def testPair(): Unit \ Assert + Pair[Int32, String] =
+        Assert.assertEq(expected = 42, Pair.first(42, "hello"))
+
+    mod Api {
+        @Export
+        pub def echoInt32(x: Int32): Int32 \ Test.DefaultHandler.Poly.Echo[Int32] =
+            Test.DefaultHandler.Poly.Echo.echo(x)
+    }
+
+}


### PR DESCRIPTION
Closes #13229

Completes support for polymorphic effects in entry points and default handlers.

The entry-point checker now preserves concrete applied effects in diagnostics. Default-handler validation quantifies the handled effect parameters, and entry-point wrapping subtracts the concrete application such as Emit[Int32] rather than the erased effect constructor.

The new monomorphizer infers default-handler type arguments from the complete handler signature and retains explicit type arguments as a specialization key. This prevents distinct instantiations whose arrow types become identical after effect erasure from resolving to the same specialized definition.

Tests cover:

- valid polymorphic default handlers
- rejection of a handler fixed to one effect instantiation
- primitive and reference instantiations of the same handler
- multiple effect parameters
- exported entry points
- preservation of applied effects in entry-point diagnostics
- both monomorphization pipelines

Test results:

- 305 TestEntryPoints and TestTyper tests passed
- focused default-handler runtime tests passed with both monomorphizers
- full CompilerSuite passed with both monomorphizers before restacking