### PR TITLE
feat: report unused type parameters on effects

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -80,6 +80,7 @@ object Redundancy {
       errorsFromTraits ++
       checkUnusedDefs()(sctx, root) ++
       checkUnusedEffects()(sctx, root) ++
+      checkUnusedTypeParamsEffects()(root) ++
       checkUnusedEnumsAndTags()(sctx, root) ++
       checkUnusedTypeParamsEnums()(root) ++
       checkUnusedStructsAndFields()(sctx, root) ++
@@ -111,6 +112,28 @@ object Redundancy {
     for ((_, eff) <- root.effects) {
       if (deadEffect(eff)) {
         result += UnusedEffSym(eff.sym)
+      }
+    }
+    result.toList
+  }
+
+  /**
+    * Checks for unused type parameters in effects.
+    *
+    * A type parameter is used if it occurs in the parameters, result type, or constraints of some operation.
+    * The effect of an operation is not consulted: the Kinder adds the effect itself (applied to all its
+    * type parameters) to every operation, so every type parameter would otherwise count as used.
+    */
+  private def checkUnusedTypeParamsEffects()(implicit root: Root): List[RedundancyError] = {
+    val result = new ArrayBuffer[RedundancyError]
+    for ((_, decl) <- root.effects) {
+      val usedTypeVars = decl.ops.foldLeft(Set.empty[Symbol.KindedTypeVarSym]) {
+        case (acc, Op(_, Spec(_, _, _, _, fparams, _, retTpe, _, tconstrs, econstrs), _)) =>
+          val tpes = fparams.toList.map(_.tpe) ::: retTpe :: tconstrs.map(_.arg) ::: econstrs.map(_.tpe1) ::: econstrs.map(_.tpe2)
+          acc ++ tpes.flatMap(_.typeVars.map(_.sym))
+      }
+      result ++= decl.tparams.collect {
+        case tparam if deadTypeVar(tparam.sym, usedTypeVars) => UnusedTypeParam(tparam.name, tparam.loc)
       }
     }
     result.toList

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -127,13 +127,21 @@ object Redundancy {
   private def checkUnusedTypeParamsEffects()(implicit root: Root): List[RedundancyError] = {
     val result = new ArrayBuffer[RedundancyError]
     for ((_, decl) <- root.effects) {
-      val usedTypeVars = decl.ops.foldLeft(Set.empty[Symbol.KindedTypeVarSym]) {
-        case (acc, Op(_, Spec(_, _, _, _, fparams, _, retTpe, _, tconstrs, econstrs), _)) =>
-          val tpes = fparams.toList.map(_.tpe) ::: retTpe :: tconstrs.map(_.arg) ::: econstrs.map(_.tpe1) ::: econstrs.map(_.tpe2)
-          acc ++ tpes.flatMap(_.typeVars.map(_.sym))
+      val usedTypeVars = Set.newBuilder[Symbol.KindedTypeVarSym]
+      def addTypeVars(tpe: Type): Unit = tpe.typeVars.foreach(tvar => usedTypeVars += tvar.sym)
+      for (op <- decl.ops) {
+        val spec = op.spec
+        spec.fparams.foreach(fparam => addTypeVars(fparam.tpe))
+        addTypeVars(spec.retTpe)
+        spec.tconstrs.foreach(tconstr => addTypeVars(tconstr.arg))
+        spec.econstrs.foreach { econstr =>
+          addTypeVars(econstr.tpe1)
+          addTypeVars(econstr.tpe2)
+        }
       }
+      val used = usedTypeVars.result()
       result ++= decl.tparams.collect {
-        case tparam if deadTypeVar(tparam.sym, usedTypeVars) => UnusedTypeParam(tparam.name, tparam.loc)
+        case tparam if deadTypeVar(tparam.sym, used) => UnusedTypeParam(tparam.name, tparam.loc)
       }
     }
     result.toList

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -841,18 +841,6 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectSuccess(result)
   }
 
-  test("PrefixedTypeParam.Effect.01") {
-    val input =
-      s"""
-         |eff E[_a] {
-         |    def op(): Unit
-         |}
-         |
-       """.stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectSuccess(result)
-  }
-
   test("UnusedFormalParam.Def.01") {
     val input =
       s"""

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -841,6 +841,18 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectSuccess(result)
   }
 
+  test("PrefixedTypeParam.Effect.01") {
+    val input =
+      s"""
+         |eff E[_a] {
+         |    def op(): Unit
+         |}
+         |
+       """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectSuccess(result)
+  }
+
   test("UnusedFormalParam.Def.01") {
     val input =
       s"""
@@ -1051,6 +1063,65 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
          |    f1: a
          |    f2: b
          |}
+         |
+       """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[RedundancyError.UnusedTypeParam](result)
+  }
+
+  test("UnusedTypeParam.Effect.01") {
+    val input =
+      s"""
+         |eff E[a] {
+         |    def op(): Unit
+         |}
+         |
+       """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[RedundancyError.UnusedTypeParam](result)
+  }
+
+  test("UnusedTypeParam.Effect.02") {
+    val input =
+      s"""
+         |eff E[a, b] {
+         |    def op(x: a): Unit
+         |}
+         |
+       """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[RedundancyError.UnusedTypeParam](result)
+  }
+
+  test("UnusedTypeParam.Effect.03") {
+    val input =
+      s"""
+         |eff E[a, b] {
+         |    def op(): b
+         |}
+         |
+       """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[RedundancyError.UnusedTypeParam](result)
+  }
+
+  test("UnusedTypeParam.Effect.04") {
+    val input =
+      s"""
+         |eff E[a, b, c] {
+         |    def op1(x: a): Unit
+         |    def op2(): c
+         |}
+         |
+       """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[RedundancyError.UnusedTypeParam](result)
+  }
+
+  test("UnusedTypeParam.Effect.05") {
+    val input =
+      s"""
+         |eff E[a]
          |
        """.stripMargin
     val result = check(input, Options.TestWithLibNix)

--- a/main/test/flix/Test.Dec.Effect.flix
+++ b/main/test/flix/Test.Dec.Effect.flix
@@ -22,7 +22,7 @@ mod Test.Dec.Effect {
 
     }
 
-    pub eff Polymorphic[a]
+    pub eff Polymorphic[_a]
 
     pub eff PolymorphicWithKinds[a: Type, b: Type] {
         def op(x: a): b


### PR DESCRIPTION
Effects with type parameters currently accept parameters that no operation uses:

```flix
eff E[a] {
    def op(): Unit
}
```

Enums, structs and type aliases already report `UnusedTypeParam` for this. This PR adds the same check for effects.

A parameter counts as used when it appears in an operation's parameters, result type, trait constraints or equality constraints. The operation's effect is deliberately excluded: Kinder adds `E[a, b, ...]` to every operation's effect, so consulting it would mark every parameter as used. The `_` prefix suppresses the error, as elsewhere.

`Test.Dec.Effect.flix` declared a body-less `eff Polymorphic[a]`, which the new check flags; it now uses `Polymorphic[_a]` so the declaration shape it exercises is unchanged.

Part of the polymorphic effects work in #13229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CtTJ9ezmtaGUbEjqjcgSC
