### PR TITLE
fix: reject polymorphic effect constructor variables

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -129,6 +129,7 @@ object ErrorCode {
   case object E3421 extends ErrorCode
   case object E3428 extends ErrorCode
   case object E3435 extends ErrorCode
+  case object E3442 extends ErrorCode
   case object E3458 extends ErrorCode
   case object E3463 extends ErrorCode
   case object E3512 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/KindError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/KindError.scala
@@ -17,6 +17,7 @@ package ca.uwaterloo.flix.language.errors
 
 import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, TypedAst}
+import ca.uwaterloo.flix.language.ast.shared.VarText
 import ca.uwaterloo.flix.language.errors.Highlighter.highlight
 import ca.uwaterloo.flix.language.fmt.FormatKind.formatKind
 import ca.uwaterloo.flix.util.{Formatter, Grammar}
@@ -29,6 +30,35 @@ sealed trait KindError extends CompilationMessage {
 }
 
 object KindError {
+
+  /**
+    * An error raised when a type variable is applied as an effect constructor.
+    *
+    * @param sym the type variable symbol.
+    * @param loc the location where the error occurred.
+    */
+  case class IllegalPolymorphicEffectConstructor(sym: Symbol.UnkindedTypeVarSym, loc: SourceLocation) extends KindError {
+    def code: ErrorCode = ErrorCode.E3442
+
+    private val name = sym.text match {
+      case VarText.Absent => "type variable"
+      case VarText.SourceText(s) => s
+    }
+
+    def summary: String = s"Illegal polymorphic effect constructor '$name'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Illegal polymorphic effect constructor '${red(name)}'.
+         |
+         |${highlight(loc, "effect constructor must be concrete", fmt)}
+         |
+         |${underline("Explanation:")} An effect constructor must refer to a declared effect.
+         |A type variable such as '$name' cannot be applied to produce an effect, even
+         |when it has a higher kind such as 'Type -> Eff'.
+         |""".stripMargin
+    }
+  }
 
   /**
     * An error raised to indicate wrong number of type arguments for an effect.

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1152,7 +1152,15 @@ object Kinder {
       val t2 = visitType(t20, Kind.Wild, kenv, root)
       val k1 = Kind.mkArrow(t2.kind, expectedKind)
       val t1 = visitType(t10, k1, kenv, root)
-      mkApply(t1, t2, loc)
+      val app = mkApply(t1, t2, loc)
+      (tpe0.baseType, app.kind) match {
+        case (UnkindedType.Var(sym, _), Kind.Eff) =>
+          sctx.errors.add(KindError.IllegalPolymorphicEffectConstructor(sym, loc))
+          // Keep the illegal application underneath the error so later phases can still see
+          // its type variables and avoid reporting them as unused.
+          Type.Apply(Type.freshError(Kind.mkArrow(app.kind, Kind.Error), loc), app, loc)
+        case _ => app
+      }
 
     case UnkindedType.Ascribe(t, k, loc) =>
       unify(k, expectedKind) match {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver2.scala
@@ -154,7 +154,7 @@ object ConstraintSolver2 {
     * Collects pointwise equalities between saturated applications of the same effect constructor.
     * Every occurrence in one constraint system must agree on the constructor's type arguments.
     * An application is saturated when all the constructor's type parameters are supplied and the
-    * result has kind `Eff`; for `F: Type -> Eff`, `F[Int32]` is saturated while `F` is not.
+    * result has kind `Eff`; for a declared effect `F: Type -> Eff`, `F[Int32]` is saturated while `F` is not.
     *
     * For example, given the declarations:
     * {{{

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
@@ -218,7 +218,7 @@ object EffUnification3 {
   /**
     * Returns whether `tpe` is a saturated application of an effect constructor.
     *
-    * For example, if `F` has kind `Type -> Eff`, then `F[Int32]` is saturated while `F` is not.
+    * For example, if a declared effect `F` has kind `Type -> Eff`, then `F[Int32]` is saturated while `F` is not.
     */
   private def isSaturatedEffect(tpe: Type): Boolean = {
     if (tpe.kind != Kind.Eff) {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -472,6 +472,28 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
+  // ---------------------------------------------------------------------------
+  // --- KindError.IllegalPolymorphicEffectConstructor ---
+  // ---------------------------------------------------------------------------
+
+  test("KindError.IllegalPolymorphicEffectConstructor.Def.01") {
+    val input =
+      """
+        |def f(): Unit \ ec[Int32] = ???
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectOneError[KindError.IllegalPolymorphicEffectConstructor](result)
+  }
+
+  test("KindError.IllegalPolymorphicEffectConstructor.TypeAlias.01") {
+    val input =
+      """
+        |type alias E[ec: Type -> Eff, a: Type] = ec[a]
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectOneError[KindError.IllegalPolymorphicEffectConstructor](result)
+  }
+
   test("IllegalTypeApplication.01") {
     val input =
       """


### PR DESCRIPTION
Follow-up to #13229.

Summary:
- Reject type-variable applications that produce an effect during kinding.
- Report the dedicated E3442 IllegalPolymorphicEffectConstructor diagnostic without cascading type or redundancy errors.
- Add isolated regression tests for direct effect signatures and effect aliases.
- Clarify that saturated polymorphic effects have declared effect constructors.

Tests:
- ./mill --no-server flix.test.testOnly ca.uwaterloo.flix.language.phase.TestKinder
- ./mill --no-server flix.test (16,724 passed; 8 ignored)