### PR TITLE
feat: report duplicate type parameters

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -454,7 +454,9 @@ object WeededAst {
 
   case class SelectChannelRule(ident: Name.Ident, exp1: Expr, exp2: Expr, loc: SourceLocation)
 
-  sealed trait TypeParam
+  sealed trait TypeParam {
+    def ident: Name.Ident
+  }
 
   object TypeParam {
 

--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -264,6 +264,7 @@ object ErrorCode {
   case object E8465 extends ErrorCode
   case object E8518 extends ErrorCode
   case object E8576 extends ErrorCode
+  case object E8577 extends ErrorCode
   case object E8629 extends ErrorCode
   case object E8652 extends ErrorCode
   case object E8687 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -132,6 +132,32 @@ object WeederError {
   }
 
   /**
+    * An error raised to indicate that the type parameter `name` was declared multiple times.
+    *
+    * @param name the name of the type parameter.
+    * @param loc1 the location of the first type parameter.
+    * @param loc2 the location of the second type parameter.
+    */
+  case class DuplicateTypeParam(name: String, loc1: SourceLocation, loc2: SourceLocation) extends WeederError {
+    def code: ErrorCode = ErrorCode.E8577
+
+    def summary: String = s"Duplicate type parameter: '$name'."
+
+    def message(formatter: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import formatter.*
+      s""">> Duplicate type parameter '${red(name)}'.
+         |
+         |${src(loc1, "first declaration")}
+         |
+         |${src(loc2, "duplicate")}
+         |""".stripMargin
+    }
+
+    def loc: SourceLocation = loc1
+
+  }
+
+  /**
     * An error raised to indicate that a loop does not contain any fragments.
     *
     * @param loc the location of the for-loop with no fragments.

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3207,8 +3207,9 @@ object Weeder2 {
       */
     private def checkDuplicateTypeParams(tparams: List[TypeParam])(implicit sctx: SharedContext): Unit = {
       val tparamsWithoutWildcards = tparams.filter(!_.ident.isWild)
-      val errors = SeqOps.getDuplicates(tparamsWithoutWildcards, (t: TypeParam) => t.ident.name)
-        .map(pair => DuplicateTypeParam(pair._1.ident.name, pair._1.ident.loc, pair._2.ident.loc))
+      val errors = SeqOps.getDuplicates(tparamsWithoutWildcards, (t: TypeParam) => t.ident.name).map {
+        case (tparam1, tparam2) => DuplicateTypeParam(tparam1.ident.name, tparam1.ident.loc, tparam2.ident.loc)
+      }
       errors.foreach(sctx.errors.add)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3141,6 +3141,7 @@ object Weeder2 {
         case Some(tparamsTree) =>
           val parameters = pickAll(TreeKind.Parameter, tparamsTree)
           val tparams = parameters.map(visitParameter)
+          checkDuplicateTypeParams(tparams)
           val kinded = tparams.collect { case t: TypeParam.Kinded => t }
           val unkinded = tparams.collect { case t: TypeParam.Unkinded => t }
           (kinded, unkinded) match {
@@ -3168,6 +3169,7 @@ object Weeder2 {
         case Some(tparamsTree) =>
           val parameters = pickAll(TreeKind.Parameter, tparamsTree)
           val tparams = parameters.map(visitParameter)
+          checkDuplicateTypeParams(tparams)
           val kinded = tparams.collect { case t: TypeParam.Kinded => t }
           val unkinded = tparams.collect { case t: TypeParam.Unkinded => t }
           (kinded, unkinded) match {
@@ -3196,6 +3198,18 @@ object Weeder2 {
       tryPickKind(tree)
         .map(kind => TypeParam.Kinded(ident, kind))
         .getOrElse(TypeParam.Unkinded(ident))
+    }
+
+    /**
+      * Reports a [[DuplicateTypeParam]] error for every type parameter in `tparams` that repeats an earlier name.
+      *
+      * Wildcard names (prefixed with `_`) are exempt, as they are for formal parameters.
+      */
+    private def checkDuplicateTypeParams(tparams: List[TypeParam])(implicit sctx: SharedContext): Unit = {
+      val tparamsWithoutWildcards = tparams.filter(!_.ident.isWild)
+      val errors = SeqOps.getDuplicates(tparamsWithoutWildcards, (t: TypeParam) => t.ident.name)
+        .map(pair => DuplicateTypeParam(pair._1.ident.name, pair._1.ident.loc, pair._2.ident.loc))
+      errors.foreach(sctx.errors.add)
     }
 
     def pickConstraints(tree: Tree)(implicit sctx: SharedContext): List[TraitConstraint] = {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -124,6 +124,68 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.DuplicateStructField](result)
   }
 
+  test("DuplicateTypeParam.01") {
+    val input = "def f[a: Type, a: Type](x: a): a = x"
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.DuplicateTypeParam](result)
+  }
+
+  test("DuplicateTypeParam.02") {
+    val input =
+      """enum E[a, a] {
+        |    case E(a)
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.DuplicateTypeParam](result)
+  }
+
+  test("DuplicateTypeParam.03") {
+    val input =
+      """enum E[a: Type, b: Type, a: Type] {
+        |    case E(a, b)
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.DuplicateTypeParam](result)
+  }
+
+  test("DuplicateTypeParam.04") {
+    val input =
+      """struct S[a, a, r] {
+        |    x: a
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.DuplicateTypeParam](result)
+  }
+
+  test("DuplicateTypeParam.05") {
+    val input = "type alias T[a, a] = a"
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.DuplicateTypeParam](result)
+  }
+
+  test("DuplicateTypeParam.06") {
+    val input =
+      """eff E[a, a] {
+        |    def op(x: a): Unit
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.DuplicateTypeParam](result)
+  }
+
+  test("DuplicateTypeParam.07") {
+    val input =
+      """trait T[a] {
+        |    pub def f[b: Type, b: Type](x: b): a
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[WeederError.DuplicateTypeParam](result)
+  }
+
   test("EmptyForFragment.01") {
     val input =
       """


### PR DESCRIPTION
Declarations currently accept repeated type parameter names:

```flix
enum E[a, a] {
    case E(a)
}
```

This compiles, with the later `a` silently shadowing the earlier one. The same holds for defs, signatures, structs, type aliases and effects.

This PR adds a check in the Weeder that reports `DuplicateTypeParam` for every repeated name in a type parameter list, mirroring `DuplicateFormalParam`. The check is shared by the two type-parameter-list visitors, so every declaration kind is covered; traits take a single parameter and need no check. Underscore-prefixed names are exempt, as they are for formal parameters.

Found while probing polymorphic effects (#13229), but the gap is not specific to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CtTJ9ezmtaGUbEjqjcgSC
