### PR TITLE
fix: reject Java method calls on primitive receivers

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction2.scala
@@ -211,7 +211,14 @@ object TypeReduction2 {
     if (!typesAreKnown) return JavaResolution.UnresolvedTypes
 
     // Rigid type variables and other non-Java types fall back to Object.
-    retrieveMethod(JavaTypes.erasedDescriptorOf(thisObj), methodName, ts, static = false, loc)
+    val owner = JavaTypes.erasedDescriptorOf(thisObj)
+
+    // Primitives (e.g. Int32) have no methods and must not fall back to Object,
+    // since the receiver is never boxed and invoking Object methods on it would
+    // produce invalid bytecode.
+    if (owner.isPrimitive) return JavaResolution.NotFound
+
+    retrieveMethod(owner, methodName, ts, static = false, loc)
   }
 
   /** Tries to find a static method of `owner` that takes arguments of type `ts`. */

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -966,6 +966,46 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[TypeError.MethodNotFound](result)
   }
 
+  test("UndefinedJvmMethod.09") {
+    val input =
+      raw"""
+           |def foo(): String \ IO =
+           |    (2).toString()
+       """.stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MethodNotFound](result)
+  }
+
+  test("UndefinedJvmMethod.10") {
+    val input =
+      raw"""
+           |def foo(): Bool \ IO =
+           |    true.equals(true)
+       """.stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MethodNotFound](result)
+  }
+
+  test("UndefinedJvmMethod.11") {
+    val input =
+      raw"""
+           |def foo(): Int32 \ IO =
+           |    (2.0f64).hashCode()
+       """.stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MethodNotFound](result)
+  }
+
+  test("UndefinedJvmMethod.12") {
+    val input =
+      raw"""
+           |def foo(): String \ IO =
+           |    'a'.toString()
+       """.stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectError[TypeError.MethodNotFound](result)
+  }
+
   test("UndefinedJvmField.01") {
     val input =
       """


### PR DESCRIPTION
Fixes #12135

Calling a Java method on a receiver whose type erases to a JVM primitive (e.g. `(2).toString()`) compiled but crashed at runtime with a `VerifyError`. The resolver found no methods on `int` and fell back to `Object`, so the backend emitted an `invokevirtual` on an unboxed value.

Instance method lookup in `TypeReduction2` now returns `NotFound` when the receiver erases to a primitive, so the existing `MethodNotFound` type error is reported instead:

```
>> Method not found: 'toString' on type 'Int32' with arguments ().
```

Receivers backed by real classes (`BigInt`, `BigDecimal`, `String`, `Regex`) are unaffected. Field lookup already returned nothing for primitive owners and needed no change.

Four regression tests added to `TestResolver` covering `Int32`, `Bool`, `Float64`, and `Char` receivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GP3hxycqPHfMpRnbzCQf4y
