### PR TITLE
fix: document effect type parameters and add a polymorphic effect example

### DIFF
--- a/examples/effects-and-handlers/advanced/polymorphic-effects.flix
+++ b/examples/effects-and-handlers/advanced/polymorphic-effects.flix
@@ -7,22 +7,6 @@ eff State[s] {
     def put(x: s): Unit
 }
 
-///
-/// Runs `f` with the initial state `init` and returns its result together
-/// with the final state. The handler works for every state type `s`.
-///
-def runState(init: s, f: Unit -> a \ State[s] + ef): (a, s) \ ef = region rc {
-    let cell = Ref.fresh(rc, init);
-    let result = run f() with handler State {
-        def get(k) = k(Ref.get(cell))
-        def put(x, k) = {
-            Ref.put(x, cell);
-            k(())
-        }
-    };
-    (result, Ref.get(cell))
-}
-
 /// Increments an `Int32` state `n` times.
 def tick(n: Int32): Unit \ State[Int32] =
     if (n <= 0) () else {
@@ -30,23 +14,14 @@ def tick(n: Int32): Unit \ State[Int32] =
         tick(n - 1)
     }
 
-/// Appends `word` to a `String` state.
-def say(word: String): Unit \ State[String] =
-    State.put(State.get() + word)
-
-def countTicks(): Int32 =
-    let (_, count) = runState(0, () -> tick(3));
-    count
-
-def greeting(): String =
-    let (_, text) = runState("", () -> {
-        say("Hello");
-        say(", ");
-        say("World!")
-    });
-    text
-
-def main(): Unit \ IO = {
-    println("count = ${countTicks()}");
-    println("text = ${greeting()}")
+def main(): Unit \ IO = region rc {
+    let cell = Ref.fresh(rc, 0);
+    run tick(3) with handler State {
+        def get(k) = k(Ref.get(cell))
+        def put(x, k) = {
+            Ref.put(x, cell);
+            k(())
+        }
+    };
+    println("count = ${Ref.get(cell)}")
 }

--- a/examples/effects-and-handlers/advanced/polymorphic-effects.flix
+++ b/examples/effects-and-handlers/advanced/polymorphic-effects.flix
@@ -1,0 +1,52 @@
+///
+/// An effect can be polymorphic in a type. Here `State[s]` describes a
+/// mutable cell holding a value of type `s`.
+///
+eff State[s] {
+    def get(): s
+    def put(x: s): Unit
+}
+
+///
+/// Runs `f` with the initial state `init` and returns its result together
+/// with the final state. The handler works for every state type `s`.
+///
+def runState(init: s, f: Unit -> a \ State[s] + ef): (a, s) \ ef = region rc {
+    let cell = Ref.fresh(rc, init);
+    let result = run f() with handler State {
+        def get(k) = k(Ref.get(cell))
+        def put(x, k) = {
+            Ref.put(x, cell);
+            k(())
+        }
+    };
+    (result, Ref.get(cell))
+}
+
+/// Increments an `Int32` state `n` times.
+def tick(n: Int32): Unit \ State[Int32] =
+    if (n <= 0) () else {
+        State.put(State.get() + 1);
+        tick(n - 1)
+    }
+
+/// Appends `word` to a `String` state.
+def say(word: String): Unit \ State[String] =
+    State.put(State.get() + word)
+
+def countTicks(): Int32 =
+    let (_, count) = runState(0, () -> tick(3));
+    count
+
+def greeting(): String =
+    let (_, text) = runState("", () -> {
+        say("Hello");
+        say(", ");
+        say("World!")
+    });
+    text
+
+def main(): Unit \ IO = {
+    println("count = ${countTicks()}");
+    println("text = ${greeting()}")
+}

--- a/examples/effects-and-handlers/advanced/polymorphic-effects.flix
+++ b/examples/effects-and-handlers/advanced/polymorphic-effects.flix
@@ -9,9 +9,11 @@ eff State[s] {
 
 /// Increments an `Int32` state `n` times.
 def tick(n: Int32): Unit \ State[Int32] =
-    if (n <= 0) () else {
+    if (n > 0) {
         State.put(State.get() + 1);
         tick(n - 1)
+    } else {
+        ()
     }
 
 def main(): Unit \ IO = region rc {

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -766,6 +766,7 @@ object HtmlDocumentor {
     sb.append("<code>")
     sb.append("<span class='keyword'>eff</span> ")
     sb.append(s"<span class='name'>${esc(eff.name)}</span>")
+    docTypeParams(eff.decl.tparams)
     sb.append("</code>")
     docActions(None, eff.decl.loc)
     sb.append("</div>")


### PR DESCRIPTION
## Summary

- The HTML documentor rendered `eff Emit` for a polymorphic effect, dropping its type parameters. Effect pages now use the same type-parameter printer as enum, trait, and alias pages, so `Emit[t]` renders as `eff Emit[t: Type]` and `Exchange[a, b]` as `eff Exchange[a: Type, b: Type]`.
- Adds `examples/effects-and-handlers/advanced/polymorphic-effects.flix`, the first example of a polymorphic effect. It declares `State[s]` and handles it at `Int32` in `main`. The file is in canonical formatter form and is picked up by `ExampleSuite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMhAmmQNnEg3gwYZgwNvfX
