### PR TITLE
fix: report mismatched arity for under-applied effects inside set operators

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1149,11 +1149,14 @@ object Kinder {
       }
 
     case UnkindedType.Apply(t10, t20, loc) =>
-      val t2 = visitType(t20, Kind.Wild, kenv, root)
+      val base = tpe0.baseType
+      // Visit the argument with the kind demanded by the head constructor (if known),
+      // so that an ill-kinded argument is reported at the argument rather than at the head.
+      val t2 = visitType(t20, getExpectedArgKind(base, tpe0), kenv, root)
       val k1 = Kind.mkArrow(t2.kind, expectedKind)
       val t1 = visitType(t10, k1, kenv, root)
       val app = mkApply(t1, t2, loc)
-      (tpe0.baseType, app.kind) match {
+      (base, app.kind) match {
         case (UnkindedType.Var(sym, _), Kind.Eff) =>
           sctx.errors.add(KindError.IllegalPolymorphicEffectConstructor(sym, loc))
           // Keep the illegal application underneath the error so later phases can still see
@@ -1369,6 +1372,33 @@ object Kinder {
     case _: UnkindedType.UnappliedNative => throw InternalCompilerException("unexpected unapplied native type", tpe0.loc)
 
 
+  }
+
+  /**
+    * Returns the kind expected of the last argument of the type application `app` whose base type is `base`.
+    *
+    * For example, in `E + IO`, i.e. `Apply(Apply(Union, E), IO)`, the argument `IO` is expected
+    * to have kind `Eff` because `Union` has kind `Eff -> Eff -> Eff`.
+    *
+    * Returns [[Kind.Wild]] if the kind of `base` is not statically known (e.g. it is a type variable)
+    * or if `app` applies more arguments than the kind of `base` accepts.
+    */
+  private def getExpectedArgKind(base: UnkindedType, app: UnkindedType)(implicit declKinds: DeclKinds): Kind = {
+    val baseKind = base match {
+      case UnkindedType.Cst(cst, _) => Some(cst.kind)
+      case UnkindedType.Enum(sym, _) => Some(declKinds.enumKinds(sym))
+      case UnkindedType.Effect(sym, _) => Some(declKinds.effectKinds(sym))
+      case UnkindedType.Struct(sym, _) => Some(declKinds.structKinds(sym))
+      case UnkindedType.RestrictableEnum(sym, _) => Some(declKinds.restrictableEnumKinds(sym))
+      case UnkindedType.Arrow(_, arity, _) => Some(Kind.mkArrow(arity))
+      case _ => None
+    }
+    baseKind match {
+      case Some(k) =>
+        // The argument of `app` is its last type argument, i.e. it is at index `numArgs - 1`.
+        Kind.kindArgs(k).lift(app.typeArguments.length - 1).getOrElse(Kind.Wild)
+      case None => Kind.Wild
+    }
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -708,6 +708,71 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.MismatchedArityOfEffect](result)
   }
 
+  test("KindError.MismatchedArityOfEffect.Def.Union.01") {
+    val input =
+      """
+        |eff E[a] {
+        |    def op(x: a): Unit
+        |}
+        |
+        |def foo(): Unit \ E + IO = ()
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.MismatchedArityOfEffect](result)
+  }
+
+  test("KindError.MismatchedArityOfEffect.Def.Union.02") {
+    val input =
+      """
+        |eff E[a] {
+        |    def op(x: a): Unit
+        |}
+        |
+        |def foo(): Unit \ IO + E = ()
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.MismatchedArityOfEffect](result)
+  }
+
+  test("KindError.MismatchedArityOfEffect.Def.Difference.01") {
+    val input =
+      """
+        |eff E[a] {
+        |    def op(x: a): Unit
+        |}
+        |
+        |def foo(): Unit \ IO - E = ()
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.MismatchedArityOfEffect](result)
+  }
+
+  test("KindError.MismatchedArityOfEffect.Def.Difference.02") {
+    val input =
+      """
+        |eff E[a] {
+        |    def op(x: a): Unit
+        |}
+        |
+        |def foo(f: Unit -> Unit \ ef): Unit \ ef - E = f()
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.MismatchedArityOfEffect](result)
+  }
+
+  test("KindError.MismatchedArityOfEffect.TypeAlias.Difference.01") {
+    val input =
+      """
+        |eff E[a] {
+        |    def op(x: a): Unit
+        |}
+        |
+        |type alias A[ef: Eff] = ef - E
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.MismatchedArityOfEffect](result)
+  }
+
   // ---------------------------------------------------------------------------
   // --- KindError.MismatchedArityOfEnum ---
   // ---------------------------------------------------------------------------
@@ -1025,17 +1090,6 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  test("KindError.UnexpectedKind.Def.LocalDef.Type.02") {
-    val input =
-      """
-        |def g(): Int32 =
-        |    def f(x: {} -> Int32 \ Int32): Int32 = ???;
-        |    f(_ -> 1)
-        |""".stripMargin
-    val result = check(input, DefaultOptions)
-    expectError[KindError.UnexpectedKind](result)
-  }
-
   test("KindError.UnexpectedKind.Def.LocalDef.Return.01") {
     val input =
       """
@@ -1064,15 +1118,6 @@ class TestKinder extends AnyFunSuite with TestUtils {
     val input =
       """
         |def f(x: Int32[Int32]): Int32 = ???
-        |""".stripMargin
-    val result = check(input, DefaultOptions)
-    expectError[KindError.UnexpectedKind](result)
-  }
-
-  test("KindError.UnexpectedKind.Def.Type.02") {
-    val input =
-      """
-        |def f(x: {} -> Int32 \ Int32): Int32 = ???
         |""".stripMargin
     val result = check(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -1190,15 +1235,6 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |enum E[a]
         |
         |instance C[E[a]] with D[a]
-        |""".stripMargin
-    val result = check(input, DefaultOptions)
-    expectError[KindError.UnexpectedKind](result)
-  }
-
-  test("KindError.UnexpectedKind.TypeAlias.01") {
-    val input =
-      """
-        |type alias T = {} -> Int32
         |""".stripMargin
     val result = check(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -1572,6 +1608,17 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedEffect](result)
   }
 
+  test("KindError.UnexpectedEffect.Def.LocalDef.Param.02") {
+    val input =
+      """
+        |def g(): Int32 =
+        |    def f(x: {} -> Int32 \ Int32): Int32 = ???;
+        |    f(_ -> 1)
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.UnexpectedEffect](result)
+  }
+
   test("KindError.UnexpectedEffect.Def.LocalDef.Return.01") {
     val input =
       """
@@ -1588,6 +1635,15 @@ class TestKinder extends AnyFunSuite with TestUtils {
     val input =
       """
         |def f(x: {}): Int32 = ???
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.UnexpectedEffect](result)
+  }
+
+  test("KindError.UnexpectedEffect.Def.Param.02") {
+    val input =
+      """
+        |def f(x: {} -> Int32 \ Int32): Int32 = ???
         |""".stripMargin
     val result = check(input, DefaultOptions)
     expectError[KindError.UnexpectedEffect](result)
@@ -1619,6 +1675,15 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |struct S [r] {
         |    c: { }
         |}
+        |""".stripMargin
+    val result = check(input, DefaultOptions)
+    expectError[KindError.UnexpectedEffect](result)
+  }
+
+  test("KindError.UnexpectedEffect.TypeAlias.01") {
+    val input =
+      """
+        |type alias T = {} -> Int32
         |""".stripMargin
     val result = check(input, DefaultOptions)
     expectError[KindError.UnexpectedEffect](result)


### PR DESCRIPTION
An under-applied effect inside `+` or `-` was reported as `UnexpectedKind` on the operator instead of `MismatchedArityOfEffect` on the effect:

```
>> Unexpected kind: expected '(Type -> Eff) -> Eff -> Eff', found 'Eff -> Eff -> Eff'.

5 | def f(): Unit \ E + IO = ???
                    ^^^^^^
                    has unexpected kind
```

In a type alias body the outer expected kind is wild, so the message also printed `???`:

```
>> Unexpected kind: expected 'Eff -> (Type -> Eff) -> ???', found 'Eff -> Eff -> Eff'.
```

**Cause.** `Kinder.visitType` visited every `Apply` argument with `Kind.Wild`, so an under-applied `E` unified with the wild kind and the mismatch only surfaced when the operator's kind was compared against the bottom-up kind built from its arguments.

**Fix.** The `Apply` case now visits the argument with the kind demanded by the head constructor when that kind is statically known (constants, enums, effects, structs, restrictable enums, arrows). An under-applied effect then fails its own arity check:

```
>> Mismatched arity: effect 'E' expects 1 type argument but 0 type arguments were given.

5 | def f(): Unit \ E + IO = ???
                    ^
                    wrong number of type arguments
```

Type-variable heads and over-applied constructors keep the previous wild fallback.

Three existing tests built on `{} -> Int32` now report the more specific `UnexpectedEffect` at `{}` (and `UnexpectedType` at `\ Int32`) instead of `UnexpectedKind` on the arrow. They have been moved to the `UnexpectedEffect` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMhAmmQNnEg3gwYZgwNvfX
