### PR TITLE
ci: remove flixball from community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -63,7 +63,6 @@ jobs:
           - "jaschdoc/flix-test-pkg-trust-transitive-plain"
           - "jaschdoc/flix-test-pkg-trust-transitive-java"
           - "mlutze/flix-json"
-          - "mlutze/flixball"
           - "mlutze/flixball-2"
           - "rywiese/scope-graphs"
           - "stephentetley/flix-htmldoc"


### PR DESCRIPTION
Flixball 2 is better anyway