### PR TITLE
chore: add flix/extras to the community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -53,6 +53,7 @@ jobs:
         repo:
           - "flix/chalk"
           - "flix/datalog2"
+          - "flix/extras"
           - "flix/test-pkg-trust-plain"
           - "flix/test-pkg-trust-unchecked-cast"
           - "JonathanStarup/Flix-ANSI-Terminal"


### PR DESCRIPTION
Adds [flix/extras](https://github.com/flix/extras) to the community build matrix, placed alphabetically within the `flix/*` group.
