### PR TITLE
feat: reject public modules nested inside other modules

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ErrorCode.scala
@@ -192,6 +192,7 @@ object ErrorCode {
   case object E5410 extends ErrorCode
   case object E5467 extends ErrorCode
   case object E5512 extends ErrorCode
+  case object E5544 extends ErrorCode
   case object E5578 extends ErrorCode
   case object E5623 extends ErrorCode
   case object E5658 extends ErrorCode

--- a/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
@@ -223,6 +223,34 @@ object NameError {
     }
   }
 
+
+  /**
+    * An error raised to indicate that the public module `ns` is declared inside another module.
+    *
+    * A public module must be declared at the top level of its own file.
+    *
+    * @param ns  the fully qualified name of the nested public module.
+    * @param loc the location of the module name.
+    */
+  case class IllegalNestedPublicModule(ns: Name.NName, loc: SourceLocation) extends NameError {
+    def code: ErrorCode = ErrorCode.E5544
+
+    def summary: String = s"Nested public module: '$ns'."
+
+    def message(fmt: Formatter)(implicit root: Option[TypedAst.Root]): String = {
+      import fmt.*
+      s""">> Nested public module: '${red(ns.toString)}'.
+         |
+         |${highlight(loc, "nested public module", fmt)}
+         |
+         |${underline("Explanation:")} A public module must be declared at the top level of its
+         |own file, not inside another module. For example:
+         |
+         |  // File ${ns.parts.mkString("/")}.flix
+         |  pub mod $ns { ... }
+         |""".stripMargin
+    }
+  }
   /**
     * An error raised to indicate that the given `name` is a reserved name.
     *

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -202,16 +202,21 @@ object Namer {
   private def visitMod(decl: DesugaredAst.Declaration.Mod, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): NamedAst.Declaration.Mod = decl match {
     case DesugaredAst.Declaration.Mod(doc, ann, mod, qname, usesAndImports0, decls, loc) =>
 
-      //
-      // Check for [[NameError.IllegalModuleFile]] -- i.e. that public modules reside at correct paths.
-      //
+      val ns = Name.NName(ns0.idents ++ qname.namespace.idents ++ List(qname.ident), qname.loc)
 
-      // If the module is A.B.C then we build the path A/B/C.flix.
-      val expectedPath: Path = qname.namespace.idents.map(_.name).foldLeft(Path.of("")) {
-        case (p, name) => p.resolve(name)
-      }.resolve(qname.ident.name + ".flix")
+      //
+      // Check for [[NameError.IllegalNestedPublicModule]] -- i.e. that public modules are declared
+      // at the top level -- and [[NameError.IllegalModuleFile]] -- i.e. that they reside at correct paths.
+      //
+      if (mod.isPublic && !ns0.isRoot) {
+        // A nested public module is never at a correct path, so we report only this error.
+        sctx.errors.add(NameError.IllegalNestedPublicModule(ns, qname.loc))
+      } else if (mod.isPublic) {
+        // If the module is A.B.C then we build the path A/B/C.flix.
+        val expectedPath: Path = qname.namespace.idents.map(_.name).foldLeft(Path.of("")) {
+          case (p, name) => p.resolve(name)
+        }.resolve(qname.ident.name + ".flix")
 
-      if (mod.isPublic) {
         val optPath = loc.source.input match {
           case Input.RealFile(realPath, _)  => Some(realPath)
           case Input.VirtualFile(virtualPath, _, _) => Some(virtualPath)
@@ -234,8 +239,6 @@ object Namer {
             }
         }
       }
-
-      val ns = Name.NName(ns0.idents ++ qname.namespace.idents ++ List(qname.ident), qname.loc)
 
       //
       // Check for [[NameError.IllegalMainModule]] -- i.e. that no top-level module takes

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -595,32 +595,6 @@ class TestNamer extends AnyFunSuite with TestUtils {
     rejectError[NameError.DuplicateModule](result)
   }
 
-  test("IllegalReservedName.Enum.01") {
-    val input =
-      """pub enum Int32 {
-        |  case Value,
-        |}
-    """.stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[NameError.IllegalReservedName](result)
-  }
-
-  test("IllegalReservedName.Alias.01") {
-    val input =
-      """type alias Float32[k] = (k,k)
-    """.stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[NameError.IllegalReservedName](result)
-  }
-
-  test("IllegalReservedName.Struct.01") {
-    val input =
-      """struct Float64 {}
-    """.stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[NameError.IllegalReservedName](result)
-  }
-
   test("IllegalMainModule.01") {
     val input =
       """
@@ -656,6 +630,105 @@ class TestNamer extends AnyFunSuite with TestUtils {
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
     rejectError[NameError.IllegalMainModule](result)
+  }
+
+  test("IllegalNestedPublicModule.01") {
+    val input =
+      """
+        |mod A {
+        |    pub mod B {
+        |        pub def f(): Int32 = 1
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectOneError[NameError.IllegalNestedPublicModule](result)
+  }
+
+  test("IllegalNestedPublicModule.02") {
+    // Nesting at any depth is rejected.
+    val input =
+      """
+        |mod A {
+        |    mod B {
+        |        pub mod C {
+        |            pub def f(): Int32 = 1
+        |        }
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectOneError[NameError.IllegalNestedPublicModule](result)
+  }
+
+  test("IllegalNestedPublicModule.03") {
+    // The enclosing module may use the dotted form; the nested public module is still rejected.
+    val input =
+      """
+        |mod A.B {
+        |    pub mod C {
+        |        pub def f(): Int32 = 1
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectOneError[NameError.IllegalNestedPublicModule](result)
+  }
+
+  test("IllegalNestedPublicModule.04") {
+    // A private nested module is fine.
+    val input =
+      """
+        |mod A {
+        |    mod B {
+        |        pub def f(): Int32 = 1
+        |    }
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    rejectError[NameError.IllegalNestedPublicModule](result)
+  }
+
+  test("IllegalNestedPublicModule.05") {
+    // A public module declared at the top level with the dotted form is not nested.
+    val input =
+      """
+        |mod A {
+        |    pub def f(): Int32 = 1
+        |}
+        |
+        |pub mod A.B {
+        |    pub def g(): Int32 = 2
+        |}
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    rejectError[NameError.IllegalNestedPublicModule](result)
+  }
+
+  test("IllegalReservedName.Enum.01") {
+    val input =
+      """pub enum Int32 {
+        |  case Value,
+        |}
+    """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[NameError.IllegalReservedName](result)
+  }
+
+  test("IllegalReservedName.Alias.01") {
+    val input =
+      """type alias Float32[k] = (k,k)
+    """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[NameError.IllegalReservedName](result)
+  }
+
+  test("IllegalReservedName.Struct.01") {
+    val input =
+      """struct Float64 {}
+    """.stripMargin
+    val result = check(input, Options.TestWithLibNix)
+    expectError[NameError.IllegalReservedName](result)
   }
 
   test("IllegalReservedName.Trait.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -360,18 +360,18 @@ class TestResolver extends AnyFunSuite with TestUtils {
   }
 
   test("InaccessibleModule.02") {
+    // `B` is accessible from its sibling `D`, but `C` is private to `A.B`.
     val input =
       s"""
          |mod A {
-         |    pub mod B {
+         |    mod B {
          |        mod C {
          |            pub def foo(): Int32 = 123
          |        }
          |    }
-         |}
-         |
-         |mod D {
-         |    def g(): Int32 = A.B.C.foo()
+         |    mod D {
+         |        def g(): Int32 = A.B.C.foo()
+         |    }
          |}
          |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
@@ -379,11 +379,12 @@ class TestResolver extends AnyFunSuite with TestUtils {
   }
 
   test("InaccessibleModule.03") {
+    // `B` is private to `A`, so the path is blocked at `B`.
     val input =
       s"""
          |mod A {
          |    mod B {
-         |        pub mod C {
+         |        mod C {
          |            pub def foo(): Int32 = 123
          |        }
          |    }
@@ -421,7 +422,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       s"""
          |mod A {
-         |    pub mod B {
+         |    mod B {
          |        mod C {
          |            pub enum Color {
          |                case Red,
@@ -429,10 +430,9 @@ class TestResolver extends AnyFunSuite with TestUtils {
          |            }
          |        }
          |    }
-         |}
-         |
-         |mod D {
-         |    def f(): A.B.C.Color = A.B.C.Color.Red
+         |    mod D {
+         |        def f(): A.B.C.Color = A.B.C.Color.Red
+         |    }
          |}
          |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
@@ -521,17 +521,16 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       s"""
          |mod A {
-         |    pub mod B {
+         |    mod B {
          |        mod C {
          |            pub trait Show[a] {
          |                pub def show(x: a): String
          |            }
          |        }
          |    }
-         |}
-         |
-         |mod D {
-         |    def f(x: a): String with A.B.C.Show[a] = ???
+         |    mod D {
+         |        def f(x: a): String with A.B.C.Show[a] = ???
+         |    }
          |}
          |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
@@ -555,25 +554,6 @@ class TestResolver extends AnyFunSuite with TestUtils {
   }
 
   test("InaccessibleModule.12") {
-    // `C` is private to `A.B`, so it is not accessible from `A.D`, which lies outside `A.B`.
-    val input =
-      s"""
-         |mod A {
-         |    mod B {
-         |        mod C {
-         |            pub def foo(): Int32 = 123
-         |        }
-         |    }
-         |    mod D {
-         |        pub def g(): Int32 = A.B.C.foo()
-         |    }
-         |}
-         |""".stripMargin
-    val result = check(input, Options.TestWithLibNix)
-    expectError[ResolutionError.InaccessibleModule](result)
-  }
-
-  test("InaccessibleModule.13") {
     // A `use` does not bypass the check: the error is reported where the name is referenced.
     val input =
       s"""


### PR DESCRIPTION
Follow-up to #12148 and #13258.

A `pub mod` declared inside the body of another module slipped past the module-file check, because the expected path was built from the short name as written rather than the full name. The same source, `mod A { pub mod B { } }`, was rejected in `A.flix` with an error naming `'B'`, yet accepted in `X/B.flix` where nothing in the path mentions `A`.

This PR rejects the nested form outright. A public module must be a top-level declaration, written as `pub mod A.B { ... }` in `A/B.flix`. That is already how every public module in the library and the examples is written, and it is the only form the file rule can enforce meaningfully. With every public module at the top level, its written name is its full name, so the existing path computation becomes correct by construction.

### Changes

- **`NameError.scala`, `ErrorCode.scala`**: new `IllegalNestedPublicModule` (E5544). The message names the full module and shows the expected file and header:
  ```
  >> Nested public module: 'A.B'.
  Explanation: A public module must be declared at the top level of its
  own file, not inside another module. For example:
    // File A/B.flix
    pub mod A.B { ... }
  ```
- **`Namer.scala`**: in `visitMod`, report the error for a `pub mod` whose enclosing namespace is not the root, and skip the file-path check for it so the user gets one clear error instead of a second misleading one.
- **`TestNamer.scala`**: three rejections (direct nesting, two levels deep, and inside a dotted `mod A.B` header), each asserting exactly one error, plus two acceptances for a private nested module and a top-level dotted `pub mod A.B`. The module tests are now grouped together, which also makes the `IllegalReservedName` group contiguous again.
- **`TestResolver.scala`**: the four `InaccessibleModule` cases that used a nested `pub mod` to reach an inner private module now use a private sibling instead. The case that became identical to the rewritten `.02` is dropped and the last one renumbered.

### Impact

No nested `pub mod` exists in the standard library, the examples, or the Flix test files. The new check also applies to sources inside `.fpkg` packages, which the file check currently exempts, so a published package that nests public modules would stop compiling. I could not find any such code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xat3kxetDXhAKCCCM1JSfd
